### PR TITLE
chore: add stale-action workflow

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,0 +1,45 @@
+name: "Close stale issues"
+
+# Controls when the action will run.
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@v2
+      with:
+        # Setting messages to an empty string will cause the automation to skip
+        # that category
+        ancient-issue-message: We have noticed this issue has not recieved attention in 2 years. We will close this issue for now. If you think this is in error, please feel free to comment and reopen the issue.
+        stale-issue-message: This issue has not recieved a response in 2 weeks. If you want to keep this issue open, please just leave a comment below and auto-close will be canceled.
+
+        # These labels are required
+        stale-issue-label: closing-soon
+        exempt-issue-label: no-autoclose
+        stale-pr-label: no-pr-activity
+        exempt-pr-label: awaiting-approval
+        response-requested-label: response-requested
+
+        # Don't set closed-for-staleness label to skip closing very old issues
+        # regardless of label
+        closed-for-staleness-label: closed-for-staleness
+
+        # Issue timing
+        days-before-stale: 14
+        days-before-close: 7
+        days-before-ancient: 750
+
+        # If you don't want to mark a issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 10
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        #loglevel: DEBUG
+        # Set dry-run to true to not perform label or close actions.
+        dry-run: true

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@v2
+    - uses: aws-actions/stale-issue-cleanup@v3
       with:
         # Setting messages to an empty string will cause the automation to skip
         # that category

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -31,7 +31,7 @@ jobs:
         # Issue timing
         days-before-stale: 14
         days-before-close: 7
-        days-before-ancient: 750
+        days-before-ancient: 1095
 
         # If you don't want to mark a issue as being ancient based on a
         # threshold of "upvotes", you can set this here. An "upvote" is
@@ -42,4 +42,4 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         #loglevel: DEBUG
         # Set dry-run to true to not perform label or close actions.
-        dry-run: true
+        # dry-run: true


### PR DESCRIPTION
*Description of changes:*
Adds a github actions workflow to drive monitoring and handling stale actions on the repo.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
