### PR TITLE
Add support for using IHostBuilder when targeting .NET Core 3.1

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction{TStartup}.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction{TStartup}.cs
@@ -31,12 +31,9 @@ namespace Amazon.Lambda.AspNetCoreServer
         }
 
         /// <inheritdoc/>
-        protected override IWebHostBuilder CreateWebHostBuilder() =>
-            base.CreateWebHostBuilder().UseStartup<TStartup>();
-
-        /// <inheritdoc/>
         protected override void Init(IWebHostBuilder builder)
         {
+            builder.UseStartup<TStartup>();
         }
     }
 }

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction{TStartup}.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction{TStartup}.cs
@@ -31,12 +31,10 @@ namespace Amazon.Lambda.AspNetCoreServer
         }
 
         /// <inheritdoc/>
-        protected override IWebHostBuilder CreateWebHostBuilder() =>
-            base.CreateWebHostBuilder().UseStartup<TStartup>();
-
-        /// <inheritdoc/>
         protected override void Init(IWebHostBuilder builder)
         {
+            builder.UseStartup<TStartup>();
         }
+
     }
 }

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
@@ -251,7 +251,7 @@ namespace Amazon.Lambda.AspNetCoreServer
         /// Setting the Startup class is required in this method.
         /// <para>
         /// It is recommended to not configure the IWebHostBuilder from this method. Instead configure the IWebHostBuilder
-        /// in the Init(IWebHostBuilder builder) method. If you configure the IWebHostBuilder in this method the IWebHostBuilder will
+        /// in the Init(IWebHostBuilder builder) method. If you configure the IWebHostBuilder in this method the IWebHostBuilder will be
         /// configured twice, here and and as part of CreateHostBuilder.
         /// </para>
         /// </summary>
@@ -338,8 +338,8 @@ namespace Amazon.Lambda.AspNetCoreServer
             _server = this._hostServices.GetService(typeof(Microsoft.AspNetCore.Hosting.Server.IServer)) as LambdaServer;
             if (_server == null)
             {
-                throw new Exception("Failed to find the Lambda implementation for the IServer interface in the IServiceProvider for the Host. This happens if UseLambdaServer was " + 
-                        "not called when constructing the IWebHostBuilder. If CreateHostBuilder was overriden it is recommended that ConfigureWebHostLambdaDefaults should be used " + 
+                throw new Exception("Failed to find the Lambda implementation for the IServer interface in the IServiceProvider for the Host. This happens if UseLambdaServer was " +
+                        "not called when constructing the IWebHostBuilder. If CreateHostBuilder was overridden it is recommended that ConfigureWebHostLambdaDefaults should be used " + 
                         "instead of ConfigureWebHostDefaults to make sure the property Lambda services are registered.");
             }
             _logger = ActivatorUtilities.CreateInstance<Logger<APIGatewayProxyFunction>>(this._hostServices);

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
@@ -334,7 +334,9 @@ namespace Amazon.Lambda.AspNetCoreServer
             else
 #endif
             {
+#pragma warning disable 618
                 var builder = CreateWebHostBuilder();
+#pragma warning restore 618
 
                 var host = builder.Build();
                 PostCreateWebHost(host);

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
@@ -193,6 +193,9 @@ namespace Amazon.Lambda.AspNetCoreServer
         /// registration for Lambda.
         /// </summary>
         /// <returns></returns>
+#if !NETCOREAPP_2_1
+        [Obsolete("Functions should migrate to CreateHostBuilder and use IHostBuilder to setup their ASP.NET Core application. In a future major version update of this library support for IWebHostBuilder will be removed for non .NET Core 2.1 Lambda functions.")]
+#endif
         protected virtual IWebHostBuilder CreateWebHostBuilder()
         {
             var builder = new WebHostBuilder()

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction{TStartup}.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction{TStartup}.cs
@@ -31,12 +31,10 @@ namespace Amazon.Lambda.AspNetCoreServer
         }
 
         /// <inheritdoc/>
-        protected override IWebHostBuilder CreateWebHostBuilder() =>
-            base.CreateWebHostBuilder().UseStartup<TStartup>();
-
         /// <inheritdoc/>
         protected override void Init(IWebHostBuilder builder)
         {
+            builder.UseStartup<TStartup>();
         }
     }
 }

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/HostBuilderExtensions.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/HostBuilderExtensions.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using Amazon.Lambda.AspNetCoreServer.Internal;
+using Microsoft.AspNetCore.Hosting.Server;
+
+using Microsoft.AspNetCore.Hosting;
+using System.IO;
+
+#if !NETCOREAPP_2_1
+namespace Microsoft.Extensions.Hosting
+{
+    /// <summary>
+    /// Extension methods for IHostBuilder.
+    /// </summary>
+    public static class HostBuilderExtensions
+    {
+        /// <summary>
+        /// Configures the default settings for IWebHostBuilder when running in Lambda. The major difference between ConfigureWebHostDefaults and ConfigureWebHostLambdaDefaults
+        /// is that it calls "webBuilder.UseLambdaServer()" to swap out Kestrel for Lambda as the IServer.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="configure"></param>
+        /// <returns></returns>
+        public static IHostBuilder ConfigureWebHostLambdaDefaults(this IHostBuilder builder, Action<IWebHostBuilder> configure)
+        {
+            builder.ConfigureWebHostDefaults(webBuilder =>
+                    {
+                        webBuilder
+                            .UseContentRoot(Directory.GetCurrentDirectory())
+                            .ConfigureLogging((hostingContext, logging) =>
+                            {
+                                logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
+
+                                if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("LAMBDA_TASK_ROOT")))
+                                {
+                                    logging.AddConsole();
+                                    logging.AddDebug();
+                                }
+                                else
+                                {
+                                    logging.AddLambdaLogger(hostingContext.Configuration, "Logging");
+                                }
+                            })
+                            .UseDefaultServiceProvider((hostingContext, options) =>
+                            {
+                                options.ValidateScopes = hostingContext.HostingEnvironment.IsDevelopment();
+                            });
+
+                        // Swap out Kestrel as the webserver and use our implementation of IServer
+                        webBuilder.UseLambdaServer();
+
+                        configure(webBuilder);
+                    });
+
+            
+            return builder;
+        }
+    }
+}
+#endif

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/Utilities.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/Utilities.cs
@@ -31,16 +31,16 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
             // This makes sure there is only one registered IServer using LambdaServer and removes any other registrations.
             foreach (var serviceDescription in serviceDescriptions)
             {
-                // If Lambda server has already been added the skip out.
                 if (serviceDescription.ImplementationType == typeof(LambdaServer))
                 {
                     lambdaServiceCount++;
-                    if(lambdaServiceCount > 1)
+                    // If more then one LambdaServer registration has occurred then remove the extra registrations.
+                    if (lambdaServiceCount > 1)
                     {
                         toRemove.Add(serviceDescription);
                     }
                 }                        
-                // If there is an IServer registered that isn't LambdaServer then remove it. This is mostly likely caused
+                // If there is an IServer registered that isn't LambdaServer then remove it. This is most likely caused
                 // by leaving the UseKestrel call.
                 else
                 {
@@ -48,12 +48,12 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
                 }
             }
 
-            foreach(var serviceDescription in toRemove)
+            foreach (var serviceDescription in toRemove)
             {
                 services.Remove(serviceDescription);
             }
 
-            if(lambdaServiceCount == 0)
+            if (lambdaServiceCount == 0)
             {
                 services.AddSingleton<IServer, LambdaServer>();
             }

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/README.md
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/README.md
@@ -88,11 +88,11 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
 
 Amazon.Lambda.AspNetCoreServer creates this `IHostBuilder` and configures all of the default settings needed to run the ASP.NET Core application in Lambda. 
 
-There are 2 `Init` methods that can be overriden to customize the `IHostBuilder`. The most common customization is to override the `Init(IWebHostBuilder)` method and set the startup class via the `UseStartup` method. To customize the `IHostBuilder` then override the `Init(IHostBuilder)`. **Do not call `ConfigureWebHostDefaults` when overriding `Init(IHostBuilder)` because Amazon.Lambda.AspNetCoreServer will call `ConfigureWebHostDefaults` when creating the `IHostBuilder`. By calling `ConfigureWebHostDefaults` in the `Init(IHostBuilder)` method causes the `IWebHostBuilder` to be configured twice.**
+There are two `Init` methods that can be overridden to customize the `IHostBuilder`. The most common customization is to override the `Init(IWebHostBuilder)` method and set the startup class via the `UseStartup` method. To customize the `IHostBuilder` then override the `Init(IHostBuilder)`. **Do not call `ConfigureWebHostDefaults` when overriding `Init(IHostBuilder)` because Amazon.Lambda.AspNetCoreServer will call `ConfigureWebHostDefaults` when creating the `IHostBuilder`. By calling `ConfigureWebHostDefaults` in the `Init(IHostBuilder)` method, the `IWebHostBuilder` will be configured twice.**
 
 If you want complete control over creating the `IHostBuilder` then override the `CreateHostBuilder` method. When overriding the `CreateHostBuilder` method neither of the `Init` methods will be called unless the override calls the base implementation. When overriding `CreateHostBuilder` it is recommended to call `ConfigureWebHostLambdaDefaults` instead of `ConfigureWebHostDefaults` to configure the `IWebHostBuilder` for Lambda.
 
-If the `CreateWebHostBuilder` is overriden in an ASP.NET Core 3.1 application then only the `IWebHostBuilder` is used for bootstrapping using the same pattern that ASP.NET Core 2.1 applications use. `CreateHostBuilder` and `Init(IHostBuilder)` will not be called when `CreateWebHostBuilder` is overriden.
+If the `CreateWebHostBuilder` is overridden in an ASP.NET Core 3.1 application then only the `IWebHostBuilder` is used for bootstrapping using the same pattern that ASP.NET Core 2.1 applications use. `CreateHostBuilder` and `Init(IHostBuilder)` will not be called when `CreateWebHostBuilder` is overridden.
 
 
 

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/WebHostBuilderExtensions.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/WebHostBuilderExtensions.cs
@@ -39,19 +39,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             return hostBuilder.ConfigureServices(services =>
             {
-                var serviceDescription = services.FirstOrDefault(x => x.ServiceType == typeof(IServer));
-                if (serviceDescription != null)
-                {
-                    // If Lambda server has already been added the skip out.
-                    if (serviceDescription.ImplementationType == typeof(LambdaServer))
-                        return;
-                    // If there is already an IServer registered then remove it. This is mostly likely caused
-                    // by leaving the UseKestrel call.
-                    else
-                        services.Remove(serviceDescription);
-                }
-
-                services.AddSingleton<IServer, LambdaServer>();
+                Utilities.EnsureLambdaServerRegistered(services);
             });
         }
     }

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestWhichBuilderIsUsed.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestWhichBuilderIsUsed.cs
@@ -30,6 +30,8 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
         [InlineData(typeof(HostBuilderOverridingInit), true)]
         [InlineData(typeof(HostBuilderOverridingCreateWebHostBuilder), false)]
         [InlineData(typeof(HostBuilderOverridingCreateHostBuilder), true)]
+        [InlineData(typeof(HostBuilderOverridingInitHostBuilderAndCallsConfigureWebHostDefaults), true)]
+        [InlineData(typeof(HostBuilderOverridingInitHostBuilderAndCallsConfigureWebHostLambdaDefaults), true)]
         public async Task TestUsingGenericBaseClass(Type functionType, bool initHostCalled)
         {
             var methodsCalled = await InvokeAPIGatewayRequestWithContent(functionType);

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestWhichBuilderIsUsed.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestWhichBuilderIsUsed.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.TestUtilities;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+using TestWebApp;
+
+using Xunit;
+
+namespace Amazon.Lambda.AspNetCoreServer.Test
+{
+
+    public class TestWhichBuilderIsUsed
+    {
+#if !NETCOREAPP_2_1
+
+        [Theory]
+        [InlineData(typeof(HostBuilderUsingGenericClass), true)]
+        [InlineData(typeof(HostBuilderOverridingInit), true)]
+        [InlineData(typeof(HostBuilderOverridingCreateWebHostBuilder), false)]
+        [InlineData(typeof(HostBuilderOverridingCreateHostBuilder), true)]
+        public async Task TestUsingGenericBaseClass(Type functionType, bool initHostCalled)
+        {
+            var methodsCalled = await InvokeAPIGatewayRequestWithContent(functionType);
+            Assert.Equal(initHostCalled, methodsCalled.InitHostBuilder);
+
+            Assert.True(methodsCalled.InitHostWebBuilder);
+        }
+
+        private async Task<IMethodsCalled> InvokeAPIGatewayRequestWithContent(Type functionType)
+        {
+            var context = new TestLambdaContext();
+
+            var filePath = Path.Combine(Path.GetDirectoryName(this.GetType().GetTypeInfo().Assembly.Location), "values-get-all-apigateway-request.json");
+            var requestContent = File.ReadAllText(filePath);
+
+            var lambdaFunction = Activator.CreateInstance(functionType) as APIGatewayProxyFunction;
+            var requestStream = new MemoryStream(System.Text.UTF8Encoding.UTF8.GetBytes(requestContent));
+            var request = new Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer().Deserialize<APIGatewayProxyRequest>(requestStream);
+            await lambdaFunction.FunctionHandlerAsync(request, context);
+            return lambdaFunction as IMethodsCalled;
+        }
+
+#endif
+    }
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestWhichBuilderIsUsed.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestWhichBuilderIsUsed.cs
@@ -48,7 +48,8 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
             var lambdaFunction = Activator.CreateInstance(functionType) as APIGatewayProxyFunction;
             var requestStream = new MemoryStream(System.Text.UTF8Encoding.UTF8.GetBytes(requestContent));
             var request = new Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer().Deserialize<APIGatewayProxyRequest>(requestStream);
-            await lambdaFunction.FunctionHandlerAsync(request, context);
+            var response = await lambdaFunction.FunctionHandlerAsync(request, context);
+            Assert.Equal(200, response.StatusCode);
             return lambdaFunction as IMethodsCalled;
         }
 

--- a/Libraries/test/TestWebApp/HostBuilderTestClasses.cs
+++ b/Libraries/test/TestWebApp/HostBuilderTestClasses.cs
@@ -1,0 +1,97 @@
+﻿using Amazon.Lambda.AspNetCoreServer;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+#if !NETCOREAPP_2_1
+namespace TestWebApp
+{
+    public interface IMethodsCalled
+    {
+        bool InitHostBuilder { get; set; }
+        bool InitHostWebBuilder { get; set; }
+    }
+
+    public class HostBuilderUsingGenericClass : APIGatewayProxyFunction<Startup>, IMethodsCalled
+    {
+        public bool InitHostBuilder { get; set; }
+        public bool InitHostWebBuilder { get; set; }
+
+        protected override void Init(IWebHostBuilder builder)
+        {
+            base.Init(builder);
+            InitHostWebBuilder = true;
+        }
+
+        protected override void Init(IHostBuilder builder)
+        {
+            base.Init(builder);
+            InitHostBuilder = true;
+        }
+    }
+
+    public class HostBuilderOverridingInit : APIGatewayProxyFunction, IMethodsCalled
+    {
+        public bool InitHostBuilder { get; set; }
+        public bool InitHostWebBuilder { get; set; }
+
+        protected override void Init(IWebHostBuilder builder)
+        {
+            builder.UseStartup<Startup>();
+
+            InitHostWebBuilder = true;
+        }
+
+        protected override void Init(IHostBuilder builder)
+        {
+            base.Init(builder);
+            InitHostBuilder = true;
+        }
+    }
+
+    public class HostBuilderOverridingCreateWebHostBuilder : APIGatewayProxyFunction, IMethodsCalled
+    {
+        public bool InitHostBuilder { get; set; }
+        public bool InitHostWebBuilder { get; set; }
+
+        protected override IWebHostBuilder CreateWebHostBuilder()
+        {
+            return base.CreateWebHostBuilder();
+        }
+
+        protected override void Init(IWebHostBuilder builder)
+        {
+            builder.UseStartup<Startup>();
+            InitHostWebBuilder = true;
+        }
+
+        protected override void Init(IHostBuilder builder)
+        {
+            base.Init(builder);
+            InitHostBuilder = true;
+        }
+    }
+
+    public class HostBuilderOverridingCreateHostBuilder : APIGatewayProxyFunction, IMethodsCalled
+    {
+        public bool InitHostBuilder { get; set; }
+        public bool InitHostWebBuilder { get; set; }
+
+        protected override IHostBuilder CreateHostBuilder()
+        {
+            return base.CreateHostBuilder();
+        }
+
+        protected override void Init(IWebHostBuilder builder)
+        {
+            builder.UseStartup<Startup>();
+            InitHostWebBuilder = true;
+        }
+
+        protected override void Init(IHostBuilder builder)
+        {
+            base.Init(builder);
+            InitHostBuilder = true;
+        }
+    }
+}
+#endif

--- a/Libraries/test/TestWebApp/HostBuilderTestClasses.cs
+++ b/Libraries/test/TestWebApp/HostBuilderTestClasses.cs
@@ -93,5 +93,52 @@ namespace TestWebApp
             InitHostBuilder = true;
         }
     }
+
+
+    public class HostBuilderOverridingInitHostBuilderAndCallsConfigureWebHostDefaults : APIGatewayProxyFunction, IMethodsCalled
+    {
+        public bool InitHostBuilder { get; set; }
+        public bool InitHostWebBuilder { get; set; }
+
+
+        protected override void Init(IWebHostBuilder builder)
+        {
+            InitHostWebBuilder = true;
+        }
+
+        protected override void Init(IHostBuilder builder)
+        {
+            InitHostBuilder = true;
+
+            builder
+                  .ConfigureWebHostDefaults(webBuilder =>
+                  {
+                      webBuilder.UseStartup<Startup>();
+                  });
+        }
+    }
+
+    public class HostBuilderOverridingInitHostBuilderAndCallsConfigureWebHostLambdaDefaults : APIGatewayProxyFunction, IMethodsCalled
+    {
+        public bool InitHostBuilder { get; set; }
+        public bool InitHostWebBuilder { get; set; }
+
+
+        protected override void Init(IWebHostBuilder builder)
+        {
+            InitHostWebBuilder = true;
+        }
+
+        protected override void Init(IHostBuilder builder)
+        {
+            InitHostBuilder = true;
+
+            builder
+                  .ConfigureWebHostLambdaDefaults(webBuilder =>
+                  {
+                      webBuilder.UseStartup<Startup>();
+                  });
+        }
+    }
 }
 #endif


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/616

*Description of changes:*
.NET Core 3.1 prefers to use the newer IHostBuilder instead of IWebHostBuilder start up ASP.NET Core applications. This PR switches to IHostBuilder for .NET Core 3.1 Lambda functions unless the CreateWebBuilder has been overridden. 

The check for CreateWebBuilder being overridden is to support developers that have existing ASP.NET Core Lambda functions that are already using CreateWebBuilder. The CreateWebBuilder  method has been marked as obsolete for non .NET Core 2.1 functions and will be removed for non .NET Core 2.1 functions in a major version update in the future.

Both `Init(IHostBuilder)` and `Init(IWebHostBuilder)` are valid even when using IHostBuilder because the IHostBuilder uses an inner IWebHostBuilder to setup things like the startup class.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
