### PR TITLE
Updated default PowerShell Core to 6.1.1

### DIFF
--- a/PowerShell/Module/Private/_Constants.ps1
+++ b/PowerShell/Module/Private/_Constants.ps1
@@ -20,5 +20,5 @@ if (!($AwsPowerShellFunctionEnvName))
 
 if (!($AwsPowerShellDefaultSdkVersion))
 {
-    New-Variable -Name AwsPowerShellDefaultSdkVersion -Value '6.1.0' -Option Constant
+    New-Variable -Name AwsPowerShellDefaultSdkVersion -Value '6.1.1' -Option Constant
 }


### PR DESCRIPTION
*Issue #, if available:*
There is no issue related to this.

*Description of changes:*
Updated the default version of PowerShell Core to 6.1.1, which is [available](https://www.nuget.org/packages/Microsoft.PowerShell.SDK) on NuGet.org.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
