### PR TITLE
Minor Typo Fix in Code Comments for the the Web Api Blueprint

### DIFF
--- a/Blueprints/BlueprintDefinitions/netcore2.1/AspNetCoreWebAPI/template/test/BlueprintBaseName.1.Tests/S3ProxyControllerTests.cs
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/AspNetCoreWebAPI/template/test/BlueprintBaseName.1.Tests/S3ProxyControllerTests.cs
@@ -38,7 +38,7 @@ namespace BlueprintBaseName._1.Tests
 
             this.Configuration = builder.Build();
 
-            // Use the region and possible profile specified in the appsettings.json file to construct an Amaozn S3 service client.
+            // Use the region and possible profile specified in the appsettings.json file to construct an Amazon S3 service client.
             this.S3Client = Configuration.GetAWSOptions().CreateServiceClient<IAmazonS3>();
 
             // Create a bucket used for the test which will be deleted along with any data in the bucket once the test is complete.

--- a/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebAPI/template/test/BlueprintBaseName.1.Tests/S3ProxyControllerTests.cs
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebAPI/template/test/BlueprintBaseName.1.Tests/S3ProxyControllerTests.cs
@@ -38,7 +38,7 @@ namespace BlueprintBaseName._1.Tests
 
             this.Configuration = builder.Build();
 
-            // Use the region and possible profile specified in the appsettings.json file to construct an Amaozn S3 service client.
+            // Use the region and possible profile specified in the appsettings.json file to construct an Amazon S3 service client.
             this.S3Client = Configuration.GetAWSOptions().CreateServiceClient<IAmazonS3>();
 
             // Create a bucket used for the test which will be deleted along with any data in the bucket once the test is complete.


### PR DESCRIPTION
Typo fixes

*Issue #, if available:*

Minor incorrect typo in code comments "Amaozn", where it should be "Amazon".

*Description of changes:*

Fixed the typo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
