### PR TITLE
Support for Simple Email Service events

### DIFF
--- a/Libraries/Libraries.sln
+++ b/Libraries/Libraries.sln
@@ -52,6 +52,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Amazon.Lambda.Tools.Test", 
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "TestFunction", "test\TestFunction\TestFunction.xproj", "{11A53C8D-A49B-4477-BFD9-E00C77D1291C}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Amazon.Lambda.SimpleEmailEvents", "src\Amazon.Lambda.SimpleEmailEvents\Amazon.Lambda.SimpleEmailEvents.xproj", "{A6348510-7948-46B1-A2C4-396B8C55440C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -138,6 +140,10 @@ Global
 		{11A53C8D-A49B-4477-BFD9-E00C77D1291C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{11A53C8D-A49B-4477-BFD9-E00C77D1291C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{11A53C8D-A49B-4477-BFD9-E00C77D1291C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A6348510-7948-46B1-A2C4-396B8C55440C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A6348510-7948-46B1-A2C4-396B8C55440C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A6348510-7948-46B1-A2C4-396B8C55440C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A6348510-7948-46B1-A2C4-396B8C55440C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -163,5 +169,6 @@ Global
 		{95294EBA-F227-4FE7-AD93-8BEAB8E1CC70} = {AAB54E74-20B1-42ED-BC3D-CE9F7BC7FD12}
 		{06804AE7-14E9-494D-A1F7-258EA6432C09} = {1DE4EE60-45BA-4EF7-BE00-B9EB861E4C69}
 		{11A53C8D-A49B-4477-BFD9-E00C77D1291C} = {1DE4EE60-45BA-4EF7-BE00-B9EB861E4C69}
+		{A6348510-7948-46B1-A2C4-396B8C55440C} = {AAB54E74-20B1-42ED-BC3D-CE9F7BC7FD12}
 	EndGlobalSection
 EndGlobal

--- a/Libraries/src/Amazon.Lambda.SNSEvents/README.md
+++ b/Libraries/src/Amazon.Lambda.SNSEvents/README.md
@@ -1,4 +1,4 @@
-# Amazon.Lambda.S3Events
+# Amazon.Lambda.SNSEvents
 
 This package contains classes that can be used as input types for Lambda functions that process Amazon Simple Notification Service (Amazon SNS) events. 
 

--- a/Libraries/src/Amazon.Lambda.SimpleEmailEvents/Amazon.Lambda.SimpleEmailEvents.xproj
+++ b/Libraries/src/Amazon.Lambda.SimpleEmailEvents/Amazon.Lambda.SimpleEmailEvents.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>a6348510-7948-46b1-a2c4-396b8c55440c</ProjectGuid>
+    <RootNamespace>Amazon.Lambda.SimpleEmailEvents</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/Libraries/src/Amazon.Lambda.SimpleEmailEvents/Properties/AssemblyInfo.cs
+++ b/Libraries/src/Amazon.Lambda.SimpleEmailEvents/Properties/AssemblyInfo.cs
@@ -2,35 +2,12 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Amazon.Lambda.SimpleEmailEvents")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Amazon.Lambda.SimpleEmailEvents")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
+[assembly: AssemblyDescription("Lambda event interfaces for Simple Email Service (SES) event source.")]
+[assembly: AssemblyProduct("Amazon Web Services Lambda Interface for .NET")]
+[assembly: AssemblyCompany("Amazon.com, Inc")]
+[assembly: AssemblyCopyright("Copyright 2009-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.")]
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("a6348510-7948-46b1-a2c4-396b8c55440c")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: System.CLSCompliant(true)]
+[assembly: AssemblyVersion("1.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Libraries/src/Amazon.Lambda.SimpleEmailEvents/Properties/AssemblyInfo.cs
+++ b/Libraries/src/Amazon.Lambda.SimpleEmailEvents/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Amazon.Lambda.SimpleEmailEvents")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Amazon.Lambda.SimpleEmailEvents")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("a6348510-7948-46b1-a2c4-396b8c55440c")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Libraries/src/Amazon.Lambda.SimpleEmailEvents/README.md
+++ b/Libraries/src/Amazon.Lambda.SimpleEmailEvents/README.md
@@ -1,0 +1,21 @@
+# Amazon.Lambda.SimpleEmailEvents
+
+This package contains classes that can be used as input types for Lambda functions that process Amazon Simple Email Service (Amazon SES) events. 
+
+# Sample Function
+
+Below is a sample class and Lambda function that illustrates how a SimpleEmailEvent can be used. The function logs a summary of the events it received, including the event source, the timestamp, and the message of each event. (Note that by default anything written to Console will be logged as CloudWatch Logs events.)
+
+```
+public class Function
+{
+    public string Handler(SimpleEmailEvent sesEvent)
+    {
+		foreach (var record in sesEvent.Records)
+		{
+			var sesRecord = record.Ses;
+			Console.WriteLine($"[{record.EventSource} {sesRecord.Mail.Timestamp}] Subject = {sesRecord.Mail.CommonHeaders.Subject}");
+		}
+    }
+}
+```

--- a/Libraries/src/Amazon.Lambda.SimpleEmailEvents/SimpleEmailEvent.cs
+++ b/Libraries/src/Amazon.Lambda.SimpleEmailEvents/SimpleEmailEvent.cs
@@ -1,0 +1,225 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Amazon.Lambda.SimpleEmailEvents
+{
+    /// <summary>
+    /// Simple Email Service event
+    /// http://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-ses-email-receiving
+    /// </summary>
+    public class SimpleEmailEvent
+    {
+        /// <summary>
+        /// List of SNS records.
+        /// </summary>
+        public IList<SimpleEmailRecord> Records { get; set; }
+
+        /// <summary>
+        /// An SES record.
+        /// </summary>
+        public class SimpleEmailRecord
+        {
+            /// <summary>
+            /// The event version.
+            /// </summary>
+            public string EventVersion { get; set; }
+
+            /// <summary>
+            /// The event source.
+            /// </summary>
+            public string EventSource { get; set; }
+
+            /// <summary>
+            /// The SES message.
+            /// </summary>
+            public SimpleEmailService Ses { get; set; }
+        }
+
+        /// <summary>
+        /// An SES message record.
+        /// </summary>
+        public class SimpleEmailService
+        {
+            /// <summary>
+            /// The mail data for the SES message.
+            /// </summary>
+            public SimpleEmailMessage Mail { get; set; }
+
+            /// <summary>
+            /// The receipt data for the SES message.
+            /// </summary>
+            public SimpleEmailReceipt Receipt { get; set; }
+        }
+
+        /// <summary>
+        /// The mail data for the SES message.
+        /// </summary>
+        public class SimpleEmailMessage
+        {
+            /// <summary>
+            /// A few of the most important headers from the message.
+            /// </summary>
+            public SimpleEmailCommonHeaders CommonHeaders { get; set; }
+
+            /// <summary>
+            /// The source email address of the message, i.e. SMTP FROM.
+            /// </summary>
+            public string Source { get; set; }
+
+            /// <summary>
+            /// The timestamp of the message.
+            /// </summary>
+            public DateTime Timestamp { get; set; }
+
+            /// <summary>
+            /// The destination recipients of the message.
+            /// </summary>
+            public IList<string> Destination { get; set; }
+
+            /// <summary>
+            /// The headers associated with the message.
+            /// </summary>
+            public IList<SimpleEmailHeader> Headers { get; set; }
+
+            /// <summary>
+            /// Whether or not the Headers property is truncated.
+            /// </summary>
+            public bool HeadersTruncated { get; set; }
+
+            /// <summary>
+            /// The SES Message ID, which will also be the filename of the S3 object containing the message. Not to be confused with the incoming message's Message-ID header.
+            /// </summary>
+            public string MessageId { get; set; }
+        }
+
+        /// <summary>
+        /// The receipt data for the SES message.
+        /// </summary>
+        public class SimpleEmailReceipt
+        {
+            /// <summary>
+            /// The recipients of the message.
+            /// </summary>
+            public IList<string> Recipients { get; set; }
+
+            /// <summary>
+            /// The timestamp of the message.
+            /// </summary>
+            public DateTime Timestamp { get; set; }
+
+            /// <summary>
+            /// The spam verdict of the message, e.g. status: PASS.
+            /// </summary>
+            public SimpleEmailVerdict SpamVerdict { get; set; }
+
+            /// <summary>
+            /// The DKIM verdict of the message, e.g. status: PASS.
+            /// </summary>
+            public SimpleEmailVerdict DKIMVerdict { get; set; }
+
+            /// <summary>
+            /// The SPF verdict of the message, e.g. status: PASS.
+            /// </summary>
+            public SimpleEmailVerdict SPFVerdict { get; set; }
+
+            /// <summary>
+            /// The virus verdict of the message, e.g. status: PASS.
+            /// </summary>
+            public SimpleEmailVerdict VirusVerdict { get; set; }
+
+            /// <summary>
+            /// The virus verdict of the message, e.g. status: PASS.
+            /// </summary>
+            public SimpleEmailReceiptAction Action { get; set; }
+
+            /// <summary>
+            /// How long this incoming message took to process.
+            /// </summary>
+            public long ProcessingTimeMillis { get; set; }
+        }
+
+        /// <summary>
+        /// An SES message header.
+        /// </summary>
+        public class SimpleEmailHeader
+        {
+            /// <summary>
+            /// The header name.
+            /// </summary>
+            public string Name { get; set; }
+
+            /// <summary>
+            /// The header value.
+            /// </summary>
+            public string Value { get; set; }
+        }
+    }
+
+    /// <summary>
+    /// A few of the most important headers of the message.
+    /// </summary>
+    public class SimpleEmailCommonHeaders
+    {
+        /// <summary>
+        /// The From header's address(es)
+        /// </summary>
+        public IList<string> From { get; set; }
+
+        /// <summary>
+        /// The To header's address(es)
+        /// </summary>
+        public IList<string> To { get; set; }
+
+        /// <summary>
+        /// The Return-Path header.
+        /// </summary>
+        public string ReturnPath { get; set; }
+
+        /// <summary>
+        /// The incoming message's Message-ID header. Not to be confused with the SES messageId.
+        /// </summary>
+        public string MessageId { get; set; }
+
+        /// <summary>
+        /// The Date header.
+        /// </summary>
+        public string Date { get; set; }
+
+        /// <summary>
+        /// The Subject header.
+        /// </summary>
+        public string Subject { get; set; }
+    }
+
+    /// <summary>
+    /// The SES receipt's action.
+    /// </summary>
+    public class SimpleEmailReceiptAction
+    {
+        /// <summary>
+        /// The type of the action, e.g. "Lambda"
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// The type of invocation, e.g. "Event"
+        /// </summary>
+        public string InvocationType { get; set; }
+
+        /// <summary>
+        /// The ARN of this function.
+        /// </summary>
+        public string FunctionArn { get; set; }
+    }
+
+    /// <summary>
+    /// Verdict to return status of Spam, DKIM, SPF, and Virus.
+    /// </summary>
+    public class SimpleEmailVerdict
+    {
+        /// <summary>
+        /// The verdict status, e.g. PASS or FAIL.
+        /// </summary>
+        public string Status { get; set; }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.SimpleEmailEvents/project.json
+++ b/Libraries/src/Amazon.Lambda.SimpleEmailEvents/project.json
@@ -1,0 +1,33 @@
+{
+  "name": "Amazon.Lambda.SimpleEmailEvents",
+  "version": "1.0.0-*",
+  "title": "Amazon.Lambda.SimpleEmailEvents",
+  "authors": [
+    "Amazon Web Services"
+  ],
+  "packOptions": {
+    "licenseUrl": "http://aws.amazon.com/apache2.0/",
+    "projectUrl": "https://aws.amazon.com/lambda/",
+    "iconUrl": "http://media.amazonwebservices.com/aws_singlebox_01.png",
+    "tags": [
+      "AWS",
+      "Amazon",
+      "Lambda"
+    ]
+  },
+  "description": "Amazon Lambda .NET Core support - SimpleEmailEvents package.",
+  "buildOptions": {
+    "emitEntryPoint": false,
+    "xmlDoc": true,
+    "warningsAsErrors": true
+  },
+  "dependencies": {
+    "System.Runtime": "4.1.0"
+  },
+  "frameworks": {
+    "netstandard1.3": {
+      "imports": "dnxcore50"
+    }
+  }
+}
+

--- a/Libraries/test/EventsTests/project.json
+++ b/Libraries/test/EventsTests/project.json
@@ -17,6 +17,7 @@
     "Amazon.Lambda.DynamoDBEvents": { "target": "project" },
     "Amazon.Lambda.KinesisEvents": { "target": "project" },
     "Amazon.Lambda.S3Events": { "target": "project" },
+    "Amazon.Lambda.SimpleEmailEvents": { "target": "project" },
     "Amazon.Lambda.SNSEvents": { "target": "project" },
     "Amazon.Lambda.APIGatewayEvents": { "target": "project" },
     "xunit": "2.2.0-beta2-build3300",

--- a/Libraries/test/EventsTests/simple-email-event.json
+++ b/Libraries/test/EventsTests/simple-email-event.json
@@ -1,0 +1,97 @@
+﻿{
+  "Records": [
+    {
+      "eventVersion": "1.0",
+      "ses": {
+        "mail": {
+          "commonHeaders": {
+            "from": [
+              "Amazon Web Services <aws@amazon.com>"
+            ],
+            "to": [
+              "lambda@amazon.com"
+            ],
+            "returnPath": "aws@amazon.com",
+            "messageId": "<CAEddw6POFV_On91m+ZoL_SN8B_M2goDe_Ni355owhc7QSjPQSQ@amazon.com>",
+            "date": "Mon, 5 Dec 2016 18:40:08 -0800",
+            "subject": "Test Subject"
+          },
+          "source": "aws@amazon.com",
+          "timestamp": "2016-12-06T02:40:08.000Z",
+          "destination": [
+            "lambda@amazon.com"
+          ],
+          "headers": [
+            {
+              "name": "Return-Path",
+              "value": "<aws@amazon.com>"
+            },
+            {
+              "name": "Received",
+              "value": "from mx.amazon.com (mx.amazon.com [127.0.0.1]) by inbound-smtp.us-east-1.amazonaws.com with SMTP id 6n4thuhcbhpfiuf25gshf70rss364fuejrvmqko1 for lambda@amazon.com; Tue, 06 Dec 2016 02:40:10 +0000 (UTC)"
+            },
+            {
+              "name": "DKIM-Signature",
+              "value": "v=1; a=rsa-sha256; c=relaxed/relaxed; d=iatn.net; s=amazon; h=mime-version:from:date:message-id:subject:to; bh=chlJxa/vZ11+0O9lf4tKDM/CcPjup2nhhdITm+hSf3c=; b=SsoNPK0wX7umtWnw8pln3YSib+E09XO99d704QdSc1TR1HxM0OTti/UaFxVD4e5b0+okBqo3rgVeWgNZ0sWZEUhBaZwSL3kTd/nHkcPexeV0XZqEgms1vmbg75F6vlz9igWflO3GbXyTRBNMM0gUXKU/686hpVW6aryEIfM/rLY="
+            },
+            {
+              "name": "MIME-Version",
+              "value": "1.0"
+            },
+            {
+              "name": "From",
+              "value": "Amazon Web Services <aws@amazon.com>"
+            },
+            {
+              "name": "Date",
+              "value": "Mon, 5 Dec 2016 18:40:08 -0800"
+            },
+            {
+              "name": "Message-ID",
+              "value": "<CAEddw6POFV_On91m+ZoL_SN8B_M2goDe_Ni355owhc7QSjPQSQ@amazon.com>"
+            },
+            {
+              "name": "Subject",
+              "value": "Test Subject"
+            },
+            {
+              "name": "To",
+              "value": "lambda@amazon.com"
+            },
+            {
+              "name": "Content-Type",
+              "value": "multipart/alternative; boundary=94eb2c0742269658b10542f452a9"
+            }
+          ],
+          "headersTruncated": false,
+          "messageId": "6n4thuhcbhpfiuf25gshf70rss364fuejrvmqko1"
+        },
+        "receipt": {
+          "recipients": [
+            "lambda@amazon.com"
+          ],
+          "timestamp": "2016-12-06T02:40:08.000Z",
+          "spamVerdict": {
+            "status": "PASS"
+          },
+          "dkimVerdict": {
+            "status": "PASS"
+          },
+          "processingTimeMillis": 574,
+          "action": {
+            "type": "Lambda",
+            "invocationType": "Event",
+            "functionArn": "arn:aws:lambda:us-east-1:000000000000:function:my-ses-lambda-function"
+          },
+          "spfVerdict": {
+            "status": "PASS"
+          },
+          "virusVerdict": {
+            "status": "PASS"
+          }
+        }
+      },
+      "eventSource": "aws:ses"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ These are the packages and their README.md files:
 * [Amazon.Lambda.DynamoDBEvents](Libraries/src/Amazon.Lambda.DynamoDBEvents) - [README.md](Libraries/src/Amazon.Lambda.DynamoDBEvents/README.md)
 * [Amazon.Lambda.KinesisEvents](Libraries/src/Amazon.Lambda.KinesisEvents) - [README.md](Libraries/src/Amazon.Lambda.KinesisEvents/README.md)
 * [Amazon.Lambda.S3Events](Libraries/src/Amazon.Lambda.S3Events) - [README.md](Libraries/src/Amazon.Lambda.S3Events/README.md)
+* [Amazon.Lambda.SimpleEmailEvents](Libraries/src/Amazon.Lambda.SimpleEmailEvents) - [README.md](Libraries/src/Amazon.Lambda.SimpleEmailEvents/README.md)
 * [Amazon.Lambda.SNSEvents](Libraries/src/Amazon.Lambda.SNSEvents) - [README.md](Libraries/src/Amazon.Lambda.SNSEvents/README.md)
 
 ### Amazon.Lambda.Tools


### PR DESCRIPTION
I based this off of how you guys are doing the SNSEvent stuff, so hopefully I'm on the right track. 

I named the event SimpleEmailEvent rather than SESEvent because I saw other references in the AWS SDK to "SimpleEmail," hope that's right.

I also fixed a simple typo in the SNSEvent readme.

I've tested this SimpleEmailEvent class in my own private lambda event for processing SES inbound email, and it works. 