### PR TITLE
Usages of AWSLambdaFullAccess changed to AWSLambda_FullAccess 

### DIFF
--- a/Blueprints/BlueprintDefinitions/netcore2.1/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/serverless.template
@@ -14,7 +14,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess"
+          "AWSLambda_FullAccess"
         ],
         "Environment": {
           "Variables": {}

--- a/Blueprints/BlueprintDefinitions/netcore2.1/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/serverless.template
@@ -46,7 +46,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess"
+          "AWSLambda_FullAccess"
         ],
         "Environment": {
           "Variables": {

--- a/Blueprints/BlueprintDefinitions/netcore2.1/AspNetCoreWebApp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/AspNetCoreWebApp/template/src/BlueprintBaseName.1/serverless.template
@@ -15,7 +15,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess"
+          "AWSLambda_FullAccess"
         ],
         "Environment": {
           "Variables": {}

--- a/Blueprints/BlueprintDefinitions/netcore2.1/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/serverless.template
@@ -47,7 +47,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess",
+          "AWSLambda_FullAccess",
           "AmazonRekognitionReadOnlyAccess"
         ],
         "Events": {

--- a/Blueprints/BlueprintDefinitions/netcore2.1/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/serverless.template
@@ -47,7 +47,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess",
+          "AWSLambda_FullAccess",
           "AmazonRekognitionReadOnlyAccess"
         ],
         "Events": {

--- a/Blueprints/BlueprintDefinitions/netcore2.1/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/serverless.template
@@ -59,7 +59,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess"
+          "AWSLambda_FullAccess"
         ],
         "Environment": {
           "Variables": {
@@ -98,7 +98,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess"
+          "AWSLambda_FullAccess"
         ],
         "Environment": {
           "Variables": {
@@ -137,7 +137,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess"
+          "AWSLambda_FullAccess"
         ],
         "Environment": {
           "Variables": {
@@ -176,7 +176,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess"
+          "AWSLambda_FullAccess"
         ],
         "Environment": {
           "Variables": {

--- a/Blueprints/BlueprintDefinitions/netcore2.1/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/serverless.template
@@ -15,7 +15,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess"
+          "AWSLambda_FullAccess"
         ],
         "Environment": {
           "Variables": {}

--- a/Blueprints/BlueprintDefinitions/netcore2.1/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/serverless.template
@@ -47,7 +47,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess",
+          "AWSLambda_FullAccess",
           "AmazonRekognitionReadOnlyAccess"
         ],
         "Events": {

--- a/Blueprints/BlueprintDefinitions/netcore2.1/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/serverless.template
@@ -47,7 +47,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess",
+          "AWSLambda_FullAccess",
           "AmazonRekognitionReadOnlyAccess"
         ],
         "Events": {

--- a/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/serverless.template
@@ -14,7 +14,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess"
+          "AWSLambda_FullAccess"
         ],
         "Environment": {
           "Variables": {}

--- a/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/serverless.template
@@ -21,7 +21,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess"
+          "AWSLambda_FullAccess"
         ],
         "Environment": {
           "Variables": {}

--- a/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/serverless.template
@@ -22,7 +22,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess"
+          "AWSLambda_FullAccess"
         ],
         "Events": {
           "ProxyResource": {

--- a/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/serverless.template
@@ -15,7 +15,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess"
+          "AWSLambda_FullAccess"
         ],
         "Events": {
           "ProxyResource": {

--- a/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebApp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/AspNetCoreWebApp/template/src/BlueprintBaseName.1/serverless.template
@@ -15,7 +15,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess"
+          "AWSLambda_FullAccess"
         ],
         "Environment": {
           "Variables": {}

--- a/Blueprints/BlueprintDefinitions/netcore3.1/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/serverless.template
@@ -47,7 +47,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess",
+          "AWSLambda_FullAccess",
           "AmazonRekognitionReadOnlyAccess"
         ],
         "Events": {

--- a/Blueprints/BlueprintDefinitions/netcore3.1/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/serverless.template
@@ -47,7 +47,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess",
+          "AWSLambda_FullAccess",
           "AmazonRekognitionReadOnlyAccess"
         ],
         "Events": {

--- a/Blueprints/BlueprintDefinitions/netcore3.1/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/serverless.template
@@ -59,7 +59,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess"
+          "AWSLambda_FullAccess"
         ],
         "Environment": {
           "Variables": {
@@ -98,7 +98,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess"
+          "AWSLambda_FullAccess"
         ],
         "Environment": {
           "Variables": {
@@ -137,7 +137,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess"
+          "AWSLambda_FullAccess"
         ],
         "Environment": {
           "Variables": {
@@ -176,7 +176,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess"
+          "AWSLambda_FullAccess"
         ],
         "Environment": {
           "Variables": {

--- a/Blueprints/BlueprintDefinitions/netcore3.1/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/serverless.template
@@ -15,7 +15,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess"
+          "AWSLambda_FullAccess"
         ],
         "Environment": {
           "Variables": {}

--- a/Blueprints/BlueprintDefinitions/netcore3.1/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/serverless.template
@@ -47,7 +47,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess",
+          "AWSLambda_FullAccess",
           "AmazonRekognitionReadOnlyAccess"
         ],
         "Events": {

--- a/Blueprints/BlueprintDefinitions/netcore3.1/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/serverless.template
@@ -47,7 +47,7 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambdaFullAccess",
+          "AWSLambda_FullAccess",
           "AmazonRekognitionReadOnlyAccess"
         ],
         "Events": {

--- a/Libraries/test/TestWebApp/serverless.template
+++ b/Libraries/test/TestWebApp/serverless.template
@@ -15,7 +15,7 @@
         "MemorySize": 256,
         "Timeout": 30,
         "Role": null,
-        "Policies": [ "AWSLambdaFullAccess" ],
+        "Policies": [ "AWSLambda_FullAccess" ],
         "Events": {
           "PutResource": {
             "Type": "Api",

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore21/ServerlessTemplateExample/serverless.template
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore21/ServerlessTemplateExample/serverless.template
@@ -18,7 +18,7 @@
         "MemorySize": 256,
         "Timeout": 30,
         "Role": null,
-        "Policies": [ "AWSLambdaFullAccess" ],
+        "Policies": [ "AWSLambda_FullAccess" ],
         "Environment" : {
         },
         "Events": {
@@ -39,7 +39,7 @@
         "Timeout":30,
         "Role":null,
         "Policies":[ 
-            "AWSLambdaFullAccess"
+            "AWSLambda_FullAccess"
         ],
         "Environment":{ 
 

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/ServerlessTemplateExample/serverless.template
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/ServerlessTemplateExample/serverless.template
@@ -17,7 +17,7 @@
             "Timeout":30,
             "Role":null,
             "Policies":[ 
-               "AWSLambdaFullAccess"
+               "AWSLambda_FullAccess"
             ],
             "Environment":{ 
 
@@ -40,7 +40,7 @@
             "Timeout":30,
             "Role":null,
             "Policies":[ 
-               "AWSLambdaFullAccess"
+               "AWSLambda_FullAccess"
             ],
             "Environment":{ 
 


### PR DESCRIPTION
*Description of changes:*
Lambda is deprecating the **AWSLambdaFullAccess** managed policies. It is being replaced with a new version called **AWSLambda_FullAccess**.

This PR updates all of the usages of **AWSLambdaFullAccess** to the new version which is mostly the blueprints as well as some test files.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
