### PR TITLE
Fix typo in PowerShell logging message

### DIFF
--- a/PowerShell/Module/Private/_ProjectCreationFunctions.ps1
+++ b/PowerShell/Module/Private/_ProjectCreationFunctions.ps1
@@ -64,7 +64,7 @@ function _initializeScriptFromTemplate
                             if ($lines[$i].Contains('#Requires') -and $lines[$i].Contains($_.Name) -and $lines[$i].Contains($_.Version.ToString()) )
                             {
                                 $lines[$i] = $lines.Replace($_.Version.ToString(), $installedVersion)
-                                Write-Host ("Configuring script to use installed version $installedVersion of $(_.Name)")
+                                Write-Host ("Configuring script to use installed version $installedVersion of ($_.Name)")
                                 break
                             }
                         }


### PR DESCRIPTION
*Description of changes:*
Fix typo in logging message for substituting local version of referenced AWS Module


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
