### PR TITLE
Fixed security group argument instead of subnets.

### DIFF
--- a/Libraries/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
+++ b/Libraries/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
@@ -173,7 +173,7 @@ namespace Amazon.Lambda.Tools.Commands
                             VpcConfig = new VpcConfig
                             {
                                 SubnetIds = this.GetStringValuesOrDefault(this.SubnetIds, DefinedCommandOptions.ARGUMENT_FUNCTION_SUBNETS, false)?.ToList(),
-                                SecurityGroupIds = this.GetStringValuesOrDefault(this.SecurityGroupIds, DefinedCommandOptions.ARGUMENT_FUNCTION_SUBNETS, false)?.ToList()
+                                SecurityGroupIds = this.GetStringValuesOrDefault(this.SecurityGroupIds, DefinedCommandOptions.ARGUMENT_FUNCTION_SECURITY_GROUPS, false)?.ToList()
                             }
                         };
 


### PR DESCRIPTION
I got this error running 'dotnet lambda deploy-function FuncName' with an aws-lambda-tools-defaults.json file populated with 'function-subnets' and 'function-security-groups' for my VPC:

```
Creating new Lambda function FuncName
Error creating Lambda function: Error occurred while DescribeSecurityGroups. EC2
 Error Code: InvalidGroupId.Malformed. EC2 Error Message: Invalid id: "subnet-85
f423ba" (expecting "sg-...")
```

Checked the source and saw it was using the SUBNETS argument instead of SECURITY_GROUPS.