### PR TITLE
Fixes image reference in sample code in Readme for lambda image templates

### DIFF
--- a/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -44,7 +44,7 @@ Alternatively the Docker file could be written to use [multi-stage](https://docs
 have the .NET project built inside the container. Below is an example of building .NET 5 project inside the image.
 
 ```dockerfile
-FROM ecr.aws/lambda/dotnet:5.0 AS base
+FROM public.ecr.aws/lambda/dotnet:5.0 AS base
 
 FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim as build
 WORKDIR /src

--- a/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/Readme.md
@@ -51,7 +51,7 @@ Alternatively the Docker file could be written to use [multi-stage](https://docs
 have the .NET project built inside the container. Below is an example of building .NET 5 project inside the image.
 
 ```dockerfile
-FROM ecr.aws/lambda/dotnet:5.0 AS base
+FROM public.ecr.aws/lambda/dotnet:5.0 AS base
 
 FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim as build
 WORKDIR /src

--- a/Blueprints/BlueprintDefinitions/netcore3.1/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -22,7 +22,7 @@ Alternatively the Docker file could be written to use [multi-stage](https://docs
 have the .NET project built inside the container. Below is an example of building .NET 5 project inside the image.
 
 ```dockerfile
-FROM ecr.aws/lambda/dotnet:5.0 AS base
+FROM public.ecr.aws/lambda/dotnet:5.0 AS base
 
 FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim as build
 WORKDIR /src

--- a/Blueprints/BlueprintDefinitions/netcore3.1/EmptyFunction-Image/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/EmptyFunction-Image/template/src/BlueprintBaseName.1/Readme.md
@@ -22,7 +22,7 @@ Alternatively the Docker file could be written to use [multi-stage](https://docs
 have the .NET project built inside the container. Below is an example of building .NET 5 project inside the image.
 
 ```dockerfile
-FROM ecr.aws/lambda/dotnet:5.0 AS base
+FROM public.ecr.aws/lambda/dotnet:5.0 AS base
 
 FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim as build
 WORKDIR /src

--- a/Blueprints/BlueprintDefinitions/netcore3.1/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -24,7 +24,7 @@ Alternatively the Docker file could be written to use [multi-stage](https://docs
 have the .NET project built inside the container. Below is an example of building .NET 5 project inside the image.
 
 ```dockerfile
-FROM ecr.aws/lambda/dotnet:5.0 AS base
+FROM public.ecr.aws/lambda/dotnet:5.0 AS base
 
 FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim as build
 WORKDIR /src

--- a/Blueprints/BlueprintDefinitions/netcore3.1/EmptyServerless-Image/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/EmptyServerless-Image/template/src/BlueprintBaseName.1/Readme.md
@@ -24,7 +24,7 @@ Alternatively the Docker file could be written to use [multi-stage](https://docs
 have the .NET project built inside the container. Below is an example of building .NET 5 project inside the image.
 
 ```dockerfile
-FROM ecr.aws/lambda/dotnet:5.0 AS base
+FROM public.ecr.aws/lambda/dotnet:5.0 AS base
 
 FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim as build
 WORKDIR /src


### PR DESCRIPTION
*Description of changes:*
This is just a readme fix of the sample code for multi-stage docker builds in the blueprints for lambda images.

Caused me 5 minutes of puzzlement as my first experience with public ecr repos so hopefully we can spare others that. :)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
