### PR TITLE
Set HOME environment variable for PowerShell Lambda

### DIFF
--- a/Libraries/src/Amazon.Lambda.PowerShellHost/Amazon.Lambda.PowerShellHost.csproj
+++ b/Libraries/src/Amazon.Lambda.PowerShellHost/Amazon.Lambda.PowerShellHost.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <Description>AWS Lambda PowerShell Host.</Description>
     <AssemblyTitle>Amazon.Lambda.PowerShellHost</AssemblyTitle>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.PowerShellHost</AssemblyName>
     <PackageId>Amazon.Lambda.PowerShellHost</PackageId>
     <PackageTags>AWS;Amazon;Lambda;PowerShell</PackageTags>

--- a/Libraries/test/PowerShellTests/ScriptInvokeTests.cs
+++ b/Libraries/test/PowerShellTests/ScriptInvokeTests.cs
@@ -123,7 +123,25 @@ namespace Amazon.Lambda.PowerShellTests
             Assert.Contains("AWS Lambda", resultString);
         }
 
+#if NETCOREAPP3_1
+        [Fact]
+        public void ForObjectParallelTest()
+        {
+            var logger = new TestLambdaLogger();
+            var context = new TestLambdaContext
+            {
+                Logger = logger
+            };
 
+            var inputString = "";
+            var function = new PowerShellScriptsAsFunctions.Function("ForObjectParallel.ps1");
 
+            function.ExecuteFunction(ConvertToStream(inputString), context);
+
+            Assert.Contains("Running against: 1 for SharedVariable: Hello Shared Variable", logger.Buffer.ToString());
+            Assert.Contains("Running against: 50 for SharedVariable: Hello Shared Variable", logger.Buffer.ToString());
+            Assert.Contains("Running against: 100 for SharedVariable: Hello Shared Variable", logger.Buffer.ToString());
+        }
+#endif
     }
 }

--- a/Libraries/test/TestPowerShellFunctions/PowerShellScriptsAsFunctions/ForObjectParallel.ps1
+++ b/Libraries/test/TestPowerShellFunctions/PowerShellScriptsAsFunctions/ForObjectParallel.ps1
@@ -1,0 +1,5 @@
+$SharedVariable = "Hello Shared Variable"
+@(1..100) | ForEach-Object -Parallel { 
+    $i = $_
+    Write-Host "Running against: $i for SharedVariable: $($using:SharedVariable)"
+}

--- a/Libraries/test/TestPowerShellFunctions/PowerShellScriptsAsFunctions/TempEnvCheck.ps1
+++ b/Libraries/test/TestPowerShellFunctions/PowerShellScriptsAsFunctions/TempEnvCheck.ps1
@@ -1,0 +1,5 @@
+
+Write-Host $env:HOME
+Write-Host $env:TMP
+
+return $env:TMP

--- a/PowerShell/Module/Private/_Constants.ps1
+++ b/PowerShell/Module/Private/_Constants.ps1
@@ -20,7 +20,7 @@ if (!($AwsPowerShellFunctionEnvName))
 
 if (!($AwsPowerShellDefaultSdkVersion))
 {
-    New-Variable -Name AwsPowerShellDefaultSdkVersion -Value '7.0.0' -Option Constant
+    New-Variable -Name AwsPowerShellDefaultSdkVersion -Value '7.0.3' -Option Constant
 }
 
 if (!($AwsPowerShellTargetFramework))

--- a/PowerShell/Module/Templates/Blueprints/projectfile.csproj.txt
+++ b/PowerShell/Module/Templates/Blueprints/projectfile.csproj.txt
@@ -17,6 +17,6 @@
         <PackageReference Include="Microsoft.PowerShell.SDK" Version="POWERSHELL_SDK_VERSION" />
 
         <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-        <PackageReference Include="Amazon.Lambda.PowerShellHost" Version="2.0.0" />
+        <PackageReference Include="Amazon.Lambda.PowerShellHost" Version="2.1.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
This is to work around an issue with using the -Parallel feature. The issue has been reported on the PowerShell repository:
https://github.com/PowerShell/PowerShell/issues/13189

The fix is done in the **Amazon.Lambda.PowerShellHost** package which host PowerShell inside the .NET Core Lambda runtime. The PowerShell module used to create the PowerShell Lambda bundle is updated to use the new version.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
