### PR TITLE
Rework test targets

### DIFF
--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/Amazon.Lambda.RuntimeSupport.IntegrationTests.csproj
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/Amazon.Lambda.RuntimeSupport.IntegrationTests.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.101.12" />
     <PackageReference Include="AWSSDK.Lambda" Version="3.3.102.4" />
     <PackageReference Include="AWSSDK.S3" Version="3.3.102.3" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.101.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
@@ -17,6 +16,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
+
+    <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.101.4" />
   </ItemGroup>
 
   <Target Name="PackageTestFunction" BeforeTargets="BeforeBuild">

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/Amazon.Lambda.RuntimeSupport.IntegrationTests.csproj
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/Amazon.Lambda.RuntimeSupport.IntegrationTests.csproj
@@ -6,11 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.9.20" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.3.19.21" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.31.20" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.101.12" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.3.102.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.102.3" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.101.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/buildtools/build.proj
+++ b/buildtools/build.proj
@@ -14,7 +14,8 @@
     </PropertyGroup>
     <Target Name="full-build" DependsOnTargets="full-build-notests;run-tests;test-lambda-test-tool"></Target>
     <Target Name="full-build-notests" DependsOnTargets="test-blueprints-dotnetnew-legacy;package-blueprints;build-nuget-packages;copy-awslambdapscore-module;build-lambda-test-tool-package"></Target>
-    <Target Name="tests" DependsOnTargets="run-unit-tests;test-blueprints-dotnetnew-cicd;test-lambda-test-tool-cicd"></Target>
+    <Target Name="unit-tests" DependsOnTargets="run-unit-tests;test-blueprints-dotnetnew-cicd;test-lambda-test-tool-cicd"></Target>
+    <Target Name="integ-tests" DependsOnTargets="run-integ-tests"></Target>
     <Target Name="build" DependsOnTargets="build-project-packages;run-blueprint-packager;build-lambda-test-tool-package-cicd"></Target>
     <Target Name="copy-awslambdapscore-module" DependsOnTargets="init">
         <ItemGroup>
@@ -127,6 +128,9 @@
     </Target>
     <Target Name="run-unit-tests">
         <Exec Command="dotnet test -c $(Configuration)" WorkingDirectory="..\Libraries\test\Amazon.Lambda.RuntimeSupport.Tests\Amazon.Lambda.RuntimeSupport.UnitTests"/>
+    </Target>
+    <Target Name="run-integ-tests">
+        <Exec Command="dotnet test -c $(Configuration)" WorkingDirectory="..\Libraries\test\Amazon.Lambda.RuntimeSupport.Tests\Amazon.Lambda.RuntimeSupport.IntegrationTests"/>
     </Target>
     <Target Name="create-nuget-packages-cicd" DependsOnTargets="build-project-packages">
         <Exec Command="$(PackCommand)" WorkingDirectory="..\Libraries\src\%(LibraryName.FileName)"/>


### PR DESCRIPTION
*Description of changes:*
* Add a project reference to STS so that the SDK can use an assume role profile to run integ tests.
* Add a target to build.proj for integ testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
