### PR TITLE
CloudWatchLogsEvents: use Stream.CopyTo() to decompress data

### DIFF
--- a/Libraries/src/Amazon.Lambda.CloudWatchLogsEvents/CloudWatchLogsEvents.cs
+++ b/Libraries/src/Amazon.Lambda.CloudWatchLogsEvents/CloudWatchLogsEvents.cs
@@ -44,18 +44,15 @@ namespace Amazon.Lambda.CloudWatchLogsEvents
                     return this.EncodedData;
 
                 var bytes = Convert.FromBase64String(this.EncodedData);
-                var uncompressedBytes = new List<byte>();
+                var uncompressedStream = new MemoryStream();
 
                 using (var stream = new GZipStream(new MemoryStream(bytes), CompressionMode.Decompress))
                 {
-                    int b;
-                    while((b = stream.ReadByte()) != -1)
-                    {
-                        uncompressedBytes.Add((byte)b);
-                    }
+                    stream.CopyTo(uncompressedStream);
+                    uncompressedStream.Position = 0;
                 }
 
-                var decodedString = Encoding.UTF8.GetString(uncompressedBytes.ToArray());
+                var decodedString = Encoding.UTF8.GetString(uncompressedStream.ToArray());
                 return decodedString;
             }
 	    }


### PR DESCRIPTION
*Description of changes:* Use Stream.CopyTo() instead of List<byte>.Add() to decompress data for `CloudWatchLogsEvent.EncodedData `

## Original
```csharp
int b;
while((b = stream.ReadByte()) != -1) {
    uncompressedBytes.Add((byte)b);
}
```

## Proposed
```csharp
stream.CopyTo(uncompressedStream);
uncompressedStream.Position = 0;
```

## Benchmark Results
```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.778 (1909/November2018Update/19H2)
Intel Core i7-6700K CPU 4.00GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.2 (CoreCLR 4.700.20.6602, CoreFX 4.700.20.6702), X64 RyuJIT
  DefaultJob : .NET Core 3.1.2 (CoreCLR 4.700.20.6602, CoreFX 4.700.20.6702), X64 RyuJIT


|           Method |      Mean |     Error |    StdDev |
|----------------- |----------:|----------:|----------:|
|    DecodeDataAdd | 55.102 us | 0.4690 us | 0.4158 us |
| DecodeDataStream |  5.359 us | 0.0576 us | 0.0481 us |
```

See this repo for benchmark details: https://github.com/bjorg/GzipPerformance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
