### PR TITLE
Add the AmazonS3ReadOnlyAccess required policy

### DIFF
--- a/Blueprints/BlueprintDefinitions/netcore3.1/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/serverless.template
@@ -48,7 +48,8 @@
         "Role": null,
         "Policies": [
           "AWSLambda_FullAccess",
-          "AmazonRekognitionReadOnlyAccess"
+          "AmazonRekognitionReadOnlyAccess",
+          "AmazonS3ReadOnlyAccess"
         ],
         "Events": {
           "NewImagesBucket": {


### PR DESCRIPTION
*Description of changes:*

Add the AmazonS3ReadOnlyAccess required policy in the _serverless.template_ file so that the function can access the S3 bucket. Without this policy the `this.S3Client.GetObjectMetadataAsync(s3Event.Bucket.Name, s3Event.Object.Key);` call gets a permission denied error.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
