### PR TITLE
#750: Return cookies through proxy response message to support multiple cookies

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction.cs
@@ -14,6 +14,7 @@ using Amazon.Lambda.AspNetCoreServer.Internal;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using System.Globalization;
 using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
 
 namespace Amazon.Lambda.AspNetCoreServer
 {
@@ -198,6 +199,14 @@ namespace Amazon.Lambda.AspNetCoreServer
                 response.Headers = new Dictionary<string, string>();
                 foreach (var kvp in responseFeatures.Headers)
                 {
+                    if (kvp.Key.Equals(HeaderNames.SetCookie, StringComparison.CurrentCultureIgnoreCase))
+                    {
+                        // Cookies must be passed through the proxy response property and not as a 
+                        // header to be able to pass back multiple cookies in a single request.
+                        response.Cookies = kvp.Value.ToArray();
+                        continue;
+                    }
+
                     response.SetHeaderValues(kvp.Key, kvp.Value.ToArray(), false);
 
                     // Remember the Content-Type for possible later use

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestApiGatewayHttpApiV2Calls.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestApiGatewayHttpApiV2Calls.cs
@@ -197,7 +197,18 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
         {
             var response = await this.InvokeAPIGatewayRequest("cookies-get-returned-httpapi-v2-request.json");
 
-            Assert.StartsWith("TestCookie=TestValue", response.Headers["Set-Cookie"]);
+            Assert.Collection(response.Cookies,
+                actual => Assert.StartsWith("TestCookie=TestValue", actual));
+        }
+
+        [Fact]
+        public async Task TestReturningMultipleCookies()
+        {
+            var response = await this.InvokeAPIGatewayRequest("cookies-get-multiple-returned-httpapi-v2-request.json");
+
+            Assert.Collection(response.Cookies.OrderBy(s => s),
+                actual => Assert.StartsWith("TestCookie1=TestValue1", actual),
+                actual => Assert.StartsWith("TestCookie2=TestValue2", actual));
         }
 
         [Fact]

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/cookies-get-multiple-returned-httpapi-v2-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/cookies-get-multiple-returned-httpapi-v2-request.json
@@ -1,0 +1,44 @@
+﻿{
+  "version": "2.0",
+  "routeKey": "ANY /{proxy+}",
+  "rawPath": "/api/cookietests/multiple",
+  "rawQueryString": "",
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip, deflate",
+    "cache-control": "no-cache",
+    "content-length": "41",
+    "content-type": "application/json",
+    "contentlength": "45",
+    "host": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "postman-token": "18165e8d-ecd0-4e4c-8fd2-4963a0af62d1",
+    "user-agent": "PostmanRuntime/7.20.1",
+    "x-amzn-trace-id": "Root=1-5e7ae61f-bb13a2d967a67dd51b8aca50",
+    "x-forwarded-for": "192.182.149.40",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "requestContext": {
+    "accountId": "626492997873",
+    "apiId": "uo9pe23ec6",
+    "domainName": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "uo9pe23ec6",
+    "http": {
+      "method": "GET",
+      "path": "/api/cookietests/multiple",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "192.182.149.40",
+      "userAgent": "PostmanRuntime/7.20.1"
+    },
+    "requestId": "J7jk9g-7oAMEJGw=",
+    "routeKey": "ANY /{proxy+}",
+    "stage": "$default",
+    "time": "25/Mar/2020:05:03:27 +0000",
+    "timeEpoch": 1585112607686
+  },
+  "pathParameters": {
+    "proxy": "api/cookietests/multiple"
+  },
+  "body": null,
+  "isBase64Encoded": false
+}

--- a/Libraries/test/TestWebApp/Controllers/CookieTestsController.cs
+++ b/Libraries/test/TestWebApp/Controllers/CookieTestsController.cs
@@ -21,6 +21,18 @@ namespace TestWebApp.Controllers
             return String.Empty;
         }
 
+        [HttpGet("multiple")]
+        public string GetMulti()
+        {
+            var cookieOptions = new Microsoft.AspNetCore.Http.CookieOptions
+            {
+                Expires = DateTime.Now.AddMinutes(5)
+            };
+            Response.Cookies.Append("TestCookie1", "TestValue1", cookieOptions);
+            Response.Cookies.Append("TestCookie2", "TestValue2", cookieOptions);
+            return String.Empty;
+        }
+
         [HttpGet("{id}")]
         public string Get(string id)
         {


### PR DESCRIPTION
*Issue #, if available:* #750 

*Description of changes:*
Multiple returned cookies are incorrectly formatted if they are sent back as a HTTP header in the API Gateway proxy response, so they should instead be returned using the dedicated field for this in the proxy response.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
