### PR TITLE
Displaying the lambda tools version for the help command

### DIFF
--- a/Libraries/src/Amazon.Lambda.Tools/Program.cs
+++ b/Libraries/src/Amazon.Lambda.Tools/Program.cs
@@ -21,9 +21,9 @@ namespace Amazon.Lambda.Tools
                 {
                     attribute = Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>();
                 }
-                catch (AmbiguousMatchException e)
+                catch (AmbiguousMatchException)
                 {
-                    Console.Error.WriteLine(e.Message);
+                    // Catch exception and continue if multiple attributes are found.
                 }
                 return attribute?.InformationalVersion;
             }

--- a/Libraries/src/Amazon.Lambda.Tools/Program.cs
+++ b/Libraries/src/Amazon.Lambda.Tools/Program.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
-using System.Threading.Tasks;
 
 using Amazon.Lambda.Tools.Commands;
 using Amazon.Lambda.Tools.Options;
@@ -12,6 +12,23 @@ namespace Amazon.Lambda.Tools
 {
     public class Program
     {
+        private static string Version
+        {
+            get
+            {
+                AssemblyInformationalVersionAttribute attribute = null;
+                try
+                {
+                    attribute = Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+                }
+                catch (AmbiguousMatchException e)
+                {
+                    Console.Error.WriteLine(e.Message);
+                }
+                return attribute?.InformationalVersion;
+            }
+        }
+
         public static void Main(string[] args)
         {
             try
@@ -98,7 +115,13 @@ namespace Amazon.Lambda.Tools
 
         private static void PrintUsageHeader()
         {
-            Console.WriteLine("AWS Lambda Tools for .NET Core functions");
+            var sb = new StringBuilder("AWS Lambda Tools for .NET Core functions");
+            var version = Version;
+            if (!string.IsNullOrEmpty(version))
+            {
+                sb.Append($" ({version})");
+            }
+            Console.WriteLine(sb.ToString());
             Console.WriteLine("Project Home: https://github.com/aws/aws-lambda-dotnet");
             Console.WriteLine("\t");
         }


### PR DESCRIPTION
`dotnet lambda help` displays the version of the Amazon.Lambda.Tools.

```
AWS Lambda Tools for .NET Core functions (1.5.0)
Project Home: https://github.com/aws/aws-lambda-dotnet
```