### PR TITLE
Fix typos in Lambda.TestTool/WebTester js files

### DIFF
--- a/Tools/LambdaTestTool/Amazon.Lambda.TestTool/WebTester/embedded-wwwroot/js/monitor-dlq.js
+++ b/Tools/LambdaTestTool/Amazon.Lambda.TestTool/WebTester/embedded-wwwroot/js/monitor-dlq.js
@@ -232,6 +232,6 @@ function onConfirmedPurgeDlqClick() {
         }
     })
     .fail(function (data) {
-        alert('Error purging queue, is the .NET Lambda Test Tool been still running?');
+        alert('Error purging queue, is the .NET Lambda Test Tool still running?');
     });
 }

--- a/Tools/LambdaTestTool/Amazon.Lambda.TestTool/WebTester/embedded-wwwroot/js/test-invoke.js
+++ b/Tools/LambdaTestTool/Amazon.Lambda.TestTool/WebTester/embedded-wwwroot/js/test-invoke.js
@@ -34,7 +34,7 @@ function onExecute() {
             }
         })
         .fail(function (data) {
-            alert('Error sending execute request, is the .NET Lambda Test Tool been still running?');
+            alert('Error sending execute request, is the .NET Lambda Test Tool still running?');
         });
 }
 
@@ -91,6 +91,6 @@ function onSaveRequest() {
             }
         })
         .fail(function (data) {
-            alert('Error saving request, is the .NET Lambda Test Tool been still running?');
+            alert('Error saving request, is the .NET Lambda Test Tool still running?');
         });
 }


### PR DESCRIPTION
Fixed grammatical typos in the JavaScript alert in the Lambda WebTester Tool.

Changed:
'...is the .NET Lambda Test Tool been still running?'
To:
'...is the .NET Lambda Test Tool still running?'


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
