### PR TITLE
Use dotnet compression on .NET Core 2.0^ for all platforms

### DIFF
--- a/Libraries/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/Libraries/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -39,6 +39,10 @@
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp1.0'">
+    <DefineConstants>$(DefineConstants);NATIVE_ZIP</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>

--- a/Libraries/src/Amazon.Lambda.Tools/DotNetCLIWrapper.cs
+++ b/Libraries/src/Amazon.Lambda.Tools/DotNetCLIWrapper.cs
@@ -31,6 +31,7 @@ namespace Amazon.Lambda.Tools
         /// <param name="outputLocation"></param>
         /// <param name="targetFramework"></param>
         /// <param name="configuration"></param>
+        /// <param name="msbuildParameters"></param>
         /// <param name="deploymentTargetPackageStoreManifestContent"></param>
         public int Publish(LambdaToolsDefaults defaults, string projectLocation, string outputLocation, string targetFramework, string configuration, string msbuildParameters, string deploymentTargetPackageStoreManifestContent)
         {

--- a/Libraries/src/Amazon.Lambda.Tools/LambdaPackager.cs
+++ b/Libraries/src/Amazon.Lambda.Tools/LambdaPackager.cs
@@ -102,30 +102,24 @@ namespace Amazon.Lambda.Tools
                 new DirectoryInfo(zipArchiveParentDirectory).Create();
             }
 
-
-#if NETCORE
-            if(RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                BundleWithDotNetCompression(zipArchivePath, publishLocation, flattenRuntime, logger);
-            }
-            else
+#if NATIVE_ZIP
+            if(!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // Use the native zip utility if it exist which will maintain linux/osx file permissions
                 var zipCLI = DotNetCLIWrapper.FindExecutableInPath("zip");
                 if (!string.IsNullOrEmpty(zipCLI))
                 {
                     BundleWithZipCLI(zipCLI, zipArchivePath, publishLocation, flattenRuntime, logger);
+                    return true;
                 }
                 else
                 {
                     throw new LambdaToolsException("Failed to find the \"zip\" utility program in path. This program is required to maintain Linux file permissions in the zip archive.", LambdaToolsException.ErrorCode.FailedToFindZipProgram);
                 }
             }
-#else
-            BundleWithDotNetCompression(zipArchivePath, publishLocation, flattenRuntime, logger);
 #endif
 
-
+            BundleWithDotNetCompression(zipArchivePath, publishLocation, flattenRuntime, logger);
 
             return true;
         }

--- a/Libraries/src/Amazon.Lambda.Tools/LambdaPackager.cs
+++ b/Libraries/src/Amazon.Lambda.Tools/LambdaPackager.cs
@@ -37,8 +37,9 @@ namespace Amazon.Lambda.Tools
         /// <param name="logger"></param>
         /// <param name="workingDirectory"></param>
         /// <param name="projectLocation"></param>
-        /// <param name="targetFramework"></param>
         /// <param name="configuration"></param>
+        /// <param name="targetFramework"></param>
+        /// <param name="msbuildParameters"></param>
         /// <param name="disableVersionCheck"></param>
         /// <param name="publishLocation"></param>
         /// <param name="zipArchivePath"></param>


### PR DESCRIPTION
The need for using native zip on non-Windows platform was to workaround the issue where the contents of the zip file didn't have the correct attributes.

The fix for this was landed in 2.0 (https://github.com/dotnet/corefx/pull/18565), so we can now restrict this workaround to just `netcoreapp1.0`