### PR TITLE
Add Termination Protection flag to CDK Stack

### DIFF
--- a/LambdaRuntimeDockerfiles/dotnet5/Infrastructure/src/Infrastructure/Program.cs
+++ b/LambdaRuntimeDockerfiles/dotnet5/Infrastructure/src/Infrastructure/Program.cs
@@ -29,7 +29,10 @@ namespace Infrastructure
         {
             var configuration = new Configuration();
             var app = new App();
-            new PipelineStack(app, Configuration.ProjectName, configuration);
+            new PipelineStack(app, Configuration.ProjectName, configuration, new StackProps 
+            { 
+                TerminationProtection = true
+            });
             app.Synth();
         }
     }


### PR DESCRIPTION
*Issue #, if available:*
https://t.corp.amazon.com/V319283415

*Description of changes:*
Add Termination Protection flag to Stack to fix Missing CloudFormation termination protection risk from aws-dotnet-devex-devops@amazon.com

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
