### PR TITLE
Included AWSProjectType to allow easy publishing

### DIFF
--- a/Blueprints/BlueprintDefinitions/Msbuild-NETCore_2_1/SimpleSQSFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/Msbuild-NETCore_2_1/SimpleSQSFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Right click "Publish to AWS Lambda..." doesn't seem to work in Visual Studio without this property in the .csproj


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
