### PR TITLE
fix: simulate lambda behavior for empty payload

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaExecutor.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaExecutor.cs
@@ -194,9 +194,10 @@ namespace Amazon.Lambda.TestTool.Runtime
                 {
                     parmValues[i] = context;
                 }
-                else if(request.Payload != null)
+                else
                 {
-                    var stream = new MemoryStream(Encoding.UTF8.GetBytes(request.Payload));
+                    var bytes = Encoding.UTF8.GetBytes((request.Payload != null) ? request.Payload : "{}");
+                    var stream = new MemoryStream(bytes);
                     if (request.Function.Serializer != null)
                     {
                         var genericMethodInfo = request.Function.Serializer.GetType()

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/InvokeFunctionTests.cs
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/InvokeFunctionTests.cs
@@ -87,6 +87,18 @@ namespace Amazon.Lambda.TestTool.Tests
         }
 
         [Fact]
+        public async Task WithEventParameterTest()
+        {
+
+            var response = await ExecuteFunctionAsync(
+                "FunctionSignatureExamples::FunctionSignatureExamples.InstanceMethods::WithEventParameter",
+                null);
+
+            Assert.True(response.IsSuccess);
+            Assert.Equal("\"WithEventParameter-event-not-null\"", response.Response);
+        }
+
+        [Fact]
         public async Task TaskWithNoResultTest()
         {
             var payload = "\"TestData\"";

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore21/FunctionSignatureExamples/FunctionSignatureExamples.csproj
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore21/FunctionSignatureExamples/FunctionSignatureExamples.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="1.0.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.1.0" />
+	<PackageReference Include="Amazon.Lambda.S3Events" Version="1.0.2" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Amazon.Lambda.Tools" Version="2.1.3" />

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore21/FunctionSignatureExamples/InstanceMethods.cs
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore21/FunctionSignatureExamples/InstanceMethods.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
+using Amazon.Lambda.S3Events;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
 [assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
@@ -43,6 +44,12 @@ namespace FunctionSignatureExamples
         {
             context.Logger.LogLine("Calling WithGenericParameter");
             return string.Join(',', values.ToArray());
+        }
+
+        public string WithEventParameter(S3Event evnt, ILambdaContext context)
+        {
+            context.Logger.LogLine("Calling WithEventParameter");
+            return "WithEventParameter-" + ((evnt != null) ? "event-not-null" : "event-null");
         }
     }
 }

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/FunctionSignatureExamples/FunctionSignatureExamples.csproj
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/FunctionSignatureExamples/FunctionSignatureExamples.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="1.0.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.1.0" />
+	<PackageReference Include="Amazon.Lambda.S3Events" Version="1.0.2" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Amazon.Lambda.Tools" Version="2.1.3" />

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/FunctionSignatureExamples/InstanceMethods.cs
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/FunctionSignatureExamples/InstanceMethods.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
+using Amazon.Lambda.S3Events;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
 [assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
@@ -43,6 +44,12 @@ namespace FunctionSignatureExamples
         {
             context.Logger.LogLine("Calling WithGenericParameter");
             return string.Join(',', values.ToArray());
+        }
+
+        public string WithEventParameter(S3Event evnt, ILambdaContext context)
+        {
+            context.Logger.LogLine("Calling WithEventParameter");
+            return "WithEventParameter-" + ((evnt != null) ? "event-not-null" : "event-null");
         }
     }
 }


### PR DESCRIPTION
When you invoke a function with no payload the Lambda service passes `{}` (an empty json object) to your handler input parameter.  The LambdaTestTool currently sends a null parameter not matching the way the service works.

For example, the function below is configured with `DefaultLambdaJsonSerializer`.  If you invoke with an empty payload in the LambdaTestTool the input parameter is null. Doing the the same in the Lambda service the input parameter is `{}` deserialized, which gives you an instance of `APIGatewayProxyRequest` with none of the properties set.

`public async Task<APIGatewayProxyResponse> FunctionHandler(APIGatewayProxyRequest input, ILambdaContext context)`

*Description of changes:*

* `LambdaExecutor.cs` - BuildParameters now passes `{}` for an empty payload
* `InvokeFunctionTests.cs` - WithEventParameterTest tests a method that takes an `S3Event` with an empty payload
* `FunctionSignatureExamples.csproj` - added reference to `Amazon.Lambda.S3Events`
* `InstanceMethods.cs` - added method that take an `S3Event`

