### PR TITLE
Fix for when the certificate PEM string contains a trailing new line ('\n').

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/Utilities.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/Utilities.cs
@@ -267,6 +267,7 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
 
         internal static X509Certificate2 GetX509Certificate2FromPem(string clientCertPem)
         {
+            clientCertPem = clientCertPem.TrimEnd('\n');
             if (!clientCertPem.StartsWith("-----BEGIN CERTIFICATE-----") || !clientCertPem.EndsWith("-----END CERTIFICATE-----"))
             {
                 throw new InvalidOperationException(

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
@@ -302,6 +302,14 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
         }
 
         [Fact]
+        public async Task TestAuthMTlsWithTrailingNewLine()
+        {
+            var response = await this.InvokeAPIGatewayRequest("mtls-request-trailing-newline.json");
+            Assert.Equal(200, response.StatusCode);
+            Assert.Equal("O=Internet Widgits Pty Ltd, S=Some-State, C=AU", response.Body);
+        }
+
+        [Fact]
         public async Task TestAuthTestAccess_CustomLambdaAuthorizerClaims()
         {
             var response =

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/mtls-request-trailing-newline.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/mtls-request-trailing-newline.json
@@ -1,0 +1,69 @@
+﻿{
+  "resource": "/{proxy+}",
+  "path": "/api/mtlstest",
+  "httpMethod": "GET",
+  "headers": {
+    "Authorization": "eyJraWQiOiJLdXprWCtcL0E4MWlVZGU5QSt2SFBMdzZCTUFmQzVqUGJ1NTZiT0VGNXdkaz0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiI4ZWYzZTQ1NS0zODY5LTQwMmUtYWM5ZS1mODhlODZjMzIwYjMiLCJjb2duaXRvOmdyb3VwcyI6WyJBZG1pbiJdLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiaXNzIjoiaHR0cHM6XC9cL2NvZ25pdG8taWRwLnVzLXdlc3QtMi5hbWF6b25hd3MuY29tXC91cy13ZXN0LTJfUExpM2NmMHUwIiwicGhvbmVfbnVtYmVyX3ZlcmlmaWVkIjp0cnVlLCJjb2duaXRvOnVzZXJuYW1lIjoibm9ybWoiLCJhdWQiOiIzbXVzaGZjOHNnbTh1b2FjdmlmNXZoa3Q0OSIsImV2ZW50X2lkIjoiNzU3NjBmNTgtZjk4NC0xMWU3LThkNGEtMjM4OWVmYzUwZDY4IiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1MTU5NzMyOTYsInBob25lX251bWJlciI6IisxNDI1NzM2NzM0OSIsImV4cCI6MTUxNTk3Njg5NiwiaWF0IjoxNTE1OTczMjk2LCJlbWFpbCI6ImpvaGFuc28yQGdtYWlsLmNvbSJ9.v1zIeTutUMzgXGoQy5dpOXUW6km9Ye-X-iLehgn1fO4HeJPZ9rOY9jDRMyRjyF5I57sAsN1v9uB3f98gEdStzO4qpASlYK7F7CtcenJ2lZYNU4gJPDQqEDdoMvE5Nir89RL09PYFceKaZw2Qr53VTLBfwaNGJYeSYeiZN09RL6fXwciH5h15rGwgNpl3kvzZOTLCqHNv3J7Y5POr8BjT2DvqUVJv7X1M5pOzHxWIqtBfAfyhEzZftIDqNKsI_aKZolkRd_UI77dSMNuZokJSAKlEuXc6fNJ556R3xSAhEli5DeZUIMdQLQVB7pIQzRlXvt2M0MMK-uC2d7_kUWAkVg",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "zzqupfvhrk.execute-api.us-west-2.amazonaws.com",
+    "Via": "1.1 ca79756ec49e2babf1b916300304b2fb.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "3OhHlF5fim8xxjG1-RZEFK4nos0t-JtPu6vvpNkUg9NOcl-Os53gBg==",
+    "X-Amzn-Trace-Id": "Root=1-5a5beab2-7cd6a52c614f43910ab9be30",
+    "X-Forwarded-For": "50.35.77.7, 52.46.17.45",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "queryStringParameters": null,
+  "pathParameters": {
+    "proxy": "api/mtlstest"
+  },
+  "stageVariables": null,
+  "requestContext": {
+    "resourceId": "8gffya",
+    "authorizer": {
+      "claims": {
+        "cognito:groups": "Admin",
+        "phone_number_verified": "true",
+        "cognito:username": "normj",
+        "aud": "3mushfc8sgm8uoacvif5vhkt49",
+        "event_id": "75760f58-f984-11e7-8d4a-2389efc50d68",
+        "token_use": "id",
+        "auth_time": "1515973296",
+        "you_are_special": "true"
+      }
+    },
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "requestTime": "14/Jan/2018:23:41:38 +0000",
+    "path": "/Prod/api/mtlstest",
+    "accountId": "626492997873",
+    "protocol": "HTTP/1.1",
+    "stage": "Prod",
+    "requestTimeEpoch": 1515973298687,
+    "requestId": "7713b963-f984-11e7-b02a-f346964d4540",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "sourceIp": "50.35.77.7",
+      "accessKey": null,
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": null,
+      "user": null,
+      "clientCert": {
+        "clientCertPem": "-----BEGIN CERTIFICATE-----\nMIIB3zCCAYWgAwIBAgIUImttQCULqkHxYbDivb1fzRNFYG8wCgYIKoZIzj0EAwIw\nRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGElu\ndGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMDA5MTgxNDQyMzlaFw0yMTA5MTMx\nNDQyMzlaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYD\nVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwWTATBgcqhkjOPQIBBggqhkjO\nPQMBBwNCAARwfxEb6RX+fwiz70spEdLTfK/ite5ZGfysbalM/ZlnUjWZ+Cwk+aEc\nKkER2GWoZ6Fiw3PcOlQzY8dGHMdkkHhGo1MwUTAdBgNVHQ4EFgQUOYFYa+w94G7t\nMGD3bpM3T04WAxswHwYDVR0jBBgwFoAUOYFYa+w94G7tMGD3bpM3T04WAxswDwYD\nVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNIADBFAiEAxX7N6e+2NfuwR70u3AX0\nmx5ZP9uQhdrvOi8qDBHSMMoCIEQenUMtTfYfOU8FwT3WZO4S5JB5jvPg9hCnlXPj\nNwaC\n-----END CERTIFICATE-----\n"
+      }
+    },
+    "apiId": "zzqupfvhrk"
+  },
+  "body": null,
+  "isBase64Encoded": false
+}


### PR DESCRIPTION
Fixes #814

*Description of changes:*

- Trims trailing `/n` from a certificate pem string coming from APIGW.
- Added a corresponding test.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
