### PR TITLE
Set DOTNET_VERSION to ASPNET_VERSION instead of empty

### DIFF
--- a/LambdaRuntimeDockerfiles/dotnet5/Dockerfile
+++ b/LambdaRuntimeDockerfiles/dotnet5/Dockerfile
@@ -54,9 +54,9 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
 
 
 FROM base as final
-ARG DOTNET_VERSION
+ARG ASPNET_VERSION
 
-ENV DOTNET_VERSION $DOTNET_VERSION
+ENV DOTNET_VERSION $ASPNET_VERSION
 
 COPY --from=builder-net5 ["/dotnet", "/var/lang/bin"]
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Set DOTNET_VERSION to ASPNET_VERSION instead of empty

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
