### PR TITLE
Escape a Little Less

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -186,7 +186,7 @@ namespace Amazon.Lambda.AspNetCoreServer
 
                 requestFeatures.Path = Utilities.DecodeResourcePath(requestFeatures.Path);
 
-                requestFeatures.QueryString = Utilities.CreateQueryStringParamaters(
+                requestFeatures.QueryString = Utilities.CreateQueryStringParameters(
                     apiGatewayRequest.QueryStringParameters, apiGatewayRequest.MultiValueQueryStringParameters);
 
                 Utilities.SetHeadersCollection(requestFeatures.Headers, apiGatewayRequest.Headers, apiGatewayRequest.MultiValueHeaders);

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction{TStartup}.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction{TStartup}.cs
@@ -10,6 +10,26 @@ namespace Amazon.Lambda.AspNetCoreServer
     /// <typeparam name ="TStartup">The type containing the startup methods for the application.</typeparam>
     public abstract class APIGatewayProxyFunction<TStartup> : APIGatewayProxyFunction where TStartup : class
     {
+        /// <summary>
+        /// Default Constructor. The ASP.NET Core Framework will be initialized as part of the construction.
+        /// </summary>
+        protected APIGatewayProxyFunction()
+            : base()
+        {
+
+        }
+
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="startupMode">Configure when the ASP.NET Core framework will be initialized</param>
+        protected APIGatewayProxyFunction(StartupMode startupMode)
+            : base(startupMode)
+        {
+
+        }
+
         /// <inheritdoc/>
         protected override IWebHostBuilder CreateWebHostBuilder() =>
             base.CreateWebHostBuilder().UseStartup<TStartup>();

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
@@ -64,7 +64,7 @@ namespace Amazon.Lambda.AspNetCoreServer
                 requestFeatures.Method = lambdaRequest.HttpMethod;
                 requestFeatures.Path = Utilities.DecodeResourcePath(lambdaRequest.Path);
 
-                requestFeatures.QueryString = Utilities.CreateQueryStringParamaters(
+                requestFeatures.QueryString = Utilities.CreateQueryStringParameters(
                     lambdaRequest.QueryStringParameters, lambdaRequest.MultiValueQueryStringParameters);
 
                 Utilities.SetHeadersCollection(requestFeatures.Headers, lambdaRequest.Headers, lambdaRequest.MultiValueHeaders);

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/Utilities.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/Utilities.cs
@@ -65,7 +65,7 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
             }
         }
 
-        internal static string CreateQueryStringParamaters(IDictionary<string, string> singleValues, IDictionary<string, IList<string>> multiValues)
+        internal static string CreateQueryStringParameters(IDictionary<string, string> singleValues, IDictionary<string, IList<string>> multiValues)
         {
             if (multiValues?.Count > 0)
             {
@@ -78,7 +78,7 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
                         {
                             sb.Append("&");
                         }
-                        sb.Append($"{kvp.Key}={value}");
+                        sb.Append(kvp.Key).Append('=').Append(value);
                     }
                 }
                 return sb.ToString();
@@ -95,7 +95,7 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
                         {
                             sb.Append("&");
                         }
-                        sb.Append($"{kvp.Key}={kvp.Value}");
+                        sb.Append(kvp.Key).Append('=').Append(kvp.Value);
                     }
                     return sb.ToString();
                 }

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/Utilities.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/Utilities.cs
@@ -120,16 +120,13 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
                     headers[kvp.Key] = new StringValues(kvp.Value);
                 }
             }
-
         }
 
-        internal static string DecodeResourcePath(string resourcePath)
-        {
-            // Convert any + signs to percent encoding before url decoding the path.
-            resourcePath = resourcePath.Replace("+", "%2B");
-            resourcePath = resourcePath = WebUtility.UrlDecode(resourcePath);
-
-            return resourcePath;
-        }
+        internal static string DecodeResourcePath(string resourcePath) => WebUtility.UrlDecode(resourcePath
+            // Convert any + signs to percent encoding before URL decoding the path.
+            .Replace("+", "%2B")
+            // Double-escape any %2F (encoded / characters) so that they survive URL decoding the path.
+            .Replace("%2F", "%252F")
+            .Replace("%2f", "%252f"));
     }
 }


### PR DESCRIPTION
### Issue Number

#440

### Description of Changes

Double-escapes '%2F' so that it survives unescaping by `WebUtility.UrlDecode`. This matches other implementations better, and allows path parameters containing '%2F' (or '%2f', natch) to be routed correctly by ASP.NET Core. If someone suggests a smarter solution, I'll accept it happily. (Also some smaller changes, hopefully uncontroversial, all in a separate commit.)

### License Acceptance

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.* ✔️
