### PR TITLE
Added code to load cookies from HTTPv2 request.

### DIFF
--- a/Libraries/Libraries.sln
+++ b/Libraries/Libraries.sln
@@ -39,7 +39,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.Lambda.SNSEvents", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.Lambda.TestUtilities", "src\Amazon.Lambda.TestUtilities\Amazon.Lambda.TestUtilities.csproj", "{0083B713-6399-479D-AA06-58D3E87F167D}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.Lambda.AspNetCoreServer.Test", "test\Amazon.Lambda.AspNetCoreServer.Test\Amazon.Lambda.AspNetCoreServer.Test.csproj", "{5B48AEA8-5702-45A8-9D89-CEB986E6DBC1}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.Lambda.AspNetCoreServer.Test", "test\Amazon.Lambda.AspNetCoreServer.Test\Amazon.Lambda.AspNetCoreServer.Test.csproj", "{5B48AEA8-5702-45A8-9D89-CEB986E6DBC1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestWebApp", "test\TestWebApp\TestWebApp.csproj", "{101ABE51-390D-41DF-A70B-2BD3B08B2CC7}"
 EndProject
@@ -63,7 +63,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TestFunctionFSharp", "TestF
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FSharpJsonSerializer", "test\TestFunctionFSharp\FSharpJsonSerializer\FSharpJsonSerializer.csproj", "{8C9EA16D-6055-421B-ABE7-1B0E35259DFC}"
 EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "TestFunctionFSharp", "test\TestFunctionFSharp\TestFunctionFSharp\TestFunctionFSharp.fsproj", "{CB38FA21-5814-4573-94C7-3672D61BC8B8}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "TestFunctionFSharp", "test\TestFunctionFSharp\TestFunctionFSharp\TestFunctionFSharp.fsproj", "{CB38FA21-5814-4573-94C7-3672D61BC8B8}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestFunctionCSharp", "test\TestFunctionFSharp\TestFunctionCSharp\TestFunctionCSharp.csproj", "{2810A66B-3A03-4889-A4D0-0E8838474A4A}"
 EndProject

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction.cs
@@ -131,6 +131,11 @@ namespace Amazon.Lambda.AspNetCoreServer
                     requestFeatures.Headers["Host"] = apiGatewayRequest.RequestContext.DomainName;
                 }
 
+                if (apiGatewayRequest.Cookies != null)
+                {
+                    // Add Cookies from the event
+                    requestFeatures.Headers["Cookie"] = String.Join("; ", apiGatewayRequest.Cookies);
+                }
 
                 if (!string.IsNullOrEmpty(apiGatewayRequest.Body))
                 {

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/Amazon.Lambda.AspNetCoreServer.Test.csproj
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/Amazon.Lambda.AspNetCoreServer.Test.csproj
@@ -53,5 +53,5 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-
+  
 </Project>

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestApiGatewayHttpApiV2Calls.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestApiGatewayHttpApiV2Calls.cs
@@ -192,6 +192,30 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
             Assert.NotEqual(200, response.StatusCode);
         }
 
+        [Fact]
+        public async Task TestReturningCookie()
+        {
+            var response = await this.InvokeAPIGatewayRequest("cookies-get-returned-httpapi-v2-request.json");
+
+            Assert.StartsWith("TestCookie=TestValue", response.Headers["Set-Cookie"]);
+        }
+
+        [Fact]
+        public async Task TestSingleCookie()
+        {
+            var response = await this.InvokeAPIGatewayRequest("cookies-get-single-httpapi-v2-request.json");
+
+            Assert.Equal("TestValue", response.Body);
+        }
+
+        [Fact]
+        public async Task TestMultipleCookie()
+        {
+            var response = await this.InvokeAPIGatewayRequest("cookies-get-multiple-httpapi-v2-request.json");
+
+            Assert.Equal("TestValue3", response.Body);
+        }
+
         private async Task<APIGatewayHttpApiV2ProxyResponse> InvokeAPIGatewayRequest(string fileName)
         {
             return await InvokeAPIGatewayRequestWithContent(new TestLambdaContext(), GetRequestContent(fileName));

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/cookies-get-multiple-httpapi-v2-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/cookies-get-multiple-httpapi-v2-request.json
@@ -1,0 +1,49 @@
+﻿{
+  "version": "2.0",
+  "routeKey": "ANY /{proxy+}",
+  "rawPath": "/api/cookietests/TestCookie3",
+  "rawQueryString": "",
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip, deflate",
+    "cache-control": "no-cache",
+    "content-length": "41",
+    "content-type": "application/json",
+    "contentlength": "45",
+    "host": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "postman-token": "18165e8d-ecd0-4e4c-8fd2-4963a0af62d1",
+    "user-agent": "PostmanRuntime/7.20.1",
+    "x-amzn-trace-id": "Root=1-5e7ae61f-bb13a2d967a67dd51b8aca50",
+    "x-forwarded-for": "192.182.149.40",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "requestContext": {
+    "accountId": "626492997873",
+    "apiId": "uo9pe23ec6",
+    "domainName": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "uo9pe23ec6",
+    "http": {
+      "method": "GET",
+      "path": "/api/cookietests/TestCookie3",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "192.182.149.40",
+      "userAgent": "PostmanRuntime/7.20.1"
+    },
+    "requestId": "J7jk9g-7oAMEJGw=",
+    "routeKey": "ANY /{proxy+}",
+    "stage": "$default",
+    "time": "25/Mar/2020:05:03:27 +0000",
+    "timeEpoch": 1585112607686
+  },
+  "pathParameters": {
+    "proxy": "api/cookietests/TestCookie3"
+  },
+  "cookies": [
+    "TestCookie1=TestValue1",
+    "TestCookie2=TestValue2",
+    "TestCookie3=TestValue3"
+  ],
+  "body": null,
+  "isBase64Encoded": false
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/cookies-get-returned-httpapi-v2-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/cookies-get-returned-httpapi-v2-request.json
@@ -1,0 +1,44 @@
+﻿{
+  "version": "2.0",
+  "routeKey": "ANY /{proxy+}",
+  "rawPath": "/api/cookietests",
+  "rawQueryString": "",
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip, deflate",
+    "cache-control": "no-cache",
+    "content-length": "41",
+    "content-type": "application/json",
+    "contentlength": "45",
+    "host": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "postman-token": "18165e8d-ecd0-4e4c-8fd2-4963a0af62d1",
+    "user-agent": "PostmanRuntime/7.20.1",
+    "x-amzn-trace-id": "Root=1-5e7ae61f-bb13a2d967a67dd51b8aca50",
+    "x-forwarded-for": "192.182.149.40",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "requestContext": {
+    "accountId": "626492997873",
+    "apiId": "uo9pe23ec6",
+    "domainName": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "uo9pe23ec6",
+    "http": {
+      "method": "GET",
+      "path": "/api/cookietests",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "192.182.149.40",
+      "userAgent": "PostmanRuntime/7.20.1"
+    },
+    "requestId": "J7jk9g-7oAMEJGw=",
+    "routeKey": "ANY /{proxy+}",
+    "stage": "$default",
+    "time": "25/Mar/2020:05:03:27 +0000",
+    "timeEpoch": 1585112607686
+  },
+  "pathParameters": {
+    "proxy": "api/cookietests"
+  },
+  "body": null,
+  "isBase64Encoded": false
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/cookies-get-single-httpapi-v2-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/cookies-get-single-httpapi-v2-request.json
@@ -1,0 +1,47 @@
+﻿{
+  "version": "2.0",
+  "routeKey": "ANY /{proxy+}",
+  "rawPath": "/api/cookietests/TestCookie",
+  "rawQueryString": "",
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip, deflate",
+    "cache-control": "no-cache",
+    "content-length": "41",
+    "content-type": "application/json",
+    "contentlength": "45",
+    "host": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "postman-token": "18165e8d-ecd0-4e4c-8fd2-4963a0af62d1",
+    "user-agent": "PostmanRuntime/7.20.1",
+    "x-amzn-trace-id": "Root=1-5e7ae61f-bb13a2d967a67dd51b8aca50",
+    "x-forwarded-for": "192.182.149.40",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "requestContext": {
+    "accountId": "626492997873",
+    "apiId": "uo9pe23ec6",
+    "domainName": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "uo9pe23ec6",
+    "http": {
+      "method": "GET",
+      "path": "/api/cookietests/TestCookie",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "192.182.149.40",
+      "userAgent": "PostmanRuntime/7.20.1"
+    },
+    "requestId": "J7jk9g-7oAMEJGw=",
+    "routeKey": "ANY /{proxy+}",
+    "stage": "$default",
+    "time": "25/Mar/2020:05:03:27 +0000",
+    "timeEpoch": 1585112607686
+  },
+  "pathParameters": {
+    "proxy": "api/cookietests/TestCookie"
+  },
+  "cookies": [
+    "TestCookie=TestValue"
+  ],
+  "body": null,
+  "isBase64Encoded": false
+}

--- a/Libraries/test/TestWebApp/Controllers/CookieTestsController.cs
+++ b/Libraries/test/TestWebApp/Controllers/CookieTestsController.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+
+namespace TestWebApp.Controllers
+{
+    [Route("api/[controller]")]
+    public class CookieTestsController : Controller
+    {
+        [HttpGet]
+        public string Get()
+        {
+            var cookieOptions = new Microsoft.AspNetCore.Http.CookieOptions
+            {
+                Expires = DateTime.Now.AddMinutes(5)
+            };
+            Response.Cookies.Append("TestCookie", "TestValue", cookieOptions);
+            return String.Empty;
+        }
+
+        [HttpGet("{id}")]
+        public string Get(string id)
+        {
+            return Request.Cookies.FirstOrDefault(c => c.Key == id).Value;
+        }
+    }
+}

--- a/Libraries/test/TestWebApp/TestWebApp.csproj
+++ b/Libraries/test/TestWebApp/TestWebApp.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5"><PrivateAssets Condition="'%(PackageReference.Version)' == ''">all</PrivateAssets>
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5">
 <Publish Condition="'%(PackageReference.Version)' == ''">true</Publish>
 </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="1.1.0" />

--- a/Libraries/test/TestWebApp/TestWebApp.csproj
+++ b/Libraries/test/TestWebApp/TestWebApp.csproj
@@ -20,7 +20,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5"><PrivateAssets Condition="'%(PackageReference.Version)' == ''">all</PrivateAssets>
+<Publish Condition="'%(PackageReference.Version)' == ''">true</Publish>
+</PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">


### PR DESCRIPTION
*Issue or Request:*
#713 

*Description of changes:*
This PR changes the behavior of the code that converts API GW events into ASP.NET requests by pulling the cookies from the events' `cookies` property into a `Cookies` header on the request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
