### PR TITLE
Add dotnet sample for Active Directory LDAP with Kerberos

### DIFF
--- a/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/Dockerfile
+++ b/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/Dockerfile
@@ -1,0 +1,18 @@
+ARG AWS_LAMBDA_VERSION=local
+
+FROM aws-lambda-dotnet:$AWS_LAMBDA_VERSION AS base
+RUN yum install -y krb5-workstation krb5-libs krb5-auth-dialog git gcc lib cyrus-sasl cyrus-sasl-gssapi make cyrus-sasl-devel cyrus-sasl-lib awscli
+
+# Compiling for now, since there seems to be an issue with the yum installed sasl and ldap
+RUN git clone https://github.com/openldap/openldap.git && cd openldap && ./configure --with-sasl && make install && yum erase git gcc --assumeyes
+
+FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim as build
+COPY . .
+RUN dotnet build "LDAPSample/LDAPSample.csproj" -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "LDAPSample/LDAPSample.csproj" -c Release -o /app/publish
+COPY LDAPSample/ldap_using_kerberos.sh /app/publish
+FROM base AS final
+WORKDIR /var/task
+COPY --from=publish /app/publish .

--- a/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/Function.cs
+++ b/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/Function.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Diagnostics;
+using Amazon.Lambda.Core;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace LDAPSample
+{
+    public class Input
+    {
+        public string directoryName { get; set; }
+        public string userName { get; set; }
+        public string baseDN { get; set; }
+        public string filter { get; set; }
+        public string keytabFileS3Url { get; set; }
+    }
+
+    public class Function
+    {
+        /// <summary>
+        /// This function can be used with AWS Directory Services
+        /// or Windows Active Directory for LDAP related operations.
+        /// This lambda must be placed in the same VPC as AWS Directory Services.
+        /// Also, DNS name must be enabled in the DHCP option set of the VPC
+        /// so that the directory can be accessed using directory name.
+        /// Also, add S3 endpoint as per https://aws.amazon.com/blogs/aws/new-vpc-endpoint-for-amazon-s3/.
+        ///
+        ///  Example JSON input :
+        ///  {
+        ///    "directoryName": "XXX.YYY.com",
+        ///    "userName": "USER",
+        ///    "baseDN": "DC=XXX,DC=YYY,DC=com",
+        ///    "keytabFileS3Url": "s3://KEYTABLOCATION/my.keytab",
+        ///    "filter": "(objectClass=*)"
+        ///  }
+        /// </summary>
+        /// <param name="inputJson"></param>
+        /// <param name="context"></param>
+        /// <returns>LDAP response</returns>
+        public string FunctionHandler(Input inputJson, ILambdaContext context)
+        {
+            string log = "***Start of function***\n";
+
+            using (Process compiler = new Process())
+            {
+                compiler.StartInfo.FileName = "ldap_using_kerberos.sh";
+                compiler.StartInfo.Arguments = "--directory-name " + inputJson.directoryName + " --user-name " + inputJson.userName + " --base-dn " + inputJson.baseDN + " --keytab-file-s3-url " + inputJson.keytabFileS3Url + " --filter " + inputJson.filter;
+                compiler.StartInfo.UseShellExecute = false;
+                compiler.StartInfo.RedirectStandardOutput = true;
+                compiler.Start();
+
+                var output = compiler.StandardOutput.ReadToEnd();
+                Console.WriteLine(output);
+                log += output;
+
+                compiler.WaitForExit();
+            }
+
+            return log;
+        }
+    }
+}
+

--- a/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/LDAPSample.csproj
+++ b/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/LDAPSample.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AWSProjectType>Lambda</AWSProjectType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
+  </ItemGroup>
+</Project>

--- a/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/aws-lambda-tools-defaults.json
+++ b/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/aws-lambda-tools-defaults.json
@@ -1,0 +1,18 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+    "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+    "dotnet lambda help",
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+  "profile": "",
+  "region": "",
+  "package-type": "image",
+  "function-name": "LDAPKerberosTest",
+  "function-role": "",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "image-command": "LDAPSample::LDAPSample.Function::FunctionHandler",
+  "tag": "awsldapkerberossamplelambdaimage:latest",
+  "dockerfile": "Dockerfile"
+}

--- a/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/ldap_using_kerberos.sh
+++ b/LambdaRuntimeDockerfiles/dotnet5/ActiveDirectoryLDAPSample/LDAPSample/ldap_using_kerberos.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+for i in "$@"; do
+    case "$i" in
+        --directory-name)
+            shift
+            DIRECTORY_NAME="$1"
+            continue
+            ;;
+        --user-name)
+            shift;
+            USER_NAME="$1"
+            continue
+            ;;
+        --base-dn)
+            shift;
+            BASE_DN="$1"
+            continue
+            ;;
+        --keytab-file-s3-url)
+            shift;
+            KEYTAB_FILE_S3_URL="$1"
+            continue
+            ;;
+        --filter)
+            shift;
+            FILTER="$1"
+            continue
+            ;;
+    esac
+    shift
+done
+
+export KRB5CCNAME=/tmp/krb5cc
+export PATH=./:$PATH
+export LD_LIBRARY_PATH=./:$LD_LIBRARY_PATH
+REALM=$(echo "$DIRECTORY_NAME" | tr [a-z] [A-Z])
+
+# Add endpoint as per https://aws.amazon.com/blogs/aws/new-vpc-endpoint-for-amazon-s3/
+KEYTAB_FILENAME=$(basename ${KEYTAB_FILE_S3_URL})
+for i in seq 3; do
+    aws s3 cp ${KEYTAB_FILE_S3_URL} /tmp/${KEYTAB_FILENAME} 2>&1 > /dev/null
+    STATUS=$?
+    if [ $? -eq 0 ]; then
+       break
+    fi
+    sleep 5
+done
+if [ $STATUS -ne 0 ]; then
+   echo "**ERROR** AWS S3 cp failed"
+   exit 1
+fi
+
+for i in seq 5; do
+  RETURN_VALUE=$(kinit ${USER_NAME}@${REALM} -kt /tmp/${KEYTAB_FILENAME} 2>&1 | tr -d '\n')
+  if ! echo ${RETURN_VALUE} | grep -i error; then
+     /var/task/openldap/clients/tools/ldapsearch -H ldap://${DIRECTORY_NAME} -b ${BASE_DN} -Y GSSAPI ${FILTER}
+     kdestroy -Aq
+     exit 0
+  fi
+  sleep 20
+done
+
+exit 1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This function can be used with AWS Directory Services or Windows Active Directory for LDAP related operations.
LDAP authentication done using a keytab file and a username.
This lambda must be placed in the same VPC as AWS Directory Services.
Also, DNS name must be enabled in the DHCP option set of the VPC so that the directory can be accessed using directory name. Also, add S3 endpoint as per https://aws.amazon.com/blogs/aws/new-vpc-endpoint-for-amazon-s3/

     Example JSON input :
             {
               "directoryName": "XXX.YYY.com",
               "userName": "USER",
               "baseDN": "DC=XXX,DC=YYY,DC=com",
               "keytabFileS3Url": "s3://KEYTABLOCATION/my.keytab",
                "filter": "(objectClass=*)"
            }

This is potentially a fix for #341

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
