### PR TITLE
Add FSharpJsonSerialiser

### DIFF
--- a/Libraries/src/Amazon.Lambda.Serialization.Json/Amazon.Lambda.Serialization.Json.csproj
+++ b/Libraries/src/Amazon.Lambda.Serialization.Json/Amazon.Lambda.Serialization.Json.csproj
@@ -4,8 +4,8 @@
 
   <PropertyGroup>
     <Description>Amazon Lambda .NET Core support - Serialization.Json package.</Description>
-    <TargetFramework>netstandard1.3</TargetFramework>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
+    <TargetFramework>netstandard1.6</TargetFramework>
+    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
     <AssemblyTitle>Amazon.Lambda.Serialization.Json</AssemblyTitle>
     <VersionPrefix>1.0.1</VersionPrefix>
     <AssemblyName>Amazon.Lambda.Serialization.Json</AssemblyName>
@@ -19,9 +19,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Runtime" Version="4.1.0" />
-    <PackageReference Include="System.Reflection" Version="4.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Reflection" Version="4.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="FSharp.Core" Version="4.2.3" />
+    <PackageReference Include="Fable.JsonConverter" Version="1.0.7" />    
   </ItemGroup>
 
 </Project>

--- a/Libraries/src/Amazon.Lambda.Serialization.Json/FSharpJsonSerialiser.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.Json/FSharpJsonSerialiser.cs
@@ -7,14 +7,14 @@ namespace Amazon.Lambda.Serialization.Json
 {
     /// <summary>
     /// Custom ILambdaSerializer implementation which uses Newtonsoft.Json 10.0.3
-    /// for serialization.
+    /// for serialization + Fable.JsonConverter to handle F# types.
     /// 
     /// <para>
     /// If the environment variable LAMBDA_NET_SERIALIZER_DEBUG is set to true the JSON coming
     /// in from Lambda and being sent back to Lambda will be logged.
     /// </para>
     /// </summary>
-    public class JsonSerializer : ILambdaSerializer
+    public class FSharpJsonSerializer : ILambdaSerializer
     {
         private const string DEBUG_ENVIRONMENT_VARIABLE_NAME = "LAMBDA_NET_SERIALIZER_DEBUG";
         private Newtonsoft.Json.JsonSerializer serializer;
@@ -23,12 +23,13 @@ namespace Amazon.Lambda.Serialization.Json
         /// <summary>
         /// Constructs instance of serializer.
         /// </summary>
-        public JsonSerializer()
+        public FSharpJsonSerializer()
         {
 
             JsonSerializerSettings settings = new JsonSerializerSettings();
             settings.ContractResolver = new AwsResolver();
             serializer = Newtonsoft.Json.JsonSerializer.Create(settings);
+            serializer.Converters.Add(new Fable.JsonConverter());
 
             if (string.Equals(Environment.GetEnvironmentVariable(DEBUG_ENVIRONMENT_VARIABLE_NAME), "true", StringComparison.OrdinalIgnoreCase))
             {
@@ -65,7 +66,7 @@ namespace Amazon.Lambda.Serialization.Json
         }
 
         /// <summary>
-        /// Deserializes a stream to a particular type.
+        /// Deserialize a stream to a particular type.
         /// </summary>
         /// <typeparam name="T">Type of object to deserialize to.</typeparam>
         /// <param name="requestStream">Stream to serialize.</param>


### PR DESCRIPTION
Hello,

This PR adds a F# Json Converter, that handles proprely F# types (options, discriminated union, ...).
I had to bump version of NewtonSoft.Json
