### PR TITLE
Improve event visibility in tests

### DIFF
--- a/Libraries/test/EventsTests/EventTests.cs
+++ b/Libraries/test/EventsTests/EventTests.cs
@@ -293,39 +293,40 @@ namespace Amazon.Lambda.Tests
             }
         }
 
-        string SNSJson = "{ \"Records\": [ { \"EventVersion\": \"1.0\", \"EventSubscriptionArn\": \"arn:aws:sns:EXAMPLE\", \"EventSource\": \"aws:sns\", \"Sns\": { \"SignatureVersion\": \"1\", \"Timestamp\": \"1970-01-01T00:00:00.000Z\", \"Signature\": \"EXAMPLE\", \"SigningCertUrl\": \"EXAMPLE\", \"MessageId\": \"95df01b4-ee98-5cb9-9903-4c221d41eb5e\", \"Message\": \"Hello from SNS!\", \"MessageAttributes\": { \"Test\": { \"Type\": \"String\", \"Value\": \"TestString\" }, \"TestBinary\": { \"Type\": \"Binary\", \"Value\": \"TestBinary\" } }, \"Type\": \"Notification\", \"UnsubscribeUrl\": \"EXAMPLE\", \"TopicArn\": \"arn:aws:sns:EXAMPLE\", \"Subject\": \"TestInvoke\" } } ] }";
-
         [Fact]
         public void SNSTest()
         {
-            Stream json = new MemoryStream(Encoding.UTF8.GetBytes(SNSJson));
-            json.Position = 0;
-            var serializer = new JsonSerializer();
-            var snsEvent = serializer.Deserialize<SNSEvent>(json);
-            Assert.Equal(snsEvent.Records.Count, 1);
-            var record = snsEvent.Records[0];
-            Assert.Equal(record.EventVersion, "1.0");
-            Assert.Equal(record.EventSubscriptionArn, "arn:aws:sns:EXAMPLE");
-            Assert.Equal(record.EventSource, "aws:sns");
-            Assert.Equal(record.Sns.SignatureVersion, "1");
-            Assert.Equal(record.Sns.Timestamp.ToUniversalTime(), DateTime.Parse("1970-01-01T00:00:00.000Z").ToUniversalTime());
-            Assert.Equal(record.Sns.Signature, "EXAMPLE");
-            Assert.Equal(record.Sns.SigningCertUrl, "EXAMPLE");
-            Assert.Equal(record.Sns.MessageId, "95df01b4-ee98-5cb9-9903-4c221d41eb5e");
-            Assert.Equal(record.Sns.Message, "Hello from SNS!");
-            Assert.True(record.Sns.MessageAttributes.ContainsKey("Test"));
-            Assert.Equal(record.Sns.MessageAttributes["Test"].Type, "String");
-            Assert.Equal(record.Sns.MessageAttributes["Test"].Value, "TestString");
-            Assert.True(record.Sns.MessageAttributes.ContainsKey("TestBinary"));
-            Assert.Equal(record.Sns.MessageAttributes["TestBinary"].Type, "Binary");
-            Assert.Equal(record.Sns.MessageAttributes["TestBinary"].Value, "TestBinary");
-            Assert.Equal(record.Sns.Type, "Notification");
-            Assert.Equal(record.Sns.UnsubscribeUrl, "EXAMPLE");
-            Assert.Equal(record.Sns.TopicArn, "arn:aws:sns:EXAMPLE");
-            Assert.Equal(record.Sns.Subject, "TestInvoke");
+            using (var fileStream = File.OpenRead("sns-event.json"))
+            {
+                var serializer = new JsonSerializer();
+                var snsEvent = serializer.Deserialize<SNSEvent>(fileStream);
 
-            Handle(snsEvent);
+                Assert.Equal(snsEvent.Records.Count, 1);
+                var record = snsEvent.Records[0];
+                Assert.Equal(record.EventVersion, "1.0");
+                Assert.Equal(record.EventSubscriptionArn, "arn:aws:sns:EXAMPLE");
+                Assert.Equal(record.EventSource, "aws:sns");
+                Assert.Equal(record.Sns.SignatureVersion, "1");
+                Assert.Equal(record.Sns.Timestamp.ToUniversalTime(), DateTime.Parse("1970-01-01T00:00:00.000Z").ToUniversalTime());
+                Assert.Equal(record.Sns.Signature, "EXAMPLE");
+                Assert.Equal(record.Sns.SigningCertUrl, "EXAMPLE");
+                Assert.Equal(record.Sns.MessageId, "95df01b4-ee98-5cb9-9903-4c221d41eb5e");
+                Assert.Equal(record.Sns.Message, "Hello from SNS!");
+                Assert.True(record.Sns.MessageAttributes.ContainsKey("Test"));
+                Assert.Equal(record.Sns.MessageAttributes["Test"].Type, "String");
+                Assert.Equal(record.Sns.MessageAttributes["Test"].Value, "TestString");
+                Assert.True(record.Sns.MessageAttributes.ContainsKey("TestBinary"));
+                Assert.Equal(record.Sns.MessageAttributes["TestBinary"].Type, "Binary");
+                Assert.Equal(record.Sns.MessageAttributes["TestBinary"].Value, "TestBinary");
+                Assert.Equal(record.Sns.Type, "Notification");
+                Assert.Equal(record.Sns.UnsubscribeUrl, "EXAMPLE");
+                Assert.Equal(record.Sns.TopicArn, "arn:aws:sns:EXAMPLE");
+                Assert.Equal(record.Sns.Subject, "TestInvoke");
+
+                Handle(snsEvent);
+            }
         }
+
         private static void Handle(SNSEvent snsEvent)
         {
             foreach (var record in snsEvent.Records)

--- a/Libraries/test/EventsTests/EventTests.cs
+++ b/Libraries/test/EventsTests/EventTests.cs
@@ -336,56 +336,55 @@ namespace Amazon.Lambda.Tests
             }
         }
 
-        string APIGatewayProxyRequestJson = "{ \"resource\": \"/{proxy+}\",   \"path\": \"/hello/world\",   \"httpMethod\": \"POST\",   \"headers\": {     \"Accept\": \"*/*\",     \"Accept-Encoding\": \"gzip, deflate\",     \"cache-control\": \"no-cache\",     \"CloudFront-Forwarded-Proto\": \"https\",     \"CloudFront-Is-Desktop-Viewer\": \"true\",     \"CloudFront-Is-Mobile-Viewer\": \"false\",     \"CloudFront-Is-SmartTV-Viewer\": \"false\",     \"CloudFront-Is-Tablet-Viewer\": \"false\",     \"CloudFront-Viewer-Country\": \"US\",     \"Content-Type\": \"application/json\",     \"headerName\": \"headerValue\",     \"Host\": \"gy415nuibc.execute-api.us-east-1.amazonaws.com\",     \"Postman-Token\": \"9f583ef0-ed83-4a38-aef3-eb9ce3f7a57f\",     \"User-Agent\": \"PostmanRuntime/2.4.5\",     \"Via\": \"1.1 d98420743a69852491bbdea73f7680bd.cloudfront.net (CloudFront)\",     \"X-Amz-Cf-Id\": \"pn-PWIJc6thYnZm5P0NMgOUglL1DYtl0gdeJky8tqsg8iS_sgsKD1A==\",     \"X-Forwarded-For\": \"54.240.196.186, 54.182.214.83\",     \"X-Forwarded-Port\": \"443\",     \"X-Forwarded-Proto\": \"https\"   },   \"queryStringParameters\": {     \"name\": \"me\"   },   \"pathParameters\": {     \"proxy\": \"hello/world\"   },   \"stageVariables\": {     \"stageVariableName\": \"stageVariableValue\"   },   \"requestContext\": {     \"accountId\": \"12345678912\",     \"resourceId\": \"roq9wj\",     \"stage\": \"testStage\",     \"requestId\": \"deef4878-7910-11e6-8f14-25afc3e9ae33\",     \"identity\": {       \"cognitoIdentityPoolId\": \"theCognitoIdentityPoolId\",       \"accountId\": \"theAccountId\",       \"cognitoIdentityId\": \"theCognitoIdentityId\",       \"caller\": \"theCaller\",       \"apiKey\": \"theApiKey\",       \"sourceIp\": \"192.168.196.186\",       \"cognitoAuthenticationType\": \"theCognitoAuthenticationType\",       \"cognitoAuthenticationProvider\": \"theCognitoAuthenticationProvider\",       \"userArn\": \"theUserArn\",       \"userAgent\": \"PostmanRuntime/2.4.5\",       \"user\": \"theUser\"     },     \"resourcePath\": \"/{proxy+}\",     \"httpMethod\": \"POST\",     \"apiId\": \"gy415nuibc\"   },   \"body\": \"{\\r\\n\\t\\\"a\\\": 1\\r\\n}\" }";
-
         [Fact]
         public void APIGatewayProxyRequestTest()
         {
-            Stream json = new MemoryStream(Encoding.UTF8.GetBytes(APIGatewayProxyRequestJson));
-            json.Position = 0;
-            var serializer = new JsonSerializer();
-            var proxyEvent = serializer.Deserialize<APIGatewayProxyRequest>(json);
+            using (var fileStream = File.OpenRead("proxy-event.json"))
+            {
+                var serializer = new JsonSerializer();
+                var proxyEvent = serializer.Deserialize<APIGatewayProxyRequest>(fileStream);
 
-            Assert.Equal(proxyEvent.Resource, "/{proxy+}");
-            Assert.Equal(proxyEvent.Path, "/hello/world");
-            Assert.Equal(proxyEvent.HttpMethod, "POST");
-            Assert.Equal(proxyEvent.Body, "{\r\n\t\"a\": 1\r\n}");
+                Assert.Equal(proxyEvent.Resource, "/{proxy+}");
+                Assert.Equal(proxyEvent.Path, "/hello/world");
+                Assert.Equal(proxyEvent.HttpMethod, "POST");
+                Assert.Equal(proxyEvent.Body, "{\r\n\t\"a\": 1\r\n}");
 
-            var headers = proxyEvent.Headers;
-            Assert.Equal(headers["Accept"], "*/*");
-            Assert.Equal(headers["Accept-Encoding"], "gzip, deflate");
-            Assert.Equal(headers["cache-control"], "no-cache");
-            Assert.Equal(headers["CloudFront-Forwarded-Proto"], "https");
+                var headers = proxyEvent.Headers;
+                Assert.Equal(headers["Accept"], "*/*");
+                Assert.Equal(headers["Accept-Encoding"], "gzip, deflate");
+                Assert.Equal(headers["cache-control"], "no-cache");
+                Assert.Equal(headers["CloudFront-Forwarded-Proto"], "https");
 
-            var queryStringParameters = proxyEvent.QueryStringParameters;
-            Assert.Equal(queryStringParameters["name"], "me");
+                var queryStringParameters = proxyEvent.QueryStringParameters;
+                Assert.Equal(queryStringParameters["name"], "me");
 
-            var pathParameters = proxyEvent.PathParameters;
-            Assert.Equal(pathParameters["proxy"], "hello/world");
+                var pathParameters = proxyEvent.PathParameters;
+                Assert.Equal(pathParameters["proxy"], "hello/world");
 
-            var stageVariables = proxyEvent.StageVariables;
-            Assert.Equal(stageVariables["stageVariableName"], "stageVariableValue");
+                var stageVariables = proxyEvent.StageVariables;
+                Assert.Equal(stageVariables["stageVariableName"], "stageVariableValue");
 
-            var requestContext = proxyEvent.RequestContext;
-            Assert.Equal(requestContext.AccountId, "12345678912");
-            Assert.Equal(requestContext.ResourceId, "roq9wj");
-            Assert.Equal(requestContext.Stage, "testStage");
-            Assert.Equal(requestContext.RequestId, "deef4878-7910-11e6-8f14-25afc3e9ae33");
+                var requestContext = proxyEvent.RequestContext;
+                Assert.Equal(requestContext.AccountId, "12345678912");
+                Assert.Equal(requestContext.ResourceId, "roq9wj");
+                Assert.Equal(requestContext.Stage, "testStage");
+                Assert.Equal(requestContext.RequestId, "deef4878-7910-11e6-8f14-25afc3e9ae33");
 
-            var identity = requestContext.Identity;
-            Assert.Equal(identity.CognitoIdentityPoolId, "theCognitoIdentityPoolId");
-            Assert.Equal(identity.AccountId, "theAccountId");
-            Assert.Equal(identity.CognitoIdentityId, "theCognitoIdentityId");
-            Assert.Equal(identity.Caller, "theCaller");
-            Assert.Equal(identity.ApiKey, "theApiKey");
-            Assert.Equal(identity.SourceIp, "192.168.196.186");
-            Assert.Equal(identity.CognitoAuthenticationType, "theCognitoAuthenticationType");
-            Assert.Equal(identity.CognitoAuthenticationProvider, "theCognitoAuthenticationProvider");
-            Assert.Equal(identity.UserArn, "theUserArn");
-            Assert.Equal(identity.UserAgent, "PostmanRuntime/2.4.5");
-            Assert.Equal(identity.User, "theUser");
+                var identity = requestContext.Identity;
+                Assert.Equal(identity.CognitoIdentityPoolId, "theCognitoIdentityPoolId");
+                Assert.Equal(identity.AccountId, "theAccountId");
+                Assert.Equal(identity.CognitoIdentityId, "theCognitoIdentityId");
+                Assert.Equal(identity.Caller, "theCaller");
+                Assert.Equal(identity.ApiKey, "theApiKey");
+                Assert.Equal(identity.SourceIp, "192.168.196.186");
+                Assert.Equal(identity.CognitoAuthenticationType, "theCognitoAuthenticationType");
+                Assert.Equal(identity.CognitoAuthenticationProvider, "theCognitoAuthenticationProvider");
+                Assert.Equal(identity.UserArn, "theUserArn");
+                Assert.Equal(identity.UserAgent, "PostmanRuntime/2.4.5");
+                Assert.Equal(identity.User, "theUser");
 
-            Handle(proxyEvent);
+                Handle(proxyEvent);
+            }
         }
 
         private static APIGatewayProxyResponse Handle(APIGatewayProxyRequest apigProxyEvent)

--- a/Libraries/test/EventsTests/EventTests.cs
+++ b/Libraries/test/EventsTests/EventTests.cs
@@ -154,28 +154,27 @@ namespace Amazon.Lambda.Tests
             Console.WriteLine($"Successfully processed {ddbEvent.Records.Count} records.");
         }
 
-        String CognitoEvent = "{ \"datasetName\": \"datasetName\", \"eventType\": \"SyncTrigger\", \"region\": \"us-east-1\", \"identityId\": \"identityId\", \"datasetRecords\": { \"SampleKey1\": { \"newValue\": \"newValue1\", \"oldValue\": \"oldValue1\", \"op\": \"replace\" } }, \"identityPoolId\": \"identityPoolId\", \"version\": 2 }";
-
         [Fact]
         public void CognitoTest()
         {
-            Stream json = new MemoryStream(Encoding.UTF8.GetBytes(CognitoEvent));
-            json.Position = 0;
-            var serializer = new JsonSerializer();
-            var cognitoEvent = serializer.Deserialize<CognitoEvent>(json);
-            Assert.Equal(cognitoEvent.Version, 2);
-            Assert.Equal(cognitoEvent.EventType, "SyncTrigger");
-            Assert.Equal(cognitoEvent.Region, "us-east-1");
-            Assert.Equal(cognitoEvent.DatasetName, "datasetName");
-            Assert.Equal(cognitoEvent.IdentityPoolId, "identityPoolId");
-            Assert.Equal(cognitoEvent.IdentityId, "identityId");
-            Assert.Equal(cognitoEvent.DatasetRecords.Count, 1);
-            Assert.True(cognitoEvent.DatasetRecords.ContainsKey("SampleKey1"));
-            Assert.Equal(cognitoEvent.DatasetRecords["SampleKey1"].NewValue, "newValue1");
-            Assert.Equal(cognitoEvent.DatasetRecords["SampleKey1"].OldValue, "oldValue1");
-            Assert.Equal(cognitoEvent.DatasetRecords["SampleKey1"].Op, "replace");
+            using (var fileStream = File.OpenRead("cognito-event.json"))
+            {
+                var serializer = new JsonSerializer();
+                var cognitoEvent = serializer.Deserialize<CognitoEvent>(fileStream);
+                Assert.Equal(cognitoEvent.Version, 2);
+                Assert.Equal(cognitoEvent.EventType, "SyncTrigger");
+                Assert.Equal(cognitoEvent.Region, "us-east-1");
+                Assert.Equal(cognitoEvent.DatasetName, "datasetName");
+                Assert.Equal(cognitoEvent.IdentityPoolId, "identityPoolId");
+                Assert.Equal(cognitoEvent.IdentityId, "identityId");
+                Assert.Equal(cognitoEvent.DatasetRecords.Count, 1);
+                Assert.True(cognitoEvent.DatasetRecords.ContainsKey("SampleKey1"));
+                Assert.Equal(cognitoEvent.DatasetRecords["SampleKey1"].NewValue, "newValue1");
+                Assert.Equal(cognitoEvent.DatasetRecords["SampleKey1"].OldValue, "oldValue1");
+                Assert.Equal(cognitoEvent.DatasetRecords["SampleKey1"].Op, "replace");
 
-            Handle(cognitoEvent);
+                Handle(cognitoEvent);
+            }
         }
 
         private static void Handle(CognitoEvent cognitoEvent)

--- a/Libraries/test/EventsTests/EventTests.cs
+++ b/Libraries/test/EventsTests/EventTests.cs
@@ -28,36 +28,36 @@ namespace Amazon.Lambda.Tests
 
     public class EventTest
     {
-        string S3PutJson = "{ \"Records\": [ { \"eventVersion\": \"2.0\", \"eventTime\": \"1970-01-01T00:00:00.000Z\", \"requestParameters\": { \"sourceIPAddress\": \"127.0.0.1\" }, \"s3\": { \"configurationId\": \"testConfigRule\", \"object\": { \"eTag\": \"0123456789abcdef0123456789abcdef\", \"sequencer\": \"0A1B2C3D4E5F678901\", \"key\": \"HappyFace.jpg\", \"size\": 1024 }, \"bucket\": { \"arn\": \"arn:aws:s3:::mybucket\", \"name\": \"sourcebucket\", \"ownerIdentity\": { \"principalId\": \"EXAMPLE\" } }, \"s3SchemaVersion\": \"1.0\" }, \"responseElements\": { \"x-amz-id-2\": \"EXAMPLE123/5678abcdefghijklambdaisawesome/mnopqrstuvwxyzABCDEFGH\", \"x-amz-request-id\": \"EXAMPLE123456789\" }, \"awsRegion\": \"us-east-1\", \"eventName\": \"ObjectCreated:Put\", \"userIdentity\": { \"principalId\": \"EXAMPLE\" }, \"eventSource\": \"aws:s3\" } ] }";
-
         [Fact]
         public void S3PutTest()
         {
-            Stream json = new MemoryStream(Encoding.UTF8.GetBytes(S3PutJson));
-            json.Position = 0;
-            var serializer = new JsonSerializer();
-            var s3Event = serializer.Deserialize<S3Event>(json);
-            Assert.Equal(s3Event.Records.Count, 1);
-            var record = s3Event.Records[0];
-            Assert.Equal(record.EventVersion, "2.0");
-            Assert.Equal(record.EventTime.ToUniversalTime(), DateTime.Parse("1970-01-01T00:00:00.000Z").ToUniversalTime());
-            Assert.Equal(record.RequestParameters.SourceIPAddress, "127.0.0.1");
-            Assert.Equal(record.S3.ConfigurationId, "testConfigRule");
-            Assert.Equal(record.S3.Object.ETag, "0123456789abcdef0123456789abcdef");
-            Assert.Equal(record.S3.Object.Key, "HappyFace.jpg");
-            Assert.Equal(record.S3.Object.Size, 1024);
-            Assert.Equal(record.S3.Bucket.Arn, "arn:aws:s3:::mybucket");
-            Assert.Equal(record.S3.Bucket.Name, "sourcebucket");
-            Assert.Equal(record.S3.Bucket.OwnerIdentity.PrincipalId, "EXAMPLE");
-            Assert.Equal(record.S3.S3SchemaVersion, "1.0");
-            Assert.Equal(record.ResponseElements.XAmzId2, "EXAMPLE123/5678abcdefghijklambdaisawesome/mnopqrstuvwxyzABCDEFGH");
-            Assert.Equal(record.ResponseElements.XAmzRequestId, "EXAMPLE123456789");
-            Assert.Equal(record.AwsRegion, "us-east-1");
-            Assert.Equal(record.EventName, "ObjectCreated:Put");
-            Assert.Equal(record.UserIdentity.PrincipalId, "EXAMPLE");
-            Assert.Equal(record.EventSource, "aws:s3");
+            using (var fileStream = File.OpenRead("s3-event.json"))
+            {
+                var serializer = new JsonSerializer();
+                var s3Event = serializer.Deserialize<S3Event>(fileStream);
 
-            Handle(s3Event);
+                Assert.Equal(s3Event.Records.Count, 1);
+                var record = s3Event.Records[0];
+                Assert.Equal(record.EventVersion, "2.0");
+                Assert.Equal(record.EventTime.ToUniversalTime(), DateTime.Parse("1970-01-01T00:00:00.000Z").ToUniversalTime());
+                Assert.Equal(record.RequestParameters.SourceIPAddress, "127.0.0.1");
+                Assert.Equal(record.S3.ConfigurationId, "testConfigRule");
+                Assert.Equal(record.S3.Object.ETag, "0123456789abcdef0123456789abcdef");
+                Assert.Equal(record.S3.Object.Key, "HappyFace.jpg");
+                Assert.Equal(record.S3.Object.Size, 1024);
+                Assert.Equal(record.S3.Bucket.Arn, "arn:aws:s3:::mybucket");
+                Assert.Equal(record.S3.Bucket.Name, "sourcebucket");
+                Assert.Equal(record.S3.Bucket.OwnerIdentity.PrincipalId, "EXAMPLE");
+                Assert.Equal(record.S3.S3SchemaVersion, "1.0");
+                Assert.Equal(record.ResponseElements.XAmzId2, "EXAMPLE123/5678abcdefghijklambdaisawesome/mnopqrstuvwxyzABCDEFGH");
+                Assert.Equal(record.ResponseElements.XAmzRequestId, "EXAMPLE123456789");
+                Assert.Equal(record.AwsRegion, "us-east-1");
+                Assert.Equal(record.EventName, "ObjectCreated:Put");
+                Assert.Equal(record.UserIdentity.PrincipalId, "EXAMPLE");
+                Assert.Equal(record.EventSource, "aws:s3");
+
+                Handle(s3Event);
+            }
         }
 
         private void Handle(S3Event s3Event)

--- a/Libraries/test/EventsTests/EventTests.cs
+++ b/Libraries/test/EventsTests/EventTests.cs
@@ -188,28 +188,28 @@ namespace Amazon.Lambda.Tests
             }
         }
 
-        String ConfigEvent = "{ \"configRuleId\": \"config-rule-0123456\", \"version\": \"1.0\", \"configRuleName\": \"periodic-config-rule\", \"configRuleArn\": \"arn:aws:config:us-east-1:012345678912:config-rule/config-rule-0123456\", \"invokingEvent\": \"{\\\"configSnapshotId\\\":\\\"00000000-0000-0000-0000-000000000000\\\",\\\"s3ObjectKey\\\":\\\"AWSLogs/000000000000/Config/us-east-1/2016/2/24/ConfigSnapshot/000000000000_Config_us-east-1_ConfigSnapshot_20160224T182319Z_00000000-0000-0000-0000-000000000000.json.gz\\\",\\\"s3Bucket\\\":\\\"config-bucket\\\",\\\"notificationCreationTime\\\":\\\"2016-02-24T18:23:20.328Z\\\",\\\"messageType\\\":\\\"ConfigurationSnapshotDeliveryCompleted\\\",\\\"recordVersion\\\":\\\"1.1\\\"}\", \"resultToken\": \"myResultToken\", \"eventLeftScope\": false, \"ruleParameters\": \"{\\\"<myParameterKey>\\\":\\\"<myParameterValue>\\\"}\", \"executionRoleArn\": \"arn:aws:iam::012345678912:role/config-role\", \"accountId\": \"012345678912\" }";
         String ConfigInvokingEvent = "{\"configSnapshotId\":\"00000000-0000-0000-0000-000000000000\",\"s3ObjectKey\":\"AWSLogs/000000000000/Config/us-east-1/2016/2/24/ConfigSnapshot/000000000000_Config_us-east-1_ConfigSnapshot_20160224T182319Z_00000000-0000-0000-0000-000000000000.json.gz\",\"s3Bucket\":\"config-bucket\",\"notificationCreationTime\":\"2016-02-24T18:23:20.328Z\",\"messageType\":\"ConfigurationSnapshotDeliveryCompleted\",\"recordVersion\":\"1.1\"}";
 
         [Fact]
         public void ConfigTest()
         {
-            Stream json = new MemoryStream(Encoding.UTF8.GetBytes(ConfigEvent));
-            json.Position = 0;
-            var serializer = new JsonSerializer();
-            var configEvent = serializer.Deserialize<ConfigEvent>(json);
-            Assert.Equal(configEvent.ConfigRuleId, "config-rule-0123456");
-            Assert.Equal(configEvent.Version, "1.0");
-            Assert.Equal(configEvent.ConfigRuleName, "periodic-config-rule");
-            Assert.Equal(configEvent.ConfigRuleArn, "arn:aws:config:us-east-1:012345678912:config-rule/config-rule-0123456");
-            Assert.Equal(configEvent.InvokingEvent, ConfigInvokingEvent);
-            Assert.Equal(configEvent.ResultToken, "myResultToken");
-            Assert.Equal(configEvent.EventLeftScope, false);
-            Assert.Equal(configEvent.RuleParameters, "{\"<myParameterKey>\":\"<myParameterValue>\"}");
-            Assert.Equal(configEvent.ExecutionRoleArn, "arn:aws:iam::012345678912:role/config-role");
-            Assert.Equal(configEvent.AccountId, "012345678912");
+            using (var fileStream = File.OpenRead("config-event.json"))
+            {
+                var serializer = new JsonSerializer();
+                var configEvent = serializer.Deserialize<ConfigEvent>(fileStream);
+                Assert.Equal(configEvent.ConfigRuleId, "config-rule-0123456");
+                Assert.Equal(configEvent.Version, "1.0");
+                Assert.Equal(configEvent.ConfigRuleName, "periodic-config-rule");
+                Assert.Equal(configEvent.ConfigRuleArn, "arn:aws:config:us-east-1:012345678912:config-rule/config-rule-0123456");
+                Assert.Equal(configEvent.InvokingEvent, ConfigInvokingEvent);
+                Assert.Equal(configEvent.ResultToken, "myResultToken");
+                Assert.Equal(configEvent.EventLeftScope, false);
+                Assert.Equal(configEvent.RuleParameters, "{\"<myParameterKey>\":\"<myParameterValue>\"}");
+                Assert.Equal(configEvent.ExecutionRoleArn, "arn:aws:iam::012345678912:role/config-role");
+                Assert.Equal(configEvent.AccountId, "012345678912");
 
-            Handle(configEvent);
+                Handle(configEvent);
+            }
         }
 
         private static void Handle(ConfigEvent configEvent)

--- a/Libraries/test/EventsTests/EventsTests.csproj
+++ b/Libraries/test/EventsTests/EventsTests.csproj
@@ -10,7 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="*.json">
+    <Content Include="*.json" Exclude="config-event.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="config-event.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
@@ -55,5 +58,8 @@
     <None Update="proxy-event.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Remove="config-event.json" />
   </ItemGroup>
 </Project>

--- a/Libraries/test/EventsTests/EventsTests.csproj
+++ b/Libraries/test/EventsTests/EventsTests.csproj
@@ -52,5 +52,8 @@
     <None Update="sns-event.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="proxy-event.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/Libraries/test/EventsTests/EventsTests.csproj
+++ b/Libraries/test/EventsTests/EventsTests.csproj
@@ -42,4 +42,9 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="s3-event.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/Libraries/test/EventsTests/EventsTests.csproj
+++ b/Libraries/test/EventsTests/EventsTests.csproj
@@ -46,5 +46,8 @@
     <None Update="s3-event.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="cognito-event.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/Libraries/test/EventsTests/EventsTests.csproj
+++ b/Libraries/test/EventsTests/EventsTests.csproj
@@ -49,5 +49,8 @@
     <None Update="cognito-event.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="sns-event.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/Libraries/test/EventsTests/cognito-event.json
+++ b/Libraries/test/EventsTests/cognito-event.json
@@ -1,0 +1,15 @@
+﻿{ 
+  "datasetName": "datasetName",
+  "eventType": "SyncTrigger",
+  "region": "us-east-1",
+  "identityId": "identityId",
+  "datasetRecords": {
+    "SampleKey1": {
+      "newValue": "newValue1",
+      "oldValue": "oldValue1",
+      "op": "replace"
+    }
+  },
+  "identityPoolId": "identityPoolId",
+  "version": 2
+}

--- a/Libraries/test/EventsTests/config-event.json
+++ b/Libraries/test/EventsTests/config-event.json
@@ -1,0 +1,12 @@
+﻿{
+  "configRuleId": "config-rule-0123456",
+  "version": "1.0",
+  "configRuleName": "periodic-config-rule",
+  "configRuleArn": "arn:aws:config:us-east-1:012345678912:config-rule/config-rule-0123456",
+  "invokingEvent": "{\"configSnapshotId\":\"00000000-0000-0000-0000-000000000000\",\"s3ObjectKey\":\"AWSLogs/000000000000/Config/us-east-1/2016/2/24/ConfigSnapshot/000000000000_Config_us-east-1_ConfigSnapshot_20160224T182319Z_00000000-0000-0000-0000-000000000000.json.gz\",\"s3Bucket\":\"config-bucket\",\"notificationCreationTime\":\"2016-02-24T18:23:20.328Z\",\"messageType\":\"ConfigurationSnapshotDeliveryCompleted\",\"recordVersion\":\"1.1\"}",
+  "resultToken": "myResultToken",
+  "eventLeftScope": false,
+  "ruleParameters": "{\"<myParameterKey>\":\"<myParameterValue>\"}",
+  "executionRoleArn": "arn:aws:iam::012345678912:role/config-role",
+  "accountId": "012345678912"
+}

--- a/Libraries/test/EventsTests/proxy-event.json
+++ b/Libraries/test/EventsTests/proxy-event.json
@@ -1,0 +1,58 @@
+﻿{
+  "resource": "/{proxy+}",
+  "path": "/hello/world",
+  "httpMethod": "POST",
+  "headers": {
+    "Accept": "*/*",
+    "Accept-Encoding": "gzip, deflate",
+    "cache-control": "no-cache",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Content-Type": "application/json",
+    "headerName": "headerValue",
+    "Host": "gy415nuibc.execute-api.us-east-1.amazonaws.com",
+    "Postman-Token": "9f583ef0-ed83-4a38-aef3-eb9ce3f7a57f",
+    "User-Agent": "PostmanRuntime/2.4.5",
+    "Via": "1.1 d98420743a69852491bbdea73f7680bd.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "pn-PWIJc6thYnZm5P0NMgOUglL1DYtl0gdeJky8tqsg8iS_sgsKD1A==",
+    "X-Forwarded-For": "54.240.196.186, 54.182.214.83",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "queryStringParameters": {
+    "name": "me"
+  },
+  "pathParameters": {
+    "proxy": "hello/world"
+  },
+  "stageVariables": {
+    "stageVariableName": "stageVariableValue"
+  },
+  "requestContext": {
+    "accountId": "12345678912",
+    "resourceId": "roq9wj",
+    "stage": "testStage",
+    "requestId": "deef4878-7910-11e6-8f14-25afc3e9ae33",
+    "identity": {
+      "cognitoIdentityPoolId": "theCognitoIdentityPoolId",
+      "accountId": "theAccountId",
+      "cognitoIdentityId": "theCognitoIdentityId",
+      "caller": "theCaller",
+      "apiKey": "theApiKey",
+      "sourceIp": "192.168.196.186",
+      "cognitoAuthenticationType": "theCognitoAuthenticationType",
+      "cognitoAuthenticationProvider": "theCognitoAuthenticationProvider",
+      "userArn": "theUserArn",
+      "userAgent": "PostmanRuntime/2.4.5",
+      "user": "theUser"
+    },
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "POST",
+    "apiId": "gy415nuibc"
+  },
+  "body": "{\r\n\t\"a\": 1\r\n}"
+}

--- a/Libraries/test/EventsTests/s3-event.json
+++ b/Libraries/test/EventsTests/s3-event.json
@@ -1,0 +1,36 @@
+﻿{
+  "Records": [
+    {
+      "eventVersion": "2.0",
+      "eventTime": "1970-01-01T00:00:00.000Z",
+      "requestParameters": { "sourceIPAddress": "127.0.0.1" },
+      "s3": {
+        "configurationId": "testConfigRule",
+        "object": { 
+          "eTag": "0123456789abcdef0123456789abcdef",
+          "sequencer": "0A1B2C3D4E5F678901",
+          "key": "HappyFace.jpg",
+          "size": 1024
+        },
+        "bucket": {
+          "arn": "arn:aws:s3:::mybucket",
+          "name": "sourcebucket", 
+          "ownerIdentity": {
+            "principalId": "EXAMPLE"
+          }
+        },
+        "s3SchemaVersion": "1.0"
+      },
+      "responseElements": {
+        "x-amz-id-2": "EXAMPLE123/5678abcdefghijklambdaisawesome/mnopqrstuvwxyzABCDEFGH",
+        "x-amz-request-id": "EXAMPLE123456789"
+      },
+      "awsRegion": "us-east-1",
+      "eventName": "ObjectCreated:Put",
+      "userIdentity": {
+        "principalId": "EXAMPLE"
+      }, 
+      "eventSource": "aws:s3"
+    }
+  ]
+}

--- a/Libraries/test/EventsTests/sns-event.json
+++ b/Libraries/test/EventsTests/sns-event.json
@@ -1,0 +1,31 @@
+﻿{
+  "Records": [
+    {
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:EXAMPLE",
+      "EventSource": "aws:sns",
+      "Sns": {
+        "SignatureVersion": "1",
+        "Timestamp": "1970-01-01T00:00:00.000Z",
+        "Signature": "EXAMPLE",
+        "SigningCertUrl": "EXAMPLE",
+        "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+        "Message": "Hello from SNS!",
+        "MessageAttributes": {
+          "Test": {
+            "Type": "String",
+            "Value": "TestString"
+          },
+          "TestBinary": {
+            "Type": "Binary",
+            "Value": "TestBinary"
+          }
+        },
+        "Type": "Notification",
+        "UnsubscribeUrl": "EXAMPLE",
+        "TopicArn": "arn:aws:sns:EXAMPLE",
+        "Subject": "TestInvoke"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# overview
use json files instead of string in tests

# background
In EventTest,  each test case uses  event deserialized from json files recently. I think it's better than parsing string literal because of visibility and maintainability. So I replaced events from string to json.