### PR TITLE
add naming strategy option to JsonSerializer

### DIFF
--- a/Libraries/src/Amazon.Lambda.Serialization.Json/JsonSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.Json/JsonSerializer.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Collections.Generic;
 using Amazon.Lambda.Core;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Amazon.Lambda.Serialization.Json
 {
@@ -26,14 +27,18 @@ namespace Amazon.Lambda.Serialization.Json
         /// customize the serializer settings.
         /// </summary>
         /// <param name="customizeSerializerSettings">A callback to customize the serializer settings.</param>
-        public JsonSerializer(Action<JsonSerializerSettings> customizeSerializerSettings)
+        /// <param name="namingStrategy">The naming strategy to use. This parameter makes it possible to change the naming strategy to camel case for example. When not provided, it uses the default Newtonsoft.Json DefaultNamingStrategy.</param>
+        public JsonSerializer(Action<JsonSerializerSettings> customizeSerializerSettings, NamingStrategy namingStrategy = null)
         {
             JsonSerializerSettings settings = new JsonSerializerSettings();
             customizeSerializerSettings(settings);
 
             // Set the contract resolver *after* the custom callback has been 
             // invoked. This makes sure that we always use the good resolver.
-            settings.ContractResolver = new AwsResolver();
+            settings.ContractResolver = new AwsResolver
+            {
+                NamingStrategy = namingStrategy,
+            };
 
             serializer = Newtonsoft.Json.JsonSerializer.Create(settings);
 

--- a/Libraries/test/EventsTests/EventTests.cs
+++ b/Libraries/test/EventsTests/EventTests.cs
@@ -30,9 +30,9 @@ namespace Amazon.Lambda.Tests
     using Xunit;
     using System.Linq;
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Serialization;
 
     using JsonSerializer = Amazon.Lambda.Serialization.Json.JsonSerializer;
-
 
     public class EventTest
     {
@@ -1104,6 +1104,34 @@ namespace Amazon.Lambda.Tests
         private void Handle(ECSTaskStateChangeEvent ecsEvent)
         {
             Console.WriteLine($"[{ecsEvent.Source} {ecsEvent.Time}] {ecsEvent.DetailType}");
+        }
+
+        [Fact]
+        public void SerializeCanUseNamingStrategy()
+        {
+            var namingStrategy = new CamelCaseNamingStrategy();
+            var serializer = new JsonSerializer(_ => { }, namingStrategy);
+
+            var classUsingPascalCase = new ClassUsingPascalCase
+            {
+                SomeValue = 12,
+                SomeOtherValue = "abcd",
+            };
+
+            var ms = new MemoryStream();
+
+            serializer.Serialize(classUsingPascalCase, ms);
+            ms.Position = 0;
+
+            var serializedString = new StreamReader(ms).ReadToEnd();
+
+            Assert.Equal(@"{""someValue"":12,""someOtherValue"":""abcd""}", serializedString);
+        }
+
+        class ClassUsingPascalCase
+        {
+            public int SomeValue { get; set; }
+            public string SomeOtherValue { get; set; }
         }
     }
 }

--- a/Libraries/test/EventsTests/EventTests.cs
+++ b/Libraries/test/EventsTests/EventTests.cs
@@ -1128,6 +1128,24 @@ namespace Amazon.Lambda.Tests
             Assert.Equal(@"{""someValue"":12,""someOtherValue"":""abcd""}", serializedString);
         }
 
+        [Fact]
+        public void SerializeWithCamelCaseNamingStrategyCanDeserializeBothCamelAndPascalCase()
+        {
+            var namingStrategy = new CamelCaseNamingStrategy();
+            var serializer = new JsonSerializer(_ => { }, namingStrategy);
+
+            var camelCaseString  = @"{""someValue"":12,""someOtherValue"":""abcd""}";
+            var pascalCaseString = @"{""SomeValue"":12,""SomeOtherValue"":""abcd""}";
+
+            var camelCaseObject  = serializer.Deserialize<ClassUsingPascalCase>(new MemoryStream(Encoding.ASCII.GetBytes(camelCaseString)));
+            var pascalCaseObject = serializer.Deserialize<ClassUsingPascalCase>(new MemoryStream(Encoding.ASCII.GetBytes(pascalCaseString)));
+
+            Assert.Equal(12, camelCaseObject.SomeValue);
+            Assert.Equal(12, pascalCaseObject.SomeValue);
+            Assert.Equal("abcd", camelCaseObject.SomeOtherValue);
+            Assert.Equal("abcd", pascalCaseObject.SomeOtherValue);
+        }
+
         class ClassUsingPascalCase
         {
             public int SomeValue { get; set; }


### PR DESCRIPTION
**Description of changes:**

I propose to add a Newtonsoft naming strategy to the `Amazon.Lambda.Serialization.Json.JsonSerializer`. This makes it possible to change the naming strategy to camel case for example.

This is particularly usefull for people that follow the [google guideline](https://google.github.io/styleguide/jsoncstyleguide.xml?showone=Property_Name_Format#Property_Name_Format) that says to format json documents in camel case and that also follow the [C# guideline](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-type-members#names-of-properties) that says to name properties using pascal case.

Having a consistent naming strategy is particularly important when using step functions that are case sensitive.

Here's an example of the new behaviour:

```csharp
class CamelCaseJsonSerializer : JsonSerializer
{
    public CamelCaseJsonSerializer()
        : base(_ => { }, new CamelCaseNamingStrategy())
    {
    }
}

class FooBar
{
    public int SomeValue { get; set; }
    public string SomeOtherValue { get; set; }
}

class Program
{
    private static string TestSerializer(JsonSerializer serializer)
    {
        var x = new FooBar
        {
            SomeValue = 12,
            SomeOtherValue = "1212",
        };

        var memoryStream = new MemoryStream(200);

        serializer.Serialize(x, memoryStream);
        memoryStream.Seek(0, SeekOrigin.Begin);

        StreamReader reader = new StreamReader(memoryStream);
        return reader.ReadToEnd();
    }

    static void Main(string[] args)
    {
        Console.WriteLine($"Default serialization:    {TestSerializer(new JsonSerializer())}");
        Console.WriteLine($"Camel case serialization: {TestSerializer(new CamelCaseJsonSerializer())}");
    }
}
```

This will write the following in the console:
```
Default serialization:    {"SomeValue":12,"SomeOtherValue":"1212"}
Camel case serialization: {"someValue":12,"someOtherValue":"1212"}
```

**Possible improvement:**

I think that using a `CamelCaseJsonSerializer` is a pretty common need. Should it be added to `Amazon.Lambda.Serialization.Json`?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.