### PR TITLE
Add Yaml CloudFormation support in Lambda Test Tool

### DIFF
--- a/Tools/LambdaTestTool/Amazon.Lambda.TestTool.Tests/DefaultsFileParseTests.cs
+++ b/Tools/LambdaTestTool/Amazon.Lambda.TestTool.Tests/DefaultsFileParseTests.cs
@@ -120,6 +120,25 @@ namespace Amazon.Lambda.TestTool.Tests
             Assert.Equal("ServerlessTemplateExample::ServerlessTemplateExample.Functions::ToUpper", configInfo.FunctionInfos[1].Handler);
 
         }
+        
+        [Fact]
+        public void LoadServerlessYamlTemplateConfig()
+        {
+            var defaultsFilePath = Path.GetFullPath(@"../../../../LambdaFunctions/ServerlessTemplateYamlExample/aws-lambda-tools-defaults.json");
+
+            var configInfo = LambdaDefaultsConfigFileParser.LoadFromFile(defaultsFilePath);
+            
+            Assert.Equal(2, configInfo.FunctionInfos.Count);
+            Assert.Equal("default", configInfo.AWSProfile);
+            Assert.Equal("us-west-2", configInfo.AWSRegion);
+            
+            Assert.Equal("MyHelloWorld", configInfo.FunctionInfos[0].Name);
+            Assert.Equal("ServerlessTemplateYamlExample::ServerlessTemplateYamlExample.Functions::HelloWorld", configInfo.FunctionInfos[0].Handler);
+            
+            Assert.Equal("MyToUpper", configInfo.FunctionInfos[1].Name);
+            Assert.Equal("ServerlessTemplateYamlExample::ServerlessTemplateYamlExample.Functions::ToUpper", configInfo.FunctionInfos[1].Handler);
+
+        }        
 
         private string WriteTempConfigFile(string json)
         {

--- a/Tools/LambdaTestTool/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -19,6 +19,9 @@
     <NoWarn>1701;1702;1591;1587;3021;NU5100</NoWarn>
   </PropertyGroup>  
   <ItemGroup>
+    <PackageReference Include="YamlDotNet.Signed" Version="5.2.1" />    
+  </ItemGroup>
+  <ItemGroup>
     <None Remove="WebTester\embedded-wwwroot\css\bootstrap.css" />
   </ItemGroup>
   <ItemGroup>

--- a/Tools/LambdaTestTool/LambdaFunctions/ServerlessTemplateExample/serverless.template
+++ b/Tools/LambdaTestTool/LambdaFunctions/ServerlessTemplateExample/serverless.template
@@ -36,7 +36,23 @@
             "Timeout" : 30,
             "Code" : {}
         }
-    }    
+    },
+    
+    "MissingHandler" : {
+           "Type" : "AWS::Lambda::Function",
+           "Properties" : {
+               "Role"    : null,
+               "Runtime" : "dotnetcore2.1",
+               "MemorySize" : 256,
+               "Timeout" : 30,
+               "Code" : {}
+           }
+       },
+                 
+    "MissingProperties" : {
+           "Type" : "AWS::Lambda::Function"
+           }
+       }
   },
 
   "Outputs" : {

--- a/Tools/LambdaTestTool/LambdaFunctions/ServerlessTemplateYamlExample/Functions.cs
+++ b/Tools/LambdaTestTool/LambdaFunctions/ServerlessTemplateYamlExample/Functions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+
+using Amazon;
+
+using Newtonsoft.Json;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+
+namespace ServerlessTemplateYamlExample
+{
+    public class Functions
+    {
+
+        /// <summary>
+        /// Default constructor that Lambda will invoke.
+        /// </summary>
+        public Functions()
+        {
+        }
+
+        public void HelloWorld(ILambdaContext context)
+        {
+            context.Logger.LogLine("Hello World Test");
+        }
+
+        public string ToUpper(string input, ILambdaContext context)
+        {
+            context.Logger.LogLine("Hello World Test");
+            return input?.ToUpper();
+        }
+    }
+}

--- a/Tools/LambdaTestTool/LambdaFunctions/ServerlessTemplateYamlExample/ServerlessTemplateYamlExample.csproj
+++ b/Tools/LambdaTestTool/LambdaFunctions/ServerlessTemplateYamlExample/ServerlessTemplateYamlExample.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.0.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.1.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="1.1.2" />
+
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+  </ItemGroup>
+
+
+</Project>

--- a/Tools/LambdaTestTool/LambdaFunctions/ServerlessTemplateYamlExample/aws-lambda-tools-defaults.json
+++ b/Tools/LambdaTestTool/LambdaFunctions/ServerlessTemplateYamlExample/aws-lambda-tools-defaults.json
@@ -1,0 +1,17 @@
+﻿{
+  "Information" : [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+    "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+
+    "dotnet lambda help",
+
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+
+  "profile":"default",
+  "region" : "us-west-2",
+  "configuration": "Release",
+  "framework": "netcoreapp2.1",
+  "s3-prefix": "ServerlessTemplateExample/",
+  "template": "serverless.yaml"
+}

--- a/Tools/LambdaTestTool/LambdaFunctions/ServerlessTemplateYamlExample/serverless.yaml
+++ b/Tools/LambdaTestTool/LambdaFunctions/ServerlessTemplateYamlExample/serverless.yaml
@@ -1,0 +1,36 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: An AWS Serverless Application.
+Globals:
+  Function:
+    Runtime: "dotnetcore2.1"
+Resources:
+  MyHelloWorld:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: ServerlessTemplateYamlExample::ServerlessTemplateYamlExample.Functions::HelloWorld
+      CodeUri: ''
+      MemorySize: 256
+      Timeout: 30
+      Policies:
+      - AWSLambdaBasicExecutionRole
+  MyToUpper:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: ServerlessTemplateYamlExample::ServerlessTemplateYamlExample.Functions::ToUpper
+      CodeUri: ''
+      MemorySize: 256
+      Timeout: 30
+      Policies:
+      - AWSLambdaBasicExecutionRole
+  MissingHandler:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ''
+      MemorySize: 256
+      Timeout: 30
+      Policies:
+      - AWSLambdaBasicExecutionRole
+  MissingProperties:
+    Type: AWS::Serverless::Function

--- a/Tools/LambdaTestTool/aws-lambda-test-tool.sln
+++ b/Tools/LambdaTestTool/aws-lambda-test-tool.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServerlessTemplateExample",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.Lambda.TestTool.ExternalCommands", "Amazon.Lambda.TestTool.ExternalCommands\Amazon.Lambda.TestTool.ExternalCommands.csproj", "{AC05A239-3AFB-4694-9FF8-B9A0DAE19144}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServerlessTemplateYamlExample", "LambdaFunctions\ServerlessTemplateYamlExample\ServerlessTemplateYamlExample.csproj", "{CB77D52D-5504-4639-9CAC-D4C1E4C81171}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -113,6 +115,18 @@ Global
 		{AC05A239-3AFB-4694-9FF8-B9A0DAE19144}.Release|x64.Build.0 = Release|Any CPU
 		{AC05A239-3AFB-4694-9FF8-B9A0DAE19144}.Release|x86.ActiveCfg = Release|Any CPU
 		{AC05A239-3AFB-4694-9FF8-B9A0DAE19144}.Release|x86.Build.0 = Release|Any CPU
+		{CB77D52D-5504-4639-9CAC-D4C1E4C81171}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB77D52D-5504-4639-9CAC-D4C1E4C81171}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB77D52D-5504-4639-9CAC-D4C1E4C81171}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CB77D52D-5504-4639-9CAC-D4C1E4C81171}.Debug|x64.Build.0 = Debug|Any CPU
+		{CB77D52D-5504-4639-9CAC-D4C1E4C81171}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CB77D52D-5504-4639-9CAC-D4C1E4C81171}.Debug|x86.Build.0 = Debug|Any CPU
+		{CB77D52D-5504-4639-9CAC-D4C1E4C81171}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB77D52D-5504-4639-9CAC-D4C1E4C81171}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB77D52D-5504-4639-9CAC-D4C1E4C81171}.Release|x64.ActiveCfg = Release|Any CPU
+		{CB77D52D-5504-4639-9CAC-D4C1E4C81171}.Release|x64.Build.0 = Release|Any CPU
+		{CB77D52D-5504-4639-9CAC-D4C1E4C81171}.Release|x86.ActiveCfg = Release|Any CPU
+		{CB77D52D-5504-4639-9CAC-D4C1E4C81171}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -122,6 +136,7 @@ Global
 		{69F67DCD-333A-4E9E-AB6D-54FF9D332496} = {FDA2AEAF-41B0-4D0E-9818-8CC64A09D72F}
 		{4D8D6053-60E5-4AC3-8740-22E811452CD9} = {FDA2AEAF-41B0-4D0E-9818-8CC64A09D72F}
 		{DAD2488C-F731-4719-A016-600BB5F25B48} = {FDA2AEAF-41B0-4D0E-9818-8CC64A09D72F}
+		{CB77D52D-5504-4639-9CAC-D4C1E4C81171} = {FDA2AEAF-41B0-4D0E-9818-8CC64A09D72F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CBB0C6E0-DAA0-490F-8F45-5D701EB7D0D2}


### PR DESCRIPTION
*Description of changes:*
Adds the ability to look for function definitions in Yaml based CloudFormation Templates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
