### PR TITLE
Fix issue in Lambda Test Tool 3.1 if the calling Lambda function has blocking API calls

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.WebTester31/Pages/Index.razor
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.WebTester31/Pages/Index.razor
@@ -1,5 +1,6 @@
 ﻿@page "/"
 
+@using System.Threading; 
 @using Amazon.Lambda.TestTool.Runtime;
 @using Amazon.Lambda.TestTool.SampleRequests;
 @inject LocalLambdaOptions LambdaOptions
@@ -151,17 +152,27 @@
 
     async Task OnExecuteClick()
     {
-        var function = this.LambdaOptions.LoadLambdaFuntion(FunctionPicker.ConfigFile, FunctionPicker.FunctionHandler);
 
-        var request = new ExecutionRequest()
+        ExecutionResponse response = null;
+
+        var ts = new ThreadStart(() =>
         {
-            Function = function,
-            AWSProfile = FunctionPicker.AWSProfile,
-            AWSRegion = FunctionPicker.AWSRegion,
-            Payload = this.FunctionInput
-        };
+            var function = this.LambdaOptions.LoadLambdaFuntion(FunctionPicker.ConfigFile, FunctionPicker.FunctionHandler);
 
-        var response = await this.LambdaOptions.LambdaRuntime.ExecuteLambdaFunctionAsync(request);
+            var request = new ExecutionRequest()
+            {
+                Function = function,
+                AWSProfile = FunctionPicker.AWSProfile,
+                AWSRegion = FunctionPicker.AWSRegion,
+                Payload = this.FunctionInput
+            };
+
+            response = this.LambdaOptions.LambdaRuntime.ExecuteLambdaFunctionAsync(request).GetAwaiter().GetResult();
+        });
+
+        var thread = new Thread(ts);
+        thread.Start();
+        thread.Join();
 
         if (response.IsSuccess)
         {
@@ -173,6 +184,7 @@
             this.FunctionResponse = response.Error;
             this.FunctionResponseStyle = ResponseErrorStyle;
         }
+
 
         this.FunctionLogs = response.Logs;
 


### PR DESCRIPTION
The fix is to isolate the call to the user's Lambda function in a separate thread disconnecting the user's code from the SS Blazor Synchronization Context.

*Issue #, if available:*
fixes: #704


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
