### PR TITLE
Log warning if integration doesn't match base class

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -140,6 +140,11 @@ namespace Amazon.Lambda.AspNetCoreServer
                 requestFeatures.Scheme = "https";
                 requestFeatures.Method = apiGatewayRequest.HttpMethod;
 
+				if (string.IsNullOrWhiteSpace(apiGatewayRequest.RequestContext?.DomainName))
+				{
+					_logger.LogWarning($"Request does not contain domain name information but is derived from {nameof(APIGatewayProxyFunction)}.");
+				}
+
                 string path = null;
                 if (apiGatewayRequest.PathParameters != null && apiGatewayRequest.PathParameters.ContainsKey("proxy") &&
                     !string.IsNullOrEmpty(apiGatewayRequest.Resource))

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -140,10 +140,10 @@ namespace Amazon.Lambda.AspNetCoreServer
                 requestFeatures.Scheme = "https";
                 requestFeatures.Method = apiGatewayRequest.HttpMethod;
 
-				if (string.IsNullOrWhiteSpace(apiGatewayRequest.RequestContext?.DomainName))
-				{
-					_logger.LogWarning($"Request does not contain domain name information but is derived from {nameof(APIGatewayProxyFunction)}.");
-				}
+                if (string.IsNullOrWhiteSpace(apiGatewayRequest.RequestContext?.DomainName))
+                {
+                    _logger.LogWarning($"Request does not contain domain name information but is derived from {nameof(APIGatewayProxyFunction)}.");
+                }
 
                 string path = null;
                 if (apiGatewayRequest.PathParameters != null && apiGatewayRequest.PathParameters.ContainsKey("proxy") &&

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
@@ -52,10 +52,10 @@ namespace Amazon.Lambda.AspNetCoreServer
                 throw new Exception("Unable to determine header mode, single or multi value, because both Headers and MultiValueHeaders are null.");
             }
 
-			if (lambdaRequest.RequestContext?.Elb?.TargetGroupArn == null)
-			{
-				_logger.LogWarning($"Request does not contain ELB information but is derived from {nameof(ApplicationLoadBalancerFunction)}.");
-			}
+            if (lambdaRequest.RequestContext?.Elb?.TargetGroupArn == null)
+            {
+                _logger.LogWarning($"Request does not contain ELB information but is derived from {nameof(ApplicationLoadBalancerFunction)}.");
+            }
 
             // Look to see if the request is using mutli value headers or not. This is important when
             // marshalling the response to know whether to fill in the the Headers or MultiValueHeaders collection.

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
@@ -52,6 +52,11 @@ namespace Amazon.Lambda.AspNetCoreServer
                 throw new Exception("Unable to determine header mode, single or multi value, because both Headers and MultiValueHeaders are null.");
             }
 
+			if (lambdaRequest.RequestContext?.Elb?.TargetGroupArn == null)
+			{
+				_logger.LogWarning($"Request does not contain ELB information but is derived from {nameof(ApplicationLoadBalancerFunction)}.");
+			}
+
             // Look to see if the request is using mutli value headers or not. This is important when
             // marshalling the response to know whether to fill in the the Headers or MultiValueHeaders collection.
             // Since a Lambda function compute environment is only one processing one event at a time it is safe to store


### PR DESCRIPTION
Fix for #458 

Log a warning if we suspect there to be a mismatch between the integration used and the class that the function inherits from.
