### PR TITLE
LDAP sample using dotnet5 and System.DirectoryServices.Protocols

### DIFF
--- a/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/Dockerfile
+++ b/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/Dockerfile
@@ -1,0 +1,14 @@
+ARG AWS_LAMBDA_VERSION=local
+
+FROM aws-lambda-dotnet:$AWS_LAMBDA_VERSION AS base
+
+FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim as build
+COPY . .
+RUN dotnet build "LDAPSample/LDAPSample.csproj" -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "LDAPSample/LDAPSample.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /var/task
+COPY --from=publish /app/publish .

--- a/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/Function.cs
+++ b/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/Function.cs
@@ -1,0 +1,109 @@
+using System;
+using System.DirectoryServices.Protocols;
+using SearchScope = System.DirectoryServices.Protocols.SearchScope;
+using Amazon.Lambda.Core;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace LDAPSample
+{
+    public class Input
+    {
+        public string directoryName { get; set; }
+        public string userName { get; set; }
+        public string password { get; set; }
+        public string searchString { get; set; }
+        public string baseDN { get; set; }
+        public string searchScope { get; set; }
+    }
+
+    public class Function
+    {
+        /// <summary>
+        /// This function can be used with AWS Directory Services
+        /// or Windows Active Directory for LDAP related operations.
+        /// This lambda must be placed in the same VPC as AWS Directory Services.
+        /// Also, DNS name must be enabled in the DHCP option set of the VPC
+        /// so that the directory can be accessed using directory name.
+        ///
+        /// Example JSON input :
+        /// {
+        ///   "directoryName": "example.com",
+        ///   "userName": "myUser",
+        ///   "password": "XXXXX",
+        ///   "baseDN": "dc=example,dc=com"
+        ///   "searchString" : "(objectClass=*)"
+        ///   "searchScope": "OneLevel" or "searchScope" : "Base" or "searchScope" : "SubTree"
+        ///  }
+        /// </summary>
+        /// <param name="inputJson"></param>
+        /// <param name="context"></param>
+        /// <returns>LDAP response</returns>
+        public string FunctionHandler(Input inputJson, ILambdaContext context)
+        {
+            string log = "***Start of function***\n";
+
+            var credentials =
+                new System.Net.NetworkCredential(inputJson.userName, inputJson.password, inputJson.directoryName);
+            var serverId = new LdapDirectoryIdentifier(inputJson.directoryName);
+
+            var conn = new LdapConnection(serverId, credentials);
+            conn.Bind();
+
+            Console.WriteLine("\r\nPerforming a simple search ...");
+
+            SearchScope searchScope = SearchScope.OneLevel;
+            switch (inputJson.searchScope)
+            {
+                case "Base":
+                    searchScope = SearchScope.Base;
+                    break;
+                case "OneLevel":
+                    searchScope = SearchScope.OneLevel;
+                    break;
+                case "SubTree":
+                    searchScope = SearchScope.Subtree;
+                    break;
+                default:
+                    log = "usage: SearchScope must be Base or OneLevel or SubTree";
+                    return log;
+            }
+
+            Console.WriteLine("search scope is " + searchScope);
+
+            try
+            {
+                SearchRequest searchRequest = new SearchRequest(inputJson.baseDN,
+                    inputJson.searchString,
+                    searchScope,
+                    null);
+
+                // cast the returned directory response as a SearchResponse object
+                SearchResponse searchResponse =
+                    (SearchResponse) conn.SendRequest(searchRequest);
+
+                Console.WriteLine("\r\nSearch Response Entries:{0}",
+                    searchResponse.Entries.Count);
+
+                // enumerate the entries in the search response
+                foreach (SearchResultEntry entry in searchResponse.Entries)
+                {
+                    Console.WriteLine("{0}:{1}",
+                        searchResponse.Entries.IndexOf(entry),
+                        entry.DistinguishedName);
+                    log += searchResponse.Entries.IndexOf(entry) + entry.DistinguishedName + "\n";
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("\nUnexpected exception occured:\n\t{0}: {1}",
+                    e.GetType().Name, e.ToString());
+                log = "Unexpected exception occurred" + e.GetType().Name + " " + e.ToString();
+            }
+
+            return log;
+        }
+    }
+}
+

--- a/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/LDAPSample.csproj
+++ b/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/LDAPSample.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AWSProjectType>Lambda</AWSProjectType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
+    <PackageReference Include="AWSSDK.SecretsManager" Version="3.5.0.56" />
+    <PackageReference Include="System.DirectoryServices" Version="5.0.0" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="5.0.0" />
+  </ItemGroup>
+</Project>

--- a/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/aws-lambda-tools-defaults.json
+++ b/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/aws-lambda-tools-defaults.json
@@ -1,0 +1,18 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+    "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+    "dotnet lambda help",
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+  "profile": "",
+  "region": "",
+  "package-type": "image",
+  "function-name": "LDAPTest",
+  "function-role": "",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "image-command": "LDAPSample::LDAPSample.Function::FunctionHandler",
+  "tag": "awsldapsamplelambdaimage:latest",
+  "dockerfile": "Dockerfile"
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This function can be used with AWS Directory Services or Windows Active Directory for LDAP related operations.
This lambda must be placed in the same VPC as AWS Directory Services. Also, DNS name must be enabled in the DHCP option set of the VPC so that the directory can be accessed using directory name.
    
         Example JSON input :
         {
           "directoryName": "example.com",
           "userName": "myUser",
           "password": "XXXXX",
           "baseDN": "dc=example,dc=com"
           "searchString" : "(objectClass=*)"
           "searchScope": "OneLevel" or "searchScope" : "Base" or "searchScope" : "SubTree"
          }
This is potentially a fix for #341


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
