### PR TITLE
add constructor that allows changing the serializer settings

### DIFF
--- a/Libraries/src/Amazon.Lambda.Serialization.Json/JsonSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.Json/JsonSerializer.cs
@@ -22,18 +22,33 @@ namespace Amazon.Lambda.Serialization.Json
         private bool debug;
 
         /// <summary>
-        /// Constructs instance of serializer.
+        /// Constructs instance of serializer. This constructor is usefull to 
+        /// customize the serializer settings.
         /// </summary>
-        public JsonSerializer()
+        /// <param name="customizeSerializerSettings">A callback to customize the serializer settings.</param>
+        public JsonSerializer(Action<JsonSerializerSettings> customizeSerializerSettings)
         {
             JsonSerializerSettings settings = new JsonSerializerSettings();
+            customizeSerializerSettings(settings);
+
+            // Set the contract resolver *after* the custom callback has been 
+            // invoked. This makes sure that we always use the good resolver.
             settings.ContractResolver = new AwsResolver();
+
             serializer = Newtonsoft.Json.JsonSerializer.Create(settings);
 
             if (string.Equals(Environment.GetEnvironmentVariable(DEBUG_ENVIRONMENT_VARIABLE_NAME), "true", StringComparison.OrdinalIgnoreCase))
             {
                 this.debug = true;
             }
+        }
+
+        /// <summary>
+        /// Constructs instance of serializer.
+        /// </summary>
+        public JsonSerializer()
+            :this(customizeSerializerSettings: _ => { /* Nothing to customize by default. */ })
+        {
         }
 
         /// <summary>


### PR DESCRIPTION
*Issue #500*

*Description of changes:*

As described in related issue, I add a constructor that makes it easy to customize the lambda json serialization settings. 

Here's an example of how the json serialization settings can be changed by using a derived class:

```csharp
public class MySerializer : JsonSerializer
{
    public MySerializer()
        : base(CustomizeSerializerSettings)
    {
    }

    private static void CustomizeSerializerSettings(JsonSerializerSettings serializerSettings)
    {
        serializerSettings.Converters = new List<JsonConverter>
        {
            new StringEnumConverter() { CamelCaseText = false }
        };
    }
}
```

The new serializer could then be used like this:
```csharp
[assembly: LambdaSerializer(typeof(MySerializer))]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
