### PR TITLE
fixes Lambdas to Lambda functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For a history of releases view the [release change log](RELEASE.CHANGELOG.md)
 
 
 ## NuGet Packages
-This repo contains a number of different tools and libraries to support development of Lambdas using .NET. These packages have individual README docs outlining specific information for that particular package. These packages are cataloged here.
+This repo contains a number of different tools and libraries to support development of Lambda functions using .NET. These packages have individual README docs outlining specific information for that particular package. These packages are cataloged here.
 
 ### Events
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Lambdas is the improper branding of Lambda functions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
I am munns@amazon.com, lead of Developer Advocacy for Serverless services at AWS.