### PR TITLE
Add DMARC verdict

### DIFF
--- a/Libraries/src/Amazon.Lambda.SimpleEmailEvents/SimpleEmailEvent.cs
+++ b/Libraries/src/Amazon.Lambda.SimpleEmailEvents/SimpleEmailEvent.cs
@@ -139,6 +139,11 @@ namespace Amazon.Lambda.SimpleEmailEvents
             public SimpleEmailVerdict VirusVerdict { get; set; }
 
             /// <summary>
+            /// The DMARC verdict of the message, e.g. status: PASS.
+            /// </summary>
+            public SimpleEmailVerdict DMARCVerdict { get; set; }
+
+            /// <summary>
             /// The action of the message (i.e, which lambda was invoked, where it was stored in S3, etc)
             /// </summary>
             public TReceiptAction Action { get; set; }
@@ -203,7 +208,7 @@ namespace Amazon.Lambda.SimpleEmailEvents
     }
 
     /// <summary>
-    /// Verdict to return status of Spam, DKIM, SPF, and Virus.
+    /// Verdict to return status of Spam, DKIM, SPF, Virus, and DMARC.
     /// </summary>
     public class SimpleEmailVerdict
     {

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -460,6 +460,7 @@ namespace Amazon.Lambda.Tests
                 Assert.Equal(record.Ses.Receipt.DKIMVerdict.Status, "PASS");
                 Assert.Equal(record.Ses.Receipt.SPFVerdict.Status, "PASS");
                 Assert.Equal(record.Ses.Receipt.VirusVerdict.Status, "PASS");
+                Assert.Equal(record.Ses.Receipt.DMARCVerdict.Status, "PASS");
                 Assert.Equal(record.Ses.Receipt.ProcessingTimeMillis, 574);
                 
                 Handle(sesEvent);

--- a/Libraries/test/EventsTests.Shared/simple-email-event-lambda.json
+++ b/Libraries/test/EventsTests.Shared/simple-email-event-lambda.json
@@ -88,6 +88,9 @@
           },
           "virusVerdict": {
             "status": "PASS"
+          },
+          "dmarcVerdict": {
+            "status": "PASS"
           }
         }
       },


### PR DESCRIPTION
*Resolves #778*

*Description of changes:*

- Added the necessary property to deserialize the DMARC verdict on SimpleEmailReceipt.

- Updated the EventTests json file with the serialized SimpleEmailEvent and added an extra Assert to ensure the verdict status is correctly deserialized.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
