### PR TITLE
Fix RemainingTime returning negative values

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Context/LambdaContext.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Context/LambdaContext.cs
@@ -21,7 +21,7 @@ namespace Amazon.Lambda.RuntimeSupport
 {
     internal class LambdaContext : ILambdaContext
     {
-        private static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1);
+        private static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         private LambdaEnvironment _lambdaEnvironment;
         private RuntimeApiHeaders _runtimeApiHeaders;
@@ -69,6 +69,6 @@ namespace Amazon.Lambda.RuntimeSupport
 
         public int MemoryLimitInMB => _memoryLimitInMB;
 
-        public TimeSpan RemainingTime => TimeSpan.FromMilliseconds(_deadlineMs - (DateTime.Now - UnixEpoch).TotalMilliseconds);
+        public TimeSpan RemainingTime => TimeSpan.FromMilliseconds(_deadlineMs - (DateTime.UtcNow - UnixEpoch).TotalMilliseconds);
     }
 }

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaContextTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaContextTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Xunit;
+
+namespace Amazon.Lambda.RuntimeSupport.UnitTests
+{
+    public class LambdaContextTests
+    {
+        private readonly TestEnvironmentVariables _environmentVariables;
+
+        public LambdaContextTests()
+        {
+            _environmentVariables = new TestEnvironmentVariables();
+        }
+
+        [Fact]
+        public void RemainingTimeIsPositive()
+        {
+            var deadline = DateTimeOffset.UtcNow.AddHours(1);
+            var deadlineMs = deadline.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture);
+
+            var headers = new Dictionary<string, IEnumerable<string>>
+            {
+                ["Lambda-Runtime-Aws-Request-Id"] = new[] { Guid.NewGuid().ToString() },
+                ["Lambda-Runtime-Deadline-Ms"] = new[] { deadlineMs },
+                ["Lambda-Runtime-Invoked-Function-Arn"] = new[] { "my-function-arn" }
+            };
+
+            var runtimeApiHeaders = new RuntimeApiHeaders(headers);
+            var lambdaEnvironment = new LambdaEnvironment(_environmentVariables);
+
+            var context = new LambdaContext(runtimeApiHeaders, lambdaEnvironment);
+
+            Assert.True(context.RemainingTime >= TimeSpan.Zero, $"Remaining time is not a positive value: {context.RemainingTime}");
+        }
+    }
+}


### PR DESCRIPTION
Fix `LambdaContext.RemainingTime` returning negative values in a local time zone east of UTC due to local time being used for Unix epoch and clock.

This was working as expected for the last few months in some tests we had that run on our local developer machines, but since the UK moved to British Summer Time (UTC+1), the `RemainingTime` property is now returning a value approximately equal to -1 hour.

This PR fixes that by explicitly specifying that the Unix Epoch is in UTC, rather than the default of `DateTimeKind.Unspecified`, and then uses `UtcNow` instead of `Now`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
