### PR TITLE
Add missing PathParameters property for HTTP API v2 Format

### DIFF
--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayHttpApiV2ProxyRequest.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayHttpApiV2ProxyRequest.cs
@@ -56,6 +56,11 @@ namespace Amazon.Lambda.APIGatewayEvents
         public string Body { get; set; }
 
         /// <summary>
+        /// Path parameters sent with the request.
+        /// </summary>
+        public IDictionary<string, string> PathParameters { get; set; }
+
+        /// <summary>
         /// True if the body of the request is base 64 encoded.
         /// </summary>
         public bool IsBase64Encoded { get; set; }

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -78,6 +78,9 @@ namespace Amazon.Lambda.Tests
                 Assert.Equal("value1", request.StageVariables["stageVariable1"]);
                 Assert.Equal("value2", request.StageVariables["stageVariable2"]);
 
+                Assert.Equal(1, request.PathParameters.Count);
+                Assert.Equal("value1", request.PathParameters["parameter1"]);
+
                 var rc = request.RequestContext;
                 Assert.NotNull(rc);
                 Assert.Equal("123456789012", rc.AccountId);

--- a/Libraries/test/EventsTests.Shared/http-api-v2-request.json
+++ b/Libraries/test/EventsTests.Shared/http-api-v2-request.json
@@ -41,6 +41,7 @@
     "timeEpoch": 1583348638390
   },
   "body": "Hello from Lambda",
+  "pathParameters": { "parameter1": "value1" },
   "isBase64Encoded": true,
   "stageVariables": {
     "stageVariable1": "value1",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/640

*Description of changes:*
The `APIGatewayHttpApiV2ProxyRequest` class which is meant to represent the HTTP API v2 proxy format was missing the `PathParameters` property. This PR adds the property updates the test for it.

Link to the documentation for HTTP API v2 proxy format
https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
