### PR TITLE
Fixed and removed links in several READMEs

### DIFF
--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/README.md
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/README.md
@@ -2,7 +2,7 @@
 
 This package contains classes that can be used as input types for Lambda functions that process Amazon API Gateway events.
 
-API Gateway events consist of a request that was routed to a Lambda function by API Gateway. When this happens, API Gateway expects the result of the function to be the response that API Gateway should respond with. To see a more detailed example of this, take a look at the [Amazon.Lambda.AspNetCoreServer README.md file](Libraries/src/Amazon.Lambda.AspNetCoreServer/README.md). 
+API Gateway events consist of a request that was routed to a Lambda function by API Gateway. When this happens, API Gateway expects the result of the function to be the response that API Gateway should respond with. To see a more detailed example of this, take a look at the [Amazon.Lambda.AspNetCoreServer README.md file](../Amazon.Lambda.AspNetCoreServer/README.md). 
 
 # Sample Function
 

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/README.md
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/README.md
@@ -9,7 +9,7 @@ framework into the response body that API Gateway Proxy understands.
 
 ## Example Lambda Function
 
-In the ASP.NET Core application add a class that extends from [ApiGatewayFunction](Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs)
+In the ASP.NET Core application add a class that extends from [ApiGatewayFunction](../Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs)
 and implement the Init method.
 
 Here is an example implementation of the Lamba function in an ASP.NET Core Web API application.

--- a/Libraries/src/Amazon.Lambda.KinesisEvents/README.md
+++ b/Libraries/src/Amazon.Lambda.KinesisEvents/README.md
@@ -15,7 +15,7 @@ byte[] dataBytes = Convert.FromBase64String(dataBase64);
 MemoryStream stream = new MemoryStream(dataBytes);
 ```
 
-A Newtonsoft.Json `IContractResolver` implementation which handles this custom serialization is located in [Amazon.Lambda.Serialization.Json\AwsResolver.cs](Libraries/src/Amazon.Lambda.Serialization.Json/AwsResolver.cs) and [Amazon.Lambda.Serialization.Json\KinesisEventRecordDataConverter.cs](Libraries/src/Amazon.Lambda.Serialization.Json/KinesisEventRecordDataConverter.cs), consult this source for more information.
+A Newtonsoft.Json `IContractResolver` implementation which handles this custom serialization is located in [Amazon.Lambda.Serialization.Json\AwsResolver.cs](../Amazon.Lambda.Serialization.Json/AwsResolver.cs), consult this source for more information.
 
 # Sample Function
 

--- a/Libraries/src/Amazon.Lambda.S3Events/README.md
+++ b/Libraries/src/Amazon.Lambda.S3Events/README.md
@@ -10,7 +10,7 @@ If you are using this package with Amazon Lambda but are not also using `Amazon.
 1. `XAmzRequestId` should be treated as `x-amz-request-id`
 2. `XAmzId2` should be treated as `x-amz-id-2`
 
-A Newtonsoft.Json `IContractResolver` implementation which handles this custom serialization is located in [Amazon.Lambda.Serialization.Json\AwsResolver.cs](Libraries/src/Amazon.Lambda.Serialization.Json/AwsResolver.cs), consult this source for more information. 
+A Newtonsoft.Json `IContractResolver` implementation which handles this custom serialization is located in [Amazon.Lambda.Serialization.Json\AwsResolver.cs](../Amazon.Lambda.Serialization.Json/AwsResolver.cs), consult this source for more information. 
 
 # Sample Function
 


### PR DESCRIPTION
Several links are broken. So, I changed them to relative path.
And I removed link to 'KinesisEventRecordDataConverter.cs' in 'Amazon.Lambda.KinesisEvents/README.md' Because 'KinesisEventRecordDataConverter.cs' doesn't exist in this repository.