### PR TITLE
#679 Implement `NullScope` for netcore 3.1 packages compatibility

### DIFF
--- a/Libraries/src/Amazon.Lambda.Logging.AspNetCore/Amazon.Lambda.Logging.AspNetCore.csproj
+++ b/Libraries/src/Amazon.Lambda.Logging.AspNetCore/Amazon.Lambda.Logging.AspNetCore.csproj
@@ -17,9 +17,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.0,3.2.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0,3.2.0)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[3.1.0,3.2.0)" />
   </ItemGroup>
 
 </Project>

--- a/Libraries/src/Amazon.Lambda.Logging.AspNetCore/Amazon.Lambda.Logging.AspNetCore.csproj
+++ b/Libraries/src/Amazon.Lambda.Logging.AspNetCore/Amazon.Lambda.Logging.AspNetCore.csproj
@@ -17,9 +17,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.0,3.2.0)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0,3.2.0)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[3.1.0,3.2.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.0" />
   </ItemGroup>
 
 </Project>

--- a/Libraries/src/Amazon.Lambda.Logging.AspNetCore/NullExternalScopeProvider.cs
+++ b/Libraries/src/Amazon.Lambda.Logging.AspNetCore/NullExternalScopeProvider.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions.Internal;
 using System;
 
 namespace Amazon.Lambda.Logging.AspNetCore
@@ -27,6 +26,19 @@ namespace Amazon.Lambda.Logging.AspNetCore
         IDisposable IExternalScopeProvider.Push(object state)
         {
             return NullScope.Instance;
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new NullScope();
+
+            private NullScope()
+            {
+            }
+
+            public void Dispose()
+            {
+            }
         }
     }
 }

--- a/Libraries/test/Amazon.Lambda.Logging.AspNetCore.Tests/Amazon.Lambda.Logging.AspNetCore.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.Logging.AspNetCore.Tests/Amazon.Lambda.Logging.AspNetCore.Tests.csproj
@@ -41,10 +41,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Issue:*
#679 

*Description of changes:*
Implementing `NullScope` which became `internal` in `Microsoft.Extensions.Logging.Abstractions` 3.1.

Note: I wasn't able to compile whole solution, couldn't find any developer instructions. Unit tests for logging are passing.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
