### PR TITLE
Fix typo in Amazon.Lambda.CloudWatchLogsEvents/README.md

### DIFF
--- a/Libraries/src/Amazon.Lambda.CloudWatchLogsEvents/README.md
+++ b/Libraries/src/Amazon.Lambda.CloudWatchLogsEvents/README.md
@@ -11,7 +11,7 @@ public class Function
 {
     public string Handler(CloudWatchLogsEvent cloudWatchLogsEvent)
     {
-        Console.WriteLine($"Log content - {cloudWatchLogsEvent.Awslogs.Data}");
+        Console.WriteLine($"Log content - {cloudWatchLogsEvent.Awslogs.DecodeData()}");
     }
 }
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The `Data` property no longer exists.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
