### PR TITLE
Updating primaryOutputs in template.json to remove leading ./

### DIFF
--- a/Blueprints/BlueprintDefinitions/netcore2.1/AspNetCoreWebAPI-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/AspNetCoreWebAPI-FSharp/template/.template.config/template.json
@@ -43,7 +43,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/AspNetCoreWebAPI/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/AspNetCoreWebAPI/template/.template.config/template.json
@@ -43,7 +43,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/AspNetCoreWebApp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/AspNetCoreWebApp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/ChatBotTutorial/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/ChatBotTutorial/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/CustomRuntimeFunction-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/CustomRuntimeFunction-FSharp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/CustomRuntimeFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/CustomRuntimeFunction/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/DetectImageLabels-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/DetectImageLabels-FSharp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/DetectImageLabels/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/DetectImageLabels/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/DetectImageLabelsServerless-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/DetectImageLabelsServerless-FSharp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/DetectImageLabelsServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/DetectImageLabelsServerless/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/DynamoDBBlogAPI/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/DynamoDBBlogAPI/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/EmptyFunction-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/EmptyFunction-FSharp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/EmptyFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/EmptyFunction/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/EmptyServerless-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/EmptyServerless-FSharp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/EmptyServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/EmptyServerless/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/GiraffeWebApp-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/GiraffeWebApp-FSharp/template/.template.config/template.json
@@ -43,7 +43,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/LexBookTripSample/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/LexBookTripSample/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/SimpleApplicationLoadBalancer/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/SimpleApplicationLoadBalancer/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/SimpleDynamoDBFunction-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/SimpleDynamoDBFunction-FSharp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/SimpleDynamoDBFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/SimpleDynamoDBFunction/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/SimpleKinesisFirehoseFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/SimpleKinesisFirehoseFunction/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/SimpleKinesisFunction-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/SimpleKinesisFunction-FSharp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/SimpleKinesisFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/SimpleKinesisFunction/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/SimpleS3Function-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/SimpleS3Function-FSharp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/SimpleS3Function/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/SimpleS3Function/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/SimpleS3FunctionServerless-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/SimpleS3FunctionServerless-FSharp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/SimpleS3FunctionServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/SimpleS3FunctionServerless/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/SimpleSNSFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/SimpleSNSFunction/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/SimpleSQSFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/SimpleSQSFunction/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/StepFunctionsHelloWorld-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/StepFunctionsHelloWorld-FSharp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/StepFunctionsHelloWorld/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/StepFunctionsHelloWorld/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebAPI-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebAPI-FSharp/template/.template.config/template.json
@@ -43,7 +43,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebAPI/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebAPI/template/.template.config/template.json
@@ -43,7 +43,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebApp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebApp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/ChatBotTutorial/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/ChatBotTutorial/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction-FSharp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/CustomRuntimeFunction/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/DetectImageLabels-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/DetectImageLabels-FSharp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/DetectImageLabels/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/DetectImageLabels/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/DetectImageLabelsServerless-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/DetectImageLabelsServerless-FSharp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/DetectImageLabelsServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/DetectImageLabelsServerless/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/DynamoDBBlogAPI/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/DynamoDBBlogAPI/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/EmptyFunction-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/EmptyFunction-FSharp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/EmptyFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/EmptyFunction/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/EmptyServerless-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/EmptyServerless-FSharp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/EmptyServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/EmptyServerless/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/GiraffeWebApp-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/GiraffeWebApp-FSharp/template/.template.config/template.json
@@ -43,7 +43,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/LexBookTripSample/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/LexBookTripSample/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/SimpleApplicationLoadBalancer/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/SimpleApplicationLoadBalancer/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/SimpleDynamoDBFunction-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/SimpleDynamoDBFunction-FSharp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/SimpleDynamoDBFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/SimpleDynamoDBFunction/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/SimpleKinesisFirehoseFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/SimpleKinesisFirehoseFunction/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/SimpleKinesisFunction-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/SimpleKinesisFunction-FSharp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/SimpleKinesisFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/SimpleKinesisFunction/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/SimpleS3Function-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/SimpleS3Function-FSharp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/SimpleS3Function/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/SimpleS3Function/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/SimpleS3FunctionServerless-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/SimpleS3FunctionServerless-FSharp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/SimpleS3FunctionServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/SimpleS3FunctionServerless/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/SimpleSNSFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/SimpleSNSFunction/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/SimpleSQSFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/SimpleSQSFunction/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/StepFunctionsHelloWorld-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/StepFunctionsHelloWorld-FSharp/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/StepFunctionsHelloWorld/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/StepFunctionsHelloWorld/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/WebSocketAPIServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/WebSocketAPIServerless/template/.template.config/template.json
@@ -42,7 +42,7 @@
   },
   "primaryOutputs": [
     {
-      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+      "path": "src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
     }
   ]
 }


### PR DESCRIPTION
Updating `primaryOutputs` in `template.json` to remove leading `./` from the `primaryOutputs`. There is a bug in the TemplateEngine that this is working around. When there is a leading `./` in `primaryOutputs` this prevents the template from appearing in Visual Studio, see this blog post https://devblogs.microsoft.com/dotnet/net-cli-templates-in-visual-studio/

FYI there will be a few other things that you are likely to want to update to get the templates to behave well in Visual Studio. For example, you'll probably want to add an icon for each template. If you can start to get those icons put together, I can help you get the code changes in place. Fell free to ping me on twitter, when you are ready https://twitter.com/sayedihashimi