### PR TITLE
Tidy up new templates

### DIFF
--- a/Blueprints/BlueprintDefinitions/Msbuild/DetectImageLabels/template/src/BlueprintBaseName/Function.cs
+++ b/Blueprints/BlueprintDefinitions/Msbuild/DetectImageLabels/template/src/BlueprintBaseName/Function.cs
@@ -16,7 +16,7 @@ using Amazon.S3.Model;
 
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 
 namespace BlueprintBaseName
 {

--- a/Blueprints/BlueprintDefinitions/Msbuild/DynamoDBBlogAPI/template/src/BlueprintBaseName/Functions.cs
+++ b/Blueprints/BlueprintDefinitions/Msbuild/DynamoDBBlogAPI/template/src/BlueprintBaseName/Functions.cs
@@ -14,7 +14,7 @@ using Amazon.DynamoDBv2.DataModel;
 using Newtonsoft.Json;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 
 namespace BlueprintBaseName
 {

--- a/Blueprints/BlueprintDefinitions/Msbuild/EmptyFunction/template/src/BlueprintBaseName/Function.cs
+++ b/Blueprints/BlueprintDefinitions/Msbuild/EmptyFunction/template/src/BlueprintBaseName/Function.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Amazon.Lambda.Core;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 
 namespace BlueprintBaseName
 {

--- a/Blueprints/BlueprintDefinitions/Msbuild/EmptyFunction/template/src/BlueprintBaseName/Function.cs
+++ b/Blueprints/BlueprintDefinitions/Msbuild/EmptyFunction/template/src/BlueprintBaseName/Function.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
-using Amazon.Lambda.Serialization;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
 [assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]

--- a/Blueprints/BlueprintDefinitions/Msbuild/EmptyServerless/template/src/BlueprintBaseName/Function.cs
+++ b/Blueprints/BlueprintDefinitions/Msbuild/EmptyServerless/template/src/BlueprintBaseName/Function.cs
@@ -8,7 +8,7 @@ using Amazon.Lambda.Core;
 using Amazon.Lambda.APIGatewayEvents;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 
 namespace BlueprintBaseName
 {

--- a/Blueprints/BlueprintDefinitions/Msbuild/SimpleDynamoDBFunction/template/src/BlueprintBaseName/Function.cs
+++ b/Blueprints/BlueprintDefinitions/Msbuild/SimpleDynamoDBFunction/template/src/BlueprintBaseName/Function.cs
@@ -9,7 +9,7 @@ using Amazon.Lambda.DynamoDBEvents;
 using Amazon.DynamoDBv2.Model;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 
 namespace BlueprintBaseName
 {

--- a/Blueprints/BlueprintDefinitions/Msbuild/SimpleKinesisFunction/template/src/BlueprintBaseName/Function.cs
+++ b/Blueprints/BlueprintDefinitions/Msbuild/SimpleKinesisFunction/template/src/BlueprintBaseName/Function.cs
@@ -6,7 +6,7 @@ using Amazon.Lambda.Core;
 using Amazon.Lambda.KinesisEvents;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 
 namespace BlueprintBaseName
 {

--- a/Blueprints/BlueprintDefinitions/Msbuild/SimpleS3Function/template/src/BlueprintBaseName/Function.cs
+++ b/Blueprints/BlueprintDefinitions/Msbuild/SimpleS3Function/template/src/BlueprintBaseName/Function.cs
@@ -9,7 +9,7 @@ using Amazon.S3;
 using Amazon.S3.Util;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 
 namespace BlueprintBaseName
 {

--- a/Blueprints/BlueprintDefinitions/ProjectJson/DetectImageLabels/src/Function.cs
+++ b/Blueprints/BlueprintDefinitions/ProjectJson/DetectImageLabels/src/Function.cs
@@ -16,7 +16,7 @@ using Amazon.S3.Model;
 
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 
 namespace BLUEPRINT_BASE_NAME
 {

--- a/Blueprints/BlueprintDefinitions/ProjectJson/DynamoDBBlogAPI/src/Functions.cs
+++ b/Blueprints/BlueprintDefinitions/ProjectJson/DynamoDBBlogAPI/src/Functions.cs
@@ -14,7 +14,7 @@ using Amazon.DynamoDBv2.DataModel;
 using Newtonsoft.Json;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 
 namespace BLUEPRINT_BASE_NAME
 {

--- a/Blueprints/BlueprintDefinitions/ProjectJson/EmptyFunction/src/Function.cs
+++ b/Blueprints/BlueprintDefinitions/ProjectJson/EmptyFunction/src/Function.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
-using Amazon.Lambda.Serialization;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
 [assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]

--- a/Blueprints/BlueprintDefinitions/ProjectJson/EmptyFunction/src/Function.cs
+++ b/Blueprints/BlueprintDefinitions/ProjectJson/EmptyFunction/src/Function.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Amazon.Lambda.Core;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 
 namespace BLUEPRINT_BASE_NAME
 {

--- a/Blueprints/BlueprintDefinitions/ProjectJson/EmptyServerless/src/Function.cs
+++ b/Blueprints/BlueprintDefinitions/ProjectJson/EmptyServerless/src/Function.cs
@@ -8,7 +8,7 @@ using Amazon.Lambda.Core;
 using Amazon.Lambda.APIGatewayEvents;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 
 namespace BLUEPRINT_BASE_NAME
 {

--- a/Blueprints/BlueprintDefinitions/ProjectJson/SimpleDynamoDBFunction/src/Function.cs
+++ b/Blueprints/BlueprintDefinitions/ProjectJson/SimpleDynamoDBFunction/src/Function.cs
@@ -9,7 +9,7 @@ using Amazon.Lambda.DynamoDBEvents;
 using Amazon.DynamoDBv2.Model;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 
 namespace BLUEPRINT_BASE_NAME
 {

--- a/Blueprints/BlueprintDefinitions/ProjectJson/SimpleKinesisFunction/src/Function.cs
+++ b/Blueprints/BlueprintDefinitions/ProjectJson/SimpleKinesisFunction/src/Function.cs
@@ -6,7 +6,7 @@ using Amazon.Lambda.Core;
 using Amazon.Lambda.KinesisEvents;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 
 namespace BLUEPRINT_BASE_NAME
 {

--- a/Blueprints/BlueprintDefinitions/ProjectJson/SimpleS3Function/src/Function.cs
+++ b/Blueprints/BlueprintDefinitions/ProjectJson/SimpleS3Function/src/Function.cs
@@ -9,7 +9,7 @@ using Amazon.S3;
 using Amazon.S3.Util;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 
 namespace BLUEPRINT_BASE_NAME
 {

--- a/Libraries/test/FlattenDependencyTestProjects/NativeDependencyExample/Function.cs
+++ b/Libraries/test/FlattenDependencyTestProjects/NativeDependencyExample/Function.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
-using Amazon.Lambda.Serialization;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
 [assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]

--- a/Libraries/test/FlattenDependencyTestProjects/NativeDependencyExample/Function.cs
+++ b/Libraries/test/FlattenDependencyTestProjects/NativeDependencyExample/Function.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Amazon.Lambda.Core;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 
 namespace NativeDependencyExample
 {

--- a/Libraries/test/FlattenDependencyTestProjects/NpgsqlExample/Function.cs
+++ b/Libraries/test/FlattenDependencyTestProjects/NpgsqlExample/Function.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Amazon.Lambda.Core;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 
 namespace NpgsqlExample
 {

--- a/Libraries/test/FlattenDependencyTestProjects/NpgsqlExample/Function.cs
+++ b/Libraries/test/FlattenDependencyTestProjects/NpgsqlExample/Function.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
-using Amazon.Lambda.Serialization;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
 [assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]

--- a/Libraries/test/FlattenDependencyTestProjects/SQLServerClientExample/Function.cs
+++ b/Libraries/test/FlattenDependencyTestProjects/SQLServerClientExample/Function.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Amazon.Lambda.Core;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 
 namespace SQLServerClientExample
 {

--- a/Libraries/test/FlattenDependencyTestProjects/SQLServerClientExample/Function.cs
+++ b/Libraries/test/FlattenDependencyTestProjects/SQLServerClientExample/Function.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
-using Amazon.Lambda.Serialization;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
 [assembly: LambdaSerializerAttribute(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]


### PR DESCRIPTION
2 minor tidy ups
- Removed `using Amazon.Lambda.Serialization;`, it's not needed, the usage is fully qualified (as it should be IMO)
- `LambdaSerializerAttribute` -> `LambdaSerializer` If this was in `AssemblyInfo.cs` this wouldn't matter, but if this is in going in "regular code files", idiomatic C# would usually omit the `Attribute` suffix as it is verbose and redundant.