### PR TITLE
add cloudwatch logs event

### DIFF
--- a/Libraries/Libraries.sln
+++ b/Libraries/Libraries.sln
@@ -73,6 +73,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TemplateSubstitutionTestPro
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StateMachineDefinitionStringTest", "test\TemplateSubstitutionTestProjects\StateMachineDefinitionStringTest\StateMachineDefinitionStringTest.csproj", "{D25486BF-E79F-4DFF-AEA4-D91ABFF71039}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.Lambda.CloudWatchLogsEvents", "src\Amazon.Lambda.CloudWatchLogsEvents\Amazon.Lambda.CloudWatchLogsEvents.csproj", "{32827626-2128-49A0-A2A9-2F5076AADDAD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -195,6 +197,10 @@ Global
 		{D25486BF-E79F-4DFF-AEA4-D91ABFF71039}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D25486BF-E79F-4DFF-AEA4-D91ABFF71039}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D25486BF-E79F-4DFF-AEA4-D91ABFF71039}.Release|Any CPU.Build.0 = Release|Any CPU
+		{32827626-2128-49A0-A2A9-2F5076AADDAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{32827626-2128-49A0-A2A9-2F5076AADDAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{32827626-2128-49A0-A2A9-2F5076AADDAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{32827626-2128-49A0-A2A9-2F5076AADDAD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -232,5 +238,9 @@ Global
 		{E104E093-3562-4F07-B138-821A428DE267} = {AAB54E74-20B1-42ED-BC3D-CE9F7BC7FD12}
 		{EE7F2FF6-2C90-465C-AF91-153090863D4E} = {1DE4EE60-45BA-4EF7-BE00-B9EB861E4C69}
 		{D25486BF-E79F-4DFF-AEA4-D91ABFF71039} = {EE7F2FF6-2C90-465C-AF91-153090863D4E}
+		{32827626-2128-49A0-A2A9-2F5076AADDAD} = {AAB54E74-20B1-42ED-BC3D-CE9F7BC7FD12}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {503678A4-B8D1-4486-8915-405A3E9CF0EB}
 	EndGlobalSection
 EndGlobal

--- a/Libraries/src/Amazon.Lambda.CloudWatchLogsEvents/Amazon.Lambda.CloudWatchLogsEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.CloudWatchLogsEvents/Amazon.Lambda.CloudWatchLogsEvents.csproj
@@ -1,7 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <Import Project="..\..\..\buildtools\common.props" />
-
   <PropertyGroup>
     <Description>Amazon Lambda .NET Core support - CloudWatchLogsEvents package.</Description>
     <AssemblyTitle>Amazon.Lambda.CloudWatchLogsEvents</AssemblyTitle>
@@ -11,9 +9,7 @@
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
     <Version>1.0.1</Version>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.Runtime" Version="4.1.0" />
   </ItemGroup>
-
 </Project>

--- a/Libraries/src/Amazon.Lambda.CloudWatchLogsEvents/Amazon.Lambda.CloudWatchLogsEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.CloudWatchLogsEvents/Amazon.Lambda.CloudWatchLogsEvents.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\..\buildtools\common.props" />
+
+  <PropertyGroup>
+    <Description>Amazon Lambda .NET Core support - CloudWatchLogsEvents package.</Description>
+    <AssemblyTitle>Amazon.Lambda.CloudWatchLogsEvents</AssemblyTitle>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <AssemblyName>Amazon.Lambda.CloudWatchLogsEvents</AssemblyName>
+    <PackageId>Amazon.Lambda.CloudWatchLogsEvents</PackageId>
+    <PackageTags>AWS;Amazon;Lambda</PackageTags>
+    <Version>1.0.1</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Runtime" Version="4.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/src/Amazon.Lambda.CloudWatchLogsEvents/CloudWatchLogsEvents.cs
+++ b/Libraries/src/Amazon.Lambda.CloudWatchLogsEvents/CloudWatchLogsEvents.cs
@@ -1,0 +1,26 @@
+namespace Amazon.Lambda.CloudWatchLogsEvents
+{
+    /// <summary>
+    /// AWS CloudWatch Logs event
+    /// http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Subscriptions.html
+    /// http://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-cloudwatch-logs
+    /// </summary>
+    public class CloudWatchLogsEvent
+    {
+	    /// <summary>
+	    /// The Log from the CloudWatch that is invoking the Lambda function.
+	    /// </summary>
+	    public  Log Awslogs { get; set; }
+
+	    /// <summary>
+	    /// The class identifies the Log from the CloudWatch that is invoking the Lambda function.
+	    /// </summary>
+	    public class Log
+	    {
+		    /// <summary>
+			/// The data that are base64 encoded and gziped messages in LogStreams
+		    /// </summary>
+		    public  string Data { get; set; }
+	    }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.CloudWatchLogsEvents/Properties/AssemblyInfo.cs
+++ b/Libraries/src/Amazon.Lambda.CloudWatchLogsEvents/Properties/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Amazon.Lambda.CloudWatchLogsEvents")]
+[assembly: AssemblyDescription("Lambda event interfaces for CloudWatch Logs event source.")]
+[assembly: AssemblyProduct("Amazon Web Services Lambda Interface for .NET")]
+[assembly: AssemblyCompany("Amazon.com, Inc")]
+[assembly: AssemblyCopyright("Copyright 2009-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.")]
+[assembly: ComVisible(false)]
+[assembly: System.CLSCompliant(true)]
+[assembly: AssemblyVersion("1.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Libraries/src/Amazon.Lambda.CloudWatchLogsEvents/README.md
+++ b/Libraries/src/Amazon.Lambda.CloudWatchLogsEvents/README.md
@@ -1,0 +1,17 @@
+# Amazon.Lambda.CloudWatchLogsEvents
+
+This package contains classes that can be used as input types for Lambda functions that process Amazon CloudWatch Logs events. 
+
+# Sample Function
+
+Below is a sample class and Lambda function that illustrates how an CloudWatchLogsEvents can be used. The function logs a summary of the events it received, including the type and time of event, bucket, and key. (Note that by default anything written to Console will be logged as CloudWatch Logs events.)
+
+```csharp
+public class Function
+{
+    public string Handler(CloudWatchLogsEvent cloudWatchLogsEvent)
+    {
+        Console.WriteLine($"Log content - {cloudWatchLogsEvent.Awslogs.Data}");
+    }
+}
+```


### PR DESCRIPTION
# overview
I'd like to add event class for CloudWatch Logs event so that I wrote some files by reference to other classes such as `Amazon.Lambda.ConfigEvents`.

# background
Events from  CloudWatch Logs are not so complicated like below.

```
{
 "awslogs": {
 "data":"H4sIAAAAAAAAAHWPwQqCQBCGX0Xm7EFtK+smZBEUgXoLCdMhFtKV3akI8d0bLYmibvPPN3wz00CJxmQnTO41whwWQRIctmEcB6sQbFC3CjW3XW8kxpOpP+OC22d1Wml1qZkQGtoMsScxaczKN3plG8zlaHIta5KqWsozoTYw3/djzwhpLwivWFGHGpAFe7DL68JlBUk+l7KSN7tCOEJ4M3/qOI49vMHj+zCKdlFqLaU2ZHV2a4Ct/an0/ivdX8oYc1UVX860fQDQiMdxRQEAAA=="
 }
 }
```

But, people using Lambdas triggered by CloudWatch Logs events have to define the class for the events every time . So I think this PR helps people saving time.

# issue
I wonder if you could open this on Visual Studio. So would you open this pull request on your IDE?
If you open this successfully and you think this kind of PR is not bad , I' ll add tests for `CloudWatchLogsEvents` class. 
