### PR TITLE
Rework Amazon.Lambda.Serialization.SystemTextJson

### DIFF
--- a/Libraries/src/Amazon.Lambda.ApplicationLoadBalancerEvents/Amazon.Lambda.ApplicationLoadBalancerEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.ApplicationLoadBalancerEvents/Amazon.Lambda.ApplicationLoadBalancerEvents.csproj
@@ -11,13 +11,5 @@
         <PackageId>Amazon.Lambda.ApplicationLoadBalancerEvents</PackageId>
         <PackageTags>AWS;Amazon;Lambda</PackageTags>
     </PropertyGroup>
-
-    <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-        <DefineConstants>NETSTANDARD_2_0</DefineConstants>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-        <DefineConstants>NETCOREAPP_3_1</DefineConstants>
-    </PropertyGroup>
     
 </Project>

--- a/Libraries/src/Amazon.Lambda.ApplicationLoadBalancerEvents/Amazon.Lambda.ApplicationLoadBalancerEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.ApplicationLoadBalancerEvents/Amazon.Lambda.ApplicationLoadBalancerEvents.csproj
@@ -3,13 +3,21 @@
     <Import Project="..\..\..\buildtools\common.props" />
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
         <Description>Amazon Lambda .NET Core support - Application Load Balancer package.</Description>
         <AssemblyTitle>Amazon.Lambda.ApplicationLoadBalancerEvents</AssemblyTitle>
-        <VersionPrefix>1.0.0</VersionPrefix>
+        <VersionPrefix>2.0.0</VersionPrefix>
         <AssemblyName>Amazon.Lambda.ApplicationLoadBalancerEvents</AssemblyName>
         <PackageId>Amazon.Lambda.ApplicationLoadBalancerEvents</PackageId>
         <PackageTags>AWS;Amazon;Lambda</PackageTags>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <DefineConstants>NETSTANDARD_2_0</DefineConstants>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+        <DefineConstants>NETCOREAPP_3_1</DefineConstants>
     </PropertyGroup>
     
 </Project>

--- a/Libraries/src/Amazon.Lambda.ApplicationLoadBalancerEvents/ApplicationLoadBalancerResponse.cs
+++ b/Libraries/src/Amazon.Lambda.ApplicationLoadBalancerEvents/ApplicationLoadBalancerResponse.cs
@@ -14,12 +14,18 @@ namespace Amazon.Lambda.ApplicationLoadBalancerEvents
         /// The HTTP status code for the request
         /// </summary>
         [DataMember(Name = "statusCode")]
+#if NETCOREAPP_3_1
+        [System.Text.Json.Serialization.JsonPropertyName("statusCode")]
+#endif
         public int StatusCode { get; set; }
         
         /// <summary>
         /// The HTTP status description for the request
         /// </summary>
         [DataMember(Name = "statusDescription")]
+#if NETCOREAPP_3_1
+        [System.Text.Json.Serialization.JsonPropertyName("statusDescription")]
+#endif
         public string StatusDescription { get; set; }
 
         /// <summary>
@@ -27,6 +33,9 @@ namespace Amazon.Lambda.ApplicationLoadBalancerEvents
         /// Note: Use this property when "Multi value headers" is disabled on ELB Target Group.
         /// </summary>
         [DataMember(Name = "headers")]
+#if NETCOREAPP_3_1
+        [System.Text.Json.Serialization.JsonPropertyName("headers")]
+#endif
         public IDictionary<string, string> Headers { get; set; }
 
         /// <summary>
@@ -34,18 +43,27 @@ namespace Amazon.Lambda.ApplicationLoadBalancerEvents
         /// Note: Use this property when "Multi value headers" is enabled on ELB Target Group.
         /// </summary>
         [DataMember(Name = "multiValueHeaders")]
+#if NETCOREAPP_3_1
+        [System.Text.Json.Serialization.JsonPropertyName("multiValueHeaders")]
+#endif
         public IDictionary<string, IList<string>> MultiValueHeaders { get; set; }
 
         /// <summary>
         /// The response body
         /// </summary>
         [DataMember(Name = "body")]
+#if NETCOREAPP_3_1
+        [System.Text.Json.Serialization.JsonPropertyName("body")]
+#endif
         public string Body { get; set; }
 
         /// <summary>
         /// Flag indicating whether the body should be treated as a base64-encoded string
         /// </summary>
         [DataMember(Name = "isBase64Encoded")]
+#if NETCOREAPP_3_1
+        [System.Text.Json.Serialization.JsonPropertyName("isBase64Encoded")]
+#endif
         public bool IsBase64Encoded { get; set; }        
     }
 }

--- a/Libraries/src/Amazon.Lambda.ApplicationLoadBalancerEvents/ApplicationLoadBalancerResponse.cs
+++ b/Libraries/src/Amazon.Lambda.ApplicationLoadBalancerEvents/ApplicationLoadBalancerResponse.cs
@@ -14,7 +14,7 @@ namespace Amazon.Lambda.ApplicationLoadBalancerEvents
         /// The HTTP status code for the request
         /// </summary>
         [DataMember(Name = "statusCode")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
         [System.Text.Json.Serialization.JsonPropertyName("statusCode")]
 #endif
         public int StatusCode { get; set; }
@@ -23,7 +23,7 @@ namespace Amazon.Lambda.ApplicationLoadBalancerEvents
         /// The HTTP status description for the request
         /// </summary>
         [DataMember(Name = "statusDescription")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
         [System.Text.Json.Serialization.JsonPropertyName("statusDescription")]
 #endif
         public string StatusDescription { get; set; }
@@ -33,7 +33,7 @@ namespace Amazon.Lambda.ApplicationLoadBalancerEvents
         /// Note: Use this property when "Multi value headers" is disabled on ELB Target Group.
         /// </summary>
         [DataMember(Name = "headers")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
         [System.Text.Json.Serialization.JsonPropertyName("headers")]
 #endif
         public IDictionary<string, string> Headers { get; set; }
@@ -43,7 +43,7 @@ namespace Amazon.Lambda.ApplicationLoadBalancerEvents
         /// Note: Use this property when "Multi value headers" is enabled on ELB Target Group.
         /// </summary>
         [DataMember(Name = "multiValueHeaders")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
         [System.Text.Json.Serialization.JsonPropertyName("multiValueHeaders")]
 #endif
         public IDictionary<string, IList<string>> MultiValueHeaders { get; set; }
@@ -52,7 +52,7 @@ namespace Amazon.Lambda.ApplicationLoadBalancerEvents
         /// The response body
         /// </summary>
         [DataMember(Name = "body")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
         [System.Text.Json.Serialization.JsonPropertyName("body")]
 #endif
         public string Body { get; set; }
@@ -61,7 +61,7 @@ namespace Amazon.Lambda.ApplicationLoadBalancerEvents
         /// Flag indicating whether the body should be treated as a base64-encoded string
         /// </summary>
         [DataMember(Name = "isBase64Encoded")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
         [System.Text.Json.Serialization.JsonPropertyName("isBase64Encoded")]
 #endif
         public bool IsBase64Encoded { get; set; }        

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
@@ -343,7 +343,7 @@ namespace Amazon.Lambda.AspNetCoreServer
 #if NETCOREAPP_2_1
         [LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 #elif NETCOREAPP_3_1
-        [LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public virtual async Task<TRESPONSE> FunctionHandlerAsync(TREQUEST request, ILambdaContext lambdaContext)
         {

--- a/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/Amazon.Lambda.KinesisAnalyticsEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/Amazon.Lambda.KinesisAnalyticsEvents.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <Description>Amazon Lambda .NET Core support - Amazon Kinesis Analytics package.</Description>
     <AssemblyTitle>Amazon.Lambda.KinesisAnalyticsEvents</AssemblyTitle>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.KinesisAnalyticsEvents</AssemblyName>
     <PackageId>Amazon.Lambda.KinesisAnalyticsEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda;KinesisAnalytics</PackageTags>
@@ -14,9 +14,6 @@
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>NETCOREAPP_3_1</DefineConstants>
-  </PropertyGroup>  
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
-  </ItemGroup>  
+  </PropertyGroup>
+  
 </Project>

--- a/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/Amazon.Lambda.KinesisAnalyticsEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/Amazon.Lambda.KinesisAnalyticsEvents.csproj
@@ -11,9 +11,5 @@
     <PackageId>Amazon.Lambda.KinesisAnalyticsEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda;KinesisAnalytics</PackageTags>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <DefineConstants>NETCOREAPP_3_1</DefineConstants>
-  </PropertyGroup>
   
 </Project>

--- a/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsInputPreprocessingResponse.cs
+++ b/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsInputPreprocessingResponse.cs
@@ -33,8 +33,8 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
         /// The records.
         /// </value>
         [DataMember(Name = "records")]
-#if NETCOREAPP_3_1
-            [System.Text.Json.Serialization.JsonPropertyName("records")]
+#if NETCOREAPP3_1
+        [System.Text.Json.Serialization.JsonPropertyName("records")]
 #endif
         public IList<Record> Records { get; set; }
 
@@ -51,7 +51,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The record identifier.
             /// </value>
             [DataMember(Name = "recordId")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("recordId")]
 #endif
             public string RecordId { get; set; }
@@ -63,7 +63,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The result.
             /// </value>
             [DataMember(Name = "result")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("result")]
 #endif
             public string Result { get; set; }
@@ -75,7 +75,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The base64 encoded data.
             /// </value>
             [DataMember(Name = "data")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("data")]
 #endif
             public string Base64EncodedData { get; set; }

--- a/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsOutputDeliveryEvent.cs
+++ b/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsOutputDeliveryEvent.cs
@@ -85,7 +85,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The base64 encoded data.
             /// </value>
             [DataMember(Name = "data")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("data")]
 #endif
             public string Base64EncodedData { get; set; }

--- a/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsOutputDeliveryResponse.cs
+++ b/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsOutputDeliveryResponse.cs
@@ -28,7 +28,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
         /// The records.
         /// </value>
         [DataMember(Name = "records")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
         [System.Text.Json.Serialization.JsonPropertyName("records")]
 #endif
         public IList<Record> Records { get; set; }
@@ -46,7 +46,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The record identifier.
             /// </value>
             [DataMember(Name = "recordId")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("recordId")]
 #endif
             public string RecordId { get; set; }
@@ -58,7 +58,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The result.
             /// </value>
             [DataMember(Name = "result")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("result")]
 #endif
             public string Result { get; set; }

--- a/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsOutputDeliveryResponse.cs
+++ b/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsOutputDeliveryResponse.cs
@@ -28,6 +28,9 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
         /// The records.
         /// </value>
         [DataMember(Name = "records")]
+#if NETCOREAPP_3_1
+        [System.Text.Json.Serialization.JsonPropertyName("records")]
+#endif
         public IList<Record> Records { get; set; }
 
         /// <summary>
@@ -43,6 +46,9 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The record identifier.
             /// </value>
             [DataMember(Name = "recordId")]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("recordId")]
+#endif
             public string RecordId { get; set; }
 
             /// <summary>
@@ -52,6 +58,9 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The result.
             /// </value>
             [DataMember(Name = "result")]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("result")]
+#endif
             public string Result { get; set; }
         }
     }

--- a/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsStreamsInputPreprocessingEvent.cs
+++ b/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsStreamsInputPreprocessingEvent.cs
@@ -131,7 +131,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The base64 encoded data.
             /// </value>
             [DataMember(Name = "data")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("data")]
 #endif
             public string Base64EncodedData { get; set; }

--- a/Libraries/src/Amazon.Lambda.KinesisFirehoseEvents/KinesisFirehoseResponse.cs
+++ b/Libraries/src/Amazon.Lambda.KinesisFirehoseEvents/KinesisFirehoseResponse.cs
@@ -32,6 +32,9 @@ namespace Amazon.Lambda.KinesisFirehoseEvents
         /// The transformed records from the KinesisFirehoseEvent.
         /// </summary>        
         [DataMember(Name = "records")]
+#if NETCOREAPP_3_1
+        [System.Text.Json.Serialization.JsonPropertyName("records")]
+#endif
         public IList<FirehoseRecord> Records { get; set; }
 
         /// <summary>
@@ -46,6 +49,9 @@ namespace Amazon.Lambda.KinesisFirehoseEvents
             ///transformed record is treated as a data transformation failure.
             /// </summary>
             [DataMember(Name = "recordId")]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("recordId")]
+#endif
             public string RecordId { get; set; }
 
             /// <summary>
@@ -72,6 +78,9 @@ namespace Amazon.Lambda.KinesisFirehoseEvents
             /// </list>
             /// </summary>
             [DataMember(Name = "result")]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("result")]
+#endif
             public string Result { get; set; }
 
             /// <summary>

--- a/Libraries/src/Amazon.Lambda.LexEvents/Amazon.Lambda.LexEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.LexEvents/Amazon.Lambda.LexEvents.csproj
@@ -4,16 +4,16 @@
 
   <PropertyGroup>
     <Description>Amazon Lambda .NET Core support - Amazon Lex package.</Description>
-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.LexEvents</AssemblyTitle>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.LexEvents</AssemblyName>
     <PackageId>Amazon.Lambda.LexEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda;Lex</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
-  </ItemGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <DefineConstants>NETCOREAPP_3_1</DefineConstants>
+  </PropertyGroup>
 
 </Project>

--- a/Libraries/src/Amazon.Lambda.LexEvents/Amazon.Lambda.LexEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.LexEvents/Amazon.Lambda.LexEvents.csproj
@@ -12,8 +12,4 @@
     <PackageTags>AWS;Amazon;Lambda;Lex</PackageTags>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <DefineConstants>NETCOREAPP_3_1</DefineConstants>
-  </PropertyGroup>
-
 </Project>

--- a/Libraries/src/Amazon.Lambda.LexEvents/LexResponse.cs
+++ b/Libraries/src/Amazon.Lambda.LexEvents/LexResponse.cs
@@ -15,6 +15,9 @@
         /// Application-specific session attributes. This is an optional field.
         /// </summary>
         [DataMember(Name = "sessionAttributes", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+        [System.Text.Json.Serialization.JsonPropertyName("sessionAttributes")]
+#endif
         public IDictionary<string, string> SessionAttributes { get; set; }
 
         /// <summary>
@@ -23,6 +26,9 @@
         /// after Amazon Lex returns a response to the client.
         /// </summary>\
         [DataMember(Name = "dialogAction", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+        [System.Text.Json.Serialization.JsonPropertyName("dialogAction")]
+#endif
         public LexDialogAction DialogAction { get; set; }
 
         /// <summary>
@@ -35,42 +41,63 @@
             /// The type of action for Lex to take with the response from the Lambda function.
             /// </summary>
             [DataMember(Name = "type", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("type")]
+#endif
             public string Type { get; set; }
 
             /// <summary>
             /// The state of the fullfillment. "Fulfilled" or "Failed"
             /// </summary>
             [DataMember(Name = "fulfillmentState", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("fulfillmentState")]
+#endif
             public string FulfillmentState { get; set; }
 
             /// <summary>
             /// The message to be sent to the user.
             /// </summary>
             [DataMember(Name = "message", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("message")]
+#endif
             public LexMessage Message { get; set; }
 
             /// <summary>
             /// The intent name you want to confirm or elicit.
             /// </summary>
             [DataMember(Name = "intentName", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("intentName")]
+#endif
             public string IntentName { get; set; }
 
             /// <summary>
             /// The values for all of the slots when response is of type "Delegate".
             /// </summary>
             [DataMember(Name = "slots", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("slots")]
+#endif
             public IDictionary<string, string> Slots { get; set; }
 
             /// <summary>
             /// The slot to elicit when the Type is "ElicitSlot"
             /// </summary>
             [DataMember(Name = "slotToElicit", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("slotToElicit")]
+#endif
             public string SlotToElicit { get; set; }
 
             /// <summary>
             /// The response card provides information back to the bot to display for the user.
             /// </summary>
             [DataMember(Name = "responseCard", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("responseCard")]
+#endif
             public LexResponseCard ResponseCard { get; set; }
         }
 
@@ -84,12 +111,18 @@
             /// The content type of the message. PlainText or SSML
             /// </summary>
             [DataMember(Name = "contentType", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("contentType")]
+#endif
             public string ContentType { get; set; }
 
             /// <summary>
             /// The message to be asked to the user by the bot.
             /// </summary>
             [DataMember(Name = "content", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("content")]
+#endif
             public string Content { get; set; }
         }
 
@@ -103,18 +136,27 @@
             /// The version of the response card.
             /// </summary>
             [DataMember(Name = "version", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("version")]
+#endif
             public int? Version { get; set; }
 
             /// <summary>
             /// The content type of the response card. The default is "application/vnd.amazonaws.card.generic".
             /// </summary>
             [DataMember(Name = "contentType", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("contentType")]
+#endif
             public string ContentType { get; set; } = "application/vnd.amazonaws.card.generic";
 
             /// <summary>
             /// The list of attachments sent back with the response card.
             /// </summary>
             [DataMember(Name = "genericAttachments", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("genericAttachments")]
+#endif
             public IList<LexGenericAttachments> GenericAttachments { get; set; }
         }
 
@@ -128,30 +170,45 @@
             /// The card's title.
             /// </summary>
             [DataMember(Name = "title", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("title")]
+#endif
             public string Title { get; set; }
 
             /// <summary>
             /// The card's sub title.
             /// </summary>
             [DataMember(Name = "subTitle", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("subTitle")]
+#endif
             public string SubTitle { get; set; }
 
             /// <summary>
             /// URL to an image to be shown.
             /// </summary>
             [DataMember(Name = "imageUrl", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("imageUrl")]
+#endif
             public string ImageUrl { get; set; }
 
             /// <summary>
             /// URL of the attachment to be associated with the card.
             /// </summary>
             [DataMember(Name = "attachmentLinkUrl", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("attachmentLinkUrl")]
+#endif
             public string AttachmentLinkUrl { get; set; }
 
             /// <summary>
             /// The list of buttons to be displayed with the response card.
             /// </summary>
             [DataMember(Name = "buttons", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("buttons")]
+#endif
             public IList<LexButton> Buttons { get; set; }
         }
 
@@ -165,12 +222,18 @@
             /// The text for the button.
             /// </summary>
             [DataMember(Name = "text", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("text")]
+#endif
             public string Text { get; set; }
 
             /// <summary>
             /// The value of the button sent back to the server.
             /// </summary>
             [DataMember(Name = "value", EmitDefaultValue=false)]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("value")]
+#endif
             public string Value { get; set; }
         }
     }

--- a/Libraries/src/Amazon.Lambda.LexEvents/LexResponse.cs
+++ b/Libraries/src/Amazon.Lambda.LexEvents/LexResponse.cs
@@ -15,7 +15,7 @@
         /// Application-specific session attributes. This is an optional field.
         /// </summary>
         [DataMember(Name = "sessionAttributes", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
         [System.Text.Json.Serialization.JsonPropertyName("sessionAttributes")]
 #endif
         public IDictionary<string, string> SessionAttributes { get; set; }
@@ -26,7 +26,7 @@
         /// after Amazon Lex returns a response to the client.
         /// </summary>\
         [DataMember(Name = "dialogAction", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
         [System.Text.Json.Serialization.JsonPropertyName("dialogAction")]
 #endif
         public LexDialogAction DialogAction { get; set; }
@@ -41,7 +41,7 @@
             /// The type of action for Lex to take with the response from the Lambda function.
             /// </summary>
             [DataMember(Name = "type", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("type")]
 #endif
             public string Type { get; set; }
@@ -50,7 +50,7 @@
             /// The state of the fullfillment. "Fulfilled" or "Failed"
             /// </summary>
             [DataMember(Name = "fulfillmentState", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("fulfillmentState")]
 #endif
             public string FulfillmentState { get; set; }
@@ -59,7 +59,7 @@
             /// The message to be sent to the user.
             /// </summary>
             [DataMember(Name = "message", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("message")]
 #endif
             public LexMessage Message { get; set; }
@@ -68,7 +68,7 @@
             /// The intent name you want to confirm or elicit.
             /// </summary>
             [DataMember(Name = "intentName", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("intentName")]
 #endif
             public string IntentName { get; set; }
@@ -77,7 +77,7 @@
             /// The values for all of the slots when response is of type "Delegate".
             /// </summary>
             [DataMember(Name = "slots", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("slots")]
 #endif
             public IDictionary<string, string> Slots { get; set; }
@@ -86,7 +86,7 @@
             /// The slot to elicit when the Type is "ElicitSlot"
             /// </summary>
             [DataMember(Name = "slotToElicit", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("slotToElicit")]
 #endif
             public string SlotToElicit { get; set; }
@@ -95,7 +95,7 @@
             /// The response card provides information back to the bot to display for the user.
             /// </summary>
             [DataMember(Name = "responseCard", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("responseCard")]
 #endif
             public LexResponseCard ResponseCard { get; set; }
@@ -111,7 +111,7 @@
             /// The content type of the message. PlainText or SSML
             /// </summary>
             [DataMember(Name = "contentType", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("contentType")]
 #endif
             public string ContentType { get; set; }
@@ -120,7 +120,7 @@
             /// The message to be asked to the user by the bot.
             /// </summary>
             [DataMember(Name = "content", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("content")]
 #endif
             public string Content { get; set; }
@@ -136,7 +136,7 @@
             /// The version of the response card.
             /// </summary>
             [DataMember(Name = "version", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("version")]
 #endif
             public int? Version { get; set; }
@@ -145,7 +145,7 @@
             /// The content type of the response card. The default is "application/vnd.amazonaws.card.generic".
             /// </summary>
             [DataMember(Name = "contentType", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("contentType")]
 #endif
             public string ContentType { get; set; } = "application/vnd.amazonaws.card.generic";
@@ -154,7 +154,7 @@
             /// The list of attachments sent back with the response card.
             /// </summary>
             [DataMember(Name = "genericAttachments", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("genericAttachments")]
 #endif
             public IList<LexGenericAttachments> GenericAttachments { get; set; }
@@ -170,7 +170,7 @@
             /// The card's title.
             /// </summary>
             [DataMember(Name = "title", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("title")]
 #endif
             public string Title { get; set; }
@@ -179,7 +179,7 @@
             /// The card's sub title.
             /// </summary>
             [DataMember(Name = "subTitle", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("subTitle")]
 #endif
             public string SubTitle { get; set; }
@@ -188,7 +188,7 @@
             /// URL to an image to be shown.
             /// </summary>
             [DataMember(Name = "imageUrl", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("imageUrl")]
 #endif
             public string ImageUrl { get; set; }
@@ -197,7 +197,7 @@
             /// URL of the attachment to be associated with the card.
             /// </summary>
             [DataMember(Name = "attachmentLinkUrl", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("attachmentLinkUrl")]
 #endif
             public string AttachmentLinkUrl { get; set; }
@@ -206,7 +206,7 @@
             /// The list of buttons to be displayed with the response card.
             /// </summary>
             [DataMember(Name = "buttons", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("buttons")]
 #endif
             public IList<LexButton> Buttons { get; set; }
@@ -222,7 +222,7 @@
             /// The text for the button.
             /// </summary>
             [DataMember(Name = "text", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("text")]
 #endif
             public string Text { get; set; }
@@ -231,7 +231,7 @@
             /// The value of the button sent back to the server.
             /// </summary>
             [DataMember(Name = "value", EmitDefaultValue=false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("value")]
 #endif
             public string Value { get; set; }

--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/Amazon.Lambda.Serialization.SystemTextJson.csproj
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/Amazon.Lambda.Serialization.SystemTextJson.csproj
@@ -9,7 +9,7 @@
         <AssemblyName>Amazon.Lambda.Serialization.SystemTextJson</AssemblyName>
         <PackageId>Amazon.Lambda.Serialization.SystemTextJson</PackageId>
         <PackageTags>AWS;Amazon;Lambda</PackageTags>
-        <VersionPrefix>1.0.0</VersionPrefix>
+        <VersionPrefix>2.0.0</VersionPrefix>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/AwsNamingPolicy.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/AwsNamingPolicy.cs
@@ -15,6 +15,27 @@ namespace Amazon.Lambda.Serialization.SystemTextJson
                 {"XAmzRequestId", "x-amz-request-id" }
             };
 
+        private readonly JsonNamingPolicy _fallbackNamingPolicy;
+
+        /// <summary>
+        /// Creates the AWS Naming policy. If the name matches one of the reserved AWS words it will return the
+        /// appropriate mapping for it. Otherwise the name will be return as is like the JsonDefaultNamingPolicy.
+        /// </summary>
+        public AwsNamingPolicy()
+        {
+            
+        }
+
+        /// <summary>
+        /// Creates the AWS Naming policy. If the name matches one of the reserved AWS words it will return the
+        /// appropriate mapping for it. Otherwise the JsonNamingPolicy passed in will be used to map the name.
+        /// </summary>
+        /// <param name="fallbackNamingPolicy"></param>
+        public AwsNamingPolicy(JsonNamingPolicy fallbackNamingPolicy)
+        {
+            _fallbackNamingPolicy = fallbackNamingPolicy;
+        }
+
         /// <summary>
         /// Map names that don't camel case.
         /// </summary>
@@ -27,7 +48,16 @@ namespace Amazon.Lambda.Serialization.SystemTextJson
                 return mapNamed;
             }
 
-            return JsonNamingPolicy.CamelCase.ConvertName(name);
+            if (_fallbackNamingPolicy == null)
+            {
+                // If no naming policy given then just return the name like the JsonDefaultNamingPolicy policy.
+                // https://github.com/dotnet/runtime/blob/master/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonDefaultNamingPolicy.cs
+                return name;
+            }
+            else
+            {
+                return _fallbackNamingPolicy.ConvertName(name);
+            }
         }
     }
 }

--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/AwsNamingPolicy.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/AwsNamingPolicy.cs
@@ -19,7 +19,7 @@ namespace Amazon.Lambda.Serialization.SystemTextJson
 
         /// <summary>
         /// Creates the AWS Naming policy. If the name matches one of the reserved AWS words it will return the
-        /// appropriate mapping for it. Otherwise the name will be return as is like the JsonDefaultNamingPolicy.
+        /// appropriate mapping for it. Otherwise the name will be returned as is like the JsonDefaultNamingPolicy.
         /// </summary>
         public AwsNamingPolicy()
         {
@@ -48,16 +48,9 @@ namespace Amazon.Lambda.Serialization.SystemTextJson
                 return mapNamed;
             }
 
-            if (_fallbackNamingPolicy == null)
-            {
-                // If no naming policy given then just return the name like the JsonDefaultNamingPolicy policy.
-                // https://github.com/dotnet/runtime/blob/master/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonDefaultNamingPolicy.cs
-                return name;
-            }
-            else
-            {
-                return _fallbackNamingPolicy.ConvertName(name);
-            }
+            // If no naming policy given then just return the name like the JsonDefaultNamingPolicy policy.
+            // https://github.com/dotnet/runtime/blob/master/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonDefaultNamingPolicy.cs
+            return _fallbackNamingPolicy?.ConvertName(name) ?? name;
         }
     }
 }

--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/CamelCaseLambdaJsonSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/CamelCaseLambdaJsonSerializer.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+
+namespace Amazon.Lambda.Serialization.SystemTextJson
+{
+    /// <summary>
+    /// Custom ILambdaSerializer implementation which uses System.Text.Json
+    /// for serialization.
+    ///
+    /// <para>
+    /// When serializing objects to JSON camel casing will be used for JSON property names.
+    /// </para>
+    /// <para>
+    /// If the environment variable LAMBDA_NET_SERIALIZER_DEBUG is set to true the JSON coming
+    /// in from Lambda and being sent back to Lambda will be logged.
+    /// </para>
+    /// </summary>
+    public class CamelCaseLambdaJsonSerializer : DefaultLambdaJsonSerializer
+    {
+        /// <summary>
+        /// Constructs instance of serializer.
+        /// </summary>
+        public CamelCaseLambdaJsonSerializer()
+            : base(ConfigureJsonSerializerOptions)
+        {
+            
+        }
+
+        private static void ConfigureJsonSerializerOptions(JsonSerializerOptions options)
+        {
+            options.PropertyNamingPolicy = new AwsNamingPolicy(JsonNamingPolicy.CamelCase);
+        }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/DefaultLambdaJsonSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/DefaultLambdaJsonSerializer.cs
@@ -45,10 +45,8 @@ namespace Amazon.Lambda.Serialization.SystemTextJson
                 }
             };
 
-            if (string.Equals(Environment.GetEnvironmentVariable(DEBUG_ENVIRONMENT_VARIABLE_NAME), "true", StringComparison.OrdinalIgnoreCase))
-            {
-                this._debug = true;
-            }            
+            this._debug = string.Equals(Environment.GetEnvironmentVariable(DEBUG_ENVIRONMENT_VARIABLE_NAME), "true",
+                StringComparison.OrdinalIgnoreCase); 
         }
 
         /// <summary>

--- a/Libraries/test/EventsTests.NETCore31/TestResponseCasing.cs
+++ b/Libraries/test/EventsTests.NETCore31/TestResponseCasing.cs
@@ -1,0 +1,55 @@
+using System.IO;
+
+using Xunit;
+
+using Amazon.Lambda.Serialization.SystemTextJson;
+using Newtonsoft.Json.Linq;
+
+namespace EventsTests31
+{
+    public class TestResponseCasing
+    {
+        [Fact]
+        public void TestPascalCase()
+        {
+            var serializer = new DefaultLambdaJsonSerializer();
+
+            var response = new DummyResponse
+            {
+                BingBong = "Joy"
+            };
+            
+            MemoryStream ms = new MemoryStream();
+            serializer.Serialize(response, ms);
+            ms.Position = 0;
+            var json = new StreamReader(ms).ReadToEnd();
+            
+            var serialized = JObject.Parse(json);
+            Assert.Equal("Joy", serialized["BingBong"]?.ToString());
+        }
+        
+        [Fact]
+        public void TestCamelCase()
+        {
+            var serializer = new CamelCaseLambdaJsonSerializer();
+
+            var response = new DummyResponse
+            {
+                BingBong = "Joy"
+            };
+            
+            MemoryStream ms = new MemoryStream();
+            serializer.Serialize(response, ms);
+            ms.Position = 0;
+            var json = new StreamReader(ms).ReadToEnd();
+            
+            var serialized = JObject.Parse(json);
+            Assert.Equal("Joy", serialized["bingBong"]?.ToString());
+        }        
+
+        public class DummyResponse
+        {
+            public string BingBong { get; set; }
+        }
+    }
+}

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -1,5 +1,6 @@
 using Amazon.Lambda.Core;
 
+#pragma warning disable 618
 namespace Amazon.Lambda.Tests
 {
     using Amazon.Lambda;
@@ -50,6 +51,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void HttpApiV2Format(Type serializerType)
         {
@@ -131,6 +133,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void S3PutTest(Type serializerType)
         {
@@ -176,6 +179,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void KinesisTest(Type serializerType)
         {
@@ -220,6 +224,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void DynamoDbUpdateTest(Type serializerType)
         {
@@ -267,6 +272,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void CognitoTest(Type serializerType)
         {
@@ -307,6 +313,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void ConfigTest(Type serializerType)
         {
@@ -340,6 +347,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void SimpleEmailTest(Type serializerType)
         {
@@ -406,6 +414,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void SimpleEmailLambdaActionTest(Type serializerType)
         {
@@ -428,6 +437,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void SimpleEmailS3ActionTest(Type serializerType)
         {
@@ -462,6 +472,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void SNSTest(Type serializerType)
         {
@@ -509,6 +520,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void SQSTest(Type serializerType)
         {
@@ -577,6 +589,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void APIGatewayProxyRequestTest(Type serializerType)
         {
@@ -651,6 +664,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void APIGatewayProxyResponseTest(Type serializerType)
         {
@@ -685,6 +699,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void APIGatewayAuthorizerResponseTest(Type serializerType)
         {
@@ -739,6 +754,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void ApplicationLoadBalancerRequestSingleValueTest(Type serializerType)
         {
@@ -770,6 +786,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void ApplicationLoadBalancerRequestMultiValueTest(Type serializerType)
         {
@@ -810,6 +827,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void ApplicationLoadBalancerSingleHeaderResponseTest(Type serializerType)
         {
@@ -852,6 +870,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void ApplicationLoadBalancerMultiHeaderResponseTest(Type serializerType)
         {
@@ -898,6 +917,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void LexEvent(Type serializerType)
         {
@@ -939,6 +959,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void LexResponse(Type serializerType)
         {
@@ -987,6 +1008,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void KinesisFirehoseEvent(Type serializerType)
         {
@@ -1010,6 +1032,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void KinesisFirehoseResponseTest(Type serializerType)
         {
@@ -1041,6 +1064,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void KinesisAnalyticsOutputDeliveryEvent(Type serializerType)
         {
@@ -1060,6 +1084,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void KinesisAnalyticsOutputDeliveryResponseTest(Type serializerType)
         {
@@ -1087,6 +1112,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void KinesisAnalyticsInputProcessingEventTest(Type serializerType)
         {
@@ -1108,6 +1134,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void KinesisAnalyticsInputProcessingResponseTest(Type serializerType)
         {
@@ -1139,6 +1166,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void CloudWatchLogEvent(Type serializerType)
         {
@@ -1168,6 +1196,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void BatchJobStateChangeEventTest(Type serializerType)
         {
@@ -1219,6 +1248,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void ScheduledEventTest(Type serializerType)
         {
@@ -1250,6 +1280,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void ECSContainerInstanceStateChangeEventTest(Type serializerType)
         {
@@ -1300,6 +1331,7 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP_3_1        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
         public void ECSTaskStateChangeEventTest(Type serializerType)
         {
@@ -1400,3 +1432,4 @@ namespace Amazon.Lambda.Tests
         }
     }
 }
+#pragma warning restore 618


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/624
https://github.com/aws/aws-lambda-dotnet/issues/628

*Description of changes:*
Amazon.Lambda.Serialization.SystemTextJson unintentionally used camel casing when serializing response objects to JSON. This is different then both Amazon.Lambda.Serialization.Json and the default behavior of System.Text.Json.

Fixing the behavior in `LambdaJsonSerializer` would be runtime breaking behavior and there is no metrics to know how impactful the change would be path. Instead I took the safer approach and created a new serializer called `DefaultLambdaJsonSerializer` that would use System.Text.Json's default casing behavior which is to use the casing matching the properties of the .NET property. For developers that did want the camel casing behavior there is also a new serializer called `CamelCaseLambdaJsonSerializer`.

`LambdaJsonSerializer` has been marked as `Obsolete` with no plans to change it going forward.

Here is a link to a zip file of a preview build of all of the packages for anybody that would like to test the change. https://normj-packages.s3.us-west-2.amazonaws.com/rework-serialization-preview2.zip


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
