### PR TITLE
Fix issue #227

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -97,7 +97,7 @@ namespace Amazon.Lambda.AspNetCoreServer
         }
 
         /// <summary>
-        /// Should be called in the derrived constructor 
+        /// Should be called in the derived constructor 
         /// </summary>
         protected void Start()
         {


### PR DESCRIPTION
*Issue #227*

- Move the code from the consturctor into a new private start method
- Constructor takes in a delayStart boolean, with the default keeping the existing behavior
- If the _server is null then run the new private start method.
- Continuing processing request as done today.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.