### PR TITLE
Added "ConnectionId" and "DomainName" to APIGatewayProxyRequest

### DIFF
--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayProxyRequest.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayProxyRequest.cs
@@ -112,6 +112,16 @@
             public string ApiId { get; set; }
 
             /// <summary>
+            /// The connectionId identifies a unique client connection in a WebSocket API
+            /// </summary>
+            public string ConnectionId { get; set; }
+
+            /// <summary>
+            /// The domainName part in a WebSocket API address
+            /// </summary>
+            public string DomainName { get; set; }
+
+            /// <summary>
             /// The APIGatewayCustomAuthorizerContext containing the custom properties set by a custom authorizer.
             /// </summary>
             public APIGatewayCustomAuthorizerContext Authorizer { get; set; }

--- a/Libraries/test/EventsTests/EventTests.cs
+++ b/Libraries/test/EventsTests/EventTests.cs
@@ -435,8 +435,6 @@ namespace Amazon.Lambda.Tests
                 Assert.Equal(requestContext.ResourceId, "roq9wj");
                 Assert.Equal(requestContext.Stage, "testStage");
                 Assert.Equal(requestContext.RequestId, "deef4878-7910-11e6-8f14-25afc3e9ae33");
-                Assert.Equal(requestContext.ConnectionId, "d034bc98-beed-4fdf-9e85-11bfc15bf734");
-                Assert.Equal(requestContext.DomainName, "somerandomdomain.net");
 
                 var identity = requestContext.Identity;
                 Assert.Equal(identity.CognitoIdentityPoolId, "theCognitoIdentityPoolId");

--- a/Libraries/test/EventsTests/EventTests.cs
+++ b/Libraries/test/EventsTests/EventTests.cs
@@ -435,6 +435,8 @@ namespace Amazon.Lambda.Tests
                 Assert.Equal(requestContext.ResourceId, "roq9wj");
                 Assert.Equal(requestContext.Stage, "testStage");
                 Assert.Equal(requestContext.RequestId, "deef4878-7910-11e6-8f14-25afc3e9ae33");
+                Assert.Equal(requestContext.ConnectionId, "d034bc98-beed-4fdf-9e85-11bfc15bf734");
+                Assert.Equal(requestContext.DomainName, "somerandomdomain.net");
 
                 var identity = requestContext.Identity;
                 Assert.Equal(identity.CognitoIdentityPoolId, "theCognitoIdentityPoolId");

--- a/Libraries/test/EventsTests/proxy-event.json
+++ b/Libraries/test/EventsTests/proxy-event.json
@@ -52,7 +52,9 @@
     },
     "resourcePath": "/{proxy+}",
     "httpMethod": "POST",
-    "apiId": "gy415nuibc"
+    "apiId": "gy415nuibc",
+    "connectionId": "d034bc98-beed-4fdf-9e85-11bfc15bf734",
+    "domainName": "somerandomdomain.net"
   },
   "body": "{\r\n\t\"a\": 1\r\n}"
 }


### PR DESCRIPTION
*Issue #367*

*Added "ConnectionId" and "DomainName" to APIGatewayProxyRequest. Fixed proxy-event unit test.*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
