### PR TITLE
Adding support for content type image/jpg

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -67,6 +67,7 @@ namespace Amazon.Lambda.AspNetCoreServer
             ["image/png"] = ResponseContentEncoding.Base64,
             ["image/gif"] = ResponseContentEncoding.Base64,
             ["image/jpeg"] = ResponseContentEncoding.Base64,
+            ["image/jpg"] = ResponseContentEncoding.Base64,
             ["application/zip"] = ResponseContentEncoding.Base64,
             ["application/pdf"] = ResponseContentEncoding.Base64,
         };


### PR DESCRIPTION
Adding content type image/jpg as base64 into this _responseContentEncodingForContentType

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
