### PR TITLE
Fix ASP.NET Core API tests failing in debug mode

### DIFF
--- a/Blueprints/BlueprintDefinitions/PreviewAspNetCoreWebAPI/test/Common/TestLambdaEntryPoint.cs
+++ b/Blueprints/BlueprintDefinitions/PreviewAspNetCoreWebAPI/test/Common/TestLambdaEntryPoint.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using System.IO;
+using System.Reflection;
+using Microsoft.Extensions.PlatformAbstractions;
+
+namespace BLUEPRINT_BASE_NAME.Tests
+{
+    /// <summary>
+    /// This class extends from APIGatewayProxyFunction which contains the method FunctionHandlerAsync which is the 
+    /// actual Lambda function entry point. The Lambda handler field should be set to
+    /// 
+    /// BLUEPRINT_BASE_NAME::BLUEPRINT_BASE_NAME.LambdaEntryPoint::FunctionHandlerAsync
+    /// </summary>
+    public class TestLambdaEntryPoint : Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction
+    {
+        protected override void Init(IWebHostBuilder builder)
+        {
+            var contentRoot = TestUtils.GetProjectPath(Path.Combine(string.Empty));
+
+            builder
+                .UseContentRoot(contentRoot)
+                .UseStartup<Startup>()
+                .UseApiGateway();
+        }
+    }
+}

--- a/Blueprints/BlueprintDefinitions/PreviewAspNetCoreWebAPI/test/Common/TestUtils.cs
+++ b/Blueprints/BlueprintDefinitions/PreviewAspNetCoreWebAPI/test/Common/TestUtils.cs
@@ -1,46 +1,25 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Hosting;
 using System.IO;
 using System.Reflection;
 using Microsoft.Extensions.PlatformAbstractions;
 
 namespace BLUEPRINT_BASE_NAME.Tests
 {
-    /// <summary>
-    /// This class extends from APIGatewayProxyFunction which contains the method FunctionHandlerAsync which is the 
-    /// actual Lambda function entry point. The Lambda handler field should be set to
-    /// 
-    /// BLUEPRINT_BASE_NAME::BLUEPRINT_BASE_NAME.LambdaEntryPoint::FunctionHandlerAsync
-    /// </summary>
-    public class TestLambdaEntryPoint : Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction
+    public static class TestUtils
     {
-        protected override void Init(IWebHostBuilder builder)
-        {
-            var contentRoot = GetProjectPath(Path.Combine(string.Empty));
-
-            builder
-                .UseContentRoot(contentRoot)
-                .UseStartup<Startup>()
-                .UseApiGateway();
-        }
-
         /// <summary>
-        /// Gets the full path to the target project path that we wish to test
+        ///     Gets the full path to the target project path that we wish to test
         /// </summary>
         /// <param name="solutionRelativePath">
-        /// The parent directory of the target project.
-        /// e.g. src, samples, test, or test/Websites
+        ///     The parent directory of the target project.
+        ///     e.g. src, samples, test, or test/Websites
         /// </param>
         /// <returns>The full path to the target project.</returns>
         public static string GetProjectPath(string solutionRelativePath)
         {
             // Get the target project's assembly.
             var startupAssembly = typeof(Startup).GetTypeInfo().Assembly;
-            
+
             // Get name of the target project which we want to test
             var projectName = startupAssembly.GetName().Name;
 
@@ -59,10 +38,15 @@ namespace BLUEPRINT_BASE_NAME.Tests
                 }
 
                 directoryInfo = directoryInfo.Parent;
-            }
-            while (directoryInfo.Parent != null);
+            } while (directoryInfo.Parent != null);
 
             throw new Exception($"Solution root could not be located using application root {applicationBasePath}.");
+        }
+
+        // Returns a path relative to the current project directory
+        public static string GetRelativeToProjectPath(string path)
+        {
+            return Path.Combine(PlatformServices.Default.Application.ApplicationBasePath, path);
         }
     }
 }

--- a/Blueprints/BlueprintDefinitions/PreviewAspNetCoreWebAPI/test/S3ProxyControllerTests.cs
+++ b/Blueprints/BlueprintDefinitions/PreviewAspNetCoreWebAPI/test/S3ProxyControllerTests.cs
@@ -33,7 +33,7 @@ namespace BLUEPRINT_BASE_NAME.Tests
         public S3ProxyControllerTests()
         {
             var builder = new ConfigurationBuilder()
-                .SetBasePath(TestLambdaEntryPoint.GetProjectPath(Path.Combine(string.Empty)))
+                .SetBasePath(TestUtils.GetProjectPath(Path.Combine(string.Empty)))
                 .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
 
             this.Configuration = builder.Build();
@@ -53,7 +53,7 @@ namespace BLUEPRINT_BASE_NAME.Tests
             Startup.Configuration[Startup.AppS3BucketKey] = this.BucketName;
 
             // Use sample API Gateway request that uploads an object with object key "foo.txt" and content of "Hello World".
-            var requestStr = File.ReadAllText("./SampleRequests/S3ProxyController-Put.json");
+            var requestStr = File.ReadAllText(TestUtils.GetRelativeToProjectPath("SampleRequests/S3ProxyController-Put.json"));
             var request = JsonConvert.DeserializeObject<APIGatewayProxyRequest>(requestStr);
             var context = new TestLambdaContext();
             var response = await lambdaFunction.FunctionHandlerAsync(request, context);
@@ -61,7 +61,7 @@ namespace BLUEPRINT_BASE_NAME.Tests
             Assert.Equal(response.StatusCode, 200);
 
             // Get with no object key in the resource path does an object list call
-            requestStr = File.ReadAllText("./SampleRequests/S3ProxyController-Get.json");
+            requestStr = File.ReadAllText(TestUtils.GetRelativeToProjectPath("SampleRequests/S3ProxyController-Get.json"));
             request = JsonConvert.DeserializeObject<APIGatewayProxyRequest>(requestStr);
             context = new TestLambdaContext();
             response = await lambdaFunction.FunctionHandlerAsync(request, context);
@@ -71,7 +71,7 @@ namespace BLUEPRINT_BASE_NAME.Tests
             Assert.True(response.Body.Contains("foo.txt"));
 
             // Return the content of the new s3 object foo.txt
-            requestStr = File.ReadAllText("./SampleRequests/S3ProxyController-GetByKey.json");
+            requestStr = File.ReadAllText(TestUtils.GetRelativeToProjectPath("SampleRequests/S3ProxyController-GetByKey.json"));
             request = JsonConvert.DeserializeObject<APIGatewayProxyRequest>(requestStr);
             context = new TestLambdaContext();
             response = await lambdaFunction.FunctionHandlerAsync(request, context);
@@ -81,7 +81,7 @@ namespace BLUEPRINT_BASE_NAME.Tests
             Assert.Equal("Hello World", response.Body);
 
             // Delete the object
-            requestStr = File.ReadAllText("./SampleRequests/S3ProxyController-Delete.json");
+            requestStr = File.ReadAllText(TestUtils.GetRelativeToProjectPath("SampleRequests/S3ProxyController-Delete.json"));
             request = JsonConvert.DeserializeObject<APIGatewayProxyRequest>(requestStr);
             context = new TestLambdaContext();
             response = await lambdaFunction.FunctionHandlerAsync(request, context);
@@ -89,7 +89,7 @@ namespace BLUEPRINT_BASE_NAME.Tests
             Assert.Equal(response.StatusCode, 200);
 
             // Make sure the object was deleted
-            requestStr = File.ReadAllText("./SampleRequests/S3ProxyController-GetByKey.json");
+            requestStr = File.ReadAllText(TestUtils.GetRelativeToProjectPath("SampleRequests/S3ProxyController-GetByKey.json"));
             request = JsonConvert.DeserializeObject<APIGatewayProxyRequest>(requestStr);
             context = new TestLambdaContext();
             response = await lambdaFunction.FunctionHandlerAsync(request, context);

--- a/Blueprints/BlueprintDefinitions/PreviewAspNetCoreWebAPI/test/S3ProxyControllerTests.cs
+++ b/Blueprints/BlueprintDefinitions/PreviewAspNetCoreWebAPI/test/S3ProxyControllerTests.cs
@@ -33,7 +33,7 @@ namespace BLUEPRINT_BASE_NAME.Tests
         public S3ProxyControllerTests()
         {
             var builder = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
+                .SetBasePath(TestLambdaEntryPoint.GetProjectPath(Path.Combine(string.Empty)))
                 .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
 
             this.Configuration = builder.Build();
@@ -49,7 +49,7 @@ namespace BLUEPRINT_BASE_NAME.Tests
         [Fact]
         public async Task TestSuccessWorkFlow()
         {
-            var lambdaFunction = new LambdaEntryPoint();
+            var lambdaFunction = new TestLambdaEntryPoint();
             Startup.Configuration[Startup.AppS3BucketKey] = this.BucketName;
 
             // Use sample API Gateway request that uploads an object with object key "foo.txt" and content of "Hello World".

--- a/Blueprints/BlueprintDefinitions/PreviewAspNetCoreWebAPI/test/S3ProxyControllerTests.cs
+++ b/Blueprints/BlueprintDefinitions/PreviewAspNetCoreWebAPI/test/S3ProxyControllerTests.cs
@@ -58,7 +58,7 @@ namespace BLUEPRINT_BASE_NAME.Tests
             var context = new TestLambdaContext();
             var response = await lambdaFunction.FunctionHandlerAsync(request, context);
 
-            Assert.Equal(response.StatusCode, 200);
+            Assert.Equal(200, response.StatusCode);
 
             // Get with no object key in the resource path does an object list call
             requestStr = File.ReadAllText(TestUtils.GetRelativeToProjectPath("SampleRequests/S3ProxyController-Get.json"));
@@ -66,7 +66,7 @@ namespace BLUEPRINT_BASE_NAME.Tests
             context = new TestLambdaContext();
             response = await lambdaFunction.FunctionHandlerAsync(request, context);
 
-            Assert.Equal(response.StatusCode, 200);
+            Assert.Equal(200, response.StatusCode);
             Assert.Equal("text/json", response.Headers["Content-Type"]);
             Assert.True(response.Body.Contains("foo.txt"));
 
@@ -76,7 +76,7 @@ namespace BLUEPRINT_BASE_NAME.Tests
             context = new TestLambdaContext();
             response = await lambdaFunction.FunctionHandlerAsync(request, context);
 
-            Assert.Equal(response.StatusCode, 200);
+            Assert.Equal(200, response.StatusCode);
             Assert.Equal("text/plain", response.Headers["Content-Type"]);
             Assert.Equal("Hello World", response.Body);
 
@@ -86,7 +86,7 @@ namespace BLUEPRINT_BASE_NAME.Tests
             context = new TestLambdaContext();
             response = await lambdaFunction.FunctionHandlerAsync(request, context);
 
-            Assert.Equal(response.StatusCode, 200);
+            Assert.Equal(200, response.StatusCode);
 
             // Make sure the object was deleted
             requestStr = File.ReadAllText(TestUtils.GetRelativeToProjectPath("SampleRequests/S3ProxyController-GetByKey.json"));
@@ -94,7 +94,7 @@ namespace BLUEPRINT_BASE_NAME.Tests
             context = new TestLambdaContext();
             response = await lambdaFunction.FunctionHandlerAsync(request, context);
 
-            Assert.Equal(response.StatusCode, 404);
+            Assert.Equal(404, response.StatusCode);
         }
 
 

--- a/Blueprints/BlueprintDefinitions/PreviewAspNetCoreWebAPI/test/TestLambdaEntryPoint.cs
+++ b/Blueprints/BlueprintDefinitions/PreviewAspNetCoreWebAPI/test/TestLambdaEntryPoint.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using System.IO;
+using System.Reflection;
+using Microsoft.Extensions.PlatformAbstractions;
+
+namespace BLUEPRINT_BASE_NAME.Tests
+{
+    /// <summary>
+    /// This class extends from APIGatewayProxyFunction which contains the method FunctionHandlerAsync which is the 
+    /// actual Lambda function entry point. The Lambda handler field should be set to
+    /// 
+    /// BLUEPRINT_BASE_NAME::BLUEPRINT_BASE_NAME.LambdaEntryPoint::FunctionHandlerAsync
+    /// </summary>
+    public class TestLambdaEntryPoint : Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction
+    {
+        protected override void Init(IWebHostBuilder builder)
+        {
+            var contentRoot = GetProjectPath(Path.Combine(string.Empty));
+
+            builder
+                .UseContentRoot(contentRoot)
+                .UseStartup<Startup>()
+                .UseApiGateway();
+        }
+
+        /// <summary>
+        /// Gets the full path to the target project path that we wish to test
+        /// </summary>
+        /// <param name="solutionRelativePath">
+        /// The parent directory of the target project.
+        /// e.g. src, samples, test, or test/Websites
+        /// </param>
+        /// <returns>The full path to the target project.</returns>
+        public static string GetProjectPath(string solutionRelativePath)
+        {
+            // Get the target project's assembly.
+            var startupAssembly = typeof(Startup).GetTypeInfo().Assembly;
+            
+            // Get name of the target project which we want to test
+            var projectName = startupAssembly.GetName().Name;
+
+            // Get currently executing test project path
+            var applicationBasePath = PlatformServices.Default.Application.ApplicationBasePath;
+
+            // Find the folder which contains the solution file. We then use this information to find the target
+            // project which we want to test.
+            var directoryInfo = new DirectoryInfo(applicationBasePath);
+            do
+            {
+                var solutionFileInfo = new FileInfo(Path.Combine(directoryInfo.FullName, "BLUEPRINT_BASE_NAME.sln"));
+                if (solutionFileInfo.Exists)
+                {
+                    return Path.GetFullPath(Path.Combine(directoryInfo.FullName, solutionRelativePath, projectName));
+                }
+
+                directoryInfo = directoryInfo.Parent;
+            }
+            while (directoryInfo.Parent != null);
+
+            throw new Exception($"Solution root could not be located using application root {applicationBasePath}.");
+        }
+    }
+}

--- a/Blueprints/BlueprintDefinitions/PreviewAspNetCoreWebAPI/test/ValuesControllerTests.cs
+++ b/Blueprints/BlueprintDefinitions/PreviewAspNetCoreWebAPI/test/ValuesControllerTests.cs
@@ -25,7 +25,7 @@ namespace BLUEPRINT_BASE_NAME.Tests
         {
             var lambdaFunction = new TestLambdaEntryPoint();
 
-            var requestStr = File.ReadAllText("./SampleRequests/ValuesController-Get.json");
+            var requestStr = File.ReadAllText(TestUtils.GetRelativeToProjectPath("SampleRequests/ValuesController-Get.json"));
             var request = JsonConvert.DeserializeObject<APIGatewayProxyRequest>(requestStr);
             var context = new TestLambdaContext();
             var response = await lambdaFunction.FunctionHandlerAsync(request, context);

--- a/Blueprints/BlueprintDefinitions/PreviewAspNetCoreWebAPI/test/ValuesControllerTests.cs
+++ b/Blueprints/BlueprintDefinitions/PreviewAspNetCoreWebAPI/test/ValuesControllerTests.cs
@@ -30,7 +30,7 @@ namespace BLUEPRINT_BASE_NAME.Tests
             var context = new TestLambdaContext();
             var response = await lambdaFunction.FunctionHandlerAsync(request, context);
 
-            Assert.Equal(response.StatusCode, 200);
+            Assert.Equal(200, response.StatusCode);
             Assert.Equal("[\"value1\",\"value2\"]", response.Body);
             Assert.True(response.Headers.ContainsKey("Content-Type"));
             Assert.Equal("application/json; charset=utf-8", response.Headers["Content-Type"]);

--- a/Blueprints/BlueprintDefinitions/PreviewAspNetCoreWebAPI/test/ValuesControllerTests.cs
+++ b/Blueprints/BlueprintDefinitions/PreviewAspNetCoreWebAPI/test/ValuesControllerTests.cs
@@ -23,7 +23,7 @@ namespace BLUEPRINT_BASE_NAME.Tests
         [Fact]
         public async Task TestGet()
         {
-            var lambdaFunction = new LambdaEntryPoint();
+            var lambdaFunction = new TestLambdaEntryPoint();
 
             var requestStr = File.ReadAllText("./SampleRequests/ValuesController-Get.json");
             var request = JsonConvert.DeserializeObject<APIGatewayProxyRequest>(requestStr);


### PR DESCRIPTION
The tests where not working under debug mode because it couldn't resolve project path correctly.
More specifically, running tests in debug mode in Visual Studio fails with `FileNotFoundException` because `Directory.GetCurrentDirectory()` equals `C:\Windows\System32`.
This fixes the regression by following Microsoft example here (`TextFixture`):
https://docs.microsoft.com/en-us/aspnet/core/mvc/controllers/testing