### PR TITLE
Fixed InstalledOnly parameter implementation

### DIFF
--- a/PowerShell/Module/Private/_BlueprintFunctions.ps1
+++ b/PowerShell/Module/Private/_BlueprintFunctions.ps1
@@ -20,7 +20,7 @@ function _getHostedBlueprintsContent
         'https://d3rrggjwfhwld2.cloudfront.net'
         'https://aws-vs-toolkit.s3.amazonaws.com'
     )
-    
+
     $_altOrigin = $env:PSLAMBDA_BLUEPRINTS_ORIGIN
 
     if ($_altOrigin)
@@ -93,10 +93,17 @@ function _getBlueprintsContent
     (
         # the relative path and filename to the content to load
         [Parameter(Mandatory = $true)]
-        [string]$ContentPath
+        [string]$ContentPath,
+
+        # Defines whether to load Blueprints from online data sources
+        [switch]$Online
     )
 
-    $_content = _getHostedBlueprintsContent -Contentpath $ContentPath
+    if ($Online)
+    {
+        $_content = _getHostedBlueprintsContent -Contentpath $ContentPath
+    }
+
     if (!($_content))
     {
         $_content = _getLocalBlueprintsContent -ContentPath $ContentPath
@@ -115,7 +122,22 @@ function _getBlueprintsContent
 #>
 function _loadBlueprintManifest
 {
-    return ConvertFrom-Json -InputObject (_getBlueprintsContent -ContentPath $_manifestFilename)
+    param
+    (
+        # Defines whether to load Blueprints from online data sources
+        [switch]$Online
+    )
+
+    $_getBlueprintsContent = @{
+        ContentPath = $_manifestFilename
+    }
+
+    if ($Online)
+    {
+        $_getBlueprintsContent.Add('Online', $true)
+    }
+
+    return ConvertFrom-Json -InputObject (_getBlueprintsContent @_getBlueprintsContent)
 }
 
 <#

--- a/PowerShell/Module/Public/Get-AWSPowerShellLambdaTemplate.ps1
+++ b/PowerShell/Module/Public/Get-AWSPowerShellLambdaTemplate.ps1
@@ -26,13 +26,25 @@
 #>
 function Get-AWSPowerShellLambdaTemplate
 {
-
     [CmdletBinding()]
+    param
+    (
+        [switch]$InstalledOnly
+    )
 
-    $manifest = _loadBlueprintManifest
-    foreach ($b in $manifest.blueprints) {
+    if ($InstalledOnly)
+    {
+        $manifest = _loadBlueprintManifest
+    }
+    else
+    {
+        $manifest = _loadBlueprintManifest -Online
+    }
+
+    foreach ($b in $manifest.blueprints)
+    {
         [PSCustomObject]@{
-            Template = $b.name
+            Template    = $b.name
             Description = $b.description
         }
     }

--- a/PowerShell/Tests/Get-AWSPowerShelLambdaTemplate.Tests.ps1
+++ b/PowerShell/Tests/Get-AWSPowerShelLambdaTemplate.Tests.ps1
@@ -1,0 +1,52 @@
+$module = 'AWSLambdaPSCore'
+$moduleManifestPath = [System.IO.Path]::Combine('..', 'Module', "$module.psd1")
+
+if (Get-Module -Name $module) {Remove-Module -Name $module}
+Import-Module $moduleManifestPath
+
+InModuleScope -ModuleName $module -ScriptBlock {
+    Describe -Name 'Get-AWSPowerShellLambdaTemplate' -Fixture {
+
+        function LoadFakeData
+        {
+            ConvertTo-Json -InputObject @{
+                manifestVersion = 1
+                blueprints      = @(
+                    @{
+                        name        = 'Basic'
+                        description = 'Bare bones script'
+                        content     = @(
+                            @{
+                                source   = 'basic.ps1.txt'
+                                output   = '{basename}.ps1'
+                                filetype = 'lambdaFunction'
+                            },
+                            @{
+                                source = 'readme.txt'
+                                output = 'readme.txt'
+                            }
+                        )
+                    }
+                )
+            }
+        }
+        Mock -CommandName '_getHostedBlueprintsContent' -MockWith {LoadFakeData}
+        Mock -CommandName '_getLocalBlueprintsContent' -MockWith {LoadFakeData}
+
+        Context -Name 'Online Templates' -Fixture {
+            It -Name 'Retrieves Blueprints from online sources by default' -Test {
+                $null = Get-AWSPowerShellLambdaTemplate
+                Assert-MockCalled -CommandName '_getHostedBlueprintsContent' -Times 1 -Scope 'It'
+                Assert-MockCalled -CommandName '_getLocalBlueprintsContent' -Times 0 -Scope 'It'
+            }
+        }
+
+        Context -Name 'Offline Templates' -Fixture {
+            It -Name 'Retrieves Blueprints from local source when InstalledOnly is specified' -Test {
+                $null = Get-AWSPowerShellLambdaTemplate -InstalledOnly
+                Assert-MockCalled -CommandName '_getHostedBlueprintsContent' -Times 0 -Scope 'It'
+                Assert-MockCalled -CommandName '_getLocalBlueprintsContent' -Times 1 -Scope 'It'
+            }
+        }
+    } # End Describe
+} # End InModuleScope


### PR DESCRIPTION
*Issue #466*

*Description of changes:*
* Fixed the implementation of the ```Get-AWSPowerShellLambdaTemplate -InstalledOnly``` parameter.
* Added a Pester unit test to validate the fix.
* Updated Get-AWSPowerShellLambdaTemplate to Allman style braces to match the rest of the code.
* VSCode removed additional white space

*Test output*

```powershell
PS>Invoke-Pester
Executing all tests in '.'

Executing script C:\workspace\aws-lambda-dotnet\PowerShell\Tests\Get-AWSPowerShelLambdaTemplate.Tests.ps1

  Describing Get-AWSPowerShellLambdaTemplate

    Context Online Templates
      [+] Retrieves Blueprints from online sources by default 15ms

    Context Offline Templates
      [+] Retrieves Blueprints from local source when InstalledOnly is specified 14ms
Tests completed in 341ms
Tests Passed: 2, Failed: 0, Skipped: 0, Pending: 0, Inconclusive: 0
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
