### PR TITLE
Changed APIGatewayProxyFunction from LambdaContextLogger to use ILogger instead, in order to reduce noise in CloudWatch

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -102,7 +102,7 @@ namespace Amazon.Lambda.AspNetCoreServer
                     var identity = new ClaimsIdentity(authorizer.Claims.Select(
                         entry => new Claim(entry.Key, entry.Value.ToString())), "AuthorizerIdentity");
 
-                    lambdaContext.Logger.LogLine(
+                    _logger.LogDebug(
                         $"Configuring HttpContext.User with {authorizer.Claims.Count} claims coming from API Gateway's Request Context");
                     context.HttpContext.User = new ClaimsPrincipal(identity);
                 }
@@ -113,7 +113,7 @@ namespace Amazon.Lambda.AspNetCoreServer
                         authorizer.Where(x => !string.Equals(x.Key, "claims", StringComparison.OrdinalIgnoreCase))
                             .Select(entry => new Claim(entry.Key, entry.Value.ToString())), "AuthorizerIdentity");
 
-                    lambdaContext.Logger.LogLine(
+                    _logger.LogDebug(
                         $"Configuring HttpContext.User with {authorizer.Count} claims coming from API Gateway's Request Context");
                     context.HttpContext.User = new ClaimsPrincipal(identity);
                 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove repeated log statements to CloudWatch.

The following is printed to CloudWatch for each request.

"Configuring HttpContext.User with 2 claims coming from API Gateway's Request Context"

Why not use the  microsoft  _logger instead...

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
