### PR TITLE
Fixed issue with .NET Core 2.1 test tool not using the custom assembly resolver

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaAssemblyLoadContext.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaAssemblyLoadContext.cs
@@ -57,11 +57,11 @@ namespace Amazon.Lambda.TestTool.Runtime
             string assemblyPath = null;
 #if !NETCORE_2_1
             assemblyPath = _builtInResolver.ResolveAssemblyToPath(assemblyName);
+#endif
             if(assemblyPath == null || !File.Exists(assemblyPath))
             {
                 assemblyPath = _customResolver.ResolveAssemblyToPath(assemblyName);
             }
-#endif
             if (assemblyPath != null)
             {
                 return LoadFromAssemblyPath(assemblyPath);


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/619

*Description of changes:*
The .NET Core 2.1 version of the Mock Lambda Test Tool was using the new AssemblyLoadContext but not the custom assembly resolver to find the assembly path. Causing it to fail to find it which causes the .NET runtime to fallback to the Default AssemblyLoadContext. The default AssemblyLoadContext already has its version of AWSSDK.Core loaded so that is used which in the case of the issue the Core is older than the Core used in Lambda code the Lambda code and doesn't have the RetryMode property.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
