### PR TITLE
Update ApiGateway v2 events with Lamba and IAM auth

### DIFF
--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayHttpApiV2ProxyRequest.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayHttpApiV2ProxyRequest.cs
@@ -252,6 +252,15 @@ namespace Amazon.Lambda.APIGatewayEvents
             /// </summary>
             public JwtDescription Jwt { get; set; }
 
+            /// <summary>
+            /// The Lambda authorizer description.
+            /// </summary>
+            public IDictionary<string, string> Lambda { get; set; }
+
+            /// <summary>
+            /// The IAM description.
+            /// </summary>
+            public IAM IAM { get; set; }
 
             /// <summary>
             /// Describes the information in the JWT token
@@ -266,6 +275,68 @@ namespace Amazon.Lambda.APIGatewayEvents
                 /// List of the scopes for the requester.
                 /// </summary>
                 public string[] Scopes { get; set; }
+            }
+
+            /// <summary>
+            /// Describes the information in the IAM context
+            /// </summary>
+            public class IAM
+            {
+            /// <summary>
+            /// The access key.
+            /// </summary>
+            public string AccessKey { get; set; }
+
+            /// <summary>
+            /// The account id.
+            /// </summary>
+            public string AccountId { get; set; }
+
+            /// <summary>
+            /// The caller id.
+            /// </summary>
+            public string CallerId { get; set; }
+
+            /// <summary>
+            /// The Cognito Identity.
+            /// </summary>
+            public CognitoIdentity CognitoIdentity { get; set; }
+
+            /// <summary>
+            /// The principal org id.
+            /// </summary>
+            public string PrincipalOrgId { get; set; }
+
+            /// <summary>
+            /// The user Arn.
+            /// </summary>
+            public string UserArn { get; set; }
+
+            /// <summary>
+            /// The user id.
+            /// </summary>
+            public string UserId { get; set; }
+            }
+
+            /// <summary>
+            /// Describes the information in the CognitoIdentity
+            /// </summary>
+            public class CognitoIdentity
+            {
+            /// <summary>
+            /// List of the amr.
+            /// </summary>
+            public string[] Amr { get; set; }
+
+            /// <summary>
+            /// The identity id.
+            /// </summary>
+            public string IdentityId { get; set; }
+
+            /// <summary>
+            /// The identity pool id.
+            /// </summary>
+            public string IdentityPoolId { get; set; }
             }
         }
     }


### PR DESCRIPTION
*Description of changes:*
On Sept 9th,[ API Gateway launched support](https://aws.amazon.com/about-aws/whats-new/2020/09/api-gateway-http-apis-now-supports-lambda-and-iam-authorization-options/) for customers to secure Amazon API Gateway HTTP APIs using two new authorization options: Lambda authorizers and IAM authorizers. These new options enable customers to make flexible authorization decisions by providing an AWS Lambda function, or leveraging AWS IAM policies to control access to their APIs without writing any code. 

Updating API Gateway v2 event to support new context variables.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
