### PR TITLE
Populate RemoteIpAddress and RemotePort on HttpContext.Connection

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http.Features;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Reflection;
 using System.Text;
 using System.Text.Encodings.Web;
@@ -214,13 +215,14 @@ namespace Amazon.Lambda.AspNetCoreServer
         }
 
         /// <summary>
-        /// Convert the JSON document received from API Gateway in the ASP.NET Core IHttpRequestFeature object.
-        /// IHttpRequestFeature is then passed into IHttpApplication to create the ASP.NET Core request objects.
+        /// Convert the JSON document received from API Gateway into the InvokeFeatures object.
+        /// InvokeFeatures is then passed into IHttpApplication to create the ASP.NET Core request objects.
         /// </summary>
-        /// <param name="requestFeatures"></param>
+        /// <param name="features"></param>
         /// <param name="apiGatewayRequest"></param>
-        protected void MarshallRequest(IHttpRequestFeature requestFeatures, APIGatewayProxyRequest apiGatewayRequest)
+        protected void MarshallRequest(InvokeFeatures features, APIGatewayProxyRequest apiGatewayRequest)
         {
+            var requestFeatures = (IHttpRequestFeature)features;
             requestFeatures.Scheme = "https";
             requestFeatures.Path = apiGatewayRequest.Path;
             requestFeatures.Method = apiGatewayRequest.HttpMethod;
@@ -272,6 +274,13 @@ namespace Amazon.Lambda.AspNetCoreServer
                     binaryBody = UTF8Encoding.UTF8.GetBytes(apiGatewayRequest.Body);
                 }
                 requestFeatures.Body = new MemoryStream(binaryBody);
+            }
+            // set up connection features
+            var connectionFeatures = (IHttpConnectionFeature)features;
+            connectionFeatures.RemoteIpAddress = IPAddress.Parse(apiGatewayRequest.RequestContext.Identity.SourceIp);
+            if (apiGatewayRequest.Headers?.ContainsKey("X-Forwarded-Port") == true)
+            {
+                connectionFeatures.RemotePort = int.Parse(apiGatewayRequest.Headers["X-Forwarded-Port"]);
             }
         }
 

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/InvokeFeatures.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/InvokeFeatures.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
@@ -14,11 +15,11 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
 {
     public class InvokeFeatures : IFeatureCollection,
                              IHttpRequestFeature,
-                             IHttpResponseFeature
+                             IHttpResponseFeature,
+                             IHttpConnectionFeature
     /*
     ,
                          IHttpUpgradeFeature,
-                         IHttpConnectionFeature,
                          IHttpRequestLifetimeFeature*/
     {
 
@@ -26,6 +27,7 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
         {
             _features[typeof(IHttpRequestFeature)] = this;
             _features[typeof(IHttpResponseFeature)] = this;
+            _features[typeof(IHttpConnectionFeature)] = this;
         }
 
         #region IFeatureCollection
@@ -146,5 +148,18 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
         }
         #endregion
 
+        #region IHttpConnectionFeature
+
+        string IHttpConnectionFeature.ConnectionId { get; set; }
+
+        IPAddress IHttpConnectionFeature.RemoteIpAddress { get; set; }
+
+        IPAddress IHttpConnectionFeature.LocalIpAddress { get; set; }
+
+        int IHttpConnectionFeature.RemotePort { get; set; }
+
+        int IHttpConnectionFeature.LocalPort { get; set; }
+
+        #endregion
     }
 }

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/swagger-get-apigatway-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/swagger-get-apigatway-request.json
@@ -19,7 +19,7 @@
       "cognitoIdentityId": null,
       "caller": "BBBBBBBBBBBB",
       "apiKey": "test-invoke-api-key",
-      "sourceIp": "test-invoke-source-ip",
+      "sourceIp": "127.0.0.1",
       "cognitoAuthenticationType": null,
       "cognitoAuthenticationProvider": null,
       "userArn": "arn:aws:iam::AAAAAAAAAAAA:root",

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-aggregateerror-apigatway-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-aggregateerror-apigatway-request.json
@@ -21,7 +21,7 @@
       "cognitoIdentityId": null,
       "caller": "BBBBBBBBBBBB",
       "apiKey": "test-invoke-api-key",
-      "sourceIp": "test-invoke-source-ip",
+      "sourceIp": "127.0.0.1",
       "cognitoAuthenticationType": null,
       "cognitoAuthenticationProvider": null,
       "userArn": "arn:aws:iam::AAAAAAAAAAAA:root",

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-all-apigatway-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-all-apigatway-request.json
@@ -19,7 +19,7 @@
       "cognitoIdentityId": null,
       "caller": "BBBBBBBBBBBB",
       "apiKey": "test-invoke-api-key",
-      "sourceIp": "test-invoke-source-ip",
+      "sourceIp": "127.0.0.1",
       "cognitoAuthenticationType": null,
       "cognitoAuthenticationProvider": null,
       "userArn": "arn:aws:iam::AAAAAAAAAAAA:root",

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-customauthorizer-apigatway-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-customauthorizer-apigatway-request.json
@@ -19,7 +19,7 @@
       "cognitoIdentityId": null,
       "caller": "BBBBBBBBBBBB",
       "apiKey": "test-invoke-api-key",
-      "sourceIp": "test-invoke-source-ip",
+      "sourceIp": "127.0.0.1",
       "cognitoAuthenticationType": null,
       "cognitoAuthenticationProvider": null,
       "userArn": "arn:aws:iam::AAAAAAAAAAAA:root",

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-error-apigatway-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-error-apigatway-request.json
@@ -21,7 +21,7 @@
       "cognitoIdentityId": null,
       "caller": "BBBBBBBBBBBB",
       "apiKey": "test-invoke-api-key",
-      "sourceIp": "test-invoke-source-ip",
+      "sourceIp": "127.0.0.1",
       "cognitoAuthenticationType": null,
       "cognitoAuthenticationProvider": null,
       "userArn": "arn:aws:iam::AAAAAAAAAAAA:root",

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-querystring-apigatway-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-querystring-apigatway-request.json
@@ -22,7 +22,7 @@
       "cognitoIdentityId": null,
       "caller": "BBBBBBBBBBBB",
       "apiKey": "test-invoke-api-key",
-      "sourceIp": "test-invoke-source-ip",
+      "sourceIp": "127.0.0.1",
       "cognitoAuthenticationType": null,
       "cognitoAuthenticationProvider": null,
       "userArn": "arn:aws:iam::AAAAAAAAAAAA:root",

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-single-apigatway-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-single-apigatway-request.json
@@ -19,7 +19,7 @@
       "cognitoIdentityId": null,
       "caller": "BBBBBBBBBBBB",
       "apiKey": "test-invoke-api-key",
-      "sourceIp": "test-invoke-source-ip",
+      "sourceIp": "127.0.0.1",
       "cognitoAuthenticationType": null,
       "cognitoAuthenticationProvider": null,
       "userArn": "arn:aws:iam::AAAAAAAAAAAA:root",

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-typeloaderror-apigatway-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-typeloaderror-apigatway-request.json
@@ -21,7 +21,7 @@
       "cognitoIdentityId": null,
       "caller": "BBBBBBBBBBBB",
       "apiKey": "test-invoke-api-key",
-      "sourceIp": "test-invoke-source-ip",
+      "sourceIp": "127.0.0.1",
       "cognitoAuthenticationType": null,
       "cognitoAuthenticationProvider": null,
       "userArn": "arn:aws:iam::AAAAAAAAAAAA:root",

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-put-withbody-apigatway-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-put-withbody-apigatway-request.json
@@ -19,7 +19,7 @@
       "cognitoIdentityId": null,
       "caller": "BBBBBBBBBBBB",
       "apiKey": "test-invoke-api-key",
-      "sourceIp": "test-invoke-source-ip",
+      "sourceIp": "127.0.0.1",
       "cognitoAuthenticationType": null,
       "cognitoAuthenticationProvider": null,
       "userArn": "arn:aws:iam::AAAAAAAAAAAA:root",


### PR DESCRIPTION
Fixes #22 

Allows the AspNetCore application to access the remote client ip/port information via HttpContext.Connection, which works when running locally via `dotnet run`.

RemoteIpAddress is obtained from the APIGatewayProxyRequest's RequestContext.Identity.SourceIp
RemotePort is obtained from the APIGatewayProxyRequest's Headers["X-Forwarded-Port"]

For example this would allow for a WebAPI Controller to use the remote info:
```c#
[HttpGet]
public string GetRemote()
{
    var c = HttpContext.Connection;
    return $"{c.RemoteIpAddress}:{c.RemotePort}";
}
```

Updated the test input to provide the source IP, did not add the header "X-Forwarded-Port" in case a better place to get port information from is known by the maintainer.