### PR TITLE
support for asp.net response compression from lambda function

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -76,7 +76,7 @@ namespace Amazon.Lambda.AspNetCoreServer
 
         }
 
-      
+
         /// <summary>
         /// 
         /// </summary>
@@ -103,8 +103,8 @@ namespace Amazon.Lambda.AspNetCoreServer
         protected override void MarshallRequest(InvokeFeatures features, APIGatewayProxyRequest apiGatewayRequest, ILambdaContext lambdaContext)
         {
             {
-                var authFeatures = (IHttpAuthenticationFeature) features;
-                
+                var authFeatures = (IHttpAuthenticationFeature)features;
+
                 var authorizer = apiGatewayRequest?.RequestContext?.Authorizer;
 
                 if (authorizer != null)
@@ -134,10 +134,10 @@ namespace Amazon.Lambda.AspNetCoreServer
 
                 // Call consumers customize method in case they want to change how API Gateway's request
                 // was marshalled into ASP.NET Core request.
-                PostMarshallHttpAuthenticationFeature(authFeatures, apiGatewayRequest, lambdaContext);                
+                PostMarshallHttpAuthenticationFeature(authFeatures, apiGatewayRequest, lambdaContext);
             }
             {
-                var requestFeatures = (IHttpRequestFeature) features;
+                var requestFeatures = (IHttpRequestFeature)features;
                 requestFeatures.Scheme = "https";
                 requestFeatures.Method = apiGatewayRequest.HttpMethod;
 
@@ -219,7 +219,7 @@ namespace Amazon.Lambda.AspNetCoreServer
 
             {
                 // set up connection features
-                var connectionFeatures = (IHttpConnectionFeature) features;
+                var connectionFeatures = (IHttpConnectionFeature)features;
 
                 if (!string.IsNullOrEmpty(apiGatewayRequest?.RequestContext?.Identity?.SourceIp) &&
                     IPAddress.TryParse(apiGatewayRequest.RequestContext.Identity.SourceIp, out var remoteIpAddress))
@@ -254,6 +254,7 @@ namespace Amazon.Lambda.AspNetCoreServer
             };
 
             string contentType = null;
+            string contentEncoding = null;
             if (responseFeatures.Headers != null)
             {
                 response.MultiValueHeaders = new Dictionary<string, IList<string>>();
@@ -265,21 +266,32 @@ namespace Amazon.Lambda.AspNetCoreServer
 
                     // Remember the Content-Type for possible later use
                     if (kvp.Key.Equals("Content-Type", StringComparison.CurrentCultureIgnoreCase) && response.MultiValueHeaders[kvp.Key].Count > 0)
+                    {
                         contentType = response.MultiValueHeaders[kvp.Key][0];
+                    }
+                    else if (kvp.Key.Equals("Content-Encoding", StringComparison.CurrentCultureIgnoreCase) && response.MultiValueHeaders[kvp.Key].Count > 0)
+                    {
+                        contentEncoding = response.MultiValueHeaders[kvp.Key][0];
+                    }
                 }
             }
 
-            if(contentType == null)
+            if (contentType == null)
             {
                 response.MultiValueHeaders["Content-Type"] = new List<string>() { null };
             }
 
             if (responseFeatures.Body != null)
             {
-                // Figure out how we should treat the response content
-                var rcEncoding = GetResponseContentEncodingForContentType(contentType);
+                // Figure out how we should treat the response content, check encoding first to see if body is compressed, then check content type
+                var rcEncoding = GetResponseContentEncodingForContentEncoding(contentEncoding);
+                if (rcEncoding != ResponseContentEncoding.Base64)
+                {
+                    rcEncoding = GetResponseContentEncodingForContentType(contentType);
+                }
 
                 (response.Body, response.IsBase64Encoded) = Utilities.ConvertAspNetCoreBodyToLambdaBody(responseFeatures.Body, rcEncoding);
+
             }
 
             PostMarshallResponseFeature(responseFeatures, response, lambdaContext);

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
@@ -1,16 +1,22 @@
-﻿using Amazon.Lambda.APIGatewayEvents;
-using Amazon.Lambda.TestUtilities;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Threading.Tasks;
-using TestWebApp;
-using Xunit;
-using System;
+using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.TestUtilities;
+
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+
+using TestWebApp;
+
+using Xunit;
 
 namespace Amazon.Lambda.AspNetCoreServer.Test
 {
@@ -322,6 +328,35 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
             Assert.Null(response.MultiValueHeaders["Content-Type"][0]);
 
             Assert.Equal("redirecttarget", response.MultiValueHeaders["Location"][0]);
+        }
+
+        [Fact]
+        public async Task TestGetCompressResponse()
+        {
+            var context = new TestLambdaContext();
+
+            var response = await this.InvokeAPIGatewayRequest(context, "compressresponse-get-apigateway-request.json");
+
+            Assert.Equal(200, response.StatusCode);
+
+            var bytes = Convert.FromBase64String(response.Body);
+            using (var msi = new MemoryStream(bytes))
+            using (var mso = new MemoryStream())
+            {
+                using (var gs = new GZipStream(msi, CompressionMode.Decompress))
+                {
+                    gs.CopyTo(mso);
+
+                }
+                var body = UTF8Encoding.UTF8.GetString(mso.ToArray());
+                Assert.Equal("[\"value1\",\"value2\"]", body);
+            }
+
+            Assert.True(response.MultiValueHeaders.ContainsKey("Content-Type"));
+            Assert.Equal("application/json-compress", response.MultiValueHeaders["Content-Type"][0]);
+            Assert.Equal("gzip", response.MultiValueHeaders["Content-Encoding"][0]);
+
+            Assert.Contains("OnStarting Called", ((TestLambdaLogger)context.Logger).Buffer.ToString());
         }
 
         private async Task<APIGatewayProxyResponse> InvokeAPIGatewayRequest(string fileName)

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/compressresponse-get-alb-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/compressresponse-get-alb-request.json
@@ -1,0 +1,25 @@
+﻿{
+  "requestContext": {
+    "elb": {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09"
+    }
+  },
+  "httpMethod": "GET",
+  "path": "/api/compressresponse",
+  "queryStringParameters": null,
+  "headers": {
+    "accept": "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,*\/*;q=0.8",
+    "accept-language": "en-US,en;q=0.8",
+    "accept-encoding": "gzip, deflate, br",
+    "content-type": "text/plain",
+    "cookie": "cookies",
+    "host": "lambda-846800462-us-east-2.elb.amazonaws.com",
+    "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6)",
+    "x-amzn-trace-id": "Root=1-5bdb40ca-556d8b0c50dc66f0511bf520",
+    "x-forwarded-for": "72.21.198.66",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "isBase64Encoded": false,
+  "body": null
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/compressresponse-get-apigateway-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/compressresponse-get-apigateway-request.json
@@ -1,0 +1,38 @@
+﻿{
+  "resource": "/{proxy+}",
+  "path": "/api/compressresponse",
+  "httpMethod": "GET",
+  "headers": {
+    "Accept": "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,*\/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, br",
+    "Accept-Language": "en-US,en;q=0.9"
+  },
+  "queryStringParameters": null,
+  "pathParameters": {
+    "proxy": "api/compressresponse"
+  },
+  "stageVariables": null,
+  "requestContext": {
+    "accountId": "AAAAAAAAAAAA",
+    "resourceId": "5agfss",
+    "stage": "test-invoke-stage",
+    "requestId": "test-invoke-request",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": "AAAAAAAAAAAA",
+      "cognitoIdentityId": null,
+      "caller": "BBBBBBBBBBBB",
+      "apiKey": "test-invoke-api-key",
+      "sourceIp": "127.0.0.1",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": "arn:aws:iam::AAAAAAAAAAAA:root",
+      "userAgent": "Apache-HttpClient/4.5.x (Java/1.8.0_102)",
+      "user": "AAAAAAAAAAAA"
+    },
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "apiId": "t2yh6sjnmk"
+  },
+  "body": null
+}

--- a/Libraries/test/TestWebApp/Controllers/CompressResponseController.cs
+++ b/Libraries/test/TestWebApp/Controllers/CompressResponseController.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace TestWebApp.Controllers
+{
+    [Route("api/[controller]")]
+    public class CompressResponseController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Get()
+        {
+            var response = "[\"value1\",\"value2\"]";
+            return Content(response, "application/json-compress");
+        }
+    }
+}

--- a/Libraries/test/TestWebApp/Startup.cs
+++ b/Libraries/test/TestWebApp/Startup.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -39,6 +40,13 @@ namespace TestWebApp
                 options.AddPolicy("YouAreSpecial", policy => policy.RequireClaim("you_are_special"));
             });
 
+            services.AddResponseCompression((options) =>
+            {
+                options.Providers.Add<GzipCompressionProvider>();
+                options.EnableForHttps = true;
+                options.MimeTypes = new string[] { "application/json-compress" };
+            });
+
 #if NETCOREAPP_2_1
             services.AddSwaggerGen(c =>
             {
@@ -58,6 +66,7 @@ namespace TestWebApp
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             app.UseMiddleware<Middleware>();
+            app.UseResponseCompression();
 
 #if NETCOREAPP_3_0
             app.UseRouting();


### PR DESCRIPTION
Adds support for the use of ResponseCompression middleware in an ASP.NET Core Web API lambda function

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
