### PR TITLE
#519 Match type namespace prefix as well when building `LogLevels`

### DIFF
--- a/Libraries/test/Amazon.Lambda.Logging.AspNetCore.Tests/Amazon.Lambda.Logging.AspNetCore.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.Logging.AspNetCore.Tests/Amazon.Lambda.Logging.AspNetCore.Tests.csproj
@@ -12,6 +12,9 @@
     <None Update="appsettings.exceptions.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="appsettings.nsprefix.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="appsettings.wildcard.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Libraries/test/Amazon.Lambda.Logging.AspNetCore.Tests/appsettings.nsprefix.json
+++ b/Libraries/test/Amazon.Lambda.Logging.AspNetCore.Tests/appsettings.nsprefix.json
@@ -1,0 +1,17 @@
+{
+  "Lambda.Logging": {
+    "IncludeCategory": true,
+    "IncludeLogLevel": true,
+    "IncludeNewline": true,
+    "IncludeException": false,
+    "IncludeEventId": false,
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft": "Information",
+      "System": "Warning",
+      "System.Net": "Information",
+      "System.Net.Http": "Debug"
+    }
+  }
+}


### PR DESCRIPTION
Related to #519 

*Description of changes:*
Adding support of namespace prefixes as well, alongside of wildcard support. Namespace prefixing is common in .NET, see issue.

With this change, log levels can be configured like this:

```javascript
    "LogLevel": {
      "Default": "Debug",
      "Microsoft": "Information",
      "System": "Warning",
      "System.Net": "Information",
      "System.Net.Http": "Debug"
    }
```

Wildcards are still supported and evaluated _before_ namespace prefixes.