### PR TITLE
Suggested changes for LambdaBootstrap testability

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
@@ -43,19 +43,28 @@ namespace Amazon.Lambda.RuntimeSupport
         /// <summary>
         /// Create a LambdaBootstrap that will call the given initializer and handler.
         /// </summary>
+        /// <param name="httpClient">The HTTP client to use with the Lambda runtime.</param>
+        /// <param name="handler">Delegate called for each invocation of the Lambda function.</param>
+        /// <param name="initializer">Delegate called to initialize the Lambda function.  If not provided the initialization step is skipped.</param>
+        /// <returns></returns>
+        public LambdaBootstrap(HttpClient httpClient, LambdaBootstrapHandler handler, LambdaBootstrapInitializer initializer = null)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+            _initializer = initializer;
+            _httpClient.Timeout = RuntimeApiHttpTimeout;
+            Client = new RuntimeApiClient(new SystemEnvironmentVariables(), _httpClient);
+        }
+
+        /// <summary>
+        /// Create a LambdaBootstrap that will call the given initializer and handler.
+        /// </summary>
         /// <param name="handler">Delegate called for each invocation of the Lambda function.</param>
         /// <param name="initializer">Delegate called to initialize the Lambda function.  If not provided the initialization step is skipped.</param>
         /// <returns></returns>
         public LambdaBootstrap(LambdaBootstrapHandler handler, LambdaBootstrapInitializer initializer = null)
-        {
-            _handler = handler ?? throw new ArgumentNullException(nameof(handler));
-            _initializer = initializer;
-            _httpClient = new HttpClient
-            {
-                Timeout = RuntimeApiHttpTimeout
-            };
-            Client = new RuntimeApiClient(new SystemEnvironmentVariables(), _httpClient);
-        }
+            : this(new HttpClient(), handler, initializer)
+        { }
 
         /// <summary>
         /// Create a LambdaBootstrap that will call the given initializer and handler.
@@ -65,6 +74,17 @@ namespace Amazon.Lambda.RuntimeSupport
         /// <returns></returns>
         public LambdaBootstrap(HandlerWrapper handlerWrapper, LambdaBootstrapInitializer initializer = null)
             : this(handlerWrapper.Handler, initializer)
+        { }
+
+        /// <summary>
+        /// Create a LambdaBootstrap that will call the given initializer and handler.
+        /// </summary>
+        /// <param name="httpClient">The HTTP client to use with the Lambda runtime.</param>
+        /// <param name="handlerWrapper">The HandlerWrapper to call for each invocation of the Lambda function.</param>
+        /// <param name="initializer">Delegate called to initialize the Lambda function.  If not provided the initialization step is skipped.</param>
+        /// <returns></returns>
+        public LambdaBootstrap(HttpClient httpClient, HandlerWrapper handlerWrapper, LambdaBootstrapInitializer initializer = null)
+            : this(httpClient, handlerWrapper.Handler, initializer)
         { }
 
         /// <summary>

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
@@ -103,7 +103,7 @@ namespace Amazon.Lambda.RuntimeSupport
                 {
                     await InvokeOnceAsync(cancellationToken);
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
                     // Loop cancelled
                 }

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
@@ -99,7 +99,14 @@ namespace Amazon.Lambda.RuntimeSupport
 
             while (doStartInvokeLoop && !cancellationToken.IsCancellationRequested)
             {
-                await InvokeOnceAsync();
+                try
+                {
+                    await InvokeOnceAsync(cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Loop cancelled
+                }
             }
         }
 
@@ -116,9 +123,9 @@ namespace Amazon.Lambda.RuntimeSupport
             }
         }
 
-        internal async Task InvokeOnceAsync()
+        internal async Task InvokeOnceAsync(CancellationToken cancellationToken = default)
         {
-            using (var invocation = await Client.GetNextInvocationAsync())
+            using (var invocation = await Client.GetNextInvocationAsync(cancellationToken))
             {
                 InvocationResponse response = null;
                 bool invokeSucceeded = false;

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/IRuntimeApiClient.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/IRuntimeApiClient.cs
@@ -33,16 +33,18 @@ namespace Amazon.Lambda.RuntimeSupport
         /// Report an initialization error as an asynchronous operation.
         /// </summary>
         /// <param name="exception">The exception to report.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>A Task representing the asynchronous operation.</returns>
-        Task ReportInitializationErrorAsync(Exception exception);
+        Task ReportInitializationErrorAsync(Exception exception, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Send an initialization error with a type string but no other information as an asynchronous operation.
         /// This can be used to directly control flow in Step Functions without creating an Exception class and throwing it.
         /// </summary>
         /// <param name="errorType">The type of the error to report to Lambda.  This does not need to be a .NET type name.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>A Task representing the asynchronous operation.</returns>
-        Task ReportInitializationErrorAsync(string errorType);
+        Task ReportInitializationErrorAsync(string errorType, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get the next function invocation from the Runtime API as an asynchronous operation.
@@ -57,8 +59,9 @@ namespace Amazon.Lambda.RuntimeSupport
         /// </summary>
         /// <param name="awsRequestId">The ID of the function request that caused the error.</param>
         /// <param name="exception">The exception to report.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>A Task representing the asynchronous operation.</returns>
-        Task ReportInvocationErrorAsync(string awsRequestId, Exception exception);
+        Task ReportInvocationErrorAsync(string awsRequestId, Exception exception, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Send an initialization error with a type string but no other information as an asynchronous operation.
@@ -66,15 +69,17 @@ namespace Amazon.Lambda.RuntimeSupport
         /// </summary>
         /// <param name="awsRequestId">The ID of the function request that caused the error.</param>
         /// <param name="errorType">The type of the error to report to Lambda.  This does not need to be a .NET type name.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>A Task representing the asynchronous operation.</returns>
-        Task ReportInvocationErrorAsync(string awsRequestId, string errorType);
+        Task ReportInvocationErrorAsync(string awsRequestId, string errorType, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Send a response to a function invocation to the Runtime API as an asynchronous operation.
         /// </summary>
         /// <param name="awsRequestId">The ID of the function request being responded to.</param>
         /// <param name="outputStream">The content of the response to the function invocation.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns></returns>
-        Task SendResponseAsync(string awsRequestId, Stream outputStream);
+        Task SendResponseAsync(string awsRequestId, Stream outputStream, CancellationToken cancellationToken = default);
     }
 }

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/IRuntimeApiClient.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/IRuntimeApiClient.cs
@@ -48,8 +48,9 @@ namespace Amazon.Lambda.RuntimeSupport
         /// Get the next function invocation from the Runtime API as an asynchronous operation.
         /// Completes when the next invocation is received.
         /// </summary>
+        /// <param name="cancellationToken">The optional cancellation token to use to stop listening for the next invocation.</param>
         /// <returns>A Task representing the asynchronous operation.</returns>
-        Task<InvocationRequest> GetNextInvocationAsync();
+        Task<InvocationRequest> GetNextInvocationAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Report an invocation error as an asynchronous operation.

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/RuntimeApiClient.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/RuntimeApiClient.cs
@@ -92,10 +92,11 @@ namespace Amazon.Lambda.RuntimeSupport
         /// Get the next function invocation from the Runtime API as an asynchronous operation.
         /// Completes when the next invocation is received.
         /// </summary>
+        /// <param name="cancellationToken">The optional cancellation token to use to stop listening for the next invocation.</param>
         /// <returns>A Task representing the asynchronous operation.</returns>
-        public async Task<InvocationRequest> GetNextInvocationAsync()
+        public async Task<InvocationRequest> GetNextInvocationAsync(CancellationToken cancellationToken)
         {
-            SwaggerResponse<Stream> response = await _internalClient.NextAsync(System.Threading.CancellationToken.None);
+            SwaggerResponse<Stream> response = await _internalClient.NextAsync(cancellationToken);
 
             var lambdaContext = new LambdaContext(new RuntimeApiHeaders(response.Headers), LambdaEnvironment);
             return new InvocationRequest

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/RuntimeApiClient.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/RuntimeApiClient.cs
@@ -65,13 +65,14 @@ namespace Amazon.Lambda.RuntimeSupport
         /// Report an initialization error as an asynchronous operation.
         /// </summary>
         /// <param name="exception">The exception to report.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>A Task representing the asynchronous operation.</returns>
-        public Task ReportInitializationErrorAsync(Exception exception)
+        public Task ReportInitializationErrorAsync(Exception exception, CancellationToken cancellationToken = default)
         {
             if (exception == null)
                 throw new ArgumentNullException(nameof(exception));
 
-            return _internalClient.ErrorAsync(null, LambdaJsonExceptionWriter.WriteJson(ExceptionInfo.GetExceptionInfo(exception)));
+            return _internalClient.ErrorAsync(null, LambdaJsonExceptionWriter.WriteJson(ExceptionInfo.GetExceptionInfo(exception)), cancellationToken);
         }
 
         /// <summary>
@@ -79,13 +80,14 @@ namespace Amazon.Lambda.RuntimeSupport
         /// This can be used to directly control flow in Step Functions without creating an Exception class and throwing it.
         /// </summary>
         /// <param name="errorType">The type of the error to report to Lambda.  This does not need to be a .NET type name.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>A Task representing the asynchronous operation.</returns>
-        public Task ReportInitializationErrorAsync(string errorType)
+        public Task ReportInitializationErrorAsync(string errorType, CancellationToken cancellationToken = default)
         {
             if (errorType == null)
                 throw new ArgumentNullException(nameof(errorType));
 
-            return _internalClient.ErrorAsync(errorType, null);
+            return _internalClient.ErrorAsync(errorType, null, cancellationToken);
         }
 
         /// <summary>
@@ -94,7 +96,7 @@ namespace Amazon.Lambda.RuntimeSupport
         /// </summary>
         /// <param name="cancellationToken">The optional cancellation token to use to stop listening for the next invocation.</param>
         /// <returns>A Task representing the asynchronous operation.</returns>
-        public async Task<InvocationRequest> GetNextInvocationAsync(CancellationToken cancellationToken)
+        public async Task<InvocationRequest> GetNextInvocationAsync(CancellationToken cancellationToken = default)
         {
             SwaggerResponse<Stream> response = await _internalClient.NextAsync(cancellationToken);
 
@@ -111,8 +113,9 @@ namespace Amazon.Lambda.RuntimeSupport
         /// </summary>
         /// <param name="awsRequestId">The ID of the function request that caused the error.</param>
         /// <param name="exception">The exception to report.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>A Task representing the asynchronous operation.</returns>
-        public Task ReportInvocationErrorAsync(string awsRequestId, Exception exception)
+        public Task ReportInvocationErrorAsync(string awsRequestId, Exception exception, CancellationToken cancellationToken = default)
         {
             if (awsRequestId == null)
                 throw new ArgumentNullException(nameof(awsRequestId));
@@ -121,7 +124,7 @@ namespace Amazon.Lambda.RuntimeSupport
                 throw new ArgumentNullException(nameof(exception));
 
             var exceptionInfo = ExceptionInfo.GetExceptionInfo(exception);
-            return _internalClient.Error2Async(awsRequestId, exceptionInfo.ErrorType, LambdaJsonExceptionWriter.WriteJson(exceptionInfo));
+            return _internalClient.Error2Async(awsRequestId, exceptionInfo.ErrorType, LambdaJsonExceptionWriter.WriteJson(exceptionInfo), cancellationToken);
         }
 
         /// <summary>
@@ -130,10 +133,11 @@ namespace Amazon.Lambda.RuntimeSupport
         /// </summary>
         /// <param name="awsRequestId">The ID of the function request that caused the error.</param>
         /// <param name="errorType">The type of the error to report to Lambda.  This does not need to be a .NET type name.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>A Task representing the asynchronous operation.</returns>
-        public Task ReportInvocationErrorAsync(string awsRequestId, string errorType)
+        public Task ReportInvocationErrorAsync(string awsRequestId, string errorType, CancellationToken cancellationToken = default)
         {
-            return _internalClient.Error2Async(awsRequestId, errorType, null);
+            return _internalClient.Error2Async(awsRequestId, errorType, null, cancellationToken);
         }
 
         /// <summary>
@@ -141,10 +145,11 @@ namespace Amazon.Lambda.RuntimeSupport
         /// </summary>
         /// <param name="awsRequestId">The ID of the function request being responded to.</param>
         /// <param name="outputStream">The content of the response to the function invocation.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns></returns>
-        public async Task SendResponseAsync(string awsRequestId, Stream outputStream)
+        public async Task SendResponseAsync(string awsRequestId, Stream outputStream, CancellationToken cancellationToken = default)
         {
-            await _internalClient.ResponseAsync(awsRequestId, outputStream, CancellationToken.None);
+            await _internalClient.ResponseAsync(awsRequestId, outputStream, cancellationToken);
         }
     }
 }

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaBootstrapTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaBootstrapTests.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 using System;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
@@ -29,6 +30,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
         TestInitializer _testInitializer;
         TestRuntimeApiClient _testRuntimeApiClient;
         TestEnvironmentVariables _environmentVariables;
+        HandlerWrapper _testWrapper;
 
         public LambdaBootstrapTests()
         {
@@ -36,12 +38,20 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             _testRuntimeApiClient = new TestRuntimeApiClient(_environmentVariables);
             _testInitializer = new TestInitializer();
             _testFunction = new TestHandler();
+            _testWrapper = HandlerWrapper.GetHandlerWrapper(_testFunction.HandlerVoidVoidSync);
         }
 
         [Fact]
         public void ThrowsExceptionForNullHandler()
         {
             Assert.Throws<ArgumentNullException>("handler", () => { new LambdaBootstrap((LambdaBootstrapHandler)null); });
+        }
+
+        [Fact]
+        public void ThrowsExceptionForNullHttpClient()
+        {
+            Assert.Throws<ArgumentNullException>("httpClient", () => { new LambdaBootstrap((HttpClient)null, _testFunction.BaseHandlerAsync); });
+            Assert.Throws<ArgumentNullException>("httpClient", () => { new LambdaBootstrap((HttpClient)null, _testWrapper); });
         }
 
         [Fact]

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestRuntimeApiClient.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestRuntimeApiClient.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -75,7 +76,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             }
         }
 
-        public Task<InvocationRequest> GetNextInvocationAsync(System.Threading.CancellationToken cancellationToken = default)
+        public Task<InvocationRequest> GetNextInvocationAsync(CancellationToken cancellationToken = default)
         {
             GetNextInvocationAsyncCalled = true;
 
@@ -94,31 +95,31 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             });
         }
 
-        public Task ReportInitializationErrorAsync(Exception exception)
+        public Task ReportInitializationErrorAsync(Exception exception, CancellationToken cancellationToken = default)
         {
             ReportInitializationErrorAsyncExceptionCalled = true;
             return Task.Run(() => { });
         }
 
-        public Task ReportInitializationErrorAsync(string errorType)
+        public Task ReportInitializationErrorAsync(string errorType, CancellationToken cancellationToken = default)
         {
             ReportInitializationErrorAsyncTypeCalled = true;
             return Task.Run(() => { });
         }
 
-        public Task ReportInvocationErrorAsync(string awsRequestId, Exception exception)
+        public Task ReportInvocationErrorAsync(string awsRequestId, Exception exception, CancellationToken cancellationToken = default)
         {
             ReportInvocationErrorAsyncExceptionCalled = true;
             return Task.Run(() => { });
         }
 
-        public Task ReportInvocationErrorAsync(string awsRequestId, string errorType)
+        public Task ReportInvocationErrorAsync(string awsRequestId, string errorType, CancellationToken cancellationToken = default)
         {
             ReportInvocationErrorAsyncTypeCalled = true;
             return Task.Run(() => { });
         }
 
-        public Task SendResponseAsync(string awsRequestId, Stream outputStream)
+        public Task SendResponseAsync(string awsRequestId, Stream outputStream, CancellationToken cancellationToken = default)
         {
             if (outputStream != null)
             {

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestRuntimeApiClient.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestRuntimeApiClient.cs
@@ -75,7 +75,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             }
         }
 
-        public Task<InvocationRequest> GetNextInvocationAsync()
+        public Task<InvocationRequest> GetNextInvocationAsync(System.Threading.CancellationToken cancellationToken = default)
         {
             GetNextInvocationAsyncCalled = true;
 


### PR DESCRIPTION
_This PR is initially more for discussion/suggestion as the use case might be too niche to actually change the `LambdaBootstrap` class that ships to NuGet.org, or the change to enable the use case might be better achieved in other ways for changing the public API surface_.

## Scenario

I've recently started some work on porting a .NET Core 3.0 worker service which processes SQS messages to be an AWS Lambda function instead.

As the project is already targeting .NET Core 3.0, I decided to go with the [custom runtime](https://aws.amazon.com/blogs/developer/net-core-3-0-on-lambda-with-aws-lambdas-custom-runtime/) support rather than downgrade to .NET Core 2.1 to use the built-in support.

As part of the work I looked at creating some "end-to-end" or "integration" style tests I've used before with HTTP APIs to run the project as a "black box" in-memory and exercise the code from the outside so things like configuration, serialization etc. are covered by tests as well.

This has lead to the following open source project which I put together yesterday and have published as a NuGet package as a v0.1.0 which builds on top of ASP.NET Core's [`TestServer`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.testhost.testserver): https://github.com/martincostello/lambda-test-server

Essentially it emulates the Lambda runtime that Amazon.Lambda.RuntimeSupport calls internally over HTTP to deliver requests to the message loop and listens for responses and errors from the function for inspection by the test code.

Here's some example code of what you can achieve with it: 
  * https://github.com/martincostello/lambda-test-server/blob/da1ac1800af1a10eff2a74a2aa192140a9ae26a6/tests/AwsLambdaTestServer.Tests/Examples.cs#L20-L71
  * https://github.com/martincostello/alexa-london-travel/blob/2fe871eab5eafac4a174caa0e3b57ceaa6709f74/test/LondonTravel.Skill.Tests/EndToEndTests.cs#L28-L88

## Problem

However, there's two things I've had "workaround" in the way `LambdaBootstrap` is designed to get things working.

The first is that there's no way to inject a custom `HttpClient` into `LambdaBootstrap` which provides the hook to redirect the HTTP calls in-memory. This could be achieved by hosting the Lambda test server on an actual HTTP port and setting the `AWS_LAMBDA_RUNTIME_API` environment variable to its host and port, but this increases the complexity to some degree rather than simple use of `TestServer` and makes it less lightweight.

For the time being this can be worked around in test code by using Reflection to change the runtime API client that's being used, but it's a bit of a hack. It would be cleaner if it was possible to specify a custom `HttpClient` as a constructor argument to `LambdaBootstrap`.

https://github.com/martincostello/lambda-test-server/blob/da1ac1800af1a10eff2a74a2aa192140a9ae26a6/tests/AwsLambdaTestServer.Tests/FunctionRunner.cs#L24-L32

The second is that the internal loop will invariably always be listening for at least one more message from the runtime using what's coded like long-polling after a single invocation. This can be minimised by getting the timing "just-so" so the `CancellationToken` passed to `LambdaBootstrap.RunAsync()` is cancelled before the loop starts again, but if the timing is off you need to deliver at least one more message to get the polling to stop, otherwise it hangs.

You also can't just throw an exception or return no content or an HTTP error, as it causes the loop in the bootstrapper to throw an exception either by receiving a non 2xx status code, throws the exception from the `TestServer` out to the caller or throws because one of the [required headers](https://github.com/aws/aws-lambda-dotnet/blob/4f9142b95b376bd238bce6be43f4e1ec1f983592/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/RuntimeApiHeaders.cs#L32) isn't set.

This required me to deliver a "dummy" empty JSON response back to the Lambda runtime to get the loop to terminate:

https://github.com/martincostello/lambda-test-server/blob/da1ac1800af1a10eff2a74a2aa192140a9ae26a6/src/AwsLambdaTestServer/RuntimeHandler.cs#L125-L137

This then delivers a dud message to the function handler, which may or may not handle it correctly (though it can be worked around), but having to provide an "extra" fake message to get the loop to terminate is also a bit of a hack considering that the loop has an argument for a `CancellationToken`, but that it isn't flowed through to the `HttpClient` to cancel the request to get a new message.

One way of improving this might be to flow the `CancellationToken` from `RunAsync()` through to the `HttpClient`'s requests instead of the [`None`](https://github.com/aws/aws-lambda-dotnet/blob/4f9142b95b376bd238bce6be43f4e1ec1f983592/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/RuntimeApiClient.cs#L98) value that is used today, and then catching the `OperationCancelled` exception to stop the loop.

I realise that this isn't an issue with a production Lambda runtime because the process is frozen when there are no messages so as far as the function's concerned there's a continuous loop of messages that don't need to timeout/cancel/abort, but it seems like a small change to make testing/simulation outside of the Lambda environment itself easier to work with.

## Possible Solution

This PR proposes one possible set of changes to Amazon.Lambda.RuntimeSupport that would improve the scenario described above.

The first is to provide two new constructors that accept an `HttpClient` parameter to allow for the in-process test server to be used. I considered making the `Client` property public instead, but I thought this approach neater as it removes the extra `HttpClient` being allocated that's then no longer used. The new constructors are used rather than another optional parameter as it's a non-breaking API surface area change.

The second is more contentious as it consists of two parts.

The first simpler part is catching `OperationCanceled` exception in the message loop and swallowing it, which then causes the loop to observed the `CancellationToken` has been signalled and return without having to provide "one more" message to process for the function before the token is observed.

The second part is trickier as due to the use of the public `IRuntimeApiClient` interface, it wasn't possible to pass through the `CancellationToken` without making a breaking change to the interface by introducing a new optional parameter to the `GetNextInvocationAsync()` method.

I'm open to suggestions on a better way to achieve this without having to change the public API surface area.

## Next Steps

As I said at the top of the issue, this PR is for discussion and it might not be a correct solution or enough of a real-world problem to actually change the library code.

I could expect the outcode of this PR to be one of the following outcomes (there may be others):

  1. Accept as-is for a v2.0.0 with the breaking change to `IRuntimeApiClient`
  1. Accept in-principle, but change the approach to improve the scenario in another way that may or may not make breaking changes
  1. Close the PR without merging as the changes do not fit with the overall architecture and goals of the Lambda runtime support package and/or Lambda runtime in production environments
  1. Close the PR without merging as the use-case is too niche

Thanks for taking the time to consider the above and this PR!