### PR TITLE
Handle ELB Health Check

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
@@ -74,6 +74,15 @@ namespace Amazon.Lambda.AspNetCoreServer
                     requestFeatures.Body = Utilities.ConvertLambdaRequestBodyToAspNetCoreBody(lambdaRequest.Body, lambdaRequest.IsBase64Encoded);
                 }
 
+                var userAgent = GetSingleHeaderValue(lambdaRequest, "user-agent");
+                if (userAgent != null && userAgent.StartsWith("ELB-HealthChecker/", StringComparison.OrdinalIgnoreCase))
+                {
+                    requestFeatures.Scheme = "https";
+                    requestFeatures.Headers["host"] = "localhost";
+                    requestFeatures.Headers["x-forwarded-port"] = "443";
+                    requestFeatures.Headers["x-forwarded-for"] = "127.0.0.1";
+                }
+
                 // Call consumers customize method in case they want to change how API Gateway's request
                 // was marshalled into ASP.NET Core request.
                 PostMarshallRequestFeature(requestFeatures, lambdaRequest, lambdaContext);

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestApplicationLoadBalancerCalls.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestApplicationLoadBalancerCalls.cs
@@ -151,6 +151,17 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
             Assert.False(response.IsBase64Encoded, "Response IsBase64Encoded");
         }
 
+        [Fact]
+        public async Task TestHealthCheck()
+        {
+            var response = await this.InvokeApplicationLoadBalancerRequest("alb-healthcheck.json");
+
+            Assert.Equal(200, response.StatusCode);
+            Assert.Equal("[\"value1\",\"value2\"]", response.Body);
+            Assert.True(response.Headers.ContainsKey("Content-Type"));
+            Assert.Equal("application/json; charset=utf-8", response.Headers["Content-Type"]);
+        }
+
         private async Task<ApplicationLoadBalancerResponse> InvokeApplicationLoadBalancerRequest(string fileName)
         {
             return await InvokeApplicationLoadBalancerRequest(new TestLambdaContext(), fileName);

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/alb-healthcheck.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/alb-healthcheck.json
@@ -1,0 +1,15 @@
+{
+  "requestContext": {
+    "elb": {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09"
+    }
+  },
+  "httpMethod": "GET",
+  "path": "/api/values",
+  "queryStringParameters": {},
+  "headers": {
+    "user-agent": "ELB-HealthChecker/2.0"
+  },
+  "body": "",
+  "isBase64Encoded": false
+}


### PR DESCRIPTION
Default Scheme, Host, x-forwarded-port and x-forwarded-for if the request is an ELB Health. This is done because that info isn't passed in from ELB and ASP.NET Core does not like those values being set.

This address the following issue: https://github.com/aws/aws-lambda-dotnet/issues/436

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
