### PR TITLE
Adds More Convenient Typed Startup for ASP.NET Core

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -22,7 +22,7 @@ using System.Threading.Tasks;
 namespace Amazon.Lambda.AspNetCoreServer
 {
     /// <summary>
-    /// ApiGatewayFunction is the base class that is implemented in a ASP.NET Core Web API. The derived class implements
+    /// ApiGatewayProxyFunction is the base class that is implemented in a ASP.NET Core Web API. The derived class implements
     /// the Init method similar to Main function in the ASP.NET Core. The function handler for the Lambda function will point
     /// to this base class FunctionHandlerAsync method.
     /// </summary>

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction{TStartup}.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction{TStartup}.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.AspNetCore.Hosting;
+
+namespace Amazon.Lambda.AspNetCoreServer
+{
+    /// <summary>
+    /// ApiGatewayProxyFunction is the base class that is implemented in a ASP.NET Core Web API. The derived class implements
+    /// the Init method similar to Main function in the ASP.NET Core and provides typed Startup. The function handler for
+    /// the Lambda function will point to this base class FunctionHandlerAsync method.
+    /// </summary>
+    /// <typeparam name ="TStartup">The type containing the startup methods for the application.</typeparam>
+    public abstract class APIGatewayProxyFunction<TStartup> : APIGatewayProxyFunction where TStartup : class
+    {
+        /// <inheritdoc/>
+        protected override IWebHostBuilder CreateWebHostBuilder() =>
+            base.CreateWebHostBuilder().UseStartup<TStartup>();
+    }
+}

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction{TStartup}.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction{TStartup}.cs
@@ -13,5 +13,10 @@ namespace Amazon.Lambda.AspNetCoreServer
         /// <inheritdoc/>
         protected override IWebHostBuilder CreateWebHostBuilder() =>
             base.CreateWebHostBuilder().UseStartup<TStartup>();
+
+        /// <inheritdoc/>
+        protected override void Init(IWebHostBuilder builder)
+        {
+        }
     }
 }

--- a/Libraries/test/TestWebApp/Controllers/BinaryContentController.cs
+++ b/Libraries/test/TestWebApp/Controllers/BinaryContentController.cs
@@ -1,5 +1,5 @@
-using System.IO;
 using Microsoft.AspNetCore.Mvc;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace TestWebApp.Controllers
 {
@@ -14,7 +14,7 @@ namespace TestWebApp.Controllers
             for (int i = 0; i < bytes.Length; i++)
                 bytes[i] = (byte)i;
 
-            return base.File(bytes, LambdaFunction.BinaryContentType);
+            return base.File(bytes, Application.Octet);
         }
     }
 }

--- a/Libraries/test/TestWebApp/LambdaFunction.cs
+++ b/Libraries/test/TestWebApp/LambdaFunction.cs
@@ -1,19 +1,8 @@
-﻿using System.IO;
-
-using Amazon.Lambda.AspNetCoreServer;
-using Microsoft.AspNetCore.Hosting;
+﻿using Amazon.Lambda.AspNetCoreServer;
 
 namespace TestWebApp
 {
     public class LambdaFunction : APIGatewayProxyFunction<Startup>
     {
-        public const string BinaryContentType = "application/octet-stream";
-
-        protected override void Init(IWebHostBuilder builder)
-        {
-            builder
-                .UseApiGateway()
-                .UseContentRoot(Directory.GetCurrentDirectory());
-        }
     }
 }

--- a/Libraries/test/TestWebApp/LambdaFunction.cs
+++ b/Libraries/test/TestWebApp/LambdaFunction.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Hosting;
 
 namespace TestWebApp
 {
-    public class LambdaFunction : APIGatewayProxyFunction
+    public class LambdaFunction : APIGatewayProxyFunction<Startup>
     {
         public const string BinaryContentType = "application/octet-stream";
 
@@ -13,8 +13,7 @@ namespace TestWebApp
         {
             builder
                 .UseApiGateway()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseStartup<Startup>();
+                .UseContentRoot(Directory.GetCurrentDirectory());
         }
     }
 }


### PR DESCRIPTION
*Description of changes:*

Adds an inheritor of `APIGatewayProxyFunction` that allows specifying the application's startup type as a type parameter.

This largely mirrors the method `static IWebHostBuilder CreateDefaultBuilder<TStartup>(string[]) where TStartup : class` provided by ASP.NET Core, and is nice to have for the same reasons as that method is nice to have.

<sub>also corrects the name of the class in a comment</sub>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
