### PR TITLE
Rework how Lambda Mock Test Tool Blazor version is packaged

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj
@@ -4,35 +4,17 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <Description>A tool to help debug and test your .NET Core 3.1 AWS Lambda functions locally.</Description>
+    <Description>A tool to help debug and test your .NET Core AWS Lambda functions locally.</Description>
     <LangVersion>Latest</LangVersion>
-    <VersionPrefix>0.11.0</VersionPrefix>
+    <VersionPrefix>0.11.1</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
     <NoWarn>1701;1702;1591;1587;3021;NU5100;CS1591</NoWarn>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' or '$(Configuration)' == 'Release' ">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition=" '$(Configuration)' == 'PackNETCoreApp31' ">
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <ToolCommandName>dotnet-lambda-test-tool-3.1</ToolCommandName>
-    <IsPackable>true</IsPackable>
-    <PackAsTool>true</PackAsTool>
-    <PackageId>Amazon.Lambda.TestTool-3.1</PackageId>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition=" '$(Configuration)' == 'PackNET50' ">
-    <TargetFramework>net5.0</TargetFramework>
-    <ToolCommandName>dotnet-lambda-test-tool-5.0</ToolCommandName>
-    <IsPackable>true</IsPackable>
-    <PackAsTool>true</PackAsTool>
-    <PackageId>Amazon.Lambda.TestTool-5.0</PackageId>
+	<TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>  
+
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.0" />

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester31-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester31-pack.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <Import Project="..\..\..\..\buildtools\common.props" />
+  
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Description>A tool to help debug and test your .NET Core 3.1 AWS Lambda functions locally.</Description>
+    <VersionPrefix>0.11.1</VersionPrefix>
+    <Product>AWS .NET Lambda Test Tool</Product>
+    <Copyright>Apache 2</Copyright>
+    <PackageTags>AWS;Amazon;Lambda</PackageTags>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <ToolCommandName>dotnet-lambda-test-tool-3.1</ToolCommandName>	
+    <IsPackable>true</IsPackable>
+    <PackAsTool>true</PackAsTool>
+    <PackageId>Amazon.Lambda.TestTool-3.1</PackageId>
+	<AssemblyName>Amazon.Lambda.TestTool.BlazorTester</AssemblyName>
+	<RootNamespace>Amazon.Lambda.TestTool.BlazorTester</RootNamespace>	
+  </PropertyGroup>
+
+  <ItemGroup>
+	  <ProjectReference Include="..\Amazon.Lambda.TestTool\Amazon.Lambda.TestTool.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="wwwroot\**" />
+  </ItemGroup>
+  
+</Project>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester50-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester50-pack.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <Import Project="..\..\..\..\buildtools\common.props" />
+  
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Description>A tool to help debug and test your .NET Core 5.0 AWS Lambda functions locally.</Description>
+    <VersionPrefix>0.11.1</VersionPrefix>
+    <Product>AWS .NET Lambda Test Tool</Product>
+    <Copyright>Apache 2</Copyright>
+    <PackageTags>AWS;Amazon;Lambda</PackageTags>
+    <TargetFramework>net5.0</TargetFramework>
+    <ToolCommandName>dotnet-lambda-test-tool-5.0</ToolCommandName>	
+    <IsPackable>true</IsPackable>
+    <PackAsTool>true</PackAsTool>
+    <PackageId>Amazon.Lambda.TestTool-5.0</PackageId>
+	<AssemblyName>Amazon.Lambda.TestTool.BlazorTester</AssemblyName>
+	<RootNamespace>Amazon.Lambda.TestTool.BlazorTester</RootNamespace>	
+  </PropertyGroup>
+
+  <ItemGroup>
+	  <ProjectReference Include="..\Amazon.Lambda.TestTool\Amazon.Lambda.TestTool.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="wwwroot\**" />
+  </ItemGroup>
+  
+</Project>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester50-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester50-pack.csproj
@@ -4,7 +4,7 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <Description>A tool to help debug and test your .NET Core 5.0 AWS Lambda functions locally.</Description>
+    <Description>A tool to help debug and test your .NET 5.0 AWS Lambda functions locally.</Description>
     <VersionPrefix>0.11.1</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>

--- a/buildtools/build.proj
+++ b/buildtools/build.proj
@@ -157,18 +157,8 @@
     <Target Name="build-lambda-test-tool-package" DependsOnTargets="init">
         <Exec Command="dotnet msbuild aws-lambda-test-tool-netcore.sln /t:Rebuild /p:Configuration=$(Configuration) /p:AssemblyOriginatorKeyFile=$(AssemblyOriginatorKeyFile) /p:SignAssembly=$(SignAssembly)" WorkingDirectory="..\Tools\LambdaTestTool"/>
         <Exec Command="$(PackCommand)" WorkingDirectory="..\Tools\LambdaTestTool\src\Amazon.Lambda.TestTool.WebTester21"/>
-				
-		<RemoveDir Directories="..\Tools\LambdaTestTool\src\Amazon.Lambda.TestTool.BlazorTester\bin"/>
-		<RemoveDir Directories="..\Tools\LambdaTestTool\src\Amazon.Lambda.TestTool.BlazorTester\obj"/>
-		<Exec Command="dotnet restore" WorkingDirectory="..\Tools\LambdaTestTool\src\Amazon.Lambda.TestTool.BlazorTester"/>
-        <Exec Command="dotnet build /p:Configuration=PackNETCoreApp31 /p:AssemblyOriginatorKeyFile=$(AssemblyOriginatorKeyFile) /p:SignAssembly=$(SignAssembly)" WorkingDirectory="..\Tools\LambdaTestTool\src\Amazon.Lambda.TestTool.BlazorTester"/>
-        <Exec Command="$(PackWithConfigurationCommand) --configuration PackNETCoreApp31" WorkingDirectory="..\Tools\LambdaTestTool\src\Amazon.Lambda.TestTool.BlazorTester"/>
-
-		<RemoveDir Directories="..\Tools\LambdaTestTool\src\Amazon.Lambda.TestTool.BlazorTester\bin"/>
-		<RemoveDir Directories="..\Tools\LambdaTestTool\src\Amazon.Lambda.TestTool.BlazorTester\obj"/>
-		<Exec Command="dotnet restore" WorkingDirectory="..\Tools\LambdaTestTool\src\Amazon.Lambda.TestTool.BlazorTester"/>
-        <Exec Command="dotnet build /p:Configuration=PackNET50 /p:AssemblyOriginatorKeyFile=$(AssemblyOriginatorKeyFile) /p:SignAssembly=$(SignAssembly)" WorkingDirectory="..\Tools\LambdaTestTool\src\Amazon.Lambda.TestTool.BlazorTester"/>
-        <Exec Command="$(PackWithConfigurationCommand) --configuration PackNET50" WorkingDirectory="..\Tools\LambdaTestTool\src\Amazon.Lambda.TestTool.BlazorTester"/>
+        <Exec Command="$(PackCommand) Amazon.Lambda.TestTool.BlazorTester31-pack.csproj" WorkingDirectory="..\Tools\LambdaTestTool\src\Amazon.Lambda.TestTool.BlazorTester"/>
+		<Exec Command="$(PackCommand) Amazon.Lambda.TestTool.BlazorTester50-pack.csproj" WorkingDirectory="..\Tools\LambdaTestTool\src\Amazon.Lambda.TestTool.BlazorTester"/>		
     </Target>
     <Target Name="build-lambda-test-tool-package-cicd" DependsOnTargets="init">
         <Exec Command="dotnet msbuild -restore /p:Configuration=$(Configuration) /p:AssemblyOriginatorKeyFile=$(AssemblyOriginatorKeyFile) /p:SignAssembly=$(SignAssembly)" WorkingDirectory="..\Tools\LambdaTestTool"/>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently the Blazor version of the test tool used for both .NET Core 3.1 and .NET 5.0 is managed through a single csproj file and built with different build configurations. This is works locally but not with our release pipeline which does a build of the solution in one stage and then another stage does the packaging without a build. It is also designed to work with just the Release configuration.

The change is to use the main **Amazon.Lambda.TestTool.BlazorTester.csproj** project file just for building. It will build both the .NET Core 3.1 and .NET 5.0. Then there are separate **Amazon.Lambda.TestTool.BlazorTester31-pack.csproj** and **Amazon.Lambda.TestTool.BlazorTester50-pack.csproj** project files that are not part of the solution and just used for packaging.

The release pipeline will use compile the project in the build stage with the **Amazon.Lambda.TestTool.BlazorTester.csproj** project which is part of the solution. Then in the package stage of the pipeline the new project files will be used like all of the other project files in this repository for other NuGet packaging. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
