### PR TITLE
Add support for ASP.NET Core 3.0 to Amazon.Lambda.AspNetCoreServer

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -134,7 +134,7 @@ namespace Amazon.Lambda.AspNetCoreServer
 
                 // Call consumers customize method in case they want to change how API Gateway's request
                 // was marshalled into ASP.NET Core request.
-                PostMarshallRequestFeature(authFeatures, apiGatewayRequest, lambdaContext);                
+                PostMarshallHttpAuthenticationFeature(authFeatures, apiGatewayRequest, lambdaContext);                
             }
             {
                 var requestFeatures = (IHttpRequestFeature) features;

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -115,7 +115,7 @@ namespace Amazon.Lambda.AspNetCoreServer
                         var identity = new ClaimsIdentity(authorizer.Claims.Select(
                             entry => new Claim(entry.Key, entry.Value.ToString())), "AuthorizerIdentity");
 
-`                        _logger.LogDebug(
+                        _logger.LogDebug(
                             $"Configuring HttpContext.User with {authorizer.Claims.Count} claims coming from API Gateway's Request Context");
                         authFeatures.User = new ClaimsPrincipal(identity);
                     }

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
@@ -301,7 +301,7 @@ namespace Amazon.Lambda.AspNetCoreServer
                 itemFeatures.Items = new Dictionary<object, object>();
                 itemFeatures.Items[LAMBDA_CONTEXT] = lambdaContext;
                 itemFeatures.Items[LAMBDA_REQUEST_OBJECT] = request;
-                PostMarshallRequestFeature(itemFeatures, request, lambdaContext);
+                PostMarshallItemsFeatureFeature(itemFeatures, request, lambdaContext);
             }
             
             var context = this.CreateContext(features);
@@ -420,7 +420,7 @@ namespace Amazon.Lambda.AspNetCoreServer
         /// <param name="aspNetCoreItemFeature"></param>
         /// <param name="lambdaRequest"></param>
         /// <param name="lambdaContext"></param>
-        protected virtual void PostMarshallRequestFeature(IItemsFeature aspNetCoreItemFeature, TREQUEST lambdaRequest, ILambdaContext lambdaContext)
+        protected virtual void PostMarshallItemsFeatureFeature(IItemsFeature aspNetCoreItemFeature, TREQUEST lambdaRequest, ILambdaContext lambdaContext)
         {
 
         }
@@ -433,7 +433,7 @@ namespace Amazon.Lambda.AspNetCoreServer
         /// <param name="aspNetCoreHttpAuthenticationFeature"></param>
         /// <param name="lambdaRequest"></param>
         /// <param name="lambdaContext"></param>
-        protected virtual void PostMarshallRequestFeature(IHttpAuthenticationFeature aspNetCoreHttpAuthenticationFeature, TREQUEST lambdaRequest, ILambdaContext lambdaContext)
+        protected virtual void PostMarshallHttpAuthenticationFeature(IHttpAuthenticationFeature aspNetCoreHttpAuthenticationFeature, TREQUEST lambdaRequest, ILambdaContext lambdaContext)
         {
 
         }        

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
@@ -13,6 +13,11 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
+#if NETCOREAPP_3_0
+using Microsoft.Extensions.Hosting;
+#endif
+
+
 namespace Amazon.Lambda.AspNetCoreServer
 {
     public abstract class AbstractAspNetCoreFunction

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Amazon.Lambda.AspNetCoreServer.csproj
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Amazon.Lambda.AspNetCoreServer.csproj
@@ -4,14 +4,21 @@
 
   <PropertyGroup>
     <Description>Amazon.Lambda.AspNetCoreServer makes it easy to run ASP.NET Core Web API applications as AWS Lambda functions.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.AspNetCoreServer</AssemblyTitle>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.1.9999-preview1</VersionPrefix>
     <AssemblyName>Amazon.Lambda.AspNetCoreServer</AssemblyName>
     <PackageId>Amazon.Lambda.AspNetCoreServer</PackageId>
     <PackageTags>AWS;Amazon;Lambda;aspnetcore</PackageTags>
     <LangVersion>Latest</LangVersion>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <DefineConstants>NETSTANDARD_2_0</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <DefineConstants>NETCOREAPP_3_0</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,10 +29,13 @@
     <ProjectReference Include="..\Amazon.Lambda.APIGatewayEvents\Amazon.Lambda.APIGatewayEvents.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
 </Project>

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Amazon.Lambda.AspNetCoreServer.csproj
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Amazon.Lambda.AspNetCoreServer.csproj
@@ -6,7 +6,7 @@
     <Description>Amazon.Lambda.AspNetCoreServer makes it easy to run ASP.NET Core Web API applications as AWS Lambda functions.</Description>
     <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.AspNetCoreServer</AssemblyTitle>
-    <VersionPrefix>4.0.0-preview1</VersionPrefix>
+    <VersionPrefix>4.0.0-preview2</VersionPrefix>
     <AssemblyName>Amazon.Lambda.AspNetCoreServer</AssemblyName>
     <PackageId>Amazon.Lambda.AspNetCoreServer</PackageId>
     <PackageTags>AWS;Amazon;Lambda;aspnetcore</PackageTags>

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Amazon.Lambda.AspNetCoreServer.csproj
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Amazon.Lambda.AspNetCoreServer.csproj
@@ -6,7 +6,7 @@
     <Description>Amazon.Lambda.AspNetCoreServer makes it easy to run ASP.NET Core Web API applications as AWS Lambda functions.</Description>
     <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.AspNetCoreServer</AssemblyTitle>
-    <VersionPrefix>3.1.9999-preview1</VersionPrefix>
+    <VersionPrefix>4.0.0-preview1</VersionPrefix>
     <AssemblyName>Amazon.Lambda.AspNetCoreServer</AssemblyName>
     <PackageId>Amazon.Lambda.AspNetCoreServer</PackageId>
     <PackageTags>AWS;Amazon;Lambda;aspnetcore</PackageTags>
@@ -15,7 +15,7 @@
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>NETSTANDARD_2_0</DefineConstants>
+    <DefineConstants>NETSTANDARD_2_0,NETCOREAPP_2_1</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <DefineConstants>NETCOREAPP_3_0</DefineConstants>

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
@@ -45,13 +45,9 @@ namespace Amazon.Lambda.AspNetCoreServer
         /// <inheritdoc/>
         protected override void MarshallRequest(InvokeFeatures features, ApplicationLoadBalancerRequest lambdaRequest, ILambdaContext lambdaContext)
         {
-            {
-                var requestFeatures = (IHttpAuthenticationFeature) features;
-                
-                // Call consumers customize method in case they want to change how API Gateway's request
-                // was marshalled into ASP.NET Core request.
-                PostMarshallHttpAuthenticationFeature(requestFeatures, lambdaRequest, lambdaContext);                
-            }
+            // Call consumers customize method in case they want to change how API Gateway's request
+            // was marshalled into ASP.NET Core request.
+            PostMarshallHttpAuthenticationFeature(features, lambdaRequest, lambdaContext);                
             
             // Request coming from Application Load Balancer will always send the headers X-Amzn-Trace-Id, X-Forwarded-For, X-Forwarded-Port, and X-Forwarded-Proto.
             // So this will only happen when writing tests with incomplete sample requests.

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
@@ -50,7 +50,7 @@ namespace Amazon.Lambda.AspNetCoreServer
                 
                 // Call consumers customize method in case they want to change how API Gateway's request
                 // was marshalled into ASP.NET Core request.
-                PostMarshallRequestFeature(requestFeatures, lambdaRequest, lambdaContext);                
+                PostMarshallHttpAuthenticationFeature(requestFeatures, lambdaRequest, lambdaContext);                
             }
             
             // Request coming from Application Load Balancer will always send the headers X-Amzn-Trace-Id, X-Forwarded-For, X-Forwarded-Port, and X-Forwarded-Proto.

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/InvokeFeatures.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/InvokeFeatures.cs
@@ -20,6 +20,10 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
                              IHttpRequestFeature,
                              IHttpResponseFeature,
                              IHttpConnectionFeature
+
+#if !NETCOREAPP_2_1
+                             ,IHttpResponseBodyFeature
+#endif
     /*
     ,
                          IHttpUpgradeFeature,
@@ -35,7 +39,7 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
             _features[typeof(IHttpConnectionFeature)] = this;
         }
 
-        #region IFeatureCollection
+#region IFeatureCollection
         public bool IsReadOnly => false;
 
         IDictionary<Type, object> _features = new Dictionary<Type, object>();
@@ -90,21 +94,21 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
             return this._features.GetEnumerator();
         }
 
-        #endregion
+#endregion
         
-        #region IItemsFeature
+#region IItemsFeature
         IDictionary<object, object> IItemsFeature.Items { get; set; }
-        #endregion
+#endregion
         
-        #region IHttpAuthenticationFeature
+#region IHttpAuthenticationFeature
         ClaimsPrincipal IHttpAuthenticationFeature.User { get; set; }
         
-        #if NETCOREAPP_2_1
+#if NETCOREAPP_2_1
         Microsoft.AspNetCore.Http.Features.Authentication.IAuthenticationHandler IHttpAuthenticationFeature.Handler { get; set; }
-        #endif
-        #endregion
+#endif
+#endregion
 
-        #region IHttpRequestFeature
+#region IHttpRequestFeature
         string IHttpRequestFeature.Protocol { get; set; }
 
         string IHttpRequestFeature.Scheme { get; set; }
@@ -123,9 +127,9 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
 
         Stream IHttpRequestFeature.Body { get; set; } = new MemoryStream();
 
-        #endregion
+#endregion
 
-        #region IHttpResponseFeature
+#region IHttpResponseFeature
         int IHttpResponseFeature.StatusCode
         {
             get;
@@ -211,6 +215,12 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
 
         #endregion
 
+        #region IHttpResponseBodyFeature
+#if !NETCOREAPP_2_1
+
+#endif
+        #endregion
+
         #region IHttpConnectionFeature
 
         string IHttpConnectionFeature.ConnectionId { get; set; }
@@ -223,6 +233,6 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
 
         int IHttpConnectionFeature.LocalPort { get; set; }
 
-        #endregion
+#endregion
     }
 }

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/InvokeFeatures.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/InvokeFeatures.cs
@@ -2,18 +2,21 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
+using System.Security.Claims;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Http.Features.Authentication;
 
 #pragma warning disable 1591
 
 namespace Amazon.Lambda.AspNetCoreServer.Internal
 {
     public class InvokeFeatures : IFeatureCollection,
+                             IItemsFeature,
+                             IHttpAuthenticationFeature,
                              IHttpRequestFeature,
                              IHttpResponseFeature,
                              IHttpConnectionFeature
@@ -25,6 +28,8 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
 
         public InvokeFeatures()
         {
+            _features[typeof(IItemsFeature)] = this;
+            _features[typeof(IHttpAuthenticationFeature)] = this;
             _features[typeof(IHttpRequestFeature)] = this;
             _features[typeof(IHttpResponseFeature)] = this;
             _features[typeof(IHttpConnectionFeature)] = this;
@@ -85,6 +90,18 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
             return this._features.GetEnumerator();
         }
 
+        #endregion
+        
+        #region IItemsFeature
+        IDictionary<object, object> IItemsFeature.Items { get; set; }
+        #endregion
+        
+        #region IHttpAuthenticationFeature
+        ClaimsPrincipal IHttpAuthenticationFeature.User { get; set; }
+        
+        #if NETCOREAPP_2_1
+        Microsoft.AspNetCore.Http.Features.Authentication.IAuthenticationHandler IHttpAuthenticationFeature.Handler { get; set; }
+        #endif
         #endregion
 
         #region IHttpRequestFeature

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/InvokeFeatures.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/InvokeFeatures.cs
@@ -282,11 +282,10 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
                 bufferSize: bufferSize,
                 options: FileOptions.Asynchronous | FileOptions.SequentialScan);
 
-            var destination = new MemoryStream();
             using (fileStream)
             {
                 fileStream.Seek(offset, SeekOrigin.Begin);
-                await Utilities.CopyToAsync(fileStream, destination, count, bufferSize, cancellationToken);
+                await Utilities.CopyToAsync(fileStream, ((IHttpResponseBodyFeature)this).Stream, count, bufferSize, cancellationToken);
             }
         }
 

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/InvokeFeatures.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/InvokeFeatures.cs
@@ -251,16 +251,46 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
             
         }
 
-        Task IHttpResponseBodyFeature.SendFileAsync(
-            string path,
+        // This code is taken from the Apache 2.0 licensed ASP.NET Core repo.
+        // https://github.com/aspnet/AspNetCore/blob/ab02951b37ac0cb09f8f6c3ed0280b46d89b06e0/src/Http/Http/src/SendFileFallback.cs
+        async Task IHttpResponseBodyFeature.SendFileAsync(
+            string filePath,
             long offset,
             long? count,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken)
         {
-            throw new NotImplementedException("SendFileAsync is not implemented for Serverless ASP.NET Core functions");
+            var fileInfo = new FileInfo(filePath);
+            if (offset < 0 || offset > fileInfo.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(offset), offset, string.Empty);
+            }
+            if (count.HasValue &&
+                (count.Value < 0 || count.Value > fileInfo.Length - offset))
+            {
+                throw new ArgumentOutOfRangeException(nameof(count), count, string.Empty);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            int bufferSize = 1024 * 16;
+
+            var fileStream = new FileStream(
+                filePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite,
+                bufferSize: bufferSize,
+                options: FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+            var destination = new MemoryStream();
+            using (fileStream)
+            {
+                fileStream.Seek(offset, SeekOrigin.Begin);
+                await Utilities.CopyToAsync(fileStream, destination, count, bufferSize, cancellationToken);
+            }
         }
 
-        Task IHttpResponseBodyFeature.StartAsync(CancellationToken cancellationToken = default(CancellationToken))
+        Task IHttpResponseBodyFeature.StartAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/ItemsDictionary.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/ItemsDictionary.cs
@@ -1,0 +1,166 @@
+﻿// This code is copy of the Apache 2 License code from the ASP.NET Core Repo. This is used to provide an easier experience for
+// developers by not throwing KeyNotFoundException exceptions.
+// https://github.com/aspnet/AspNetCore/blob/ab02951b37ac0cb09f8f6c3ed0280b46d89b06e0/src/Http/Http/src/Internal/ItemsDictionary.cs
+
+using System.Collections;
+using System.Collections.Generic;
+
+
+
+
+namespace Amazon.Lambda.AspNetCoreServer.Internal
+{
+    internal class ItemsDictionary : IDictionary<object, object>
+    {
+        private IDictionary<object, object> _items;
+
+        public ItemsDictionary()
+        { }
+
+        public ItemsDictionary(IDictionary<object, object> items)
+        {
+            _items = items;
+        }
+
+        public IDictionary<object, object> Items => this;
+
+        // Replace the indexer with one that returns null for missing values
+        object IDictionary<object, object>.this[object key]
+        {
+            get
+            {
+                if (_items != null && _items.TryGetValue(key, out var value))
+                {
+                    return value;
+                }
+                return null;
+            }
+            set
+            {
+                EnsureDictionary();
+                _items[key] = value;
+            }
+        }
+
+        void IDictionary<object, object>.Add(object key, object value)
+        {
+            EnsureDictionary();
+            _items.Add(key, value);
+        }
+
+        bool IDictionary<object, object>.ContainsKey(object key)
+            => _items != null && _items.ContainsKey(key);
+
+        ICollection<object> IDictionary<object, object>.Keys
+        {
+            get
+            {
+                if (_items == null)
+                {
+                    return EmptyDictionary.Dictionary.Keys;
+                }
+
+                return _items.Keys;
+            }
+        }
+
+        bool IDictionary<object, object>.Remove(object key)
+            => _items != null && _items.Remove(key);
+
+        bool IDictionary<object, object>.TryGetValue(object key, out object value)
+        {
+            value = null;
+            return _items != null && _items.TryGetValue(key, out value);
+        }
+
+        ICollection<object> IDictionary<object, object>.Values
+        {
+            get
+            {
+                if (_items == null)
+                {
+                    return EmptyDictionary.Dictionary.Values;
+                }
+
+                return _items.Values;
+            }
+        }
+
+        void ICollection<KeyValuePair<object, object>>.Add(KeyValuePair<object, object> item)
+        {
+            EnsureDictionary();
+            _items.Add(item);
+        }
+
+        void ICollection<KeyValuePair<object, object>>.Clear() => _items?.Clear();
+
+        bool ICollection<KeyValuePair<object, object>>.Contains(KeyValuePair<object, object> item)
+            => _items != null && _items.Contains(item);
+
+        void ICollection<KeyValuePair<object, object>>.CopyTo(KeyValuePair<object, object>[] array, int arrayIndex)
+        {
+            if (_items == null)
+            {
+                //Delegate to Empty Dictionary to do the argument checking.
+                EmptyDictionary.Collection.CopyTo(array, arrayIndex);
+            }
+
+            _items.CopyTo(array, arrayIndex);
+        }
+
+        int ICollection<KeyValuePair<object, object>>.Count => _items?.Count ?? 0;
+
+        bool ICollection<KeyValuePair<object, object>>.IsReadOnly => _items?.IsReadOnly ?? false;
+
+        bool ICollection<KeyValuePair<object, object>>.Remove(KeyValuePair<object, object> item)
+        {
+            if (_items == null)
+            {
+                return false;
+            }
+
+            if (_items.TryGetValue(item.Key, out var value) && Equals(item.Value, value))
+            {
+                return _items.Remove(item.Key);
+            }
+            return false;
+        }
+
+        private void EnsureDictionary()
+        {
+            if (_items == null)
+            {
+                _items = new Dictionary<object, object>();
+            }
+        }
+
+        IEnumerator<KeyValuePair<object, object>> IEnumerable<KeyValuePair<object, object>>.GetEnumerator()
+            => _items?.GetEnumerator() ?? EmptyEnumerator.Instance;
+
+        IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator() ?? EmptyEnumerator.Instance;
+
+        private class EmptyEnumerator : IEnumerator<KeyValuePair<object, object>>
+        {
+            // In own class so only initalized if GetEnumerator is called on an empty ItemsDictionary
+            public readonly static IEnumerator<KeyValuePair<object, object>> Instance = new EmptyEnumerator();
+            public KeyValuePair<object, object> Current => default;
+
+            object IEnumerator.Current => null;
+
+            public void Dispose()
+            { }
+
+            public bool MoveNext() => false;
+
+            public void Reset()
+            { }
+        }
+
+        private static class EmptyDictionary
+        {
+            // In own class so only initalized if CopyTo is called on an empty ItemsDictionary
+            public readonly static IDictionary<object, object> Dictionary = new Dictionary<object, object>();
+            public static ICollection<KeyValuePair<object, object>> Collection => Dictionary;
+        }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/LambdaServer.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/LambdaServer.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Hosting.Internal;
 
 namespace Amazon.Lambda.AspNetCoreServer.Internal
 {
@@ -20,7 +19,7 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
         /// <summary>
         /// The application is used by the Lambda function to initiate a web request through the ASP.NET Core framework.
         /// </summary>
-        public IHttpApplication<HostingApplication.Context> Application { get; set; }
+        public ApplicationWrapper Application { get; set; }
         public IFeatureCollection Features { get; } = new FeatureCollection();
 
         public void Dispose()
@@ -29,13 +28,62 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
 
         public Task StartAsync<TContext>(IHttpApplication<TContext> application, CancellationToken cancellationToken)
         {
-            this.Application = application as IHttpApplication<HostingApplication.Context>;
+            this.Application = new ApplicationWrapper<TContext>(application);
             return Task.CompletedTask;
         }
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
+        }
+
+        internal abstract class ApplicationWrapper
+        {
+            internal abstract object CreateContext(IFeatureCollection features);
+
+            internal abstract Task ProcessRequestAsync(object context);
+
+            internal abstract void DisposeContext(object context, Exception exception);
+        }
+
+        internal class ApplicationWrapper<TContext> : ApplicationWrapper, IHttpApplication<TContext>
+        {
+            private readonly IHttpApplication<TContext> _application;
+
+            public ApplicationWrapper(IHttpApplication<TContext> application)
+            {
+                _application = application;
+            }
+
+            internal override object CreateContext(IFeatureCollection features)
+            {
+                return ((IHttpApplication<TContext>)this).CreateContext(features);
+            }
+
+            TContext IHttpApplication<TContext>.CreateContext(IFeatureCollection features)
+            {
+                return _application.CreateContext(features);
+            }
+
+            internal override void DisposeContext(object context, Exception exception)
+            {
+                ((IHttpApplication<TContext>)this).DisposeContext((TContext)context, exception);
+            }
+
+            void IHttpApplication<TContext>.DisposeContext(TContext context, Exception exception)
+            {
+                _application.DisposeContext(context, exception);
+            }
+
+            internal override Task ProcessRequestAsync(object context)
+            {
+                return ((IHttpApplication<TContext>)this).ProcessRequestAsync((TContext)context);
+            }
+
+            Task IHttpApplication<TContext>.ProcessRequestAsync(TContext context)
+            {
+                return _application.ProcessRequestAsync(context);
+            }
         }
     }
 }

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/Amazon.Lambda.AspNetCoreServer.Test.csproj
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/Amazon.Lambda.AspNetCoreServer.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
     <AssemblyName>Amazon.Lambda.AspNetCoreServer.Test</AssemblyName>
     <OutputType>Library</OutputType>
     <PackageId>Amazon.Lambda.AspNetCoreServer.Test</PackageId>

--- a/Libraries/test/TestFunctionFSharp/TestFunctionCSharp/TestFunctionCSharp.csproj
+++ b/Libraries/test/TestFunctionFSharp/TestFunctionCSharp/TestFunctionCSharp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -14,7 +14,7 @@
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="FSharp.Core" Version="4.6.2" />
+    <PackageReference Include="FSharp.Core" Version="4.*" />
     <PackageReference Include="Fable.JsonConverter" Version="1.0.7" />
   </ItemGroup>
   <ItemGroup>

--- a/Libraries/test/TestWebApp/Startup.cs
+++ b/Libraries/test/TestWebApp/Startup.cs
@@ -34,15 +34,15 @@ namespace TestWebApp
         // This method gets called by the runtime. Use this method to add services to the container
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddAuthorization(options =>
+            {
+                options.AddPolicy("YouAreSpecial", policy => policy.RequireClaim("you_are_special"));
+            });
+
 #if NETCOREAPP_2_1
             services.AddSwaggerGen(c =>
             {
                 c.SwaggerDoc("v1", new Info { Title = "My API", Version = "v1" });
-            });
-
-            services.AddAuthorization(options =>
-            {
-                options.AddPolicy("YouAreSpecial", policy => policy.RequireClaim("you_are_special"));
             });
 
             // Add framework services.

--- a/Libraries/test/TestWebApp/Startup.cs
+++ b/Libraries/test/TestWebApp/Startup.cs
@@ -9,7 +9,10 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
+
+#if NETCOREAPP_2_1
 using Swashbuckle.AspNetCore.Swagger;
+#endif
 
 namespace TestWebApp
 {
@@ -22,12 +25,6 @@ namespace TestWebApp
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
                 .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
 
-            if (env.IsEnvironment("Development"))
-            {
-                // This will push telemetry data through Application Insights pipeline faster, allowing you to view results immediately.
-                builder.AddApplicationInsightsSettings(developerMode: true);
-            }
-
             builder.AddEnvironmentVariables();
             Configuration = builder.Build();
         }
@@ -37,6 +34,7 @@ namespace TestWebApp
         // This method gets called by the runtime. Use this method to add services to the container
         public void ConfigureServices(IServiceCollection services)
         {
+#if NETCOREAPP_2_1
             services.AddSwaggerGen(c =>
             {
                 c.SwaggerDoc("v1", new Info { Title = "My API", Version = "v1" });
@@ -51,19 +49,30 @@ namespace TestWebApp
             services.AddApplicationInsightsTelemetry(Configuration);
 
             services.AddMvc();
+#elif NETCOREAPP_3_0
+            services.AddControllers();
+#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-            app.UseSwagger();
-            loggerFactory.AddConsole(Configuration.GetSection("Logging"));
-            loggerFactory.AddDebug();
-
             app.UseMiddleware<Middleware>();
 
-            app.UseMvc();
+#if NETCOREAPP_3_0
+            app.UseRouting();
 
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+#else
+            app.UseSwagger();
+
+            app.UseMvc();
+#endif
             app.Run(async (context) =>
             {
                 var root = new JObject();

--- a/Libraries/test/TestWebApp/TestWebApp.csproj
+++ b/Libraries/test/TestWebApp/TestWebApp.csproj
@@ -1,20 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>TestWebApp</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>TestWebApp</PackageId>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <DefineConstants>NETCOREAPP_2_1</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <DefineConstants>NETCOREAPP_3_0</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Amazon.Lambda.AspNetCoreServer\Amazon.Lambda.AspNetCoreServer.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="1.1.0" />
   </ItemGroup>
-
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="1.1.0" />
+  </ItemGroup>
+  
 </Project>

--- a/RELEASE.CHANGELOG.md
+++ b/RELEASE.CHANGELOG.md
@@ -1,3 +1,10 @@
+### Release 2019-06-20
+* **Amazon.Lambda.TestTool-2.1 (0.9.3)**
+  * Explicily reference the latest version of Newtonsoft.Json (12.0.2). This allows 
+Lambda functions that are using a newer then what ASP.NET Core uses by default to have issues 
+loading Newtonsoft.Json.
+  
+
 ### Release 2019-06-19
 * **Amazon.Lambda.Logging.AspNetCore (2.3.0)**
   * Pull Request [#471](https://github.com/aws/aws-lambda-dotnet/pull/471) added support for logging scopes. Thanks [Piotr Karpala](https://github.com/karpikpl)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/481

*Description of changes:*
Add support for ASP.NET Core 3.0 to `Amazon.Lambda.AspNetCoreServer`. .NET Core 3.0 will not be an LTS and so will not be supported in Lambda as a built in runtime. It is possible to use .NET Core 3.0 with the `Amazon.Lambda.RuntimeSupport` NuGet package and Lambda custom runtimes. Check out the following blog post on how to use it. https://aws.amazon.com/blogs/developer/announcing-amazon-lambda-runtimesupport/

For example on how to use `Amazon.Lambda.RuntimeSupport` with ASP.NET Core 3.0 check out this example.  https://github.com/normj/LambdaNETCoreSamples The sample contains a prebuilt NuGet package of `Amazon.Lambda.AspNetCoreServer` with this PR in the `CustomRuntimeAspNetCore30/nuget-cache` directory.

## Breaking Changes
This PR will be a major version bump as there will be breaking changes to that will affect .NET Core 2.1 ASP.NET Core Lambda function's as well. The breaking change only affect users that override any of the **Post** methods to customize serialization.

The cause of the breaking changes is `Microsoft.AspNetCore.Hosting.Internal.HostingApplication.Context` was exposed in some of the virtual methods to customize the serialization. Even though the object was public the ASP.NET team did put it in an **Internal** namespace and so this library should never have directly used it let alone expose it in some of the virtual methods. In ASP.NET Core 3.0 `HostingApplication.Context` was moved to `Microsoft.AspNetCore.Hosting` namespace and marked as internal.

Breaking Change List:
* protected method CreateContext now returns back object
* protected method ProcessRequest now passes in context as an object
* protected virtual method PostCreateContext was removed
   * To customize HttpContext's User property override the `PostMarshallHttpAuthenticationFeature` method.
   * To customize the items in HttpContext's Items collection override `PostMarshallItemsFeatureFeature` method.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
