### PR TITLE
Fixes #692 by passing the encoder into the writer.

### DIFF
--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/DefaultLambdaJsonSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/DefaultLambdaJsonSerializer.cs
@@ -73,7 +73,7 @@ namespace Amazon.Lambda.Serialization.SystemTextJson
                 if (_debug)
                 {
                     using (var debugStream = new MemoryStream())
-                    using (var utf8Writer = new Utf8JsonWriter(debugStream))
+                    using (var utf8Writer = new Utf8JsonWriter(debugStream, new JsonWriterOptions { Encoder = SerializerOptions.Encoder }))
                     {
                         JsonSerializer.Serialize(utf8Writer, response, SerializerOptions);
                         debugStream.Position = 0;
@@ -88,7 +88,7 @@ namespace Amazon.Lambda.Serialization.SystemTextJson
                 }
                 else
                 {
-                    using (var writer = new Utf8JsonWriter(responseStream))
+                    using (var writer = new Utf8JsonWriter(responseStream, new JsonWriterOptions { Encoder = SerializerOptions.Encoder }))
                     {
                         JsonSerializer.Serialize(writer, response, SerializerOptions);
                     }

--- a/Libraries/test/EventsTests.NETCore31/TestResponseSerializing.cs
+++ b/Libraries/test/EventsTests.NETCore31/TestResponseSerializing.cs
@@ -1,0 +1,70 @@
+﻿using System.IO;
+
+using Xunit;
+
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace EventsTests31
+{
+	public class TestResponseSerializing
+    {
+        [Fact]
+        public void TestDefaultSerializer()
+        {
+            var serializer = new DefaultLambdaJsonSerializer();
+
+            var response = new DummyResponse
+            {
+                BingBong = "Joy"
+            };
+
+            MemoryStream ms = new MemoryStream();
+            StreamReader streamReader = new StreamReader(ms);
+            serializer.Serialize(response, ms);
+            ms.Seek(0, SeekOrigin.Begin);
+            var utf8Payload = streamReader.ReadToEnd();
+
+            var albResponse = new Amazon.Lambda.ApplicationLoadBalancerEvents.ApplicationLoadBalancerResponse
+            {
+                Body = utf8Payload
+            };
+            serializer.Serialize(albResponse, ms);
+            ms.Seek(0, SeekOrigin.Begin);
+            var json = streamReader.ReadToEnd();
+
+            Assert.Equal(106, json.Length);
+        }
+
+        [Fact]
+        public void TestDefaultSerializerWithUnsafeEncoder()
+        {
+            var serializer = new DefaultLambdaJsonSerializer(x => x.Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+
+            var response = new DummyResponse
+            {
+                BingBong = "Joy"
+            };
+
+            MemoryStream ms = new MemoryStream();
+            StreamReader streamReader = new StreamReader(ms);
+            serializer.Serialize(response, ms);
+            ms.Seek(0, SeekOrigin.Begin);
+            var utf8Payload = streamReader.ReadToEnd();
+
+            var albResponse = new Amazon.Lambda.ApplicationLoadBalancerEvents.ApplicationLoadBalancerResponse
+            {
+                Body = utf8Payload
+            };
+            serializer.Serialize(albResponse, ms);
+            ms.Seek(0, SeekOrigin.Begin);
+            var json = streamReader.ReadToEnd();
+
+            Assert.Equal(90, json.Length);
+        }
+
+        public class DummyResponse
+        {
+            public string BingBong { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
This is a fix for #692 even though it's only a partial fix. 

*Description of changes:*
Pass the optionally set encoder down to the writer so the developer can set unsafe escaping if he's building a JSON API. I've opted not to create a derived class that does this although that might be an easy way to allow developers to pick this encoder. In the current setup they would still need to implement their own type and inject it through an attribute on the method. Those issues should probably be filed separately though.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
