### PR TITLE
Add support for ITlsConnectionFeature and marshall the APIGW client cert to HttpContext (#786)

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction.cs
@@ -182,8 +182,8 @@ namespace Amazon.Lambda.AspNetCoreServer
                 var clientCertPem = apiGatewayRequest?.RequestContext?.Authentication?.ClientCert?.ClientCertPem;
                 if (clientCertPem != null)
                 {
-                    clientCertPem = clientCertPem.Replace("-----BEGIN CERTIFICATE-----", string.Empty);
-                    clientCertPem = clientCertPem.Replace("-----END CERTIFICATE-----", string.Empty);
+                    // Remove "--------BEGIN CERTIFICATE-----\n" and "-----END CERTIFICATE-----"
+                    clientCertPem = clientCertPem.Substring(28, clientCertPem.Length - 53);
                     tlsConnectionFeature.ClientCertificate = new X509Certificate2(Convert.FromBase64String(clientCertPem));
                 }
                 PostMarshallTlsConnectionFeature(tlsConnectionFeature, apiGatewayRequest, lambdaContext);

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction.cs
@@ -182,10 +182,9 @@ namespace Amazon.Lambda.AspNetCoreServer
                 var clientCertPem = apiGatewayRequest?.RequestContext?.Authentication?.ClientCert?.ClientCertPem;
                 if (clientCertPem != null)
                 {
-                    // Remove "--------BEGIN CERTIFICATE-----\n" and "-----END CERTIFICATE-----"
-                    clientCertPem = clientCertPem.Substring(28, clientCertPem.Length - 53);
-                    tlsConnectionFeature.ClientCertificate = new X509Certificate2(Convert.FromBase64String(clientCertPem));
+                    tlsConnectionFeature.ClientCertificate = Utilities.GetX509Certificate2FromPem(clientCertPem);
                 }
+
                 PostMarshallTlsConnectionFeature(tlsConnectionFeature, apiGatewayRequest, lambdaContext);
             }
         }

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -251,9 +251,7 @@ namespace Amazon.Lambda.AspNetCoreServer
                 var clientCertPem = apiGatewayRequest?.RequestContext?.Identity?.ClientCert?.ClientCertPem;
                 if (clientCertPem != null)
                 {
-                    // Remove "--------BEGIN CERTIFICATE-----\n" and "-----END CERTIFICATE-----"
-                    clientCertPem = clientCertPem.Substring(28, clientCertPem.Length - 53);
-                    tlsConnectionFeature.ClientCertificate = new X509Certificate2(Convert.FromBase64String(clientCertPem));
+                    tlsConnectionFeature.ClientCertificate = Utilities.GetX509Certificate2FromPem(clientCertPem);
                 }
                 PostMarshallTlsConnectionFeature(tlsConnectionFeature, apiGatewayRequest, lambdaContext);
             }

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -251,8 +251,7 @@ namespace Amazon.Lambda.AspNetCoreServer
                 var clientCertPem = apiGatewayRequest?.RequestContext?.Identity?.ClientCert?.ClientCertPem;
                 if (clientCertPem != null)
                 {
-                    clientCertPem = clientCertPem.Replace("-----BEGIN CERTIFICATE-----", string.Empty);
-                    clientCertPem = clientCertPem.Replace("-----END CERTIFICATE-----", string.Empty);
+                    clientCertPem = clientCertPem.Substring(28, clientCertPem.Length - 53);
                     tlsConnectionFeature.ClientCertificate = new X509Certificate2(Convert.FromBase64String(clientCertPem));
                 }
                 PostMarshallTlsConnectionFeature(tlsConnectionFeature, apiGatewayRequest, lambdaContext);

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -14,6 +14,7 @@ using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.AspNetCoreServer.Internal;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using System.Globalization;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Amazon.Lambda.AspNetCoreServer
 {
@@ -243,6 +244,18 @@ namespace Amazon.Lambda.AspNetCoreServer
                 // Call consumers customize method in case they want to change how API Gateway's request
                 // was marshalled into ASP.NET Core request.
                 PostMarshallConnectionFeature(connectionFeatures, apiGatewayRequest, lambdaContext);
+            }
+
+            {
+                var tlsConnectionFeature = (ITlsConnectionFeature) features;
+                var clientCertPem = apiGatewayRequest?.RequestContext?.Identity?.ClientCert?.ClientCertPem;
+                if (clientCertPem != null)
+                {
+                    clientCertPem = clientCertPem.Replace("-----BEGIN CERTIFICATE-----", string.Empty);
+                    clientCertPem = clientCertPem.Replace("-----END CERTIFICATE-----", string.Empty);
+                    tlsConnectionFeature.ClientCertificate = new X509Certificate2(Convert.FromBase64String(clientCertPem));
+                }
+                PostMarshallTlsConnectionFeature(tlsConnectionFeature, apiGatewayRequest, lambdaContext);
             }
         }
 

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -251,6 +251,7 @@ namespace Amazon.Lambda.AspNetCoreServer
                 var clientCertPem = apiGatewayRequest?.RequestContext?.Identity?.ClientCert?.ClientCertPem;
                 if (clientCertPem != null)
                 {
+                    // Remove "--------BEGIN CERTIFICATE-----\n" and "-----END CERTIFICATE-----"
                     clientCertPem = clientCertPem.Substring(28, clientCertPem.Length - 53);
                     tlsConnectionFeature.ClientCertificate = new X509Certificate2(Convert.FromBase64String(clientCertPem));
                 }

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
@@ -631,6 +631,19 @@ namespace Amazon.Lambda.AspNetCoreServer
         }
 
         /// <summary>
+        /// This method is called after marshalling the incoming Lambda request
+        /// into ASP.NET Core's ITlsConnectionFeature. Derived classes can overwrite this method to alter
+        /// the how the marshalling was done.
+        /// </summary>
+        /// <param name="aspNetCoreConnectionFeature"></param>
+        /// <param name="lambdaRequest"></param>
+        /// <param name="lambdaContext"></param>
+        protected virtual void PostMarshallTlsConnectionFeature(ITlsConnectionFeature aspNetCoreConnectionFeature, TREQUEST lambdaRequest, ILambdaContext lambdaContext)
+        {
+
+        }
+
+        /// <summary>
         /// This method is called after marshalling the IHttpResponseFeature that came
         /// back from making the request into ASP.NET Core into the Lamdba response object. Derived classes can overwrite this method to alter
         /// the how the marshalling was done.

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/InvokeFeatures.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/InvokeFeatures.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 #endif
 using System.Net;
 using System.Security.Claims;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -25,7 +26,8 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
                              IHttpRequestFeature,
                              IHttpResponseFeature,
                              IHttpConnectionFeature,
-                             IServiceProvidersFeature
+                             IServiceProvidersFeature,
+                             ITlsConnectionFeature
 
 #if !NETCOREAPP_2_1
                              ,IHttpResponseBodyFeature
@@ -46,9 +48,10 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
             this[typeof(IHttpResponseFeature)] = this;
             this[typeof(IHttpConnectionFeature)] = this;
             this[typeof(IServiceProvidersFeature)] = this;
+            this[typeof(ITlsConnectionFeature)] = this;
 #if !NETCOREAPP_2_1
             this[typeof(IHttpResponseBodyFeature)] = this;
-#endif            
+#endif
         }
 
         #region IFeatureCollection
@@ -127,11 +130,11 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
 
 #endregion
         
-#region IItemsFeature
+        #region IItemsFeature
         IDictionary<object, object> IItemsFeature.Items { get; set; }
 #endregion
         
-#region IHttpAuthenticationFeature
+        #region IHttpAuthenticationFeature
         ClaimsPrincipal IHttpAuthenticationFeature.User { get; set; }
         
 #if NETCOREAPP_2_1
@@ -139,7 +142,7 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
 #endif
 #endregion
 
-#region IHttpRequestFeature
+        #region IHttpRequestFeature
         string IHttpRequestFeature.Protocol { get; set; }
 
         string IHttpRequestFeature.Scheme { get; set; }
@@ -160,7 +163,7 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
 
 #endregion
 
-#region IHttpResponseFeature
+        #region IHttpResponseFeature
         int IHttpResponseFeature.StatusCode
         {
             get;
@@ -340,6 +343,17 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
             get; 
             set; 
         }
+
+        #endregion
+
+        #region ITlsConnectionFeatures
+
+        public Task<X509Certificate2> GetClientCertificateAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(ClientCertificate);
+        }
+
+        public X509Certificate2 ClientCertificate { get; set; }
 
         #endregion
     }

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/Utilities.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/Utilities.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -263,5 +264,20 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
             // Double-escape any %2F (encoded / characters) so that they survive URL decoding the path.
             .Replace("%2F", "%252F")
             .Replace("%2f", "%252f"));
+
+        internal static X509Certificate2 GetX509Certificate2FromPem(string clientCertPem)
+        {
+            if (!clientCertPem.StartsWith("-----BEGIN CERTIFICATE-----") || !clientCertPem.EndsWith("-----END CERTIFICATE-----"))
+            {
+                throw new InvalidOperationException(
+                    "Client certificate PEM was invalid. Expected to start with '-----BEGIN CERTIFICATE-----' " +
+                    "and end with '-----END CERTIFICATE-----'.");
+            }
+
+            // Remove "-----BEGIN CERTIFICATE-----\n" and "-----END CERTIFICATE-----"
+            clientCertPem = clientCertPem.Substring(28, clientCertPem.Length - 53);
+
+            return new X509Certificate2(Convert.FromBase64String(clientCertPem));
+        }
     }
 }

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/Amazon.Lambda.AspNetCoreServer.Test.csproj
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/Amazon.Lambda.AspNetCoreServer.Test.csproj
@@ -34,8 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="authtest-access-request.json" />
     <None Remove="missing-resource-request.json" />
+    <None Remove="mtls-request.json" />
     <None Remove="values-get-all-httpapi-request.json" />
   </ItemGroup>
 

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/Amazon.Lambda.AspNetCoreServer.Test.csproj
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/Amazon.Lambda.AspNetCoreServer.Test.csproj
@@ -34,8 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="authtest-access-request.json" />
     <None Remove="missing-resource-request.json" />
-    <None Remove="mtls-request.json" />
     <None Remove="values-get-all-httpapi-request.json" />
   </ItemGroup>
 

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestApiGatewayHttpApiV2Calls.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestApiGatewayHttpApiV2Calls.cs
@@ -193,6 +193,14 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
         }
 
         [Fact]
+        public async Task TestAuthMTls()
+        {
+            var response = await this.InvokeAPIGatewayRequest("mtls-request-httpapi-v2.json");
+            Assert.Equal(200, response.StatusCode);
+            Assert.Equal("O=Internet Widgits Pty Ltd, S=Some-State, C=AU", response.Body);
+        }
+
+        [Fact]
         public async Task TestReturningCookie()
         {
             var response = await this.InvokeAPIGatewayRequest("cookies-get-returned-httpapi-v2-request.json");

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
@@ -294,6 +294,14 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
         }
 
         [Fact]
+        public async Task TestAuthMTls()
+        {
+            var response = await this.InvokeAPIGatewayRequest("mtls-request.json");
+            Assert.Equal(200, response.StatusCode);
+            Assert.Equal("O=Internet Widgits Pty Ltd, S=Some-State, C=AU", response.Body);
+        }
+
+        [Fact]
         public async Task TestAuthTestAccess_CustomLambdaAuthorizerClaims()
         {
             var response =

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/mtls-request-httpapi-v2.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/mtls-request-httpapi-v2.json
@@ -1,0 +1,60 @@
+﻿{
+  "version": "2.0",
+  "routeKey": "ANY /{proxy+}",
+  "rawPath": "/api/mtlstest",
+  "rawQueryString": "",
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip, deflate",
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "host": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "postman-token": "94d77afd-073d-4e32-8529-8192f5750371",
+    "user-agent": "PostmanRuntime/7.20.1",
+    "x-amzn-trace-id": "Root=1-5e7aeb83-0b67e2a8010700549b3ca4a4",
+    "x-forwarded-for": "192.182.149.40",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "requestContext": {
+    "accountId": "626492997873",
+    "apiId": "uo9pe23ec6",
+    "authorizer": {
+      "jwt": {
+        "claims": {
+          "cognito:groups": "Admin",
+          "phone_number_verified": "true",
+          "cognito:username": "normj",
+          "aud": "3mushfc8sgm8uoacvif5vhkt49",
+          "event_id": "75760f58-f984-11e7-8d4a-2389efc50d68",
+          "token_use": "id",
+          "auth_time": "1515973296",
+          "you_are_special": "true"
+        }
+      }
+    },
+    "domainName": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "uo9pe23ec6",
+    "http": {
+      "method": "GET",
+      "path": "/api/mtlstest",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "192.182.149.40",
+      "userAgent": "PostmanRuntime/7.20.1"
+    },
+    "requestId": "J7m8fgZWoAMEJEA=",
+    "routeKey": "ANY /{proxy+}",
+    "stage": "$default",
+    "time": "25/Mar/2020:05:26:27 +0000",
+    "timeEpoch": 1585113987055,
+    "authentication" : {
+      "clientCert": {
+        "clientCertPem": "-----BEGIN CERTIFICATE-----\nMIIB3zCCAYWgAwIBAgIUImttQCULqkHxYbDivb1fzRNFYG8wCgYIKoZIzj0EAwIw\nRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGElu\ndGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMDA5MTgxNDQyMzlaFw0yMTA5MTMx\nNDQyMzlaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYD\nVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwWTATBgcqhkjOPQIBBggqhkjO\nPQMBBwNCAARwfxEb6RX+fwiz70spEdLTfK/ite5ZGfysbalM/ZlnUjWZ+Cwk+aEc\nKkER2GWoZ6Fiw3PcOlQzY8dGHMdkkHhGo1MwUTAdBgNVHQ4EFgQUOYFYa+w94G7t\nMGD3bpM3T04WAxswHwYDVR0jBBgwFoAUOYFYa+w94G7tMGD3bpM3T04WAxswDwYD\nVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNIADBFAiEAxX7N6e+2NfuwR70u3AX0\nmx5ZP9uQhdrvOi8qDBHSMMoCIEQenUMtTfYfOU8FwT3WZO4S5JB5jvPg9hCnlXPj\nNwaC\n-----END CERTIFICATE-----"
+      } 
+    } 
+  },
+  "pathParameters": {
+    "proxy": "api/authtest"
+  },
+  "isBase64Encoded": false
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/mtls-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/mtls-request.json
@@ -1,0 +1,69 @@
+﻿{
+  "resource": "/{proxy+}",
+  "path": "/api/mtlstest",
+  "httpMethod": "GET",
+  "headers": {
+    "Authorization": "eyJraWQiOiJLdXprWCtcL0E4MWlVZGU5QSt2SFBMdzZCTUFmQzVqUGJ1NTZiT0VGNXdkaz0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiI4ZWYzZTQ1NS0zODY5LTQwMmUtYWM5ZS1mODhlODZjMzIwYjMiLCJjb2duaXRvOmdyb3VwcyI6WyJBZG1pbiJdLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiaXNzIjoiaHR0cHM6XC9cL2NvZ25pdG8taWRwLnVzLXdlc3QtMi5hbWF6b25hd3MuY29tXC91cy13ZXN0LTJfUExpM2NmMHUwIiwicGhvbmVfbnVtYmVyX3ZlcmlmaWVkIjp0cnVlLCJjb2duaXRvOnVzZXJuYW1lIjoibm9ybWoiLCJhdWQiOiIzbXVzaGZjOHNnbTh1b2FjdmlmNXZoa3Q0OSIsImV2ZW50X2lkIjoiNzU3NjBmNTgtZjk4NC0xMWU3LThkNGEtMjM4OWVmYzUwZDY4IiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1MTU5NzMyOTYsInBob25lX251bWJlciI6IisxNDI1NzM2NzM0OSIsImV4cCI6MTUxNTk3Njg5NiwiaWF0IjoxNTE1OTczMjk2LCJlbWFpbCI6ImpvaGFuc28yQGdtYWlsLmNvbSJ9.v1zIeTutUMzgXGoQy5dpOXUW6km9Ye-X-iLehgn1fO4HeJPZ9rOY9jDRMyRjyF5I57sAsN1v9uB3f98gEdStzO4qpASlYK7F7CtcenJ2lZYNU4gJPDQqEDdoMvE5Nir89RL09PYFceKaZw2Qr53VTLBfwaNGJYeSYeiZN09RL6fXwciH5h15rGwgNpl3kvzZOTLCqHNv3J7Y5POr8BjT2DvqUVJv7X1M5pOzHxWIqtBfAfyhEzZftIDqNKsI_aKZolkRd_UI77dSMNuZokJSAKlEuXc6fNJ556R3xSAhEli5DeZUIMdQLQVB7pIQzRlXvt2M0MMK-uC2d7_kUWAkVg",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "zzqupfvhrk.execute-api.us-west-2.amazonaws.com",
+    "Via": "1.1 ca79756ec49e2babf1b916300304b2fb.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "3OhHlF5fim8xxjG1-RZEFK4nos0t-JtPu6vvpNkUg9NOcl-Os53gBg==",
+    "X-Amzn-Trace-Id": "Root=1-5a5beab2-7cd6a52c614f43910ab9be30",
+    "X-Forwarded-For": "50.35.77.7, 52.46.17.45",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "queryStringParameters": null,
+  "pathParameters": {
+    "proxy": "api/mtlstest"
+  },
+  "stageVariables": null,
+  "requestContext": {
+    "resourceId": "8gffya",
+    "authorizer": {
+      "claims": {
+        "cognito:groups": "Admin",
+        "phone_number_verified": "true",
+        "cognito:username": "normj",
+        "aud": "3mushfc8sgm8uoacvif5vhkt49",
+        "event_id": "75760f58-f984-11e7-8d4a-2389efc50d68",
+        "token_use": "id",
+        "auth_time": "1515973296",
+        "you_are_special": "true"
+      }
+    },
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "requestTime": "14/Jan/2018:23:41:38 +0000",
+    "path": "/Prod/api/mtlstest",
+    "accountId": "626492997873",
+    "protocol": "HTTP/1.1",
+    "stage": "Prod",
+    "requestTimeEpoch": 1515973298687,
+    "requestId": "7713b963-f984-11e7-b02a-f346964d4540",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "sourceIp": "50.35.77.7",
+      "accessKey": null,
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": null,
+      "user": null,
+      "clientCert": {
+        "clientCertPem": "-----BEGIN CERTIFICATE-----\nMIIB3zCCAYWgAwIBAgIUImttQCULqkHxYbDivb1fzRNFYG8wCgYIKoZIzj0EAwIw\nRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGElu\ndGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMDA5MTgxNDQyMzlaFw0yMTA5MTMx\nNDQyMzlaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYD\nVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwWTATBgcqhkjOPQIBBggqhkjO\nPQMBBwNCAARwfxEb6RX+fwiz70spEdLTfK/ite5ZGfysbalM/ZlnUjWZ+Cwk+aEc\nKkER2GWoZ6Fiw3PcOlQzY8dGHMdkkHhGo1MwUTAdBgNVHQ4EFgQUOYFYa+w94G7t\nMGD3bpM3T04WAxswHwYDVR0jBBgwFoAUOYFYa+w94G7tMGD3bpM3T04WAxswDwYD\nVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNIADBFAiEAxX7N6e+2NfuwR70u3AX0\nmx5ZP9uQhdrvOi8qDBHSMMoCIEQenUMtTfYfOU8FwT3WZO4S5JB5jvPg9hCnlXPj\nNwaC\n-----END CERTIFICATE-----"
+      }
+    },
+    "apiId": "zzqupfvhrk"
+  },
+  "body": null,
+  "isBase64Encoded": false
+}

--- a/Libraries/test/TestWebApp/Controllers/MTlsTestController.cs
+++ b/Libraries/test/TestWebApp/Controllers/MTlsTestController.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace TestWebApp.Controllers
+{
+    [Route("api/[controller]")]
+    public class MTlsTestController : Controller
+    {
+        // GET: api/<controller>
+        [HttpGet]
+        public string Get()
+        {
+            return Request.HttpContext.Connection.ClientCertificate.Subject;
+        }
+    }
+}

--- a/Libraries/test/TestWebApp/Controllers/MTlsTestController.cs
+++ b/Libraries/test/TestWebApp/Controllers/MTlsTestController.cs
@@ -9,7 +9,7 @@ namespace TestWebApp.Controllers
         [HttpGet]
         public string Get()
         {
-            return Request.HttpContext.Connection.ClientCertificate.Subject;
+            return Request.HttpContext.Connection.ClientCertificate?.Subject;
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

Fixes #786

*Description of changes:*

- Adds `ItlsConnectionFeature` support to `InvokeFeatures`
- Extracts incoming ClientCertificate pem to an `X509Certificate2` and sets the feature property that then flows through to HttpContext
- Works with `APIGatewayHttpApiV2ProxyRequest` and `APIGatewayProxyRequest`
- Added a test and a specific controller to TestWebApp. Works on netcoreapp2.1 and netcoeapp3.1.
- Non-breaking change.

![image](https://user-images.githubusercontent.com/57436/103167708-caea1a00-482d-11eb-837c-144dc141c2fe.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
