### PR TITLE
Bumped default PowerShell SDK to version 6.2.0

### DIFF
--- a/PowerShell/Module/Private/_Constants.ps1
+++ b/PowerShell/Module/Private/_Constants.ps1
@@ -20,5 +20,5 @@ if (!($AwsPowerShellFunctionEnvName))
 
 if (!($AwsPowerShellDefaultSdkVersion))
 {
-    New-Variable -Name AwsPowerShellDefaultSdkVersion -Value '6.1.1' -Option Constant
+    New-Variable -Name AwsPowerShellDefaultSdkVersion -Value '6.2.0' -Option Constant
 }


### PR DESCRIPTION
*Issue #, if available:*
No issue available.

*Description of changes:*
Bumped the default PowerShell SDK to version 6.2.0 per the latest stable release on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerShell.SDK).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
