### PR TITLE
Add dotnet sample for Active Directory LDAP usage.

### DIFF
--- a/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/Dockerfile
+++ b/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/Dockerfile
@@ -1,0 +1,14 @@
+ARG AWS_LAMBDA_VERSION=local
+
+FROM aws-lambda-dotnet:$AWS_LAMBDA_VERSION AS base
+
+FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim as build
+COPY . .
+RUN dotnet build "LDAPSample/LDAPSample.csproj" -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "LDAPSample/LDAPSample.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /var/task
+COPY --from=publish /app/publish .

--- a/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/Function.cs
+++ b/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/Function.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Novell.Directory.Ldap;
+
+using Amazon.Lambda.Core;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+namespace LDAPSample
+{
+    public class Input
+    {
+        public string directoryName { get; set; }
+        public string userName { get; set; }
+        public string password { get; set; }
+        public string searchString { get; set; }
+    }
+
+    public class Function
+    {
+        /// <summary>
+        /// This function can be used with AWS Directory Services
+        /// or Windows Active Directory for LDAP related operations.
+        /// This lambda must be placed in the same VPC as AWS Directory Services.
+        /// Also, DNS name must be enabled in the DHCP option set of the VPC
+        /// so that the directory can be accessed using directory name.
+        ///
+        /// Example JSON input :
+        /// {
+        ///   "directoryName": "example.com",
+        ///   "userName": "admin",
+        ///   "password": "XXXXX",
+        ///   "searchString": "dc=example,dc=com"
+        ///  }
+        /// </summary>
+        /// <param name="inputJson"></param>
+        /// <param name="context"></param>
+        /// <returns>LDAP response</returns>
+
+        private const int LdapPort = 389;
+
+        public string FunctionHandler(Input inputJson, ILambdaContext context)
+        {
+            string log = "";
+            string[] arguments = { inputJson.directoryName,
+                                   inputJson.searchString,
+                                   inputJson.userName,
+                                   inputJson.password
+                                 };
+
+            var ldapConn = new LdapConnection();
+            ldapConn.Connect(inputJson.directoryName, LdapPort);
+            ldapConn.Bind(inputJson.userName, inputJson.password);
+
+            var searchResults = ldapConn.Search(inputJson.searchString,
+                                       LdapConnection.ScopeSub,
+                                       "(objectclass=*)", null, false);
+
+            while (searchResults.HasMore())
+            {
+                LdapEntry nextEntry = null;
+                try
+                {
+                   nextEntry = searchResults.Next();
+                   log += nextEntry.ToString();
+                }
+                catch (LdapException e)
+                {
+                   log += e.ToString();
+                   return log;
+                }
+             }
+
+           return log;
+        }
+    }
+}

--- a/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/LDAPSample.csproj
+++ b/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/LDAPSample.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AWSProjectType>Lambda</AWSProjectType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
+    <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="3.5.2" />
+  </ItemGroup>
+</Project>

--- a/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/aws-lambda-tools-defaults.json
+++ b/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/aws-lambda-tools-defaults.json
@@ -1,0 +1,18 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+    "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+    "dotnet lambda help",
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+  "profile": "",
+  "region": "",
+  "package-type": "image",
+  "function-name": "LDAPTest",
+  "function-role": "",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "image-command": "LDAPSample::LDAPSample.Function::FunctionHandler",
+  "tag": "awsldapsamplelambdaimage:latest",
+  "dockerfile": "Dockerfile"
+}


### PR DESCRIPTION
*Issue #, if available:*

This function can be used with AWS Directory Services or Windows Active Directory for LDAP related operations.
This lambda must be placed in the same VPC as AWS Directory Services.
Also, DNS name must be enabled in the DHCP option set of the VPC
so that the directory can be accessed using directory name.
This is potentially a fix for  https://github.com/aws/aws-lambda-dotnet/issues/341

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
