### PR TITLE
Updated TestLambdaLogger Log method

### DIFF
--- a/Libraries/src/Amazon.Lambda.TestUtilities/TestLambdaLogger.cs
+++ b/Libraries/src/Amazon.Lambda.TestUtilities/TestLambdaLogger.cs
@@ -19,16 +19,17 @@ namespace Amazon.Lambda.TestUtilities
         public StringBuilder Buffer { get; } = new StringBuilder();
 
         /// <summary>
-        /// Write log messages to the console.
+        /// Write log messages to the console and the Buffer without appending a newline terminator.
         /// </summary>
         /// <param name="message"></param>
         public void Log(string message)
         {
-            LogLine(message);
+            Buffer.Append(message);
+            Console.Write(message);
         }
 
         /// <summary>
-        /// Write log messages to the console.
+        /// Write log messages to the console and the Buffer with a newline terminator.
         /// </summary>
         /// <param name="message"></param>
         public void LogLine(string message)


### PR DESCRIPTION
*Description of changes:*
Updated TestLambdaLogger Log method to perform consistently with the actual Lambda Logger.

Previously, TestLambdaLogger's Log method does the same as the LogLine method (i.e. it appends a newline after each log message). This leads the developer to believe that 
this is how it works in the Lambda Logger. This is not the case though; the Log method in the Lambda Logger does NOT append a newline terminator. If the developer were to assume the behavior was the same and use the Log method instead of LogLine, then things could break.

My personal example, I was validating that my code logs messages in EMF JSON format to post metrics to CloudWatch. I used the Log method (since they appeared the same in TestLambdaLogger) but when I deployed to Lambda, the metrics weren't being sent properly, as all my logs were written on a single line. I had to update all my code to use LogLine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
