### PR TITLE
Update authorizier in APIGatewayHttpApiV2ProxyRequest to include IAM and Lambda

### DIFF
--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayHttpApiV2ProxyRequest.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayHttpApiV2ProxyRequest.cs
@@ -227,7 +227,7 @@ namespace Amazon.Lambda.APIGatewayEvents
             public string Path { get; set; }
 
             /// <summary>
-            /// The protocal used ot make the rquest
+            /// The protocal used to make the rquest
             /// </summary>
             public string Protocol { get; set; }
 
@@ -252,6 +252,78 @@ namespace Amazon.Lambda.APIGatewayEvents
             /// </summary>
             public JwtDescription Jwt { get; set; }
 
+            /// <summary>
+            /// The Lambda authorizer description
+            /// </summary>
+            public IDictionary<string, object> Lambda { get; set; }
+
+            /// <summary>
+            /// The IAM authorizer description
+            /// </summary>
+            public IAMDescription IAM { get; set; }
+
+
+            /// <summary>
+            /// Describes the information from an IAM authorizer
+            /// </summary>
+            public class IAMDescription
+            {
+                /// <summary>
+                /// The Access Key of the IAM Authorizer
+                /// </summary>
+                public string AccessKey { get; set; }
+
+                /// <summary>
+                /// The Account Id of the IAM Authorizer
+                /// </summary>
+                public string AccountId { get; set; }
+
+                /// <summary>
+                /// The Caller Id of the IAM Authorizer
+                /// </summary>
+                public string CallerId { get; set; }
+
+                /// <summary>
+                /// The Cognito Identity of the IAM Authorizer
+                /// </summary>
+                public CognitoIdentityDescription CognitoIdentity { get; set; }
+
+                /// <summary>
+                /// The Principal Org Id of the IAM Authorizer
+                /// </summary>
+                public string PrincipalOrgId { get; set; }
+
+                /// <summary>
+                /// The User ARN of the IAM Authorizer
+                /// </summary>
+                public string UserARN { get; set; }
+
+                /// <summary>
+                /// The User Id of the IAM Authorizer
+                /// </summary>
+                public string UserId { get; set; }
+            }
+
+            /// <summary>
+            /// The Cognito identity description for an IAM authorizer
+            /// </summary>
+            public class CognitoIdentityDescription
+            {
+                /// <summary>
+                /// The AMR of the IAM Authorizer
+                /// </summary>
+                public IList<string> AMR { get; set; }
+
+                /// <summary>
+                /// The Identity Id of the IAM Authorizer
+                /// </summary>
+                public string IdentityId { get; set; }
+
+                /// <summary>
+                /// The Identity Pool Id of the IAM Authorizer
+                /// </summary>
+                public string IdentityPoolId { get; set; }
+            }
 
             /// <summary>
             /// Describes the information in the JWT token

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/Amazon.Lambda.APIGatewayEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/Amazon.Lambda.APIGatewayEvents.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>    
     <Description>Amazon Lambda .NET Core support - API Gateway package.</Description>
     <AssemblyTitle>Amazon.Lambda.APIGatewayEvents</AssemblyTitle>
-    <VersionPrefix>2.3.0</VersionPrefix>
+    <VersionPrefix>2.4.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.APIGatewayEvents</AssemblyName>
     <PackageId>Amazon.Lambda.APIGatewayEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -124,6 +124,49 @@ namespace Amazon.Lambda.Tests
             }
         }
 
+        [Theory]
+        [InlineData(typeof(JsonSerializer))]
+#if NETCOREAPP_3_1
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+#endif
+        public void HttpApiV2FormatLambdaAuthorizer(Type serializerType)
+        {
+            var serializer = Activator.CreateInstance(serializerType) as ILambdaSerializer;
+            using (var fileStream = LoadJsonTestFile("http-api-v2-request-lambda-authorizer.json"))
+            {
+                var request = serializer.Deserialize<APIGatewayHttpApiV2ProxyRequest>(fileStream);
+                Assert.Equal("value", request.RequestContext.Authorizer.Lambda["key"]?.ToString());
+            }
+        }
+
+        [Theory]
+        [InlineData(typeof(JsonSerializer))]
+#if NETCOREAPP_3_1
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+#endif
+        public void HttpApiV2FormatIAMAuthorizer(Type serializerType)
+        {
+            var serializer = Activator.CreateInstance(serializerType) as ILambdaSerializer;
+            using (var fileStream = LoadJsonTestFile("http-api-v2-request-iam-authorizer.json"))
+            {
+                var request = serializer.Deserialize<APIGatewayHttpApiV2ProxyRequest>(fileStream);
+                var iam = request.RequestContext.Authorizer.IAM;
+                Assert.NotNull(iam);
+                Assert.Equal("ARIA2ZJZYVUEREEIHAKY", iam.AccessKey);
+                Assert.Equal("1234567890", iam.AccountId);
+                Assert.Equal("AROA7ZJZYVRE7C3DUXHH6:CognitoIdentityCredentials", iam.CallerId);
+                Assert.Equal("foo", iam.CognitoIdentity.AMR[0]);
+                Assert.Equal("us-east-1:3f291106-8703-466b-8f2b-3ecee1ca56ce", iam.CognitoIdentity.IdentityId);
+                Assert.Equal("us-east-1:4f291106-8703-466b-8f2b-3ecee1ca56ce", iam.CognitoIdentity.IdentityPoolId);
+                Assert.Equal("AwsOrgId", iam.PrincipalOrgId);
+                Assert.Equal("arn:aws:iam::1234567890:user/Admin", iam.UserARN);
+                Assert.Equal("AROA2ZJZYVRE7Y3TUXHH6", iam.UserId);
+
+            }
+        }
+
         [Fact]
         public void SetHeadersToHttpApiV2Response()
         {

--- a/Libraries/test/EventsTests.Shared/http-api-v2-request-iam-authorizer.json
+++ b/Libraries/test/EventsTests.Shared/http-api-v2-request-iam-authorizer.json
@@ -1,0 +1,60 @@
+﻿{
+  "version": "2.0",
+  "routeKey": "$default",
+  "rawPath": "/my/path",
+  "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
+  "cookies": [
+    "cookie1",
+    "cookie2"
+  ],
+  "headers": {
+    "Header1": "value1",
+    "Header2": "value2"
+  },
+  "queryStringParameters": {
+    "parameter1": "value1,value2",
+    "parameter2": "value"
+  },
+  "pathParameters": {
+    "proxy": "hello/world"
+  },
+  "requestContext": {
+    "routeKey": "$default",
+    "accountId": "123456789012",
+    "stage": "$default",
+    "requestId": "id",
+    "authorizer": {
+      "iam": {
+        "accessKey": "ARIA2ZJZYVUEREEIHAKY",
+        "accountId": "1234567890",
+        "callerId": "AROA7ZJZYVRE7C3DUXHH6:CognitoIdentityCredentials",
+        "cognitoIdentity": {
+          "amr": [ "foo" ],
+          "identityId": "us-east-1:3f291106-8703-466b-8f2b-3ecee1ca56ce",
+          "identityPoolId": "us-east-1:4f291106-8703-466b-8f2b-3ecee1ca56ce"
+        },
+        "principalOrgId": "AwsOrgId",
+        "userArn": "arn:aws:iam::1234567890:user/Admin",
+        "userId": "AROA2ZJZYVRE7Y3TUXHH6"
+      }
+    },
+    "apiId": "api-id",
+    "domainName": "id.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "id",
+    "time": "12/Mar/2020:19:03:58+0000",
+    "timeEpoch": 1583348638390,
+    "http": {
+      "method": "GET",
+      "path": "/my/path",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "IP",
+      "userAgent": "agent"
+    }
+  },
+  "stageVariables": {
+    "stageVariable1": "value1",
+    "stageVariable2": "value2"
+  },
+  "body": "{\r\n\t\"a\": 1\r\n}",
+  "isBase64Encoded": false
+}

--- a/Libraries/test/EventsTests.Shared/http-api-v2-request-lambda-authorizer.json
+++ b/Libraries/test/EventsTests.Shared/http-api-v2-request-lambda-authorizer.json
@@ -1,0 +1,50 @@
+﻿{
+  "version": "2.0",
+  "routeKey": "$default",
+  "rawPath": "/my/path",
+  "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
+  "cookies": [
+    "cookie1",
+    "cookie2"
+  ],
+  "headers": {
+    "Header1": "value1",
+    "Header2": "value2"
+  },
+  "queryStringParameters": {
+    "parameter1": "value1,value2",
+    "parameter2": "value"
+  },
+  "pathParameters": {
+    "proxy": "hello/world"
+  },
+  "requestContext": {
+    "routeKey": "$default",
+    "accountId": "123456789012",
+    "stage": "$default",
+    "requestId": "id",
+    "authorizer": {
+      "lambda": {
+        "key": "value"
+      }
+    },
+    "apiId": "api-id",
+    "domainName": "id.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "id",
+    "time": "12/Mar/2020:19:03:58+0000",
+    "timeEpoch": 1583348638390,
+    "http": {
+      "method": "GET",
+      "path": "/my/path",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "IP",
+      "userAgent": "agent"
+    }
+  },
+  "stageVariables": {
+    "stageVariable1": "value1",
+    "stageVariable2": "value2"
+  },
+  "body": "{\r\n\t\"a\": 1\r\n}",
+  "isBase64Encoded": false
+}


### PR DESCRIPTION
*Description of changes:*
The API APIGatewayHttpApiV2ProxyRequest event object was missing the IAM and Lambda fields for authorizer. The fix add those fields and copy the [golang](https://github.com/aws/aws-lambda-go/blob/master/events/testdata/apigw-v2-request-iam.json) test cases to the event test project.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
