### PR TITLE
Fixed issue with HttpContext.RequestServices return null.

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
@@ -226,7 +226,6 @@ namespace Amazon.Lambda.AspNetCoreServer
                     options.ValidateScopes = hostingContext.HostingEnvironment.IsDevelopment();
                 });
 
-
             return builder;
         }
 
@@ -354,7 +353,6 @@ namespace Amazon.Lambda.AspNetCoreServer
 
             _logger.LogDebug($"ASP.NET Core Request PathBase: {((IHttpRequestFeature)features).PathBase}, Path: {((IHttpRequestFeature)features).Path}");
 
-
             {
                 var itemFeatures = (IItemsFeature)features;
                 itemFeatures.Items = new ItemsDictionary();
@@ -363,10 +361,20 @@ namespace Amazon.Lambda.AspNetCoreServer
                 PostMarshallItemsFeatureFeature(itemFeatures, request, lambdaContext);
             }
 
-            var context = this.CreateContext(features);
-            var response = await this.ProcessRequest(lambdaContext, context, features);
+            var scope = _host.Services.CreateScope();
+            try
+            {
+                ((IServiceProvidersFeature)features).RequestServices = scope.ServiceProvider;
 
-            return response;
+                var context = this.CreateContext(features);
+                var response = await this.ProcessRequest(lambdaContext, context, features);
+
+                return response;
+            }
+            finally
+            {
+                scope.Dispose();
+            }
         }
 
         /// <summary>

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
@@ -390,6 +390,16 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
             Assert.Contains("OnStarting Called", ((TestLambdaLogger)context.Logger).Buffer.ToString());
         }
 
+        [Fact]
+        public async Task TestRequestServicesAreAvailable()
+        {
+            var requestStr = GetRequestContent("requestservices-get-apigateway-request.json");
+            var response = await this.InvokeAPIGatewayRequestWithContent(new TestLambdaContext(), requestStr);
+
+            Assert.Equal(200, response.StatusCode);
+            Assert.Equal("Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceProviderEngineScope", response.Body);
+        }
+
         private async Task<APIGatewayProxyResponse> InvokeAPIGatewayRequest(string fileName)
         {
             return await InvokeAPIGatewayRequest(new TestLambdaContext(), fileName);

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/requestservices-get-apigateway-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/requestservices-get-apigateway-request.json
@@ -1,0 +1,34 @@
+﻿{
+  "resource": "/{proxy+}",
+  "path": "/api/RequestServicesExample",
+  "httpMethod": "GET",
+  "headers": null,
+  "queryStringParameters": null,
+  "pathParameters": {
+    "proxy": "api/RequestServicesExample"
+  },
+  "stageVariables": null,
+  "requestContext": {
+    "accountId": "AAAAAAAAAAAA",
+    "resourceId": "5agfss",
+    "stage": "test-invoke-stage",
+    "requestId": "test-invoke-request",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": "AAAAAAAAAAAA",
+      "cognitoIdentityId": null,
+      "caller": "BBBBBBBBBBBB",
+      "apiKey": "test-invoke-api-key",
+      "sourceIp": "127.0.0.1",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": "arn:aws:iam::AAAAAAAAAAAA:root",
+      "userAgent": "Apache-HttpClient/4.5.x (Java/1.8.0_102)",
+      "user": "AAAAAAAAAAAA"
+    },
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "apiId": "t2yh6sjnmk"
+  },
+  "body": null
+}

--- a/Libraries/test/TestWebApp/Controllers/RequestServicesExampleController.cs
+++ b/Libraries/test/TestWebApp/Controllers/RequestServicesExampleController.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+namespace TestWebApp.Controllers
+{
+    [Route("api/[controller]")]
+    public class RequestServicesExampleController : ControllerBase
+    {
+        [HttpGet]
+        public string Get()
+        {
+            return this.HttpContext.RequestServices?.GetType().FullName;
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/596
*Description of changes:*

The fix required the FeatureCollection used to create the HttpContext to implement the IServiceProvidersFeature interface and before starting each request creating a new service scope and setting the service provider for that scope to the RequestServices for IServiceProvidersFeature. When ASP.NET Core creates the HttpContext it will take that IServiceProvider and make it available as the HttpContext.RequestServices to the user code.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
