### PR TITLE
Proposal - Add Async PreInitAsync to allow async operations such as configuration I

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
@@ -189,6 +189,22 @@ namespace Amazon.Lambda.AspNetCoreServer
         protected virtual void Init(IWebHostBuilder builder) { }
 
         /// <summary>
+        /// Method to perform any action before initializing the web host. This is only invoked if StartupMode is set to FirstRequest.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// protected override async Task PreInitAsync()
+        /// {
+        ///     configuration = await LoadConfiguration();
+        /// }
+        /// </code>
+        /// </example>
+        protected virtual Task PreInitAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
         /// Creates the IWebHostBuilder similar to WebHost.CreateDefaultBuilder but replacing the registration of the Kestrel web server with a 
         /// registration for Lambda.
         /// </summary>
@@ -432,6 +448,7 @@ namespace Amazon.Lambda.AspNetCoreServer
         {
             if (!IsStarted)
             {
+                await PreInitAsync();
                 Start();
             }
 

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestApplicationLoadBalancerCalls.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestApplicationLoadBalancerCalls.cs
@@ -39,13 +39,15 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
         public async Task TestGetAllValuesWithStartupModeFirstRequest()
         {
             var context = new TestLambdaContext();
+            var lambdaFunction = new ALBLambdaFunction(StartupMode.FirstRequest);
 
-            var response = await this.InvokeApplicationLoadBalancerRequest(context, "values-get-all-alb-request.json", StartupMode.FirstRequest);
+            var response = await this.InvokeApplicationLoadBalancerRequest(context, "values-get-all-alb-request.json", lambdaFunction);
 
             Assert.Equal(200, response.StatusCode);
             Assert.Equal("[\"value1\",\"value2\"]", response.Body);
             Assert.True(response.Headers.ContainsKey("Content-Type"));
             Assert.Equal("application/json; charset=utf-8", response.Headers["Content-Type"]);
+            Assert.True(lambdaFunction.PreInitAsyncCalled);
 
             Assert.Contains("OnStarting Called", ((TestLambdaLogger)context.Logger).Buffer.ToString());
         }
@@ -243,9 +245,9 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
         private async Task<ApplicationLoadBalancerResponse> InvokeApplicationLoadBalancerRequest(
             TestLambdaContext context,
             string fileName,
-            StartupMode startupMode = StartupMode.Constructor)
+            ALBLambdaFunction albLambdaFunction = null)
         {
-            var lambdaFunction = new ALBLambdaFunction(startupMode);
+            var lambdaFunction = albLambdaFunction ?? new ALBLambdaFunction(StartupMode.Constructor);
             var filePath = Path.Combine(Path.GetDirectoryName(this.GetType().GetTypeInfo().Assembly.Location), fileName);
             var requestStr = File.ReadAllText(filePath);
             var request = JsonConvert.DeserializeObject<ApplicationLoadBalancerRequest>(requestStr);

--- a/Libraries/test/TestWebApp/ALBLambdaFunction.cs
+++ b/Libraries/test/TestWebApp/ALBLambdaFunction.cs
@@ -4,5 +4,8 @@ namespace TestWebApp
 {
     public class ALBLambdaFunction : ApplicationLoadBalancerFunction<Startup>
     {
+        public ALBLambdaFunction(StartupMode startupMode)
+            : base(startupMode)
+        { }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

A proposal to address #702

*Description of changes:*

- Add virtual member `PreInitAsync` to `AbstractAspNetCoreFunction` that allows async operations to happen, such as loading configuration from secrets manager, before the webhost is initialized. (I'm not too fond of the name. I'd prefer just `InitAsync()` and rename `Init()` to `InitWebHost()` but that would be a breaking change...)
- It is **only** invoked when `StartupMode` is set `FirstRequest` which in an asynchronous call stack. It is not possible to call it when `StartupMode` is set to `Constructor` as invoking async methods in a constructor is an anti-pattern. (If there is no specific advantage to using `Constructor` startup mode, could it be argued to remove it? 🤷 )
- Add test to assert `PreInitAsync()` is called. I also noticed there was no tests / test coverage for `StartMode.FirstRequest`; this test now covers it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
