### PR TITLE
Adding in CustomAuthorizer classes and tests.

### DIFF
--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerContext.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerContext.cs
@@ -1,0 +1,29 @@
+﻿namespace Amazon.Lambda.APIGatewayEvents
+{
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// An object representing the expected format of an API Gateway custom authorizer response.
+    /// </summary>
+    [DataContract]
+    public class APIGatewayCustomAuthorizerContext
+    {
+        /// <summary>
+        /// Gets or sets the 'stringKey' property.
+        /// </summary>
+        [DataMember(Name = "stringKey", IsRequired = false)]
+        public string StringKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the 'numKey' property.
+        /// </summary>
+        [DataMember(Name = "numKey", IsRequired = false)]
+        public int? NumKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the 'boolKey' property.
+        /// </summary>
+        [DataMember(Name = "boolKey", IsRequired = false)]
+        public bool? BoolKey { get; set; }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerPolicy.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerPolicy.cs
@@ -1,0 +1,41 @@
+﻿namespace Amazon.Lambda.APIGatewayEvents
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// An object representing an IAM policy.
+    /// </summary>
+    public class APIGatewayCustomAuthorizerPolicy
+    {
+        /// <summary>
+        /// Gets or sets the IAM API version.
+        /// </summary>
+        public string Version { get; set; } = "2012-10-17";
+
+        /// <summary>
+        /// Gets or sets a list of IAM policy statements to apply.
+        /// </summary>
+        public List<IAMPolicyStatement> Statement { get; set; } = new List<IAMPolicyStatement>();
+
+        /// <summary>
+        /// A class representing an IAM Policy Statement.
+        /// </summary>
+        public class IAMPolicyStatement
+        {
+            /// <summary>
+            /// Gets or sets the effect the statement has.
+            /// </summary>
+            public string Effect { get; set; } = "Allow";
+
+            /// <summary>
+            /// Gets or sets the action/s the statement has.
+            /// </summary>
+            public HashSet<string> Action { get; set; }
+
+            /// <summary>
+            /// Gets or sets the resources the statement applies to.
+            /// </summary>
+            public HashSet<string> Resource { get; set; }
+        }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerRequest.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerRequest.cs
@@ -1,0 +1,23 @@
+﻿namespace Amazon.Lambda.APIGatewayEvents
+{
+    /// <summary>
+    /// For requests coming in to a custom API Gateway authorizer function.
+    /// </summary>
+    public class APIGatewayCustomAuthorizerRequest
+    {
+        /// <summary>
+        /// Gets or sets the 'type' property.
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the 'authorizationToken' property.
+        /// </summary>
+        public string AuthorizationToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the 'methodArn' property.
+        /// </summary>
+        public string MethodArn { get; set; }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerResponse.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerResponse.cs
@@ -1,0 +1,29 @@
+﻿namespace Amazon.Lambda.APIGatewayEvents
+{
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// An object representing the expected format of an API Gateway authorization response.
+    /// </summary>
+    [DataContract]
+    public class APIGatewayCustomAuthorizerResponse
+    {
+        /// <summary>
+        /// Gets or sets the ID of the principal.
+        /// </summary>
+        [DataMember(Name = "principalId")]
+        public string PrincipalID { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="APIGatewayCustomAuthorizerPolicy"/> policy document.
+        /// </summary>
+        [DataMember(Name = "policyDocument")]
+        public APIGatewayCustomAuthorizerPolicy PolicyDocument { get; set; } = new APIGatewayCustomAuthorizerPolicy();
+
+        /// <summary>
+        /// Gets or sets the <see cref="APIGatewayCustomAuthorizerContext"/> property.
+        /// </summary>
+        [DataMember(Name = "context")]
+        public APIGatewayCustomAuthorizerContext Context { get; set; }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayProxyRequest.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayProxyRequest.cs
@@ -106,6 +106,10 @@
             /// </summary>
             public string ApiId { get; set; }
 
+            /// <summary>
+            /// The APIGatewayCustomAuthorizerContext containing the custom properties set by a custom authorizer.
+            /// </summary>
+            public APIGatewayCustomAuthorizerContext Authorizer { get; set; }
         }
 
         /// <summary>

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/project.json
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "Amazon.Lambda.APIGatewayEvents",
   "version": "1.0.1-*",
   "title": "Amazon.Lambda.APIGatewayEvents",
@@ -18,6 +18,7 @@
     "warningsAsErrors": true
   },
   "dependencies": {
+    "System.Collections": "4.0.11",
     "System.Runtime": "4.1.0",
     "System.Runtime.Serialization.Primitives": "4.1.1"
   },

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-customauthorizer-apigatway-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-customauthorizer-apigatway-request.json
@@ -1,0 +1,39 @@
+﻿{
+  "resource": "/{proxy+}",
+  "path": "/api/resourcepath/5",
+  "httpMethod": "GET",
+  "headers": null,
+  "queryStringParameters": null,
+  "pathParameters": {
+    "proxy": "api/values"
+  },
+  "stageVariables": null,
+  "requestContext": {
+    "accountId": "AAAAAAAAAAAA",
+    "resourceId": "5agfss",
+    "stage": "test-invoke-stage",
+    "requestId": "test-invoke-request",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": "AAAAAAAAAAAA",
+      "cognitoIdentityId": null,
+      "caller": "BBBBBBBBBBBB",
+      "apiKey": "test-invoke-api-key",
+      "sourceIp": "test-invoke-source-ip",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": "arn:aws:iam::AAAAAAAAAAAA:root",
+      "userAgent": "Apache-HttpClient/4.5.x (Java/1.8.0_102)",
+      "user": "AAAAAAAAAAAA"
+    },
+    "authorizer": {
+      "stringKey": "Hey there I'm a string!",
+      "numKey": 9,
+      "boolKey": true
+    },
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "apiId": "t2yh6sjnmk"
+  },
+  "body": null
+}


### PR DESCRIPTION
The current APIGateway classes have no support for the output provided by custom authorizers. Furthermore, there are no models available for creating custom authorizers in .NET.

The changes in this pull request add the classes required for custom authorizer request/responses.