### PR TITLE
Respect JsonSerializerOptions in debug mode

### DIFF
--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/LambdaJsonSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/LambdaJsonSerializer.cs
@@ -71,7 +71,7 @@ namespace Amazon.Lambda.Serialization.SystemTextJson
                     using (var debugWriter = new StringWriter())
                     using (var utf8Writer = new Utf8JsonWriter(responseStream))
                     {
-                        JsonSerializer.Serialize(utf8Writer, response);
+                        JsonSerializer.Serialize(utf8Writer, response, _options);
 
                         var jsonDocument = debugWriter.ToString();
                         Console.WriteLine($"Lambda Serialize {response.GetType().FullName}: {jsonDocument}");


### PR DESCRIPTION
Update `LambdaJsonSerializer.Serialize` to respect custom `JsonSerializerOptions` when in debug mode

#628

I think this was just an accidental omission, but if I am missing something here, let me know

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
