### PR TITLE
fix null ref in APIGatewayProxyFunction

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -146,7 +146,7 @@ namespace Amazon.Lambda.AspNetCoreServer
                     _logger.LogWarning($"Request does not contain domain name information but is derived from {nameof(APIGatewayProxyFunction)}.");
                 }
 
-                string path = null;
+                string path = "/";
                 if (apiGatewayRequest.PathParameters != null && apiGatewayRequest.PathParameters.ContainsKey("proxy") &&
                     !string.IsNullOrEmpty(apiGatewayRequest.Resource))
                 {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
it comes if apiGatewayRequest.Path is null



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
