### PR TITLE
Fix issue with incorrectly parsing image config command as a scalar instead of an array

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Utils.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Utils.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Amazon.Lambda.TestTool.Runtime;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -134,12 +135,21 @@ namespace Amazon.Lambda.TestTool
                         {
                             PropertyNameCaseInsensitive = true
                         });
+                        configFile.ConfigFileLocation = file;
 
-                        if ((!string.IsNullOrEmpty(configFile.DetermineHandler()) ||
-                            (!string.IsNullOrEmpty(configFile.Template) && File.Exists(Path.Combine(lambdaFunctionDirectory, configFile.Template)))))
+                        if (!string.IsNullOrEmpty(configFile.DetermineHandler()))
                         {
                             Console.WriteLine($"Found Lambda config file {file}");
                             configFiles.Add(file);
+                        }
+                        else if(!string.IsNullOrEmpty(configFile.Template) && File.Exists(Path.Combine(lambdaFunctionDirectory, configFile.Template)))
+                        {
+                            var config = LambdaDefaultsConfigFileParser.LoadFromFile(configFile);
+                            if(config.FunctionInfos?.Count > 0)
+                            {
+                                Console.WriteLine($"Found Lambda config file {file}");
+                                configFiles.Add(file);
+                            }
                         }
                     }
                     catch

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/ServerlessTemplateExample/serverless.template
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/ServerlessTemplateExample/serverless.template
@@ -32,7 +32,7 @@
          "Properties":{ 
             "PackageType" : "Image",
             "ImageConfig" : {
-                "Command" : "ServerlessTemplateExample::ServerlessTemplateExample.Functions::HelloWorldImageFunction"
+                "Command" : ["ServerlessTemplateExample::ServerlessTemplateExample.Functions::HelloWorldImageFunction"]
             },
             "ImageUri":"",
             "Description":"",

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/ServerlessTemplateYamlExample/serverless.yaml
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/ServerlessTemplateYamlExample/serverless.yaml
@@ -20,7 +20,8 @@ Resources:
     Properties:
       PackageType: Image
       ImageConfig:
-        Command: ServerlessTemplateExample::ServerlessTemplateExample.Functions::HelloWorldImageFunction
+        Command: 
+        - ServerlessTemplateExample::ServerlessTemplateExample.Functions::HelloWorldImageFunction
       ImageUri: ''
       MemorySize: 256
       Timeout: 30


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/774

*Description of changes:*
Fix issue reading serverless.template file for Command of ImageConfig. The code was incorrectly reading the command as a scalar which should be read as an array.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
