### PR TITLE
AspNetCoreServer: Update for default 500 error code on exception.

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -95,6 +95,7 @@ namespace Amazon.Lambda.AspNetCoreServer
         /// <param name="features">An <see cref="InvokeFeatures"/> instance.</param>
         protected async Task<APIGatewayProxyResponse> ProcessRequest(ILambdaContext lambdaContext, HostingApplication.Context context, InvokeFeatures features)
         {
+            var defaultStatusCode = 200;
             try
             {
                 await this._server.Application.ProcessRequestAsync(context);
@@ -104,6 +105,7 @@ namespace Amazon.Lambda.AspNetCoreServer
             {
                 lambdaContext?.Logger.Log($"Unknown error responding to request: {this.ErrorReport(e)}");
                 this._server.Application.DisposeContext(context, e);
+                defaultStatusCode = 500;
             }
 
             var response = this.MarshallResponse(features);
@@ -111,7 +113,7 @@ namespace Amazon.Lambda.AspNetCoreServer
             // ASP.NET Core Web API does not always set the status code if the request was
             // successful
             if (response.StatusCode == 0)
-                response.StatusCode = 200;
+                response.StatusCode = defaultStatusCode;
 
             return response;
         }

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
@@ -27,6 +27,7 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
             var request = JsonConvert.DeserializeObject<APIGatewayProxyRequest>(requestStr);
             var response = await lambdaFunction.FunctionHandlerAsync(request, null);
 
+            Assert.Equal(response.StatusCode, 200);
             Assert.Equal("[\"value1\",\"value2\"]", response.Body);
             Assert.True(response.Headers.ContainsKey("Content-Type"));
             Assert.Equal("application/json; charset=utf-8", response.Headers["Content-Type"]);
@@ -73,6 +74,19 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
             Assert.Equal("Agent, Smith", response.Body);
             Assert.True(response.Headers.ContainsKey("Content-Type"));
             Assert.Equal("text/plain; charset=utf-8", response.Headers["Content-Type"]);
+        }
+
+        [Fact]
+        public async Task TestDefaultResponseErrorCode()
+        {
+            var lambdaFunction = new LambdaFunction();
+
+            var requestStr = File.ReadAllText("values-get-error-apigatway-request.json");
+            var request = JsonConvert.DeserializeObject<APIGatewayProxyRequest>(requestStr);
+            var response = await lambdaFunction.FunctionHandlerAsync(request, null);
+
+            Assert.Equal(response.StatusCode, 500);
+            Assert.Equal(string.Empty, response.Body);
         }
     }
 }

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-error-apigatway-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-error-apigatway-request.json
@@ -1,0 +1,36 @@
+﻿{
+  "resource": "/{proxy+}",
+  "path": "/api/errortests",
+  "httpMethod": "GET",
+  "headers": null,
+  "queryStringParameters": {
+    "id": "error-expected"
+  },
+  "pathParameters": {
+    "proxy": "api/values"
+  },
+  "stageVariables": null,
+  "requestContext": {
+    "accountId": "AAAAAAAAAAAA",
+    "resourceId": "5agfss",
+    "stage": "test-invoke-stage",
+    "requestId": "test-invoke-request",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": "AAAAAAAAAAAA",
+      "cognitoIdentityId": null,
+      "caller": "BBBBBBBBBBBB",
+      "apiKey": "test-invoke-api-key",
+      "sourceIp": "test-invoke-source-ip",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": "arn:aws:iam::AAAAAAAAAAAA:root",
+      "userAgent": "Apache-HttpClient/4.5.x (Java/1.8.0_102)",
+      "user": "AAAAAAAAAAAA"
+    },
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "apiId": "t2yh6sjnmk"
+  },
+  "body": null
+}

--- a/Libraries/test/TestWebApp/Controllers/ErrorTestsController.cs
+++ b/Libraries/test/TestWebApp/Controllers/ErrorTestsController.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
+
+namespace TestWebApp.Controllers
+{
+    [Route("api/[controller]")]
+    public class ErrorTestsController
+    {
+        [HttpGet]
+        public string Get(string id)
+        {
+            throw new Exception("Unit test exception, for test conditions.");
+        }
+    }
+}


### PR DESCRIPTION
Otherwise, even on application exception, a 200 status code is returned to the consumer of your API.