### PR TITLE
Various enhancements for error handling

### DIFF
--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerContextOutput.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerContextOutput.cs
@@ -1,0 +1,29 @@
+﻿namespace Amazon.Lambda.APIGatewayEvents
+{
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// An object representing the expected format of an API Gateway custom authorizer response.
+    /// </summary>
+    [DataContract]
+    public class APIGatewayCustomAuthorizerContextOutput
+    {
+        /// <summary>
+        /// Gets or sets the 'stringKey' property.
+        /// </summary>
+        [DataMember(Name = "stringKey", IsRequired = false)]
+        public string StringKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the 'numKey' property.
+        /// </summary>
+        [DataMember(Name = "numKey", IsRequired = false)]
+        public int? NumKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the 'boolKey' property.
+        /// </summary>
+        [DataMember(Name = "boolKey", IsRequired = false)]
+        public bool? BoolKey { get; set; }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerResponse.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerResponse.cs
@@ -24,6 +24,6 @@
         /// Gets or sets the <see cref="APIGatewayCustomAuthorizerContext"/> property.
         /// </summary>
         [DataMember(Name = "context")]
-        public APIGatewayCustomAuthorizerContext Context { get; set; }
+        public APIGatewayCustomAuthorizerContextOutput Context { get; set; }
     }
 }

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/project.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": "1.0.0-*",
   "buildOptions": {
     "emitEntryPoint": false
@@ -9,11 +9,10 @@
       "type": "platform",
       "version": "1.0.1"
     },
-
     "TestWebApp": { "target": "project" },
-
     "xunit": "2.1.0-*",
-    "dotnet-test-xunit": "2.2.0-*"
+    "dotnet-test-xunit": "2.2.0-*",
+    "Amazon.Lambda.TestUtilities": "1.0.0"
   },
   "testRunner": "xunit",
 

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-aggregateerror-apigatway-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-aggregateerror-apigatway-request.json
@@ -1,0 +1,36 @@
+﻿{
+  "resource": "/{proxy+}",
+  "path": "/api/errortests",
+  "httpMethod": "GET",
+  "headers": null,
+  "queryStringParameters": {
+    "id": "aggregate-test"
+  },
+  "pathParameters": {
+    "proxy": "api/values"
+  },
+  "stageVariables": null,
+  "requestContext": {
+    "accountId": "AAAAAAAAAAAA",
+    "resourceId": "5agfss",
+    "stage": "test-invoke-stage",
+    "requestId": "test-invoke-request",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": "AAAAAAAAAAAA",
+      "cognitoIdentityId": null,
+      "caller": "BBBBBBBBBBBB",
+      "apiKey": "test-invoke-api-key",
+      "sourceIp": "test-invoke-source-ip",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": "arn:aws:iam::AAAAAAAAAAAA:root",
+      "userAgent": "Apache-HttpClient/4.5.x (Java/1.8.0_102)",
+      "user": "AAAAAAAAAAAA"
+    },
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "apiId": "t2yh6sjnmk"
+  },
+  "body": null
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-typeloaderror-apigatway-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-typeloaderror-apigatway-request.json
@@ -1,0 +1,36 @@
+﻿{
+  "resource": "/{proxy+}",
+  "path": "/api/errortests",
+  "httpMethod": "GET",
+  "headers": null,
+  "queryStringParameters": {
+    "id": "typeload-test"
+  },
+  "pathParameters": {
+    "proxy": "api/values"
+  },
+  "stageVariables": null,
+  "requestContext": {
+    "accountId": "AAAAAAAAAAAA",
+    "resourceId": "5agfss",
+    "stage": "test-invoke-stage",
+    "requestId": "test-invoke-request",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": "AAAAAAAAAAAA",
+      "cognitoIdentityId": null,
+      "caller": "BBBBBBBBBBBB",
+      "apiKey": "test-invoke-api-key",
+      "sourceIp": "test-invoke-source-ip",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": "arn:aws:iam::AAAAAAAAAAAA:root",
+      "userAgent": "Apache-HttpClient/4.5.x (Java/1.8.0_102)",
+      "user": "AAAAAAAAAAAA"
+    },
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "apiId": "t2yh6sjnmk"
+  },
+  "body": null
+}

--- a/Libraries/test/TestWebApp/Controllers/ErrorTestsController.cs
+++ b/Libraries/test/TestWebApp/Controllers/ErrorTestsController.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.IO;
+using System.Reflection;
 using Microsoft.AspNetCore.Mvc;
 
 namespace TestWebApp.Controllers
@@ -9,7 +11,21 @@ namespace TestWebApp.Controllers
         [HttpGet]
         public string Get([FromQuery]string id)
         {
-            throw new Exception("Unit test exception, for test conditions.");
+            if (id == "typeload-test")
+            {
+                var fnfEx = new FileNotFoundException("Couldn't find file", "System.String.dll");
+                throw new ReflectionTypeLoadException(new[] { typeof(String) }, new[] { fnfEx });
+            }
+
+            var ex = new Exception("Unit test exception, for test conditions.");
+            if (id == "aggregate-test")
+            {
+                throw new AggregateException(ex);
+            }
+            else
+            {
+                throw ex;
+            }
         }
     }
 }


### PR DESCRIPTION
Refactored TestCallingWebAPI tests to use TestLambdaContext instead of null so that the APIGatewayProxyFunction class can assume ILambdaContext is never null. Also moved commonly called code into a single method.
Created CustomAuthorizerContextOutput class for use by custom authorizers (since the serializer will serialize a null value).
Modified ErrorTestsController to throw different exceptions based on the query string for testing custom error handling.
Modified ErrorReport method to write to the StringBuilder rather than to Console.WriteLine