### PR TITLE
Added support for netstandard2.0 and .NET Core 2.2

### DIFF
--- a/Tools/LambdaTestTool/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -4,7 +4,7 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <ToolCommandName>dotnet-lambda-test-tool-2.1</ToolCommandName>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>

--- a/Tools/LambdaTestTool/Amazon.Lambda.TestTool/Program.cs
+++ b/Tools/LambdaTestTool/Amazon.Lambda.TestTool/Program.cs
@@ -91,7 +91,9 @@ namespace Amazon.Lambda.TestTool
                         var data = JsonMapper.ToObject(File.ReadAllText(file));
 
                         if (data.IsObject &&
-                            data.ContainsKey("framework") && data["framework"].ToString().StartsWith("netcoreapp") &&
+                            data.ContainsKey("framework") &&
+                            (data["framework"].ToString().StartsWith("netcoreapp", StringComparison.InvariantCultureIgnoreCase) ||
+                            data["framework"].ToString().StartsWith("netstandard", StringComparison.InvariantCultureIgnoreCase)) &&
                             (data.ContainsKey("function-handler") || data.ContainsKey("template")))
                         {
                             Console.WriteLine($"Found Lambda config file {file}");


### PR DESCRIPTION
Added validation for the netstandard during the config file search.  Switch to netcoreapp2.2 to avoid "System.IO.FileLoadException: Could not load file or assembly 'Microsoft.Extensions.DependencyInjection, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'. Could not find or load a specific file." error.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
