### PR TITLE
Update Custom Runtime Template to support .NET 5

### DIFF
--- a/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction-FSharp/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction-FSharp/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
   "display-name": "Custom Runtime Function",
   "system-name": "CustomRuntimeFunction",
-  "description": "Use Lambda Custom Runtime feature to build Lambda functions using .NET Core 2.2, 3.0 or 3.1.",
+  "description": "Use Lambda Custom Runtime feature to build Lambda functions using .NET 5.",
   "sort-order": 101,
   "hidden-tags": [
     "F#",

--- a/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AWSProjectType>Lambda</AWSProjectType>
     <AssemblyName>bootstrap</AssemblyName>
   </PropertyGroup>

--- a/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="FunctionTest.fs" />

--- a/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
   "display-name": "Custom Runtime Function",
   "system-name": "CustomRuntimeFunction",
-  "description": "Use Lambda Custom Runtime feature to build Lambda functions using .NET Core 2.2, 3.0 or 3.1.",
+  "description": "Use Lambda Custom Runtime feature to build Lambda functions using .NET 5.",
   "sort-order": 101,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Function"
   ],
-  "name": "Lambda Custom Runtime Function (.NET Core 3.1)",
+  "name": "Lambda Custom Runtime Function (.NET 5.0)",
   "identity": "AWS.Lambda.Function.CustomRuntimeFunction.CSharp",
   "groupIdentity": "AWS.Lambda.Function.CustomRuntimFunction",
   "shortName": "lambda.CustomRuntimeFunction",

--- a/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AWSProjectType>Lambda</AWSProjectType>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction/template/src/BlueprintBaseName.1/Readme.md
@@ -45,7 +45,7 @@ Deploy function to AWS Lambda
 
 ## Improve Cold Start
 
-.NET Core 3.1 has a new feature called ReadyToRun. When you compile your .NET Core 3.1 application you can enable ReadyToRun 
+.NET Core 3.1 and newer has a feature called ReadyToRun. When you compile your .NET Core application you can enable ReadyToRun 
 to prejit the .NET assemblies. This saves the .NET Core runtime from doing a lot of work during startup converting the 
 assemblies to a native format. ReadyToRun must be used on the same platform as the platform that will run the .NET application. In Lambda's case
 that means you have to build the Lambda package bundle in a Linux environment. To enable ReadyToRun edit the aws-lambda-tools-defaults.json

--- a/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,7 +8,7 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "framework": "netcoreapp3.1",
+  "framework": "net5.0",
   "function-runtime": "provided",
   "function-memory-size": 256,
   "function-timeout": 30,

--- a/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />

--- a/Blueprints/BlueprintDefinitions/netcore3.1/template.nuspec
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/template.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Amazon.Lambda.Templates</id>
-    <version>4.1.2</version>
+    <version>4.1.3</version>
     <authors>Amazon Web Services</authors>
     <tags>AWS Amazon Lambda</tags>
     <description>AWS Lambda templates for Microsoft Template Engine accessible with the dotnet CLI's new command</description>

--- a/Blueprints/BlueprintDefinitions/netcore3.1/template.nuspec
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/template.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Amazon.Lambda.Templates</id>
-    <version>4.1.3</version>
+    <version>4.2.0</version>
     <authors>Amazon Web Services</authors>
     <tags>AWS Amazon Lambda</tags>
     <description>AWS Lambda templates for Microsoft Template Engine accessible with the dotnet CLI's new command</description>

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Amazon.Lambda.AspNetCoreServer.csproj
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Amazon.Lambda.AspNetCoreServer.csproj
@@ -36,6 +36,9 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="System.IO.Pipelines" version="4.7.2">
+      <IncludeAssets>compile</IncludeAssets>
+    </PackageReference>
     <ProjectReference Include="..\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
   </ItemGroup>
 

--- a/Libraries/test/TestFunctionFSharp/TestFunctionCSharp/TestFunctionCSharp.csproj
+++ b/Libraries/test/TestFunctionFSharp/TestFunctionCSharp/TestFunctionCSharp.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="FSharp.Core" Version="4.*" />
+    <PackageReference Include="FSharp.Core" Version="5.0.0-beta.*" />
     <PackageReference Include="Fable.JsonConverter" Version="1.0.7" />
   </ItemGroup>
   <ItemGroup>

--- a/Libraries/test/TestFunctionFSharp/TestFunctionCSharp/TestFunctionCSharp.csproj
+++ b/Libraries/test/TestFunctionFSharp/TestFunctionCSharp/TestFunctionCSharp.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="FSharp.Core" Version="5.0.0-beta.*" />
+    <PackageReference Include="FSharp.Core" Version="4.*" />
     <PackageReference Include="Fable.JsonConverter" Version="1.0.7" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
*Issue #, if available:*
This change allows creation of .NET5  Custom Runtime Lambda Project.
*Description of changes:*
Updated the Blueprint definitions under `netcore3.1` for Custom Runtime Template to support .NET5 framework. 
Version for `FSharp.Core` bumped to `5.0.0-beta.*` to resolve errors originating due to compatibility issues with `dotnet5.0` runtime.
To resolve issue with `IO.Pipelines` stated [here](https://github.com/dotnet/runtime/issues/43324), the `Amazon.Lambda.AspNetCoreServer.csproj` file has been updated.

Testing
Build succeeds with no errors for targets- `test-blueprints-dotnew` and `tests`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
