### PR TITLE
Updated LambdaTestTool README.md to fix missing path for VSCode launcher

### DIFF
--- a/Tools/LambdaTestTool/README.md
+++ b/Tools/LambdaTestTool/README.md
@@ -80,13 +80,13 @@ To debug with Visual Studio Code and the .NET Mock Lambda Test Tool edit the [la
     "version": "0.2.0",
     "configurations": [
         {
-            "name": ".NET Core Launch (console)",
+            "name": "Mock Lambda Test Tool",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
             "program": "<home-directory>/.dotnet/tools/dotnet-lambda-test-tool-2.1.exe",
             "args": [],
-            "cwd": "${workspaceFolder}",
+            "cwd": "${workspaceFolder}\\bin\\Debug\\netcoreapp2.1",
             "console": "internalConsole",
             "stopAtEntry": false,
             "internalConsoleOptions": "openOnSessionStart"


### PR DESCRIPTION
Using the example from the README.md file for configuring VSCode to launch the Lambda Test Tool causes the following error due to the path only referencing the WorkspaceFolder:
```
Unknown error occurred causing process exit: Failed to find a deps.json file in the specified directory (C:\Projects\Vanguard\Alkami.Orb.Build)
   at Amazon.Lambda.TestTool.Runtime.LocalLambdaRuntime.Initialize(String directory, IAWSService awsService) in C:\codebuild\tmp\output\src142363207\src\Tools\LambdaTestTool\src\Amazon.Lambda.TestTool\Runtime\LocalLambdaRuntime.cs:line 62
   at Amazon.Lambda.TestTool.Runtime.LocalLambdaRuntime.Initialize(String directory) in C:\codebuild\tmp\output\src142363207\src\Tools\LambdaTestTool\src\Amazon.Lambda.TestTool\Runtime\LocalLambdaRuntime.cs:line 46
   at Amazon.Lambda.TestTool.TestToolStartup.Startup(String productName, Action`2 uiStartup, String[] args, RunConfiguration runConfiguration) in C:\codebuild\tmp\output\src142363207\src\Tools\LambdaTestTool\src\Amazon.Lambda.TestTool\TestToolStartup.cs:line 77
```
Also fixed name of launch command to align with the VS example.

*Description of changes:*
1. Updated the cwd parameter to include the full path to the bin folder
2. Updated the name of the configuration to "Mock Lambda Test Tool" to match the Visual Studio example

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
