### PR TITLE
Including Exception and EventId in Lambda Logger messages

### DIFF
--- a/Libraries/src/Amazon.Lambda.Logging.AspNetCore/LambdaILogger.cs
+++ b/Libraries/src/Amazon.Lambda.Logging.AspNetCore/LambdaILogger.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.Logging
             }
 
             // Format of the logged text, optional components are in {}
-            //  {[LogLevel] }{Category: }MessageText{\n}
+            //  {[LogLevel] }{Category: }{EventId: }MessageText {Exception}{\n}
 
             var components = new List<string>(4);
             if (_options.IncludeLogLevel)
@@ -56,11 +56,19 @@ namespace Microsoft.Extensions.Logging
             {
                 components.Add($"{_categoryName}:");
             }
+			if (_options.IncludeEventId)
+			{
+				components.Add($"{eventId}:");
+			}
 
-            var text = formatter.Invoke(state, exception);
+			var text = formatter.Invoke(state, exception);
             components.Add(text);
 
-            if (_options.IncludeNewline)
+			if(_options.IncludeException)
+			{
+				components.Add($"{exception}");
+			}
+			if (_options.IncludeNewline)
             {
                 components.Add(Environment.NewLine);
             }

--- a/Libraries/src/Amazon.Lambda.Logging.AspNetCore/LambdaLoggerOptions.cs
+++ b/Libraries/src/Amazon.Lambda.Logging.AspNetCore/LambdaLoggerOptions.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Extensions.Logging
         private const string INCLUDE_LOG_LEVEL_KEY = "IncludeLogLevel";
         private const string INCLUDE_CATEGORY_KEY = "IncludeCategory";
         private const string INCLUDE_NEWLINE_KEY = "IncludeNewline";
+        private const string INCLUDE_EXCEPTION = "IncludeException";
+        private const string INCLUDE_EVENT_ID = "IncludeEventId";
         private const string LOG_LEVEL_KEY = "LogLevel";
 
         /// <summary>
@@ -37,6 +39,18 @@ namespace Microsoft.Extensions.Logging
         /// Default is true.
         /// </summary>
         public bool IncludeNewline { get; set; }
+        
+        /// <summary>
+        /// Flag to indicate if Exception should be part of logged message.
+        /// Default is false.
+        /// </summary>
+        public bool IncludeException { get; set; }
+        
+        /// <summary>
+        /// Flag to indicate if EventId should be part of logged message.
+        /// Default is false.
+        /// </summary>
+        public bool IncludeEventId { get; set; }
 
         /// <summary>
         /// Function used to filter events based on the log level.
@@ -54,6 +68,8 @@ namespace Microsoft.Extensions.Logging
             IncludeCategory = true;
             IncludeLogLevel = true;
             IncludeNewline = true;
+            IncludeException = false;
+            IncludeEventId = false;
             Filter = null;
         }
 
@@ -102,26 +118,32 @@ namespace Microsoft.Extensions.Logging
 
             // Parse settings
 
-            string includeCategoryString;
-            if (TryGetString(loggerConfiguration, INCLUDE_CATEGORY_KEY, out includeCategoryString))
+            if (TryGetString(loggerConfiguration, INCLUDE_CATEGORY_KEY, out string includeCategoryString))
             {
                 IncludeCategory = bool.Parse(includeCategoryString);
             }
 
-            string includeLogLevelString;
-            if (TryGetString(loggerConfiguration, INCLUDE_LOG_LEVEL_KEY, out includeLogLevelString))
+            if (TryGetString(loggerConfiguration, INCLUDE_LOG_LEVEL_KEY, out string includeLogLevelString))
             {
                 IncludeLogLevel = bool.Parse(includeLogLevelString);
             }
+                
+            if (TryGetString(loggerConfiguration, INCLUDE_EXCEPTION, out string includeExceptionString))
+            {
+                IncludeException = bool.Parse(includeExceptionString);
+            }
+                
+            if (TryGetString(loggerConfiguration, INCLUDE_EVENT_ID, out string includeEventIdString))
+            {
+                IncludeEventId = bool.Parse(includeEventIdString);
+            }
 
-            string includeNewlineString;
-            if (TryGetString(loggerConfiguration, INCLUDE_NEWLINE_KEY, out includeNewlineString))
+            if (TryGetString(loggerConfiguration, INCLUDE_NEWLINE_KEY, out string includeNewlineString))
             {
                 IncludeNewline = bool.Parse(includeNewlineString);
             }
 
-            IConfiguration logLevelsSection;
-            if (TryGetSection(loggerConfiguration, LOG_LEVEL_KEY, out logLevelsSection))
+            if (TryGetSection(loggerConfiguration, LOG_LEVEL_KEY, out IConfiguration logLevelsSection))
             {
                 Filter = CreateFilter(logLevelsSection);
             }

--- a/Libraries/src/Amazon.Lambda.Logging.AspNetCore/LambdaLoggerOptions.cs
+++ b/Libraries/src/Amazon.Lambda.Logging.AspNetCore/LambdaLoggerOptions.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Extensions.Logging
         private const string INCLUDE_LOG_LEVEL_KEY = "IncludeLogLevel";
         private const string INCLUDE_CATEGORY_KEY = "IncludeCategory";
         private const string INCLUDE_NEWLINE_KEY = "IncludeNewline";
-        private const string INCLUDE_EXCEPTION = "IncludeException";
-        private const string INCLUDE_EVENT_ID = "IncludeEventId";
+        private const string INCLUDE_EXCEPTION_KEY = "IncludeException";
+		private const string INCLUDE_EVENT_ID_KEY = "IncludeEventId";
         private const string LOG_LEVEL_KEY = "LogLevel";
 
         /// <summary>
@@ -128,12 +128,12 @@ namespace Microsoft.Extensions.Logging
                 IncludeLogLevel = bool.Parse(includeLogLevelString);
             }
                 
-            if (TryGetString(loggerConfiguration, INCLUDE_EXCEPTION, out string includeExceptionString))
+            if (TryGetString(loggerConfiguration, INCLUDE_EXCEPTION_KEY, out string includeExceptionString))
             {
                 IncludeException = bool.Parse(includeExceptionString);
             }
                 
-            if (TryGetString(loggerConfiguration, INCLUDE_EVENT_ID, out string includeEventIdString))
+            if (TryGetString(loggerConfiguration, INCLUDE_EVENT_ID_KEY, out string includeEventIdString))
             {
                 IncludeEventId = bool.Parse(includeEventIdString);
             }

--- a/Libraries/test/Amazon.Lambda.Logging.AspNetCore.Tests/Amazon.Lambda.Logging.AspNetCore.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.Logging.AspNetCore.Tests/Amazon.Lambda.Logging.AspNetCore.Tests.csproj
@@ -9,6 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Update="appsettings.exceptions.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="appsettings.wildcard.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Libraries/test/Amazon.Lambda.Logging.AspNetCore.Tests/LoggingTests.cs
+++ b/Libraries/test/Amazon.Lambda.Logging.AspNetCore.Tests/LoggingTests.cs
@@ -11,257 +11,356 @@ using Xunit;
 namespace Amazon.Lambda.Tests
 {
 
-    public class LoggingTests
-    {
-        private const string SHOULD_APPEAR = "TextThatShouldAppear";
-        private const string SHOULD_NOT_APPEAR = "TextThatShouldNotAppear";
-        private static string APPSETTINGS_DIR = Directory.GetCurrentDirectory();
+	public class LoggingTests
+	{
+		private const string SHOULD_APPEAR = "TextThatShouldAppear";
+		private const string SHOULD_NOT_APPEAR = "TextThatShouldNotAppear";
+		private const string SHOULD_APPEAR_EVENT = "EventThatShouldAppear";
+		private const string SHOULD_APPEAR_EXCEPTION = "ExceptionThatShouldAppear";
+		private static string APPSETTINGS_DIR = Directory.GetCurrentDirectory();
+		private static readonly Func<int, EventId> GET_SHOULD_APPEAR_EVENT = (id) => new EventId(451, SHOULD_APPEAR_EVENT + id);
+		private static readonly EventId SHOULD_NOT_APPEAR_EVENT = new EventId(333, "EventThatShoulNotdAppear");
+		private static readonly Func<int, Exception> GET_SHOULD_APPEAR_EXCEPTION = (id) => new Exception(SHOULD_APPEAR_EXCEPTION + id);
+		private static readonly Exception SHOULD_NOT_APPEAR_EXCEPTION = new Exception("ExceptionThatShouldNotAppear");
 
-        [Fact]
-        public void TestConfiguration()
-        {
-            using (var writer = new StringWriter())
-            {
-                ConnectLoggingActionToLogger(message => writer.Write(message));
+		[Fact]
+		public void TestConfiguration()
+		{
+			using (var writer = new StringWriter())
+			{
+				ConnectLoggingActionToLogger(message => writer.Write(message));
 
-                var configuration = new ConfigurationBuilder()
-                    .AddJsonFile(GetAppSettingsPath("appsettings.json"))
-                    .Build();
+				var configuration = new ConfigurationBuilder()
+					.AddJsonFile(GetAppSettingsPath("appsettings.json"))
+					.Build();
 
-                var loggerOptions = new LambdaLoggerOptions(configuration);
-                Assert.False(loggerOptions.IncludeCategory);
-                Assert.False(loggerOptions.IncludeLogLevel);
-                Assert.False(loggerOptions.IncludeNewline);
+				var loggerOptions = new LambdaLoggerOptions(configuration);
+				Assert.False(loggerOptions.IncludeCategory);
+				Assert.False(loggerOptions.IncludeLogLevel);
+				Assert.False(loggerOptions.IncludeNewline);
 
-                var loggerfactory = new TestLoggerFactory()
-                    .AddLambdaLogger(loggerOptions);
+				var loggerfactory = new TestLoggerFactory()
+					.AddLambdaLogger(loggerOptions);
 
-                int count = 0;
+				int count = 0;
 
-                var defaultLogger = loggerfactory.CreateLogger("Default");
-                defaultLogger.LogTrace(SHOULD_NOT_APPEAR);
-                defaultLogger.LogDebug(SHOULD_APPEAR + (count++));
-                defaultLogger.LogCritical(SHOULD_APPEAR + (count++));
+				var defaultLogger = loggerfactory.CreateLogger("Default");
+				defaultLogger.LogTrace(SHOULD_NOT_APPEAR);
+				defaultLogger.LogDebug(SHOULD_APPEAR + (count++));
+				defaultLogger.LogCritical(SHOULD_APPEAR + (count++));
 
-                defaultLogger = loggerfactory.CreateLogger(null);
-                defaultLogger.LogTrace(SHOULD_NOT_APPEAR);
-                defaultLogger.LogDebug(SHOULD_APPEAR + (count++));
-                defaultLogger.LogCritical(SHOULD_APPEAR + (count++));
+				defaultLogger = loggerfactory.CreateLogger(null);
+				defaultLogger.LogTrace(SHOULD_NOT_APPEAR);
+				defaultLogger.LogDebug(SHOULD_APPEAR + (count++));
+				defaultLogger.LogCritical(SHOULD_APPEAR + (count++));
 
-                // change settings
-                int countAtChange = count;
-                loggerOptions.IncludeCategory = true;
-                loggerOptions.IncludeLogLevel = true;
-                loggerOptions.IncludeNewline = true;
+				// change settings
+				int countAtChange = count;
+				loggerOptions.IncludeCategory = true;
+				loggerOptions.IncludeLogLevel = true;
+				loggerOptions.IncludeNewline = true;
 
-                var msLogger = loggerfactory.CreateLogger("Microsoft");
-                msLogger.LogTrace(SHOULD_NOT_APPEAR);
-                msLogger.LogInformation(SHOULD_APPEAR + (count++));
-                msLogger.LogCritical(SHOULD_APPEAR + (count++));
+				var msLogger = loggerfactory.CreateLogger("Microsoft");
+				msLogger.LogTrace(SHOULD_NOT_APPEAR);
+				msLogger.LogInformation(SHOULD_APPEAR + (count++));
+				msLogger.LogCritical(SHOULD_APPEAR + (count++));
 
-                var sdkLogger = loggerfactory.CreateLogger("AWSSDK");
-                sdkLogger.LogTrace(SHOULD_APPEAR + (count++));
-                sdkLogger.LogInformation(SHOULD_APPEAR + (count++));
-                sdkLogger.LogCritical(SHOULD_APPEAR + (count++));
+				var sdkLogger = loggerfactory.CreateLogger("AWSSDK");
+				sdkLogger.LogTrace(SHOULD_APPEAR + (count++));
+				sdkLogger.LogInformation(SHOULD_APPEAR + (count++));
+				sdkLogger.LogCritical(SHOULD_APPEAR + (count++));
 
-                // get text and verify
-                var text = writer.ToString();
+				// get text and verify
+				var text = writer.ToString();
 
-                // check that there are no unexpected strings in the text
-                Assert.DoesNotContain(SHOULD_NOT_APPEAR, text);
+				// check that there are no unexpected strings in the text
+				Assert.DoesNotContain(SHOULD_NOT_APPEAR, text);
 
-                // check that all expected strings are in the text
-                for (int i = 0; i < count; i++)
-                {
-                    var expected = SHOULD_APPEAR + i;
-                    Assert.True(text.Contains(expected), $"Expected to find '{expected}' in '{text}'");
-                }
+				// check that all expected strings are in the text
+				for (int i = 0; i < count; i++)
+				{
+					var expected = SHOULD_APPEAR + i;
+					Assert.True(text.Contains(expected), $"Expected to find '{expected}' in '{text}'");
+				}
 
-                // check extras that were added mid-way
-                int numberOfExtraBits = count - countAtChange;
+				// check extras that were added mid-way
+				int numberOfExtraBits = count - countAtChange;
 
-                // count levels
-                var logLevelStrings = Enum.GetNames(typeof(LogLevel)).Select(ll => $"[{ll}").ToList();
-                Assert.Equal(numberOfExtraBits, CountMultipleOccurences(text, logLevelStrings));
+				// count levels
+				var logLevelStrings = Enum.GetNames(typeof(LogLevel)).Select(ll => $"[{ll}").ToList();
+				Assert.Equal(numberOfExtraBits, CountMultipleOccurences(text, logLevelStrings));
 
-                // count categories
-                var categoryStrings = new string[] { "Microsoft", "AWSSDK" };
-                Assert.Equal(numberOfExtraBits, CountMultipleOccurences(text, categoryStrings));
+				// count categories
+				var categoryStrings = new string[] { "Microsoft", "AWSSDK" };
+				Assert.Equal(numberOfExtraBits, CountMultipleOccurences(text, categoryStrings));
 
-                // count newlines
-                Assert.Equal(numberOfExtraBits, CountOccurences(text, Environment.NewLine));
-            }
-        }
+				// count newlines
+				Assert.Equal(numberOfExtraBits, CountOccurences(text, Environment.NewLine));
+			}
+		}
 
-        [Fact]
-        public void TestWilcardConfiguration()
-        {
-            using (var writer = new StringWriter())
-            {
-                ConnectLoggingActionToLogger(message => writer.Write(message));
+		[Fact]
+		public void TestWilcardConfiguration()
+		{
+			using (var writer = new StringWriter())
+			{
+				ConnectLoggingActionToLogger(message => writer.Write(message));
 
-                var configuration = new ConfigurationBuilder()
-                    .AddJsonFile(GetAppSettingsPath("appsettings.wildcard.json"))
-                    .Build();
+				var configuration = new ConfigurationBuilder()
+					.AddJsonFile(GetAppSettingsPath("appsettings.wildcard.json"))
+					.Build();
 
-                var loggerOptions = new LambdaLoggerOptions(configuration);
-                Assert.False(loggerOptions.IncludeCategory);
-                Assert.False(loggerOptions.IncludeLogLevel);
-                Assert.False(loggerOptions.IncludeNewline);
+				var loggerOptions = new LambdaLoggerOptions(configuration);
+				Assert.False(loggerOptions.IncludeCategory);
+				Assert.False(loggerOptions.IncludeLogLevel);
+				Assert.False(loggerOptions.IncludeNewline);
 
-                var loggerfactory = new TestLoggerFactory()
-                    .AddLambdaLogger(loggerOptions);
+				var loggerfactory = new TestLoggerFactory()
+					.AddLambdaLogger(loggerOptions);
 
-                int count = 0;
+				int count = 0;
 
-                // Should match:
-                //   "Foo.*": "Information"
-                var foobarLogger = loggerfactory.CreateLogger("Foo.Bar");
-                foobarLogger.LogTrace(SHOULD_NOT_APPEAR);
-                foobarLogger.LogDebug(SHOULD_NOT_APPEAR);
-                foobarLogger.LogInformation(SHOULD_APPEAR + (count++));
-                foobarLogger.LogWarning(SHOULD_APPEAR + (count++));
-                foobarLogger.LogError(SHOULD_APPEAR + (count++));
-                foobarLogger.LogCritical(SHOULD_APPEAR + (count++));
+				// Should match:
+				//   "Foo.*": "Information"
+				var foobarLogger = loggerfactory.CreateLogger("Foo.Bar");
+				foobarLogger.LogTrace(SHOULD_NOT_APPEAR);
+				foobarLogger.LogDebug(SHOULD_NOT_APPEAR);
+				foobarLogger.LogInformation(SHOULD_APPEAR + (count++));
+				foobarLogger.LogWarning(SHOULD_APPEAR + (count++));
+				foobarLogger.LogError(SHOULD_APPEAR + (count++));
+				foobarLogger.LogCritical(SHOULD_APPEAR + (count++));
 
-                // Should match:
-                //   "Foo.Bar.Baz": "Critical"
-                var foobarbazLogger = loggerfactory.CreateLogger("Foo.Bar.Baz");
-                foobarbazLogger.LogTrace(SHOULD_NOT_APPEAR);
-                foobarbazLogger.LogDebug(SHOULD_NOT_APPEAR);
-                foobarbazLogger.LogInformation(SHOULD_NOT_APPEAR);
-                foobarbazLogger.LogWarning(SHOULD_NOT_APPEAR);
-                foobarbazLogger.LogError(SHOULD_NOT_APPEAR);
-                foobarbazLogger.LogCritical(SHOULD_APPEAR + (count++));
+				// Should match:
+				//   "Foo.Bar.Baz": "Critical"
+				var foobarbazLogger = loggerfactory.CreateLogger("Foo.Bar.Baz");
+				foobarbazLogger.LogTrace(SHOULD_NOT_APPEAR);
+				foobarbazLogger.LogDebug(SHOULD_NOT_APPEAR);
+				foobarbazLogger.LogInformation(SHOULD_NOT_APPEAR);
+				foobarbazLogger.LogWarning(SHOULD_NOT_APPEAR);
+				foobarbazLogger.LogError(SHOULD_NOT_APPEAR);
+				foobarbazLogger.LogCritical(SHOULD_APPEAR + (count++));
 
-                // Should match:
-                //   "Foo.Bar.*": "Warning"
-                var foobarbuzzLogger = loggerfactory.CreateLogger("Foo.Bar.Buzz");
-                foobarbuzzLogger.LogTrace(SHOULD_NOT_APPEAR);
-                foobarbuzzLogger.LogDebug(SHOULD_NOT_APPEAR);
-                foobarbuzzLogger.LogInformation(SHOULD_NOT_APPEAR);
-                foobarbuzzLogger.LogWarning(SHOULD_APPEAR + (count++));
-                foobarbuzzLogger.LogError(SHOULD_APPEAR + (count++));
-                foobarbuzzLogger.LogCritical(SHOULD_APPEAR + (count++));
+				// Should match:
+				//   "Foo.Bar.*": "Warning"
+				var foobarbuzzLogger = loggerfactory.CreateLogger("Foo.Bar.Buzz");
+				foobarbuzzLogger.LogTrace(SHOULD_NOT_APPEAR);
+				foobarbuzzLogger.LogDebug(SHOULD_NOT_APPEAR);
+				foobarbuzzLogger.LogInformation(SHOULD_NOT_APPEAR);
+				foobarbuzzLogger.LogWarning(SHOULD_APPEAR + (count++));
+				foobarbuzzLogger.LogError(SHOULD_APPEAR + (count++));
+				foobarbuzzLogger.LogCritical(SHOULD_APPEAR + (count++));
 
 
-                // Should match:
-                //   "*": "Error"
-                var somethingLogger = loggerfactory.CreateLogger("something");
-                somethingLogger.LogTrace(SHOULD_NOT_APPEAR);
-                somethingLogger.LogDebug(SHOULD_NOT_APPEAR);
-                somethingLogger.LogInformation(SHOULD_NOT_APPEAR);
-                somethingLogger.LogWarning(SHOULD_NOT_APPEAR);
-                somethingLogger.LogError(SHOULD_APPEAR + (count++));
-                somethingLogger.LogCritical(SHOULD_APPEAR + (count++));
+				// Should match:
+				//   "*": "Error"
+				var somethingLogger = loggerfactory.CreateLogger("something");
+				somethingLogger.LogTrace(SHOULD_NOT_APPEAR);
+				somethingLogger.LogDebug(SHOULD_NOT_APPEAR);
+				somethingLogger.LogInformation(SHOULD_NOT_APPEAR);
+				somethingLogger.LogWarning(SHOULD_NOT_APPEAR);
+				somethingLogger.LogError(SHOULD_APPEAR + (count++));
+				somethingLogger.LogCritical(SHOULD_APPEAR + (count++));
 
-                // get text and verify
-                var text = writer.ToString();
+				// get text and verify
+				var text = writer.ToString();
 
-                // check that there are no unexpected strings in the text
-                Assert.DoesNotContain(SHOULD_NOT_APPEAR, text);
+				// check that there are no unexpected strings in the text
+				Assert.DoesNotContain(SHOULD_NOT_APPEAR, text);
 
-                // check that all expected strings are in the text
-                for (int i = 0; i < count; i++)
-                {
-                    var expected = SHOULD_APPEAR + i;
-                    Assert.True(text.Contains(expected), $"Expected to find '{expected}' in '{text}'");
-                }
-            }
-        }
+				// check that all expected strings are in the text
+				for (int i = 0; i < count; i++)
+				{
+					var expected = SHOULD_APPEAR + i;
+					Assert.True(text.Contains(expected), $"Expected to find '{expected}' in '{text}'");
+				}
+			}
+		}
 
-        [Fact]
-        public void TestOnlyOneWildcardSupported()
-        {
-            var dict = new Dictionary<string, string>
-            {
-                { "Lambda.Logging:LogLevel:*.*", "Information" }
-            };
+		[Fact]
+		public void TestOnlyOneWildcardSupported()
+		{
+			var dict = new Dictionary<string, string>
+			{
+				{ "Lambda.Logging:LogLevel:*.*", "Information" }
+			};
 
-            var configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection(dict)
-                .Build();
+			var configuration = new ConfigurationBuilder()
+				.AddInMemoryCollection(dict)
+				.Build();
 
-            ArgumentOutOfRangeException exception = null;
-            try
-            {
-                var loggerOptions = new LambdaLoggerOptions(configuration);
-            }
-            catch (ArgumentOutOfRangeException ex)
-            {
-                exception = ex;
-            }
+			ArgumentOutOfRangeException exception = null;
+			try
+			{
+				var loggerOptions = new LambdaLoggerOptions(configuration);
+			}
+			catch (ArgumentOutOfRangeException ex)
+			{
+				exception = ex;
+			}
 
-            // check that there are no unexpected strings in the text
-            Assert.NotNull(exception);
-            Assert.Contains("only 1 wildcard is supported in a category", exception.Message);
-        }
+			// check that there are no unexpected strings in the text
+			Assert.NotNull(exception);
+			Assert.Contains("only 1 wildcard is supported in a category", exception.Message);
+		}
 
-        [Fact]
-        public void TestOnlyTerminatingWildcardsSupported()
-        {
-            var dict = new Dictionary<string, string>
-            {
-                { "Lambda.Logging:LogLevel:Foo.*.Bar", "Information" }
-            };
+		[Fact]
+		public void TestOnlyTerminatingWildcardsSupported()
+		{
+			var dict = new Dictionary<string, string>
+			{
+				{ "Lambda.Logging:LogLevel:Foo.*.Bar", "Information" }
+			};
 
-            var configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection(dict)
-                .Build();
+			var configuration = new ConfigurationBuilder()
+				.AddInMemoryCollection(dict)
+				.Build();
 
-            ArgumentException exception = null;
-            try
-            {
-                var loggerOptions = new LambdaLoggerOptions(configuration);
-            }
-            catch (ArgumentException ex)
-            {
-                exception = ex;
-            }
+			ArgumentException exception = null;
+			try
+			{
+				var loggerOptions = new LambdaLoggerOptions(configuration);
+			}
+			catch (ArgumentException ex)
+			{
+				exception = ex;
+			}
 
-            // check that there are no unexpected strings in the text
-            Assert.NotNull(exception);
-            Assert.Contains("wilcards are only supported at the end of a category", exception.Message);
-        }
+			// check that there are no unexpected strings in the text
+			Assert.NotNull(exception);
+			Assert.Contains("wilcards are only supported at the end of a category", exception.Message);
+		}
 
-        private static string GetAppSettingsPath(string fileName)
-        {
-            return Path.Combine(APPSETTINGS_DIR, fileName);
-        }
-        private static void ConnectLoggingActionToLogger(Action<string> loggingAction)
-        {
-            var lambdaLoggerType = typeof(Amazon.Lambda.Core.LambdaLogger);
-            Assert.NotNull(lambdaLoggerType);
-            var loggingActionField = lambdaLoggerType
-                .GetTypeInfo()
-                .GetField("_loggingAction", BindingFlags.NonPublic | BindingFlags.Static);
-            Assert.NotNull(loggingActionField);
+		[Fact]
+		public void TestConfigurationReadingForExceptionsEvents()
+		{
+			// Arrange
+			var configuration = new ConfigurationBuilder()
+					.AddJsonFile(GetAppSettingsPath("appsettings.exceptions.json"))
+					.Build();
 
-            loggingActionField.SetValue(null, loggingAction);
-        }
-        private static int CountOccurences(string text, string substring)
-        {
-            int occurences = 0;
-            int index = 0;
-            do
-            {
-                index = text.IndexOf(substring, index, StringComparison.Ordinal);
-                if (index >= 0)
-                {
-                    occurences++;
-                    index += substring.Length;
-                }
-            } while (index >= 0);
-            return occurences;
-        }
-        private static int CountMultipleOccurences(string text, IEnumerable<string> substrings)
-        {
-            int total = 0;
-            foreach (var substring in substrings)
-            {
-                total += CountOccurences(text, substring);
-            }
-            return total;
-        }
-    }
+			// Act
+			var loggerOptions = new LambdaLoggerOptions(configuration);
+
+			// Assert
+			Assert.False(loggerOptions.IncludeCategory);
+			Assert.False(loggerOptions.IncludeLogLevel);
+			Assert.False(loggerOptions.IncludeNewline);
+			Assert.True(loggerOptions.IncludeEventId);
+			Assert.True(loggerOptions.IncludeException);
+		}
+
+		[Fact]
+		public void TestLoggingExceptionsAndEvents()
+		{
+			using (var writer = new StringWriter())
+			{
+				ConnectLoggingActionToLogger(message => writer.Write(message));
+
+				var configuration = new ConfigurationBuilder()
+					.AddJsonFile(GetAppSettingsPath("appsettings.json"))
+					.Build();
+
+				var loggerOptions = new LambdaLoggerOptions(configuration);
+				var loggerfactory = new TestLoggerFactory()
+					.AddLambdaLogger(loggerOptions);
+
+				int countMessage = 0;
+				int countEvent = 0;
+				int countException = 0;
+
+				var defaultLogger = loggerfactory.CreateLogger("Default");
+				defaultLogger.LogTrace(SHOULD_NOT_APPEAR_EVENT, SHOULD_NOT_APPEAR_EXCEPTION, SHOULD_NOT_APPEAR);
+				defaultLogger.LogDebug(SHOULD_NOT_APPEAR_EVENT, SHOULD_APPEAR + (countMessage++));
+				defaultLogger.LogCritical(SHOULD_NOT_APPEAR_EVENT, SHOULD_APPEAR + (countMessage++));
+
+				defaultLogger = loggerfactory.CreateLogger(null);
+				defaultLogger.LogTrace(SHOULD_NOT_APPEAR_EVENT, SHOULD_NOT_APPEAR);
+				defaultLogger.LogDebug(SHOULD_NOT_APPEAR_EVENT, SHOULD_APPEAR + (countMessage++));
+				defaultLogger.LogCritical(SHOULD_NOT_APPEAR_EVENT, SHOULD_APPEAR + (countMessage++));
+
+				// change settings
+				loggerOptions.IncludeCategory = true;
+				loggerOptions.IncludeLogLevel = true;
+				loggerOptions.IncludeNewline = true;
+				loggerOptions.IncludeException = true;
+				loggerOptions.IncludeEventId = true;
+
+				var msLogger = loggerfactory.CreateLogger("Microsoft");
+				msLogger.LogTrace(SHOULD_NOT_APPEAR_EVENT, SHOULD_NOT_APPEAR_EXCEPTION, SHOULD_NOT_APPEAR);
+				msLogger.LogInformation(GET_SHOULD_APPEAR_EVENT(countEvent++), GET_SHOULD_APPEAR_EXCEPTION(countException++), SHOULD_APPEAR + (countMessage++));
+				msLogger.LogCritical(GET_SHOULD_APPEAR_EVENT(countEvent++), GET_SHOULD_APPEAR_EXCEPTION(countException++), SHOULD_APPEAR + (countMessage++));
+
+				var sdkLogger = loggerfactory.CreateLogger("AWSSDK");
+				sdkLogger.LogTrace(GET_SHOULD_APPEAR_EVENT(countEvent++), GET_SHOULD_APPEAR_EXCEPTION(countException++), SHOULD_APPEAR + (countMessage++));
+				sdkLogger.LogInformation(GET_SHOULD_APPEAR_EVENT(countEvent++), GET_SHOULD_APPEAR_EXCEPTION(countException++), SHOULD_APPEAR + (countMessage++));
+				sdkLogger.LogCritical(GET_SHOULD_APPEAR_EVENT(countEvent++), GET_SHOULD_APPEAR_EXCEPTION(countException++), SHOULD_APPEAR + (countMessage++));
+
+				// get text and verify
+				var text = writer.ToString();
+
+				// check that there are no unexpected strings in the text
+				Assert.DoesNotContain(SHOULD_NOT_APPEAR, text);
+				Assert.DoesNotContain(SHOULD_NOT_APPEAR_EVENT.Id.ToString(), text);
+				Assert.DoesNotContain(SHOULD_NOT_APPEAR_EVENT.Name, text);
+				Assert.DoesNotContain(SHOULD_NOT_APPEAR_EXCEPTION.Message, text);
+
+				// check that all expected strings are in the text
+				for (int i = 0; i < countMessage; i++)
+				{
+					var expectedMessages = SHOULD_APPEAR + i;
+					Assert.True(text.Contains(expectedMessages), $"Expected to find '{expectedMessages}' in '{text}'");
+				}
+				for (int i = 0; i < countException; i++)
+				{
+					var expectedMessages = SHOULD_APPEAR_EXCEPTION + i;
+					Assert.True(text.Contains(expectedMessages), $"Expected to find '{expectedMessages}' in '{text}'");
+				}
+				for (int i = 0; i < countEvent; i++)
+				{
+					var expectedMessages = SHOULD_APPEAR_EVENT + i;
+					Assert.True(text.Contains(expectedMessages), $"Expected to find '{expectedMessages}' in '{text}'");
+				}
+			}
+		}
+
+		private static string GetAppSettingsPath(string fileName)
+		{
+			return Path.Combine(APPSETTINGS_DIR, fileName);
+		}
+		private static void ConnectLoggingActionToLogger(Action<string> loggingAction)
+		{
+			var lambdaLoggerType = typeof(Amazon.Lambda.Core.LambdaLogger);
+			Assert.NotNull(lambdaLoggerType);
+			var loggingActionField = lambdaLoggerType
+				.GetTypeInfo()
+				.GetField("_loggingAction", BindingFlags.NonPublic | BindingFlags.Static);
+			Assert.NotNull(loggingActionField);
+
+			loggingActionField.SetValue(null, loggingAction);
+		}
+		private static int CountOccurences(string text, string substring)
+		{
+			int occurences = 0;
+			int index = 0;
+			do
+			{
+				index = text.IndexOf(substring, index, StringComparison.Ordinal);
+				if (index >= 0)
+				{
+					occurences++;
+					index += substring.Length;
+				}
+			} while (index >= 0);
+			return occurences;
+		}
+		private static int CountMultipleOccurences(string text, IEnumerable<string> substrings)
+		{
+			int total = 0;
+			foreach (var substring in substrings)
+			{
+				total += CountOccurences(text, substring);
+			}
+			return total;
+		}
+	}
 }

--- a/Libraries/test/Amazon.Lambda.Logging.AspNetCore.Tests/appsettings.exceptions.json
+++ b/Libraries/test/Amazon.Lambda.Logging.AspNetCore.Tests/appsettings.exceptions.json
@@ -3,8 +3,8 @@
     "IncludeCategory": false,
     "IncludeLogLevel": false,
     "IncludeNewline": false,
-    "IncludException": false,
-    "IncludeEventId": false,
+    "IncludeException": true,
+    "IncludeEventId": true,
     "LogLevel": {
       "Default": "Debug",
       "Microsoft": "Information"


### PR DESCRIPTION
*Issue #, if available:*
Microsoft.Extensions.Logging interface supports logging **EventId** and **Exceptions**, but when LambdaLogger is configured, those objects are not saved in CloudWatch.

Sample scenario:
```
logger.LogError(LoggingEvents.DbOperationError, ex, $"SelectData: {spName} SqlException Number: {se.Number} Sql Parameter: {spc}");
```
The natural expectation is that both Logging Event and Exception will be available in CloudWatch, which is not the case.

*Description of changes:*
I've included 2 new settings on Lambda Logger Options to enable  **EventId** and **Exceptions** logging.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
