### PR TITLE
Add support for ALB in Amazon.Lambda.AspNetCoreServer 

### DIFF
--- a/Blueprints/BlueprintDefinitions/Msbuild-NETCore_2_1/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/LambdaEntryPoint.cs
+++ b/Blueprints/BlueprintDefinitions/Msbuild-NETCore_2_1/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/LambdaEntryPoint.cs
@@ -14,7 +14,10 @@ namespace BlueprintBaseName._1
     /// 
     /// BlueprintBaseName.1::BlueprintBaseName.1.LambdaEntryPoint::FunctionHandlerAsync
     /// </summary>
-    public class LambdaEntryPoint : Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction
+    public class LambdaEntryPoint :
+        // When using an ELB's Application Load Balancer as the event source change 
+        // the base class to Amazon.Lambda.AspNetCoreServer.ApplicationLoadBalancerFunction
+        Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction
     {
         /// <summary>
         /// The builder has configuration, logging and Amazon API Gateway already configured. The startup class

--- a/Blueprints/BlueprintDefinitions/Msbuild-NETCore_2_1/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/Msbuild-NETCore_2_1/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/Readme.md
@@ -19,11 +19,20 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
+### Configuring for Application Load Balancer ###
+
+To configure this project to handle requests from an Application Load Balancer instead of API Gateway change
+the base class of `LambdaEntryPoint` from `Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction` to 
+`Amazon.Lambda.AspNetCoreServer.ApplicationLoadBalancerFunction`.
+
 ### Project Files ###
 
 * serverless.template - an AWS CloudFormation Serverless Application Model template file for declaring your Serverless functions and other AWS resources
 * aws-lambda-tools-defaults.json - default argument settings for use with Visual Studio and command line deployment tools for AWS
-* LambdaEntryPoint.cs - class that derives from **Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction**. The code in this file bootstraps the ASP.NET Core hosting framework. The Lambda function is defined in the base class.
+* LambdaEntryPoint.cs - class that derives from **Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction**. The code in 
+this file bootstraps the ASP.NET Core hosting framework. The Lambda function is defined in the base class.
+Change the base class to **Amazon.Lambda.AspNetCoreServer.ApplicationLoadBalancerFunction** when using an 
+Application Load Balancer.
 * LocalEntryPoint.cs - for local development this contains the executable Main function which bootstraps the ASP.NET Core hosting framework with Kestrel, as for typical ASP.NET Core applications.
 * Startup.cs - usual ASP.NET Core Startup class used to configure the services ASP.NET Core will use.
 * web.config - used for local development.

--- a/Blueprints/BlueprintDefinitions/Msbuild-NETCore_2_1/AspNetCoreWebApp/template/src/BlueprintBaseName.1/LambdaEntryPoint.cs
+++ b/Blueprints/BlueprintDefinitions/Msbuild-NETCore_2_1/AspNetCoreWebApp/template/src/BlueprintBaseName.1/LambdaEntryPoint.cs
@@ -14,7 +14,10 @@ namespace BlueprintBaseName._1
     /// 
     /// BlueprintBaseName.1::BlueprintBaseName.1.LambdaEntryPoint::FunctionHandlerAsync
     /// </summary>
-    public class LambdaEntryPoint : Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction
+    public class LambdaEntryPoint :
+        // When using an ELB's Application Load Balancer as the event source change 
+        // the base class to Amazon.Lambda.AspNetCoreServer.ApplicationLoadBalancerFunction
+        Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction
     {
         /// <summary>
         /// The builder has configuration, logging and Amazon API Gateway already configured. The startup class

--- a/Blueprints/BlueprintDefinitions/Msbuild-NETCore_2_1/AspNetCoreWebApp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/Msbuild-NETCore_2_1/AspNetCoreWebApp/template/src/BlueprintBaseName.1/Readme.md
@@ -18,11 +18,20 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
+### Configuring for Application Load Balancer ###
+
+To configure this project to handle requests from an Application Load Balancer instead of API Gateway change
+the base class of `LambdaEntryPoint` from `Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction` to 
+`Amazon.Lambda.AspNetCoreServer.ApplicationLoadBalancerFunction`.
+
 ### Project Files ###
 
 * serverless.template - an AWS CloudFormation Serverless Application Model template file for declaring your Serverless functions and other AWS resources
 * aws-lambda-tools-defaults.json - default argument settings for use with Visual Studio and command line deployment tools for AWS
-* LambdaEntryPoint.cs - class that derives from **Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction**. The code in this file bootstraps the ASP.NET Core hosting framework. The Lambda function is defined in the base class.
+* LambdaEntryPoint.cs - class that derives from **Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction**. The code in 
+this file bootstraps the ASP.NET Core hosting framework. The Lambda function is defined in the base class.
+Change the base class to **Amazon.Lambda.AspNetCoreServer.ApplicationLoadBalancerFunction** when using an 
+Application Load Balancer.
 * LocalEntryPoint.cs - for local development this contains the executable Main function which bootstraps the ASP.NET Core hosting framework with Kestrel, as for typical ASP.NET Core applications.
 * Startup.cs - usual ASP.NET Core Startup class used to configure the services ASP.NET Core will use.
 

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -1,108 +1,66 @@
-﻿using Amazon.Lambda.APIGatewayEvents;
-using Amazon.Lambda.AspNetCoreServer.Internal;
-using Amazon.Lambda.Core;
-using Microsoft.AspNetCore;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Hosting.Internal;
-using Microsoft.AspNetCore.Http.Features;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Primitives;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net;
-using System.Reflection;
 using System.Security.Claims;
 using System.Text;
-using System.Text.Encodings.Web;
-using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Hosting.Internal;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.AspNetCoreServer.Internal;
+
 
 namespace Amazon.Lambda.AspNetCoreServer
 {
     /// <summary>
-    /// ApiGatewayProxyFunction is the base class that is implemented in a ASP.NET Core Web API. The derived class implements
-    /// the Init method similar to Main function in the ASP.NET Core. The function handler for the Lambda function will point
+    /// APIGatewayProxyFunction is the base class for Lambda functions hosting the ASP.NET Core framework and exposed to the web via API Gateway.
+    /// 
+    /// The derived class implements the Init method similar to Main function in the ASP.NET Core. The function handler for the Lambda function will point
     /// to this base class FunctionHandlerAsync method.
     /// </summary>
-    public abstract class APIGatewayProxyFunction
+    public abstract class APIGatewayProxyFunction : AbstractAspNetCoreFunction<APIGatewayProxyRequest, APIGatewayProxyResponse>
     {
         /// <summary>
         /// Key to access the ILambdaContext object from the HttpContext.Items collection.
         /// </summary>
-        public const string LAMBDA_CONTEXT = "LambdaContext";
+        [Obsolete("References should be updated to Amazon.Lambda.AspNetCoreServer.AbstractAspNetCoreFunction.LAMBDA_CONTEXT")]
+        public new const string LAMBDA_CONTEXT = AbstractAspNetCoreFunction.LAMBDA_CONTEXT;
 
         /// <summary>
         /// Key to access the APIGatewayProxyRequest object from the HttpContext.Items collection.
         /// </summary>
-        public const string APIGATEWAY_REQUEST = "APIGatewayRequest";
+        [Obsolete("References should be updated to Amazon.Lambda.AspNetCoreServer.AbstractAspNetCoreFunction.LAMBDA_REQUEST_OBJECT")]
+        public const string APIGATEWAY_REQUEST = AbstractAspNetCoreFunction.LAMBDA_REQUEST_OBJECT;
 
-        private AspNetCoreStartupMode _startupMode;
-        private IWebHost _host;
-        private APIGatewayServer _server;
-        private ILogger _logger;
 
-        // Defines a mapping from registered content types to the response encoding format
-        // which dictates what transformations should be applied before returning response content
-        private Dictionary<string, ResponseContentEncoding> _responseContentEncodingForContentType = new Dictionary<string, ResponseContentEncoding>
-        {
-            // The complete list of registered MIME content-types can be found at:
-            //    http://www.iana.org/assignments/media-types/media-types.xhtml
-
-            // Here we just include a few commonly used content types found in
-            // Web API responses and allow users to add more as needed below
-
-            ["text/plain"] = ResponseContentEncoding.Default,
-            ["text/xml"] = ResponseContentEncoding.Default,
-            ["application/xml"] = ResponseContentEncoding.Default,
-            ["application/json"] = ResponseContentEncoding.Default,
-            ["text/html"] = ResponseContentEncoding.Default,
-            ["text/css"] = ResponseContentEncoding.Default,
-            ["text/javascript"] = ResponseContentEncoding.Default,
-            ["text/ecmascript"] = ResponseContentEncoding.Default,
-            ["text/markdown"] = ResponseContentEncoding.Default,
-            ["text/csv"] = ResponseContentEncoding.Default,
-
-            ["application/octet-stream"] = ResponseContentEncoding.Base64,
-            ["image/png"] = ResponseContentEncoding.Base64,
-            ["image/gif"] = ResponseContentEncoding.Base64,
-            ["image/jpeg"] = ResponseContentEncoding.Base64,
-            ["image/jpg"] = ResponseContentEncoding.Base64,
-            ["application/zip"] = ResponseContentEncoding.Base64,
-            ["application/pdf"] = ResponseContentEncoding.Base64,
-        };
-
-        // Manage the serialization so the raw requests and responses can be logged.
-        ILambdaSerializer _serializer = new Amazon.Lambda.Serialization.Json.JsonSerializer();
-
-        /// <summary>
-        /// Defines the default treatment of response content.
-        /// </summary>
-        public ResponseContentEncoding DefaultResponseContentEncoding { get; set; } = ResponseContentEncoding.Default;
 
         /// <summary>
         /// The modes for when the ASP.NET Core framework will be initialized.
         /// </summary>
+        [Obsolete("References should be updated to Amazon.Lambda.AspNetCoreServer.StartupMode")]
         public enum AspNetCoreStartupMode
         {
             /// <summary>
             /// Initialize during the construction of APIGatewayProxyFunction
             /// </summary>
-            Constructor,
+            Constructor = StartupMode.Constructor,
 
             /// <summary>
             /// Initialize during the first incoming request
             /// </summary>
-            FirstRequest
+            FirstRequest = StartupMode.FirstRequest
         }
 
         /// <summary>
         /// Default Constructor. The ASP.NET Core Framework will be initialized as part of the construction.
         /// </summary>
         protected APIGatewayProxyFunction()
-            : this(AspNetCoreStartupMode.Constructor)
+            : base()
         {
 
         }
@@ -111,342 +69,41 @@ namespace Amazon.Lambda.AspNetCoreServer
         /// 
         /// </summary>
         /// <param name="startupMode">Configure when the ASP.NET Core framework will be initialized</param>
+        [Obsolete("Calls to the constructor should be replaced with the constructor that takes a Amazon.Lambda.AspNetCoreServer.StartupMode as the parameter.")]
         protected APIGatewayProxyFunction(AspNetCoreStartupMode startupMode)
+            : base((StartupMode)startupMode)
         {
-            _startupMode = startupMode;
 
-            if (_startupMode == AspNetCoreStartupMode.Constructor)
-            {
-                Start();
-            }
-        }
-
-        private bool IsStarted
-        {
-            get
-            {
-                return _server != null;
-            }
         }
 
         /// <summary>
-        /// Should be called in the derived constructor 
+        /// 
         /// </summary>
-        protected void Start()
+        /// <param name="startupMode">Configure when the ASP.NET Core framework will be initialized</param>
+        protected APIGatewayProxyFunction(StartupMode startupMode)
+            : base(startupMode)
         {
-            var builder = CreateWebHostBuilder();
-            Init(builder);
 
-
-            _host = builder.Build();
-            _host.Start();
-
-            _server = _host.Services.GetService(typeof(Microsoft.AspNetCore.Hosting.Server.IServer)) as APIGatewayServer;
-            if (_server == null)
-            {
-                throw new Exception("Failed to find the implementation APIGatewayServer for the IServer registration. This can happen if UseApiGateway was not called.");
-            }
-            _logger = ActivatorUtilities.CreateInstance<Logger<APIGatewayProxyFunction>>(this._host.Services);
         }
 
-        /// <summary>
-        /// Method to initialize the web builder before starting the web host. In a typical Web API this is similar to the main function. 
-        /// Setting the Startup class is required in this method.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// protected override void Init(IWebHostBuilder builder)
-        /// {
-        ///     builder
-        ///         .UseStartup&lt;Startup&gt;();
-        /// }
-        /// </code>
-        /// </example>
-        /// <param name="builder"></param>
-        protected abstract void Init(IWebHostBuilder builder);
 
-        /// <summary>
-        /// Creates the IWebHostBuilder similar to WebHost.CreateDefaultBuilder but replacing the registration of the Kestrel web server with a 
-        /// registration for ApiGateway.
-        /// </summary>
-        /// <returns></returns>
-        protected virtual IWebHostBuilder CreateWebHostBuilder()
+        private protected override void InternalPostCreateContext(HostingApplication.Context context, APIGatewayProxyRequest apiGatewayRequest, ILambdaContext lambdaContext)
         {
-            var builder = new WebHostBuilder()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .ConfigureAppConfiguration((hostingContext, config) =>
-                {
-                    var env = hostingContext.HostingEnvironment;
-
-                    config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                          .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true);
-
-                    if (env.IsDevelopment())
-                    {
-                        var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
-                        if (appAssembly != null)
-                        {
-                            config.AddUserSecrets(appAssembly, optional: true);
-                        }
-                    }
-
-                    config.AddEnvironmentVariables();
-                })
-                .ConfigureLogging((hostingContext, logging) =>
-                {
-                    if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("LAMBDA_TASK_ROOT")))
-                    {
-                        logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
-                        logging.AddConsole();
-                        logging.AddDebug();
-                    }
-                    else
-                    {
-                        logging.AddLambdaLogger(hostingContext.Configuration, "Logging");
-                    }
-                })
-                .UseDefaultServiceProvider((hostingContext, options) =>
-                {
-                    options.ValidateScopes = hostingContext.HostingEnvironment.IsDevelopment();
-                })
-                .UseApiGateway();
-
-
-            return builder;
-        }
-
-        /// <summary>
-        /// This method is what the Lambda function handler points to.
-        /// </summary>
-        /// <param name="request"></param>
-        /// <param name="lambdaContext"></param>
-        /// <returns></returns>
-        [LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
-        public virtual async Task<APIGatewayProxyResponse> FunctionHandlerAsync(APIGatewayProxyRequest request, ILambdaContext lambdaContext)
-        {
-            if (!IsStarted)
+            if (apiGatewayRequest?.RequestContext?.Authorizer?.Claims != null)
             {
-                Start();
-            }
-            _logger.LogDebug($"Incoming {request.HttpMethod} requests to {request.Path}");
-
-            InvokeFeatures features = new InvokeFeatures();
-            MarshallRequest(features, request, lambdaContext);
-            _logger.LogDebug($"ASP.NET Core Request PathBase: {((IHttpRequestFeature)features).PathBase}, Path: {((IHttpRequestFeature)features).Path}");
-
-            var context = this.CreateContext(features);
-
-            if (request?.RequestContext?.Authorizer?.Claims != null)
-            {
-                var identity = new ClaimsIdentity(request.RequestContext.Authorizer.Claims.Select(
+                var identity = new ClaimsIdentity(apiGatewayRequest.RequestContext.Authorizer.Claims.Select(
                     entry => new Claim(entry.Key, entry.Value.ToString())), "AuthorizerIdentity");
 
-                _logger.LogDebug($"Configuring HttpContext.User with {request.RequestContext.Authorizer.Claims.Count} claims coming from API Gateway's Request Context");
+                _logger.LogDebug($"Configuring HttpContext.User with {apiGatewayRequest.RequestContext.Authorizer.Claims.Count} claims coming from API Gateway's Request Context");
                 context.HttpContext.User = new ClaimsPrincipal(identity);
             }
-
-            // Add along the Lambda objects to the HttpContext to give access to Lambda to them in the ASP.NET Core application
-            context.HttpContext.Items[LAMBDA_CONTEXT] = lambdaContext;
-            context.HttpContext.Items[APIGATEWAY_REQUEST] = request;
-
-            // Allow the context to be customized before passing the request to ASP.NET Core.
-            PostCreateContext(context, request, lambdaContext);
-
-            var response = await this.ProcessRequest(lambdaContext, context, features);
-
-            return response;
         }
 
-        /// <summary>
-        /// Registers a mapping from a MIME content type to a <see cref="ResponseContentEncoding"/>.
-        /// </summary>
-        /// <remarks>
-        /// The mappings in combination with the <see cref="DefaultResponseContentEncoding"/>
-        /// setting will dictate if and how response content should be transformed before being
-        /// returned to the calling API Gateway instance.
-        /// <para>
-        /// The interface between the API Gateway and Lambda provides for repsonse content to
-        /// be returned as a UTF-8 string.  In order to return binary content without incurring
-        /// any loss or corruption due to transformations to the UTF-8 encoding, it is necessary
-        /// to encode the raw response content in Base64 and to annotate the response that it is
-        /// Base64-encoded.
-        /// </para><para>
-        /// <b>NOTE:</b>  In order to use this mechanism to return binary response content, in
-        /// addition to registering here any binary MIME content types that will be returned by
-        /// your application, it also necessary to register those same content types with the API
-        /// Gateway using either the console or the REST interface. Check the developer guide for
-        /// further information.
-        /// http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings-configure-with-console.html
-        /// http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings-configure-with-control-service-api.html
-        /// </para>
-        /// </remarks>
-        public void RegisterResponseContentEncodingForContentType(string contentType, ResponseContentEncoding encoding)
+        private protected override void InternalCustomResponseExceptionHandling(HostingApplication.Context context, APIGatewayProxyResponse apiGatewayResponse, ILambdaContext lambdaContext, Exception ex)
         {
-            _responseContentEncodingForContentType[contentType] = encoding;
+            apiGatewayResponse.Headers.Add(new KeyValuePair<string, string>("ErrorType", ex.GetType().Name));
         }
 
-        /// <summary>
-        /// Creates a <see cref="HostingApplication.Context"/> object using the <see cref="APIGatewayServer"/> field in the class.
-        /// </summary>
-        /// <param name="features"><see cref="IFeatureCollection"/> implementation.</param>
-        protected HostingApplication.Context CreateContext(IFeatureCollection features)
-        {
-            return _server.Application.CreateContext(features);
-        }
-
-        /// <summary>
-        /// Processes the current request.
-        /// </summary>
-        /// <param name="lambdaContext"><see cref="ILambdaContext"/> implementation.</param>
-        /// <param name="context">The hosting application request context object.</param>
-        /// <param name="features">An <see cref="InvokeFeatures"/> instance.</param>
-        /// <param name="rethrowUnhandledError">
-        /// If specified, an unhandled exception will be rethrown for custom error handling.
-        /// Ensure that the error handling code calls 'this.MarshallResponse(features, 500);' after handling the error to return a <see cref="APIGatewayProxyResponse"/> to the user.
-        /// </param>
-        protected async Task<APIGatewayProxyResponse> ProcessRequest(ILambdaContext lambdaContext, HostingApplication.Context context, InvokeFeatures features, bool rethrowUnhandledError = false)
-        {
-            var defaultStatusCode = 200;
-            Exception ex = null;
-            try
-            {
-                await this._server.Application.ProcessRequestAsync(context);
-            }
-            catch (AggregateException agex)
-            {
-                ex = agex;
-                _logger.LogError($"Caught AggregateException: '{agex}'");
-                var sb = new StringBuilder();
-                foreach (var newEx in agex.InnerExceptions)
-                {
-                    sb.AppendLine(this.ErrorReport(newEx));
-                }
-
-                _logger.LogError(sb.ToString());
-                defaultStatusCode = 500;
-            }
-            catch (ReflectionTypeLoadException rex)
-            {
-                ex = rex;
-                _logger.LogError($"Caught ReflectionTypeLoadException: '{rex}'");
-                var sb = new StringBuilder();
-                foreach (var loaderException in rex.LoaderExceptions)
-                {
-                    var fileNotFoundException = loaderException as FileNotFoundException;
-                    if (fileNotFoundException != null && !string.IsNullOrEmpty(fileNotFoundException.FileName))
-                    {
-                        sb.AppendLine($"Missing file: {fileNotFoundException.FileName}");
-                    }
-                    else
-                    {
-                        sb.AppendLine(this.ErrorReport(loaderException));
-                    }
-                }
-
-                _logger.LogError(sb.ToString());
-                defaultStatusCode = 500;
-            }
-            catch (Exception e)
-            {
-                ex = e;
-                if (rethrowUnhandledError) throw;
-                _logger.LogError($"Unknown error responding to request: {this.ErrorReport(e)}");
-                defaultStatusCode = 500;
-            }
-            finally
-            {
-                this._server.Application.DisposeContext(context, ex);
-            }
-
-            if(features.ResponseStartingEvents != null)
-            {
-                await features.ResponseStartingEvents.ExecuteAsync();
-            }
-            var response = this.MarshallResponse(features, lambdaContext, defaultStatusCode);
-
-            _logger.LogDebug($"Response Base 64 Encoded: {response.IsBase64Encoded}");
-
-            if (ex != null)
-                response.Headers.Add(new KeyValuePair<string, string>("ErrorType", ex.GetType().Name));
-
-            if (features.ResponseCompletedEvents != null)
-            {
-                await features.ResponseCompletedEvents.ExecuteAsync();
-            }
-
-            return response;
-        }
-
-        /// <summary>
-        /// Formats an Exception into a string, including all inner exceptions.
-        /// </summary>
-        /// <param name="e"><see cref="Exception"/> instance.</param>
-        protected string ErrorReport(Exception e)
-        {
-            var sb = new StringBuilder();
-            sb.AppendLine($"{e.GetType().Name}:\n{e}");
-
-            Exception inner = e;
-            while (inner != null)
-            {
-                // Append the messages to the StringBuilder.
-                sb.AppendLine($"{inner.GetType().Name}:\n{inner}");
-                inner = inner.InnerException;
-            }
-
-            return sb.ToString();
-        }
-
-        /// <summary>
-        /// This method is called after the APIGatewayProxyFunction has marshalled the incoming API Gateway request
-        /// into ASP.NET Core's IHttpRequestFeature. Derived classes can overwrite this method to alter
-        /// the how the marshalling was done.
-        /// </summary>
-        /// <param name="aspNetCoreRequestFeature"></param>
-        /// <param name="apiGatewayRequest"></param>
-        /// <param name="lambdaContext"></param>
-        protected virtual void PostMarshallRequestFeature(IHttpRequestFeature aspNetCoreRequestFeature, APIGatewayProxyRequest apiGatewayRequest, ILambdaContext lambdaContext)
-        {
-
-        }
-
-        /// <summary>
-        /// This method is called after the APIGatewayProxyFunction has marshalled the incoming API Gateway request
-        /// into ASP.NET Core's IHttpConnectionFeature. Derived classes can overwrite this method to alter
-        /// the how the marshalling was done.
-        /// </summary>
-        /// <param name="aspNetCoreConnectionFeature"></param>
-        /// <param name="apiGatewayRequest"></param>
-        /// <param name="lambdaContext"></param>
-        protected virtual void PostMarshallConnectionFeature(IHttpConnectionFeature aspNetCoreConnectionFeature, APIGatewayProxyRequest apiGatewayRequest, ILambdaContext lambdaContext)
-        {
-
-        }
-
-        /// <summary>
-        /// This method is called after the APIGatewayProxyFunction has marshalled IHttpResponseFeature that came
-        /// back from making the request into ASP.NET Core into API Gateway's response object APIGatewayProxyResponse. Derived classes can overwrite this method to alter
-        /// the how the marshalling was done.
-        /// </summary>
-        /// <param name="aspNetCoreResponseFeature"></param>
-        /// <param name="apiGatewayResponse"></param>
-        /// <param name="lambdaContext"></param>
-        protected virtual void PostMarshallResponseFeature(IHttpResponseFeature aspNetCoreResponseFeature, APIGatewayProxyResponse apiGatewayResponse, ILambdaContext lambdaContext)
-        {
-
-        }
-
-        /// <summary>
-        /// This method is called after the HostingApplication.Context has been created. Derived classes can overwrite this method to alter
-        /// the context before passing the request to ASP.NET Core to process the request.
-        /// </summary>
-        /// <param name="context"></param>
-        /// <param name="apiGatewayRequest"></param>
-        /// <param name="lambdaContext"></param>
-        protected virtual void PostCreateContext(HostingApplication.Context context, APIGatewayProxyRequest apiGatewayRequest, ILambdaContext lambdaContext)
-        {
-
-        }
 
         /// <summary>
         /// Convert the JSON document received from API Gateway into the InvokeFeatures object.
@@ -455,7 +112,7 @@ namespace Amazon.Lambda.AspNetCoreServer
         /// <param name="features"></param>
         /// <param name="apiGatewayRequest"></param>
         /// <param name="lambdaContext"></param>
-        protected void MarshallRequest(InvokeFeatures features, APIGatewayProxyRequest apiGatewayRequest, ILambdaContext lambdaContext)
+        protected override void MarshallRequest(InvokeFeatures features, APIGatewayProxyRequest apiGatewayRequest, ILambdaContext lambdaContext)
         {
             {
                 var requestFeatures = (IHttpRequestFeature)features;
@@ -546,16 +203,7 @@ namespace Amazon.Lambda.AspNetCoreServer
 
                 if (!string.IsNullOrEmpty(apiGatewayRequest.Body))
                 {
-                    Byte[] binaryBody;
-                    if (apiGatewayRequest.IsBase64Encoded)
-                    {
-                        binaryBody = Convert.FromBase64String(apiGatewayRequest.Body);
-                    }
-                    else
-                    {
-                        binaryBody = UTF8Encoding.UTF8.GetBytes(apiGatewayRequest.Body);
-                    }
-                    requestFeatures.Body = new MemoryStream(binaryBody);
+                    requestFeatures.Body = Utilities.ConvertLambdaRequestBodyToAspNetCoreBody(apiGatewayRequest.Body, apiGatewayRequest.IsBase64Encoded);
                 }
 
                 // Call consumers customize method in case they want to change how API Gateway's request
@@ -568,9 +216,8 @@ namespace Amazon.Lambda.AspNetCoreServer
                 // set up connection features
                 var connectionFeatures = (IHttpConnectionFeature)features;
 
-                IPAddress remoteIpAddress;
                 if (!string.IsNullOrEmpty(apiGatewayRequest?.RequestContext?.Identity?.SourceIp) &&
-                    IPAddress.TryParse(apiGatewayRequest.RequestContext.Identity.SourceIp, out remoteIpAddress))
+                    IPAddress.TryParse(apiGatewayRequest.RequestContext.Identity.SourceIp, out var remoteIpAddress))
                 {
                     connectionFeatures.RemoteIpAddress = remoteIpAddress;
                 }
@@ -595,7 +242,7 @@ namespace Amazon.Lambda.AspNetCoreServer
         /// <param name="statusCodeIfNotSet">Sometimes the ASP.NET server doesn't set the status code correctly when successful, so this parameter will be used when the value is 0.</param>
         /// <param name="lambdaContext"></param>
         /// <returns><see cref="APIGatewayProxyResponse"/></returns>
-        protected APIGatewayProxyResponse MarshallResponse(IHttpResponseFeature responseFeatures, ILambdaContext lambdaContext, int statusCodeIfNotSet = 200)
+        protected override APIGatewayProxyResponse MarshallResponse(IHttpResponseFeature responseFeatures, ILambdaContext lambdaContext, int statusCodeIfNotSet = 200)
         {
             var response = new APIGatewayProxyResponse
             {
@@ -635,53 +282,14 @@ namespace Amazon.Lambda.AspNetCoreServer
             if (responseFeatures.Body != null)
             {
                 // Figure out how we should treat the response content
-                var rcEncoding = DefaultResponseContentEncoding;
-                if (contentType != null)
-                {
-                    // ASP.NET Core will typically return content type with encoding like this "application/json; charset=utf-8"
-                    // To find the content type in the dictionary we need to strip the encoding off.
-                    var contentTypeWithoutEncoding = contentType.Split(';')[0].Trim();
-                    if (_responseContentEncodingForContentType.ContainsKey(contentTypeWithoutEncoding))
-                    {
-                        rcEncoding = _responseContentEncodingForContentType[contentTypeWithoutEncoding];
-                    }
-                }
+                var rcEncoding = GetResponseContentEncodingForContentType(contentType);
 
-                // Do we encode the response content in Base64 or treat it as UTF-8
-                if (rcEncoding == ResponseContentEncoding.Base64)
-                {
-                    // We want to read the response content "raw" and then Base64 encode it
-                    byte[] bodyBytes;
-                    if (responseFeatures.Body is MemoryStream)
-                    {
-                        bodyBytes = ((MemoryStream)responseFeatures.Body).ToArray();
-                    }
-                    else
-                    {
-                        using (var ms = new MemoryStream())
-                        {
-                            responseFeatures.Body.CopyTo(ms);
-                            bodyBytes = ms.ToArray();
-                        }
-                    }
-                    response.Body = Convert.ToBase64String(bodyBytes);
-                    response.IsBase64Encoded = true;
-                }
-                else if (responseFeatures.Body is MemoryStream)
-                {
-                    response.Body = UTF8Encoding.UTF8.GetString(((MemoryStream)responseFeatures.Body).ToArray());
-                }
-                else
-                {
-                    responseFeatures.Body.Position = 0;
-                    using (StreamReader reader = new StreamReader(responseFeatures.Body, Encoding.UTF8))
-                    {
-                        response.Body = reader.ReadToEnd();
-                    }
-                }
+                (response.Body, response.IsBase64Encoded) = Utilities.ConvertAspNetCoreBodyToLambdaBody(responseFeatures.Body, rcEncoding);
             }
 
             PostMarshallResponseFeature(responseFeatures, response, lambdaContext);
+
+            _logger.LogDebug($"Response Base 64 Encoded: {response.IsBase64Encoded}");
 
             return response;
         }

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -174,7 +174,7 @@ namespace Amazon.Lambda.AspNetCoreServer
                         {
                             sb.Append("&");
                         }
-                        sb.Append($"{WebUtility.UrlEncode(kvp.Key)}={WebUtility.UrlEncode(kvp.Value.ToString())}");
+                        sb.Append(Utilities.CreateQueryStringParameter(kvp.Key, kvp.Value.ToString()));
                     }
                     requestFeatures.QueryString = sb.ToString();
                 }

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
@@ -1,0 +1,468 @@
+﻿using Amazon.Lambda.AspNetCoreServer.Internal;
+using Amazon.Lambda.Core;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Internal;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Amazon.Lambda.AspNetCoreServer
+{
+    public abstract class AbstractAspNetCoreFunction
+    {
+        /// <summary>
+        /// Key to access the ILambdaContext object from the HttpContext.Items collection.
+        /// </summary>
+        public const string LAMBDA_CONTEXT = "LambdaContext";
+
+        /// <summary>
+        /// Key to access the Lambda request object from the HttpContext.Items collection. The object
+        /// can be either APIGatewayProxyRequest or ApplicationLoadBalancerRequest depending on the source of the event.
+        /// </summary>
+        public const string LAMBDA_REQUEST_OBJECT = "LambdaRequestObject";
+    }
+
+    public abstract class AbstractAspNetCoreFunction<TREQUEST, TRESPONSE> : AbstractAspNetCoreFunction
+    {
+        private protected IWebHost _host;
+        private protected LambdaServer _server;
+        private protected ILogger _logger;
+        private protected StartupMode _startupMode;
+
+        // Defines a mapping from registered content types to the response encoding format
+        // which dictates what transformations should be applied before returning response content
+        private Dictionary<string, ResponseContentEncoding> _responseContentEncodingForContentType = new Dictionary<string, ResponseContentEncoding>
+        {
+            // The complete list of registered MIME content-types can be found at:
+            //    http://www.iana.org/assignments/media-types/media-types.xhtml
+
+            // Here we just include a few commonly used content types found in
+            // Web API responses and allow users to add more as needed below
+
+            ["text/plain"] = ResponseContentEncoding.Default,
+            ["text/xml"] = ResponseContentEncoding.Default,
+            ["application/xml"] = ResponseContentEncoding.Default,
+            ["application/json"] = ResponseContentEncoding.Default,
+            ["text/html"] = ResponseContentEncoding.Default,
+            ["text/css"] = ResponseContentEncoding.Default,
+            ["text/javascript"] = ResponseContentEncoding.Default,
+            ["text/ecmascript"] = ResponseContentEncoding.Default,
+            ["text/markdown"] = ResponseContentEncoding.Default,
+            ["text/csv"] = ResponseContentEncoding.Default,
+
+            ["application/octet-stream"] = ResponseContentEncoding.Base64,
+            ["image/png"] = ResponseContentEncoding.Base64,
+            ["image/gif"] = ResponseContentEncoding.Base64,
+            ["image/jpeg"] = ResponseContentEncoding.Base64,
+            ["image/jpg"] = ResponseContentEncoding.Base64,
+            ["application/zip"] = ResponseContentEncoding.Base64,
+            ["application/pdf"] = ResponseContentEncoding.Base64,
+        };
+
+        /// <summary>
+        /// Default Constructor. The ASP.NET Core Framework will be initialized as part of the construction.
+        /// </summary>
+        protected AbstractAspNetCoreFunction()
+            : this(StartupMode.Constructor)
+        {
+
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="startupMode">Configure when the ASP.NET Core framework will be initialized</param>
+        protected AbstractAspNetCoreFunction(StartupMode startupMode)
+        {
+            _startupMode = startupMode;
+
+            if (_startupMode == StartupMode.Constructor)
+            {
+                Start();
+            }
+        }
+
+        /// <summary>
+        /// Defines the default treatment of response content.
+        /// </summary>
+        public ResponseContentEncoding DefaultResponseContentEncoding { get; set; } = ResponseContentEncoding.Default;
+
+        /// <summary>
+        /// Registers a mapping from a MIME content type to a <see cref="ResponseContentEncoding"/>.
+        /// </summary>
+        /// <remarks>
+        /// The mappings in combination with the <see cref="DefaultResponseContentEncoding"/>
+        /// setting will dictate if and how response content should be transformed before being
+        /// returned to the calling API Gateway instance.
+        /// <para>
+        /// The interface between the API Gateway and Lambda provides for repsonse content to
+        /// be returned as a UTF-8 string.  In order to return binary content without incurring
+        /// any loss or corruption due to transformations to the UTF-8 encoding, it is necessary
+        /// to encode the raw response content in Base64 and to annotate the response that it is
+        /// Base64-encoded.
+        /// </para><para>
+        /// <b>NOTE:</b>  In order to use this mechanism to return binary response content, in
+        /// addition to registering here any binary MIME content types that will be returned by
+        /// your application, it also necessary to register those same content types with the API
+        /// Gateway using either the console or the REST interface. Check the developer guide for
+        /// further information.
+        /// http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings-configure-with-console.html
+        /// http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings-configure-with-control-service-api.html
+        /// </para>
+        /// </remarks>
+        public void RegisterResponseContentEncodingForContentType(string contentType, ResponseContentEncoding encoding)
+        {
+            _responseContentEncodingForContentType[contentType] = encoding;
+        }
+
+
+        /// <summary>
+        /// Method to initialize the web builder before starting the web host. In a typical Web API this is similar to the main function. 
+        /// Setting the Startup class is required in this method.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// protected override void Init(IWebHostBuilder builder)
+        /// {
+        ///     builder
+        ///         .UseStartup&lt;Startup&gt;();
+        /// }
+        /// </code>
+        /// </example>
+        /// <param name="builder"></param>
+        protected abstract void Init(IWebHostBuilder builder);
+
+        /// <summary>
+        /// Creates the IWebHostBuilder similar to WebHost.CreateDefaultBuilder but replacing the registration of the Kestrel web server with a 
+        /// registration for Lambda.
+        /// </summary>
+        /// <returns></returns>
+        protected virtual IWebHostBuilder CreateWebHostBuilder()
+        {
+            var builder = new WebHostBuilder()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .ConfigureAppConfiguration((hostingContext, config) =>
+                {
+                    var env = hostingContext.HostingEnvironment;
+
+                    config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                          .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true);
+
+                    if (env.IsDevelopment())
+                    {
+                        var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
+                        if (appAssembly != null)
+                        {
+                            config.AddUserSecrets(appAssembly, optional: true);
+                        }
+                    }
+
+                    config.AddEnvironmentVariables();
+                })
+                .ConfigureLogging((hostingContext, logging) =>
+                {
+                    if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("LAMBDA_TASK_ROOT")))
+                    {
+                        logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
+                        logging.AddConsole();
+                        logging.AddDebug();
+                    }
+                    else
+                    {
+                        logging.AddLambdaLogger(hostingContext.Configuration, "Logging");
+                    }
+                })
+                .UseDefaultServiceProvider((hostingContext, options) =>
+                {
+                    options.ValidateScopes = hostingContext.HostingEnvironment.IsDevelopment();
+                })
+                .UseLambdaServer();
+
+
+            return builder;
+        }
+
+        private protected bool IsStarted
+        {
+            get
+            {
+                return _server != null;
+            }
+        }
+
+        /// <summary>
+        /// Should be called in the derived constructor 
+        /// </summary>
+        protected void Start()
+        {
+            var builder = CreateWebHostBuilder();
+            Init(builder);
+
+
+            _host = builder.Build();
+            _host.Start();
+
+            _server = _host.Services.GetService(typeof(Microsoft.AspNetCore.Hosting.Server.IServer)) as LambdaServer;
+            if (_server == null)
+            {
+                throw new Exception("Failed to find the implementation Lambda for the IServer registration. This can happen if UseApiGateway was not called.");
+            }
+            _logger = ActivatorUtilities.CreateInstance<Logger<APIGatewayProxyFunction>>(this._host.Services);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="HostingApplication.Context"/> object using the <see cref="LambdaServer"/> field in the class.
+        /// </summary>
+        /// <param name="features"><see cref="IFeatureCollection"/> implementation.</param>
+        protected HostingApplication.Context CreateContext(IFeatureCollection features)
+        {
+            return _server.Application.CreateContext(features);
+        }
+
+        /// <summary>
+        /// Gets the response content encoding for a content type.
+        /// </summary>
+        /// <param name="contentType"></param>
+        /// <returns></returns>
+        public ResponseContentEncoding GetResponseContentEncodingForContentType(string contentType)
+        {
+            if (string.IsNullOrEmpty(contentType))
+            {
+                return DefaultResponseContentEncoding;
+            }
+
+            // ASP.NET Core will typically return content type with encoding like this "application/json; charset=utf-8"
+            // To find the content type in the dictionary we need to strip the encoding off.
+            var contentTypeWithoutEncoding = contentType.Split(';')[0].Trim();
+            if (_responseContentEncodingForContentType.ContainsKey(contentTypeWithoutEncoding))
+            {
+                return _responseContentEncodingForContentType[contentTypeWithoutEncoding];
+            }
+
+            return DefaultResponseContentEncoding;
+        }
+
+        /// <summary>
+        /// Formats an Exception into a string, including all inner exceptions.
+        /// </summary>
+        /// <param name="e"><see cref="Exception"/> instance.</param>
+        protected string ErrorReport(Exception e)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{e.GetType().Name}:\n{e}");
+
+            Exception inner = e;
+            while (inner != null)
+            {
+                // Append the messages to the StringBuilder.
+                sb.AppendLine($"{inner.GetType().Name}:\n{inner}");
+                inner = inner.InnerException;
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// This method is what the Lambda function handler points to.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="lambdaContext"></param>
+        /// <returns></returns>
+        [LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+        public virtual async Task<TRESPONSE> FunctionHandlerAsync(TREQUEST request, ILambdaContext lambdaContext)
+        {
+            if (!IsStarted)
+            {
+                Start();
+            }
+
+            InvokeFeatures features = new InvokeFeatures();
+            MarshallRequest(features, request, lambdaContext);
+
+            _logger.LogDebug($"ASP.NET Core Request PathBase: {((IHttpRequestFeature)features).PathBase}, Path: {((IHttpRequestFeature)features).Path}");
+
+            var context = this.CreateContext(features);
+
+            InternalPostCreateContext(context, request, lambdaContext);
+
+            // Add along the Lambda objects to the HttpContext to give access to Lambda to them in the ASP.NET Core application
+            context.HttpContext.Items[LAMBDA_CONTEXT] = lambdaContext;
+            context.HttpContext.Items[LAMBDA_REQUEST_OBJECT] = request;
+
+            // Allow the context to be customized before passing the request to ASP.NET Core.
+            PostCreateContext(context, request, lambdaContext);
+
+            var response = await this.ProcessRequest(lambdaContext, context, features);
+
+            return response;
+        }
+
+        /// <summary>
+        /// Processes the current request.
+        /// </summary>
+        /// <param name="lambdaContext"><see cref="ILambdaContext"/> implementation.</param>
+        /// <param name="context">The hosting application request context object.</param>
+        /// <param name="features">An <see cref="InvokeFeatures"/> instance.</param>
+        /// <param name="rethrowUnhandledError">
+        /// If specified, an unhandled exception will be rethrown for custom error handling.
+        /// Ensure that the error handling code calls 'this.MarshallResponse(features, 500);' after handling the error to return a the typed Lambda object to the user.
+        /// </param>
+        protected async Task<TRESPONSE> ProcessRequest(ILambdaContext lambdaContext, HostingApplication.Context context, InvokeFeatures features, bool rethrowUnhandledError = false)
+        {
+            var defaultStatusCode = 200;
+            Exception ex = null;
+            try
+            {
+                await this._server.Application.ProcessRequestAsync(context);
+            }
+            catch (AggregateException agex)
+            {
+                ex = agex;
+                _logger.LogError($"Caught AggregateException: '{agex}'");
+                var sb = new StringBuilder();
+                foreach (var newEx in agex.InnerExceptions)
+                {
+                    sb.AppendLine(this.ErrorReport(newEx));
+                }
+
+                _logger.LogError(sb.ToString());
+                defaultStatusCode = 500;
+            }
+            catch (ReflectionTypeLoadException rex)
+            {
+                ex = rex;
+                _logger.LogError($"Caught ReflectionTypeLoadException: '{rex}'");
+                var sb = new StringBuilder();
+                foreach (var loaderException in rex.LoaderExceptions)
+                {
+                    var fileNotFoundException = loaderException as FileNotFoundException;
+                    if (fileNotFoundException != null && !string.IsNullOrEmpty(fileNotFoundException.FileName))
+                    {
+                        sb.AppendLine($"Missing file: {fileNotFoundException.FileName}");
+                    }
+                    else
+                    {
+                        sb.AppendLine(this.ErrorReport(loaderException));
+                    }
+                }
+
+                _logger.LogError(sb.ToString());
+                defaultStatusCode = 500;
+            }
+            catch (Exception e)
+            {
+                ex = e;
+                if (rethrowUnhandledError) throw;
+                _logger.LogError($"Unknown error responding to request: {this.ErrorReport(e)}");
+                defaultStatusCode = 500;
+            }
+            finally
+            {
+                this._server.Application.DisposeContext(context, ex);
+            }
+
+            if (features.ResponseStartingEvents != null)
+            {
+                await features.ResponseStartingEvents.ExecuteAsync();
+            }
+            var response = this.MarshallResponse(features, lambdaContext, defaultStatusCode);
+
+            if (ex != null)
+            {
+                InternalCustomResponseExceptionHandling(context, response, lambdaContext, ex);
+            }                
+
+            if (features.ResponseCompletedEvents != null)
+            {
+                await features.ResponseCompletedEvents.ExecuteAsync();
+            }
+
+            return response;
+        }
+
+        private protected virtual void InternalPostCreateContext(HostingApplication.Context context, TREQUEST lambdaRequest, ILambdaContext lambdaContext)
+        {
+
+        }
+
+        private protected virtual void InternalCustomResponseExceptionHandling(HostingApplication.Context context, TRESPONSE lambdaReponse, ILambdaContext lambdaContext, Exception ex)
+        {
+
+        }
+
+        /// <summary>
+        /// This method is called after the HostingApplication.Context has been created. Derived classes can overwrite this method to alter
+        /// the context before passing the request to ASP.NET Core to process the request.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="lambdaRequest"></param>
+        /// <param name="lambdaContext"></param>
+        protected virtual void PostCreateContext(HostingApplication.Context context, TREQUEST lambdaRequest, ILambdaContext lambdaContext)
+        {
+
+        }
+
+        /// <summary>
+        /// This method is called after marshalling the incoming Lambda request
+        /// into ASP.NET Core's IHttpRequestFeature. Derived classes can overwrite this method to alter
+        /// the how the marshalling was done.
+        /// </summary>
+        /// <param name="aspNetCoreRequestFeature"></param>
+        /// <param name="lambdaRequest"></param>
+        /// <param name="lambdaContext"></param>
+        protected virtual void PostMarshallRequestFeature(IHttpRequestFeature aspNetCoreRequestFeature, TREQUEST lambdaRequest, ILambdaContext lambdaContext)
+        {
+
+        }
+
+        /// <summary>
+        /// This method is called after marshalling the incoming Lambda request
+        /// into ASP.NET Core's IHttpConnectionFeature. Derived classes can overwrite this method to alter
+        /// the how the marshalling was done.
+        /// </summary>
+        /// <param name="aspNetCoreConnectionFeature"></param>
+        /// <param name="lambdaRequest"></param>
+        /// <param name="lambdaContext"></param>
+        protected virtual void PostMarshallConnectionFeature(IHttpConnectionFeature aspNetCoreConnectionFeature, TREQUEST lambdaRequest, ILambdaContext lambdaContext)
+        {
+
+        }
+
+        /// <summary>
+        /// This method is called after marshalling the IHttpResponseFeature that came
+        /// back from making the request into ASP.NET Core into the Lamdba response object. Derived classes can overwrite this method to alter
+        /// the how the marshalling was done.
+        /// </summary>
+        /// <param name="aspNetCoreResponseFeature"></param>
+        /// <param name="lambdaResponse"></param>
+        /// <param name="lambdaContext"></param>
+        protected virtual void PostMarshallResponseFeature(IHttpResponseFeature aspNetCoreResponseFeature, TRESPONSE lambdaResponse, ILambdaContext lambdaContext)
+        {
+
+        }
+
+        /// <summary>
+        /// Converts the Lambda request object into ASP.NET Core InvokeFeatures used to create the HostingApplication.Context.
+        /// </summary>
+        /// <param name="features"></param>
+        /// <param name="lambdaRequest"></param>
+        /// <param name="lambdaContext"></param>
+        protected abstract void MarshallRequest(InvokeFeatures features, TREQUEST lambdaRequest, ILambdaContext lambdaContext);
+
+        /// <summary>
+        /// Convert the ASP.NET Core response to the Lambda response object.
+        /// </summary>
+        /// <param name="responseFeatures"></param>
+        /// <param name="lambdaContext"></param>
+        /// <param name="statusCodeIfNotSet"></param>
+        /// <returns></returns>
+        protected abstract TRESPONSE MarshallResponse(IHttpResponseFeature responseFeatures, ILambdaContext lambdaContext, int statusCodeIfNotSet = 200);
+    }
+}

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Amazon.Lambda.AspNetCoreServer.csproj
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Amazon.Lambda.AspNetCoreServer.csproj
@@ -6,17 +6,18 @@
     <Description>Amazon.Lambda.AspNetCoreServer makes it easy to run ASP.NET Core Web API applications as AWS Lambda functions.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyTitle>Amazon.Lambda.AspNetCoreServer</AssemblyTitle>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.AspNetCoreServer</AssemblyName>
     <PackageId>Amazon.Lambda.AspNetCoreServer</PackageId>
     <PackageTags>AWS;Amazon;Lambda;aspnetcore</PackageTags>
-
+    <LangVersion>Latest</LangVersion>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
 
-    <Version>2.1.0</Version>
+    <Version>3.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Amazon.Lambda.ApplicationLoadBalancerEvents\Amazon.Lambda.ApplicationLoadBalancerEvents.csproj" />
     <ProjectReference Include="..\Amazon.Lambda.Core\Amazon.Lambda.Core.csproj" />
     <ProjectReference Include="..\Amazon.Lambda.Logging.AspNetCore\Amazon.Lambda.Logging.AspNetCore.csproj" />
     <ProjectReference Include="..\Amazon.Lambda.Serialization.Json\Amazon.Lambda.Serialization.Json.csproj" />

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
@@ -1,0 +1,253 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.AspNetCoreServer.Internal;
+using Amazon.Lambda.ApplicationLoadBalancerEvents;
+using System.Net;
+using Microsoft.Extensions.Primitives;
+using Microsoft.AspNetCore.Hosting.Internal;
+
+namespace Amazon.Lambda.AspNetCoreServer
+{
+    /// <summary>
+    /// ApplicationLoadBalancerFunction is the base class for Lambda functions hosting the ASP.NET Core framework and exposed to the web via ELB's Application Load Balancer.
+    /// 
+    /// The derived class implements the Init method similar to Main function in the ASP.NET Core. The function handler for the Lambda function will point
+    /// to this base class FunctionHandlerAsync method.
+    /// </summary>
+    public abstract class ApplicationLoadBalancerFunction : AbstractAspNetCoreFunction<ApplicationLoadBalancerRequest, ApplicationLoadBalancerResponse>
+    {
+        private bool _multiHeaderValuesEnabled = true;
+
+        /// <inheritdoc/>
+        protected ApplicationLoadBalancerFunction()
+            : base()
+        {
+
+        }
+
+        /// <inheritdoc/>
+        /// <param name="startupMode">Configure when the ASP.NET Core framework will be initialized</param>
+        protected ApplicationLoadBalancerFunction(StartupMode startupMode)
+            : base(startupMode)
+        {
+
+        }
+
+
+        /// <inheritdoc/>
+        protected override void MarshallRequest(InvokeFeatures features, ApplicationLoadBalancerRequest lambdaRequest, ILambdaContext lambdaContext)
+        {
+            // Look to see if the request is using mutli value headers or not. This is important when
+            // marshalling the response to know whether to fill in the the Headers or MultiValueHeaders collection.
+            // Since a Lambda function compute environment is only one processing one event at a time it is safe to store
+            // this as a member variable.
+            this._multiHeaderValuesEnabled = lambdaRequest.MultiValueHeaders != null;
+
+            {
+                var requestFeatures = (IHttpRequestFeature)features;
+                requestFeatures.Scheme = GetSingleHeaderValue(lambdaRequest, "x-forwarded-proto");
+                requestFeatures.Method = lambdaRequest.HttpMethod;
+                requestFeatures.Path = lambdaRequest.Path;
+
+
+                requestFeatures.QueryString = string.Empty;
+                if (this._multiHeaderValuesEnabled)
+                {
+                    var queryStringParameters = lambdaRequest.MultiValueQueryStringParameters;
+                    if (queryStringParameters != null)
+                    {
+                        StringBuilder sb = new StringBuilder("?");
+                        foreach (var kvp in queryStringParameters)
+                        {
+                            if (sb.Length > 1)
+                            {
+                                sb.Append("&");
+                            }
+                            foreach(var value in kvp.Value)
+                            {
+                                sb.Append($"{WebUtility.UrlEncode(kvp.Key)}={WebUtility.UrlEncode(value)}");
+                            }                            
+                        }
+                        requestFeatures.QueryString = sb.ToString();
+                    }
+                }
+                else
+                {
+                    var queryStringParameters = lambdaRequest.QueryStringParameters;
+                    if (queryStringParameters != null)
+                    {
+                        StringBuilder sb = new StringBuilder("?");
+                        foreach (var kvp in queryStringParameters)
+                        {
+                            if (sb.Length > 1)
+                            {
+                                sb.Append("&");
+                            }
+                            sb.Append($"{WebUtility.UrlEncode(kvp.Key)}={WebUtility.UrlEncode(kvp.Value.ToString())}");
+                        }
+                        requestFeatures.QueryString = sb.ToString();
+                    }
+                }
+
+                if(this._multiHeaderValuesEnabled)
+                {
+                    foreach(var kvp in lambdaRequest.MultiValueHeaders)
+                    {
+                        requestFeatures.Headers[kvp.Key] = new StringValues(kvp.Value.ToArray());
+                    }
+                }
+                else
+                {
+                    foreach (var kvp in lambdaRequest.Headers)
+                    {
+                        requestFeatures.Headers[kvp.Key] = new StringValues(kvp.Value);
+                    }
+                }
+
+                var headers = lambdaRequest.Headers;
+                if (headers != null)
+                {
+                    foreach (var kvp in headers)
+                    {
+                        requestFeatures.Headers[kvp.Key] = kvp.Value?.ToString();
+                    }
+                }
+
+
+                requestFeatures.Headers["Host"] = GetSingleHeaderValue(lambdaRequest, "host");
+
+                if (!string.IsNullOrEmpty(lambdaRequest.Body))
+                {
+                    requestFeatures.Body = Utilities.ConvertLambdaRequestBodyToAspNetCoreBody(lambdaRequest.Body, lambdaRequest.IsBase64Encoded);
+                }
+
+                // Call consumers customize method in case they want to change how API Gateway's request
+                // was marshalled into ASP.NET Core request.
+                PostMarshallRequestFeature(requestFeatures, lambdaRequest, lambdaContext);
+            }
+
+
+            {
+                // set up connection features
+                var connectionFeatures = (IHttpConnectionFeature)features;
+
+                var remoteIpAddressStr = GetSingleHeaderValue(lambdaRequest, "x-forwarded-for");
+                if (!string.IsNullOrEmpty(remoteIpAddressStr) &&
+                    IPAddress.TryParse(remoteIpAddressStr, out var remoteIpAddress))
+                {
+                    connectionFeatures.RemoteIpAddress = remoteIpAddress;
+                }
+
+                var remotePort = GetSingleHeaderValue(lambdaRequest, "x-forwarded-port");
+                if (!string.IsNullOrEmpty(remotePort))
+                {
+                    connectionFeatures.RemotePort = int.Parse(remotePort);
+                }
+
+                // Call consumers customize method in case they want to change how API Gateway's request
+                // was marshalled into ASP.NET Core request.
+                PostMarshallConnectionFeature(connectionFeatures, lambdaRequest, lambdaContext);
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override ApplicationLoadBalancerResponse MarshallResponse(IHttpResponseFeature responseFeatures, ILambdaContext lambdaContext, int statusCodeIfNotSet = 200)
+        {
+            var response = new ApplicationLoadBalancerResponse
+            {
+                StatusCode = responseFeatures.StatusCode != 0 ? responseFeatures.StatusCode : statusCodeIfNotSet                
+            };
+
+            response.StatusDescription = $"{response.StatusCode} {((System.Net.HttpStatusCode)response.StatusCode).ToString()}";
+
+
+            string contentType = null;
+            if (responseFeatures.Headers != null)
+            {
+                if(this._multiHeaderValuesEnabled)
+                    response.MultiValueHeaders = new Dictionary<string, IList<string>>();
+                else
+                    response.Headers = new Dictionary<string, string>();
+
+                foreach (var kvp in responseFeatures.Headers)
+                {
+                    if(this._multiHeaderValuesEnabled)
+                    {
+                        response.MultiValueHeaders[kvp.Key] = kvp.Value.ToList();
+                    }
+                    else
+                    {
+                        response.Headers[kvp.Key] = kvp.Value[0];
+                    }
+
+                    // Remember the Content-Type for possible later use
+                    if (kvp.Key.Equals("Content-Type", StringComparison.CurrentCultureIgnoreCase))
+                        contentType = response.Headers[kvp.Key];
+                }
+            }
+
+            if (contentType == null)
+            {
+                response.Headers["Content-Type"] = null;
+            }
+
+            if (responseFeatures.Body != null)
+            {
+                // Figure out how we should treat the response content
+                var rcEncoding = GetResponseContentEncodingForContentType(contentType);
+
+                (response.Body, response.IsBase64Encoded) = Utilities.ConvertAspNetCoreBodyToLambdaBody(responseFeatures.Body, rcEncoding);
+            }
+
+            PostMarshallResponseFeature(responseFeatures, response, lambdaContext);
+
+            _logger.LogDebug($"Response Base 64 Encoded: {response.IsBase64Encoded}");
+
+            return response;
+        }
+
+        private protected override void InternalCustomResponseExceptionHandling(HostingApplication.Context context, ApplicationLoadBalancerResponse lambdaResponse, ILambdaContext lambdaContext, Exception ex)
+        {
+            var errorName = ex.GetType().Name;
+
+            if(this._multiHeaderValuesEnabled)
+            {
+                lambdaResponse.MultiValueHeaders.Add(new KeyValuePair<string, IList<string>>("ErrorType", new List<string> { errorName }));
+            }
+            else
+            {
+                lambdaResponse.Headers.Add(new KeyValuePair<string, string>("ErrorType", errorName));
+            }            
+        }
+
+        private string GetSingleHeaderValue(ApplicationLoadBalancerRequest request, string headerName)
+        {
+            if(this._multiHeaderValuesEnabled)
+            {
+                var kvp = request.MultiValueQueryStringParameters.FirstOrDefault(x => string.Equals(x.Key, headerName, StringComparison.OrdinalIgnoreCase));
+                if (!kvp.Equals(default(KeyValuePair<string, IList<string>>)))
+                {
+                    return kvp.Value.First();
+                }
+            }
+            else
+            {
+                var kvp = request.Headers.FirstOrDefault(x => string.Equals(x.Key, headerName, StringComparison.OrdinalIgnoreCase));
+                if (!kvp.Equals(default(KeyValuePair<string, string>)))
+                {
+                    return kvp.Value;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
@@ -191,11 +191,6 @@ namespace Amazon.Lambda.AspNetCoreServer
                 }
             }
 
-            if (contentType == null)
-            {
-                response.Headers["Content-Type"] = null;
-            }
-
             if (responseFeatures.Body != null)
             {
                 // Figure out how we should treat the response content

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
@@ -74,12 +74,12 @@ namespace Amazon.Lambda.AspNetCoreServer
                         StringBuilder sb = new StringBuilder("?");
                         foreach (var kvp in queryStringParameters)
                         {
-                            if (sb.Length > 1)
-                            {
-                                sb.Append("&");
-                            }
                             foreach(var value in kvp.Value)
                             {
+                                if (sb.Length > 1)
+                                {
+                                    sb.Append("&");
+                                }
                                 sb.Append(Utilities.CreateQueryStringParameter(kvp.Key, value));
                             }
                         }

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction{TStartup}.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction{TStartup}.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNetCore.Hosting;
+
+namespace Amazon.Lambda.AspNetCoreServer
+{
+    /// <summary>
+    /// ApplicationLoadBalancerFunction is the base class that is implemented in a ASP.NET Core Web API. The derived class implements
+    /// the Init method similar to Main function in the ASP.NET Core and provides typed Startup. The function handler for
+    /// the Lambda function will point to this base class FunctionHandlerAsync method.
+    /// </summary>
+    /// <typeparam name ="TStartup">The type containing the startup methods for the application.</typeparam>
+    public abstract class ApplicationLoadBalancerFunction<TStartup> : ApplicationLoadBalancerFunction where TStartup : class
+    {
+        /// <inheritdoc/>
+        protected override IWebHostBuilder CreateWebHostBuilder() =>
+            base.CreateWebHostBuilder().UseStartup<TStartup>();
+
+        /// <inheritdoc/>
+        protected override void Init(IWebHostBuilder builder)
+        {
+        }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/LambdaServer.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/LambdaServer.cs
@@ -15,7 +15,7 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
     /// Implements the ASP.NET Core IServer interface and exposes the application object for the Lambda function
     /// to initiate a web request.
     /// </summary>
-    internal class APIGatewayServer : IServer
+    internal class LambdaServer : IServer
     {
         /// <summary>
         /// The application is used by the Lambda function to initiate a web request through the ASP.NET Core framework.

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/Utilities.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/Utilities.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 
 namespace Amazon.Lambda.AspNetCoreServer.Internal
@@ -9,6 +10,56 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
     /// </summary>
     public static class Utilities
     {
+        internal static Stream ConvertLambdaRequestBodyToAspNetCoreBody(string body, bool isBase64Encoded)
+        {
+            Byte[] binaryBody;
+            if (isBase64Encoded)
+            {
+                binaryBody = Convert.FromBase64String(body);
+            }
+            else
+            {
+                binaryBody = UTF8Encoding.UTF8.GetBytes(body);
+            }
+
+            return new MemoryStream(binaryBody);
+        }
+
+        internal static (string body, bool isBase64Encoded) ConvertAspNetCoreBodyToLambdaBody(Stream aspNetCoreBody, ResponseContentEncoding rcEncoding)
+        {
+
+            // Do we encode the response content in Base64 or treat it as UTF-8
+            if (rcEncoding == ResponseContentEncoding.Base64)
+            {
+                // We want to read the response content "raw" and then Base64 encode it
+                byte[] bodyBytes;
+                if (aspNetCoreBody is MemoryStream)
+                {
+                    bodyBytes = ((MemoryStream)aspNetCoreBody).ToArray();
+                }
+                else
+                {
+                    using (var ms = new MemoryStream())
+                    {
+                        aspNetCoreBody.CopyTo(ms);
+                        bodyBytes = ms.ToArray();
+                    }
+                }
+                return (body: Convert.ToBase64String(bodyBytes), isBase64Encoded: true);
+            }
+            else if (aspNetCoreBody is MemoryStream)
+            {
+                return (body: UTF8Encoding.UTF8.GetString(((MemoryStream)aspNetCoreBody).ToArray()), isBase64Encoded: false);
+            }
+            else
+            {
+                aspNetCoreBody.Position = 0;
+                using (StreamReader reader = new StreamReader(aspNetCoreBody, Encoding.UTF8))
+                {
+                    return (body: reader.ReadToEnd(), isBase64Encoded: false);
+                }
+            }
+        }
 
         /// <summary>
         /// Generate different casing permutations of the input string.

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/Utilities.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/Utilities.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Text;
 
 namespace Amazon.Lambda.AspNetCoreServer.Internal
@@ -114,6 +115,11 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
 
                 yield return new string(combination);
             }
+        }
+
+        internal static string CreateQueryStringParameter(string key, string value)
+        {
+            return $"{WebUtility.UrlEncode(key)}={WebUtility.UrlEncode(value)}";
         }
     }
 }

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/StartupMode.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/StartupMode.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Amazon.Lambda.AspNetCoreServer
+{
+    /// <summary>
+    /// The modes for when the ASP.NET Core framework will be initialized.
+    /// </summary>
+    public enum StartupMode
+    {
+        /// <summary>
+        /// Initialize ASP.NET Core framework during the constructor
+        /// </summary>
+        Constructor,
+
+        /// <summary>
+        /// Initialize ASP.NET Core framework during the first incoming request
+        /// </summary>
+        FirstRequest
+    }
+}

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/WebHostBuilderExtensions.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/WebHostBuilderExtensions.cs
@@ -22,23 +22,36 @@ namespace Microsoft.AspNetCore.Hosting
         /// </summary>
         /// <param name="hostBuilder"></param>
         /// <returns></returns>
+        [Obsolete("Calls should be replaced with UseLambdaServer")]
         public static IWebHostBuilder UseApiGateway(this IWebHostBuilder hostBuilder)
+        {
+            return UseLambdaServer(hostBuilder);
+        }
+
+        /// <summary>
+        /// Extension method for configuring Lambda as the server for an ASP.NET Core application.
+        /// This is called instead of UseKestrel. If UseKestrel was called before this it will remove
+        /// the service description that was added to the IServiceCollection.
+        /// </summary>
+        /// <param name="hostBuilder"></param>
+        /// <returns></returns>
+        public static IWebHostBuilder UseLambdaServer(this IWebHostBuilder hostBuilder)
         {
             return hostBuilder.ConfigureServices(services =>
             {
                 var serviceDescription = services.FirstOrDefault(x => x.ServiceType == typeof(IServer));
-                if(serviceDescription != null)
+                if (serviceDescription != null)
                 {
-                    // If Api Gateway server has already been added the skip out.
-                    if (serviceDescription.ImplementationType == typeof(APIGatewayServer))
+                    // If Lambda server has already been added the skip out.
+                    if (serviceDescription.ImplementationType == typeof(LambdaServer))
                         return;
-                    // If there is already an IServer registeried then remove. This is mostly likely caused
+                    // If there is already an IServer registered then remove it. This is mostly likely caused
                     // by leaving the UseKestrel call.
                     else
                         services.Remove(serviceDescription);
                 }
 
-                services.AddSingleton<IServer, APIGatewayServer>();
+                services.AddSingleton<IServer, LambdaServer>();
             });
         }
     }

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestApplicationLoadBalancerCalls.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestApplicationLoadBalancerCalls.cs
@@ -1,0 +1,128 @@
+﻿using Amazon.Lambda.ApplicationLoadBalancerEvents;
+using Amazon.Lambda.TestUtilities;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using TestWebApp;
+using Xunit;
+using System;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Amazon.Lambda.AspNetCoreServer.Test
+{
+    public class TestApplicationLoadBalancerCalls
+    {
+        [Fact]
+        public async Task TestGetAllValues()
+        {
+            var context = new TestLambdaContext();
+
+            var response = await this.InvokeApplicationLoadBalancerRequest(context, "values-get-all-alb-request.json");
+
+            Assert.Equal(200, response.StatusCode);
+            Assert.Equal("[\"value1\",\"value2\"]", response.Body);
+            Assert.True(response.Headers.ContainsKey("Content-Type"));
+            Assert.Equal("application/json; charset=utf-8", response.Headers["Content-Type"]);
+
+            Assert.Contains("OnStarting Called", ((TestLambdaLogger)context.Logger).Buffer.ToString());
+        }
+
+        [Fact]
+        public async Task TestGetQueryStringValue()
+        {
+            var response = await this.InvokeApplicationLoadBalancerRequest("values-get-querystring-alb-request.json");
+
+            Assert.Equal("Lewis, Meriwether", response.Body);
+            Assert.True(response.Headers.ContainsKey("Content-Type"));
+            Assert.Equal("text/plain; charset=utf-8", response.Headers["Content-Type"]);
+        }
+
+        [Fact]
+        public async Task TestPutWithBody()
+        {
+            var response = await this.InvokeApplicationLoadBalancerRequest("values-put-withbody-alb-request.json");
+
+            Assert.Equal(200, response.StatusCode);
+            Assert.Equal("Agent, Smith", response.Body);
+            Assert.True(response.Headers.ContainsKey("Content-Type"));
+            Assert.Equal("text/plain; charset=utf-8", response.Headers["Content-Type"]);
+        }
+
+        [Fact]
+        public async Task TestPutWithBodyMV()
+        {
+            var response = await this.InvokeApplicationLoadBalancerRequest("values-put-withbody-alb-mv-request.json");
+
+            Assert.Equal(200, response.StatusCode);
+            Assert.Equal("Agent, Smith", response.Body);
+            Assert.True(response.MultiValueHeaders.ContainsKey("Content-Type"));
+            Assert.Equal("text/plain; charset=utf-8", response.MultiValueHeaders["Content-Type"][0]);
+        }
+
+        [Fact]
+        public async Task TestGetSingleValue()
+        {
+            var response = await this.InvokeApplicationLoadBalancerRequest("values-get-single-alb-request.json");
+
+            Assert.Equal("value=5", response.Body);
+            Assert.True(response.Headers.ContainsKey("Content-Type"));
+            Assert.Equal("text/plain; charset=utf-8", response.Headers["Content-Type"]);
+        }
+
+        [Fact]
+        public async Task TestGetBinaryContent()
+        {
+            var response = await this.InvokeApplicationLoadBalancerRequest("values-get-binary-alb-request.json");
+
+            Assert.Equal((int)HttpStatusCode.OK, response.StatusCode);
+
+            string contentType;
+            Assert.True(response.Headers.TryGetValue("Content-Type", out contentType),
+                    "Content-Type response header exists");
+            Assert.Equal("application/octet-stream", contentType);
+            Assert.NotNull(response.Body);
+            Assert.True(response.Body.Length > 0,
+                    "Body content is not empty");
+
+            Assert.True(response.IsBase64Encoded, "Response IsBase64Encoded");
+
+            // Compute a 256-byte array, with values 0-255
+            var binExpected = new byte[byte.MaxValue].Select((val, index) => (byte)index).ToArray();
+            var binActual = Convert.FromBase64String(response.Body);
+            Assert.Equal(binExpected, binActual);
+        }
+
+        [Fact]
+        public async Task TestPutBinaryContent()
+        {
+            var response = await this.InvokeApplicationLoadBalancerRequest("values-put-binary-alb-request.json");
+
+            Assert.Equal((int)HttpStatusCode.OK, response.StatusCode);
+
+            Assert.NotNull(response.Body);
+            Assert.Equal("Greetings, programs!", response.Body);
+
+            Assert.False(response.IsBase64Encoded, "Response IsBase64Encoded");
+        }
+
+        private async Task<ApplicationLoadBalancerResponse> InvokeApplicationLoadBalancerRequest(string fileName)
+        {
+            return await InvokeApplicationLoadBalancerRequest(new TestLambdaContext(), fileName);
+        }
+
+        private async Task<ApplicationLoadBalancerResponse> InvokeApplicationLoadBalancerRequest(TestLambdaContext context, string fileName)
+        {
+            var lambdaFunction = new ALBLambdaFunction();
+            var filePath = Path.Combine(Path.GetDirectoryName(this.GetType().GetTypeInfo().Assembly.Location), fileName);
+            var requestStr = File.ReadAllText(filePath);
+            var request = JsonConvert.DeserializeObject<ApplicationLoadBalancerRequest>(requestStr);
+            return await lambdaFunction.FunctionHandlerAsync(request, context);
+        }
+
+    }
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestApplicationLoadBalancerCalls.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestApplicationLoadBalancerCalls.cs
@@ -43,6 +43,16 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
         }
 
         [Fact]
+        public async Task TestGetQueryStringValueMV()
+        {
+            var response = await this.InvokeApplicationLoadBalancerRequest("values-get-querystring-alb-mv-request.json");
+
+            Assert.Equal("value1,value2", response.Body);
+            Assert.True(response.MultiValueHeaders.ContainsKey("Content-Type"));
+            Assert.Equal("text/plain; charset=utf-8", response.MultiValueHeaders["Content-Type"].FirstOrDefault());
+        }
+
+        [Fact]
         public async Task TestPutWithBody()
         {
             var response = await this.InvokeApplicationLoadBalancerRequest("values-put-withbody-alb-request.json");

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
@@ -260,7 +260,7 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
 
         private async Task<APIGatewayProxyResponse> InvokeAPIGatewayRequest(TestLambdaContext context, string fileName)
         {
-            var lambdaFunction = new LambdaFunction();
+            var lambdaFunction = new ApiGatewayLambdaFunction();
             var filePath = Path.Combine(Path.GetDirectoryName(this.GetType().GetTypeInfo().Assembly.Location), fileName);
             var requestStr = File.ReadAllText(filePath);
             var request = JsonConvert.DeserializeObject<APIGatewayProxyRequest>(requestStr);

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-all-alb-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-all-alb-request.json
@@ -1,0 +1,24 @@
+﻿{
+  "requestContext": {
+    "elb": {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09"
+    }
+  },
+  "httpMethod": "GET",
+  "path": "/api/resourcepath",
+  "queryStringParameters": null,
+  "headers": {
+    "accept": "text/html,application/xhtml+xml",
+    "accept-language": "en-US,en;q=0.8",
+    "content-type": "text/plain",
+    "cookie": "cookies",
+    "host": "lambda-846800462-us-east-2.elb.amazonaws.com",
+    "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6)",
+    "x-amzn-trace-id": "Root=1-5bdb40ca-556d8b0c50dc66f0511bf520",
+    "x-forwarded-for": "72.21.198.66",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "isBase64Encoded": false,
+  "body": null
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-binary-alb-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-binary-alb-request.json
@@ -1,0 +1,24 @@
+﻿{
+  "requestContext": {
+    "elb": {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09"
+    }
+  },
+  "httpMethod": "GET",
+  "path": "/api/binary",
+  "queryStringParameters": null,
+  "headers": {
+    "accept": "text/html,application/xhtml+xml",
+    "accept-language": "en-US,en;q=0.8",
+    "content-type": "text/plain",
+    "cookie": "cookies",
+    "host": "lambda-846800462-us-east-2.elb.amazonaws.com",
+    "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6)",
+    "x-amzn-trace-id": "Root=1-5bdb40ca-556d8b0c50dc66f0511bf520",
+    "x-forwarded-for": "72.21.198.66",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "isBase64Encoded": false,
+  "body": null
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-querystring-alb-mv-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-querystring-alb-mv-request.json
@@ -1,0 +1,28 @@
+﻿{
+  "requestContext": {
+    "elb": {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09"
+    }
+  },
+  "httpMethod": "GET",
+  "path": "/api/querystring",
+  "multiValueQueryStringParameters": {
+    "firstName": [ "Lewis" ],
+    "lastName": [ "Meriwether" ],
+    "mv-test": [ "value1", "value2" ]
+  },
+  "multiValueHeaders": {
+    "accept": [ "text/html", "application/xhtml+xml" ],
+    "accept-language": [ "en-US,en;q=0.8" ],
+    "content-type": [ "application/json" ],
+    "cookie": [ "cookies" ],
+    "host": [ "lambda-846800462-us-east-2.elb.amazonaws.com" ],
+    "user-agent": [ "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6)" ],
+    "x-amzn-trace-id": [ "Root=1-5bdb40ca-556d8b0c50dc66f0511bf520" ],
+    "x-forwarded-for": [ "72.21.198.66" ],
+    "x-forwarded-port": [ "443" ],
+    "x-forwarded-proto": [ "https" ]
+  },
+  "isBase64Encoded": false,
+  "body": null
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-querystring-alb-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-querystring-alb-request.json
@@ -6,7 +6,7 @@
   },
   "httpMethod": "GET",
   "path": "/api/querystring",
-  "queryStringParameters":  {
+  "queryStringParameters": {
     "firstName": "Lewis",
     "lastName": "Meriwether"
   },

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-querystring-alb-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-querystring-alb-request.json
@@ -1,0 +1,27 @@
+﻿{
+  "requestContext": {
+    "elb": {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09"
+    }
+  },
+  "httpMethod": "GET",
+  "path": "/api/querystring",
+  "queryStringParameters":  {
+    "firstName": "Lewis",
+    "lastName": "Meriwether"
+  },
+  "headers": {
+    "accept": "text/html,application/xhtml+xml",
+    "accept-language": "en-US,en;q=0.8",
+    "content-type": "text/plain",
+    "cookie": "cookies",
+    "host": "lambda-846800462-us-east-2.elb.amazonaws.com",
+    "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6)",
+    "x-amzn-trace-id": "Root=1-5bdb40ca-556d8b0c50dc66f0511bf520",
+    "x-forwarded-for": "72.21.198.66",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "isBase64Encoded": false,
+  "body": null
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-single-alb-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-get-single-alb-request.json
@@ -1,0 +1,24 @@
+﻿{
+  "requestContext": {
+    "elb": {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09"
+    }
+  },
+  "httpMethod": "GET",
+  "path": "/api/resourcepath/5",
+  "queryStringParameters": null,
+  "headers": {
+    "accept": "text/html,application/xhtml+xml",
+    "accept-language": "en-US,en;q=0.8",
+    "content-type": "text/plain",
+    "cookie": "cookies",
+    "host": "lambda-846800462-us-east-2.elb.amazonaws.com",
+    "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6)",
+    "x-amzn-trace-id": "Root=1-5bdb40ca-556d8b0c50dc66f0511bf520",
+    "x-forwarded-for": "72.21.198.66",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "isBase64Encoded": false,
+  "body": null
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-put-binary-alb-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-put-binary-alb-request.json
@@ -1,0 +1,24 @@
+﻿{
+  "requestContext": {
+    "elb": {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09"
+    }
+  },
+  "httpMethod": "PUT",
+  "path": "/api/binary",
+  "queryStringParameters": null,
+  "headers": {
+    "accept": "text/html,application/xhtml+xml",
+    "accept-language": "en-US,en;q=0.8",
+    "content-type": "text/plain",
+    "cookie": "cookies",
+    "host": "lambda-846800462-us-east-2.elb.amazonaws.com",
+    "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6)",
+    "x-amzn-trace-id": "Root=1-5bdb40ca-556d8b0c50dc66f0511bf520",
+    "x-forwarded-for": "72.21.198.66",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "isBase64Encoded": true,
+  "body": "R3JlZXRpbmdzLCBwcm9ncmFtcyE="
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-put-withbody-alb-mv-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-put-withbody-alb-mv-request.json
@@ -1,0 +1,24 @@
+﻿{
+  "requestContext": {
+    "elb": {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09"
+    }
+  },
+  "httpMethod": "PUT",
+  "path": "/api/bodytests",
+  "queryStringParameters": null,
+  "multiValueHeaders": {
+    "accept": ["text/html", "application/xhtml+xml"],
+    "accept-language": ["en-US,en;q=0.8"],
+    "content-type": ["application/json"],
+    "cookie": ["cookies"],
+    "host": ["lambda-846800462-us-east-2.elb.amazonaws.com"],
+    "user-agent": ["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6)"],
+    "x-amzn-trace-id": ["Root=1-5bdb40ca-556d8b0c50dc66f0511bf520"],
+    "x-forwarded-for": ["72.21.198.66"],
+    "x-forwarded-port": ["443"],
+    "x-forwarded-proto": ["https"]
+  },
+  "isBase64Encoded": false,
+  "body": "{\"firstName\":\"Smith\",\"lastName\": \"Agent\"}"
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-put-withbody-alb-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-put-withbody-alb-request.json
@@ -1,0 +1,24 @@
+﻿{
+  "requestContext": {
+    "elb": {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09"
+    }
+  },
+  "httpMethod": "PUT",
+  "path": "/api/bodytests",
+  "queryStringParameters": null,
+  "headers": {
+    "accept": "text/html,application/xhtml+xml",
+    "accept-language": "en-US,en;q=0.8",
+    "content-type": "application/json",
+    "cookie": "cookies",
+    "host": "lambda-846800462-us-east-2.elb.amazonaws.com",
+    "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6)",
+    "x-amzn-trace-id": "Root=1-5bdb40ca-556d8b0c50dc66f0511bf520",
+    "x-forwarded-for": "72.21.198.66",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "isBase64Encoded": false,
+  "body": "{\"firstName\":\"Smith\",\"lastName\": \"Agent\"}"
+}

--- a/Libraries/test/TestWebApp/ALBLambdaFunction.cs
+++ b/Libraries/test/TestWebApp/ALBLambdaFunction.cs
@@ -1,0 +1,8 @@
+﻿using Amazon.Lambda.AspNetCoreServer;
+
+namespace TestWebApp
+{
+    public class ALBLambdaFunction : ApplicationLoadBalancerFunction<Startup>
+    {
+    }
+}

--- a/Libraries/test/TestWebApp/ApiGatewayLambdaFunction.cs
+++ b/Libraries/test/TestWebApp/ApiGatewayLambdaFunction.cs
@@ -2,7 +2,7 @@
 
 namespace TestWebApp
 {
-    public class LambdaFunction : APIGatewayProxyFunction<Startup>
+    public class ApiGatewayLambdaFunction : APIGatewayProxyFunction<Startup>
     {
     }
 }

--- a/Libraries/test/TestWebApp/Controllers/BinaryContentController.cs
+++ b/Libraries/test/TestWebApp/Controllers/BinaryContentController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using System.IO;
 using static System.Net.Mime.MediaTypeNames;
 
 namespace TestWebApp.Controllers
@@ -15,6 +16,15 @@ namespace TestWebApp.Controllers
                 bytes[i] = (byte)i;
 
             return base.File(bytes, Application.Octet);
+        }
+
+        [HttpPut]
+        public string Put()
+        {
+            using (var reader = new StreamReader(this.HttpContext.Request.Body))
+            {
+                return reader.ReadToEnd();
+            }
         }
     }
 }

--- a/Libraries/test/TestWebApp/Controllers/QueryStringController.cs
+++ b/Libraries/test/TestWebApp/Controllers/QueryStringController.cs
@@ -13,6 +13,10 @@ namespace TestWebApp.Controllers
         [HttpGet]
         public string Get([FromQuery] string firstName, [FromQuery] string lastName)
         {
+            if (HttpContext.Request.Query.TryGetValue("mv-test", out var values))
+            {
+                return string.Join(",", values);
+            }
             return $"{firstName}, {lastName}";
         }
     }


### PR DESCRIPTION
Created a new `Amazon.Lambda.AspNetCoreServer.ApplicationLoadBalancerFunction` base class similar to the existing `Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction` to handle events coming from an Application Load Balancer.

Common code was refactored out of `APIGatewayProxyFunction` into new parent base class `AbstractAspNetCoreFunction`.

ASP.NET Core blueprints were updated to have docs letting developers know how to switch the projects to use an Application Load Balancer.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
