### PR TITLE
Update for mlts

### DIFF
--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayHttpApiV2ProxyRequest.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayHttpApiV2ProxyRequest.cs
@@ -202,13 +202,13 @@ namespace Amazon.Lambda.APIGatewayEvents
             /// The date before which the certificate is invalid. Present when a client accesses an API by using a custom domain name 
             /// that has mutual TLS enabled. Present only in access logs if mutual TLS authentication fails.
             /// </summary>
-            public DateTime NotBefore { get; set; }
+            public string NotBefore { get; set; }
 
             /// <summary>
             /// The date after which the certificate is invalid. Present when a client accesses an API by using a custom domain name that 
             /// has mutual TLS enabled. Present only in access logs if mutual TLS authentication fails.
             /// </summary>
-            public DateTime NotAfter { get; set; }
+            public string NotAfter { get; set; }
         }
 
         /// <summary>

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayHttpApiV2ProxyRequest.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayHttpApiV2ProxyRequest.cs
@@ -135,6 +135,80 @@ namespace Amazon.Lambda.APIGatewayEvents
             /// Gets and sets the request time as an epoch.
             /// </summary>
             public long TimeEpoch { get; set; }
+
+            /// <summary>
+            /// Properties for authentication.
+            /// </summary>
+            public ProxyRequestAuthentication Authentication { get; set; }
+        }
+
+
+        /// <summary>
+        /// Container for authentication properties.
+        /// </summary>
+        public class ProxyRequestAuthentication
+        {
+            /// <summary>
+            /// Properties for a client certificate.
+            /// </summary>
+            public ProxyRequestClientCert ClientCert { get; set; }
+        }
+
+        /// <summary>
+        /// Container for the properties of the client certificate.
+        /// </summary>
+        public class ProxyRequestClientCert
+        {
+            /// <summary>
+            /// The PEM-encoded client certificate that the client presented during mutual TLS authentication. 
+            /// Present when a client accesses an API by using a custom domain name that has mutual 
+            /// TLS enabled. Present only in access logs if mutual TLS authentication fails.
+            /// </summary>
+            public string ClientCertPem { get; set; }
+
+            /// <summary>
+            /// The distinguished name of the subject of the certificate that a client presents. 
+            /// Present when a client accesses an API by using a custom domain name that has 
+            /// mutual TLS enabled. Present only in access logs if mutual TLS authentication fails.
+            /// </summary>
+            public string SubjectDN { get; set; }
+
+            /// <summary>
+            /// The distinguished name of the issuer of the certificate that a client presents. 
+            /// Present when a client accesses an API by using a custom domain name that has 
+            /// mutual TLS enabled. Present only in access logs if mutual TLS authentication fails.
+            /// </summary>
+            public string IssuerDN { get; set; }
+
+            /// <summary>
+            /// The serial number of the certificate. Present when a client accesses an API by 
+            /// using a custom domain name that has mutual TLS enabled. 
+            /// Present only in access logs if mutual TLS authentication fails.
+            /// </summary>
+            public string SerialNumber { get; set; }
+
+            /// <summary>
+            /// The rules for when the client cert is valid.
+            /// </summary>
+            public ClientCertValidity Validity { get; set; }
+        }
+
+        /// <summary>
+        /// Container for the validation properties of a client cert.
+        /// </summary>
+        public class ClientCertValidity
+        {
+            /// <summary>
+            /// The date before which the certificate is invalid. Present when a client accesses an API by using a custom domain name 
+            /// that has mutual TLS enabled. Present only in access logs if mutual TLS authentication fails.
+            /// </summary>
+            public DateTime NotBefore { get; set; }
+
+            /// <summary>
+            /// The date after which the certificate is invalid. Present when a client accesses an API by using a custom domain name that 
+            /// has mutual TLS enabled. Present only in access logs if mutual TLS authentication fails.
+            /// </summary>
+            public DateTime NotAfter { get; set; }
         }
 
         /// <summary>

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayProxyRequest.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayProxyRequest.cs
@@ -393,13 +393,13 @@
             /// The date before which the certificate is invalid. Present when a client accesses an API by using a custom domain name 
             /// that has mutual TLS enabled. Present only in access logs if mutual TLS authentication fails.
             /// </summary>
-            public DateTime NotBefore { get; set; }
+            public string NotBefore { get; set; }
 
             /// <summary>
             /// The date after which the certificate is invalid. Present when a client accesses an API by using a custom domain name that 
             /// has mutual TLS enabled. Present only in access logs if mutual TLS authentication fails.
             /// </summary>
-            public DateTime NotAfter { get; set; }
+            public string NotAfter { get; set; }
         }
     }
 }

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayProxyRequest.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayProxyRequest.cs
@@ -196,6 +196,11 @@
             public string DomainName { get; set; }
 
             /// <summary>
+            /// The first label of the DomainName. This is often used as a caller/customer identifier.
+            /// </summary>
+            public string DomainPrefix { get; set; }
+
+            /// <summary>
             /// The event type: CONNECT, MESSAGE, or DISCONNECT.
             /// <para>
             /// This field is only set for WebSocket API requests.
@@ -332,6 +337,69 @@
             /// The user
             /// </summary>
             public string User { get; set; }
+
+
+            /// <summary>
+            /// Properties for a client certificate.
+            /// </summary>
+            public ProxyRequestClientCert ClientCert { get; set; }
+        }
+
+        /// <summary>
+        /// Container for the properties of the client certificate.
+        /// </summary>
+        public class ProxyRequestClientCert
+        {
+            /// <summary>
+            /// The PEM-encoded client certificate that the client presented during mutual TLS authentication. 
+            /// Present when a client accesses an API by using a custom domain name that has mutual 
+            /// TLS enabled. Present only in access logs if mutual TLS authentication fails.
+            /// </summary>
+            public string ClientCertPem { get; set; }
+
+            /// <summary>
+            /// The distinguished name of the subject of the certificate that a client presents. 
+            /// Present when a client accesses an API by using a custom domain name that has 
+            /// mutual TLS enabled. Present only in access logs if mutual TLS authentication fails.
+            /// </summary>
+            public string SubjectDN { get; set; }
+
+            /// <summary>
+            /// The distinguished name of the issuer of the certificate that a client presents. 
+            /// Present when a client accesses an API by using a custom domain name that has 
+            /// mutual TLS enabled. Present only in access logs if mutual TLS authentication fails.
+            /// </summary>
+            public string IssuerDN { get; set; }
+
+            /// <summary>
+            /// The serial number of the certificate. Present when a client accesses an API by 
+            /// using a custom domain name that has mutual TLS enabled. 
+            /// Present only in access logs if mutual TLS authentication fails.
+            /// </summary>
+            public string SerialNumber { get; set; }
+
+            /// <summary>
+            /// The rules for when the client cert is valid.
+            /// </summary>
+            public ClientCertValidity Validity { get; set; }
+        }
+
+        /// <summary>
+        /// Container for the validation properties of a client cert.
+        /// </summary>
+        public class ClientCertValidity
+        {
+            /// <summary>
+            /// The date before which the certificate is invalid. Present when a client accesses an API by using a custom domain name 
+            /// that has mutual TLS enabled. Present only in access logs if mutual TLS authentication fails.
+            /// </summary>
+            public DateTime NotBefore { get; set; }
+
+            /// <summary>
+            /// The date after which the certificate is invalid. Present when a client accesses an API by using a custom domain name that 
+            /// has mutual TLS enabled. Present only in access logs if mutual TLS authentication fails.
+            /// </summary>
+            public DateTime NotAfter { get; set; }
         }
     }
 }

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -96,6 +96,15 @@ namespace Amazon.Lambda.Tests
                 Assert.Equal("12/Mar/2020:19:03:58 +0000", rc.Time);
                 Assert.Equal(1583348638390, rc.TimeEpoch);
 
+                var clientCert = request.RequestContext.Authentication.ClientCert;
+                Assert.Equal("CERT_CONTENT", clientCert.ClientCertPem);
+                Assert.Equal("www.example.com", clientCert.SubjectDN);
+                Assert.Equal("Example issuer", clientCert.IssuerDN);
+                Assert.Equal("a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1", clientCert.SerialNumber);
+
+                Assert.Equal("May 28 12:30:02 2019 GMT", clientCert.Validity.NotBefore);
+                Assert.Equal("Aug  5 09:36:04 2021 GMT", clientCert.Validity.NotAfter);
+
                 var auth = rc.Authorizer;
                 Assert.NotNull(auth);
                 Assert.Equal(2, auth.Jwt.Claims.Count);
@@ -644,6 +653,15 @@ namespace Amazon.Lambda.Tests
                 Assert.Equal(identity.UserAgent, "PostmanRuntime/2.4.5");
                 Assert.Equal(identity.User, "theUser");
                 Assert.Equal("IAM_user_access_key", identity.AccessKey);
+
+                var clientCert = identity.ClientCert;
+                Assert.Equal("CERT_CONTENT", clientCert.ClientCertPem);
+                Assert.Equal("www.example.com", clientCert.SubjectDN);
+                Assert.Equal("Example issuer", clientCert.IssuerDN);
+                Assert.Equal("a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1", clientCert.SerialNumber);
+
+                Assert.Equal("May 28 12:30:02 2019 GMT", clientCert.Validity.NotBefore);
+                Assert.Equal("Aug  5 09:36:04 2021 GMT", clientCert.Validity.NotAfter);
 
                 Handle(proxyEvent);
             }

--- a/Libraries/test/EventsTests.Shared/http-api-v2-request.json
+++ b/Libraries/test/EventsTests.Shared/http-api-v2-request.json
@@ -15,6 +15,18 @@
   "requestContext": {
     "accountId": "123456789012",
     "apiId": "api-id",
+    "authentication": {
+      "clientCert": {
+        "clientCertPem": "CERT_CONTENT",
+        "subjectDN": "www.example.com",
+        "issuerDN": "Example issuer",
+        "serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
+        "validity": {
+          "notBefore": "May 28 12:30:02 2019 GMT",
+          "notAfter": "Aug  5 09:36:04 2021 GMT"
+        }
+      }
+    },
     "authorizer": {
       "jwt": {
         "claims": {

--- a/Libraries/test/EventsTests.Shared/proxy-event.json
+++ b/Libraries/test/EventsTests.Shared/proxy-event.json
@@ -49,15 +49,26 @@
       "userArn": "theUserArn",
       "userAgent": "PostmanRuntime/2.4.5",
       "user": "theUser",
-      "accessKey": "IAM_user_access_key"
+      "accessKey": "IAM_user_access_key",
+      "clientCert": {
+        "clientCertPem": "CERT_CONTENT",
+        "subjectDN": "www.example.com",
+        "issuerDN": "Example issuer",
+        "serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
+        "validity": {
+          "notBefore": "May 28 12:30:02 2019 GMT",
+          "notAfter": "Aug  5 09:36:04 2021 GMT"
+        }
+      }
     },
-    "resourcePath": "/{proxy+}",
-    "httpMethod": "POST",
-    "apiId": "gy415nuibc",
-    "connectionId": "d034bc98-beed-4fdf-9e85-11bfc15bf734",
-    "domainName": "somerandomdomain.net",
-    "requestTime": "20/Feb/2018:22:48:57 +0000",
-    "requestTimeEpoch": 1519166937665
+      "resourcePath": "/{proxy+}",
+      "httpMethod": "POST",
+      "apiId": "gy415nuibc",
+      "connectionId": "d034bc98-beed-4fdf-9e85-11bfc15bf734",
+      "domainName": "somerandomdomain.net",
+      "requestTime": "20/Feb/2018:22:48:57 +0000",
+      "requestTimeEpoch": 1519166937665
+    
   },
   "body": "{\r\n\t\"a\": 1\r\n}"
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/736

*Description of changes:*
Update the API Gateway event object to support the new ClientCert properties for API Gateway's Mutual TLS feature.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
