### PR TITLE
Fix issue with Lambda test tool with services in the IServiceCollection not resolving.

### DIFF
--- a/Tools/LambdaTestTool/aws-lambda-test-tool-netcore.sln
+++ b/Tools/LambdaTestTool/aws-lambda-test-tool-netcore.sln
@@ -54,6 +54,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCoreAPIExample", "tests\LambdaFunctions\netcore31\AspNetCoreAPIExample\AspNetCoreAPIExample.csproj", "{5E1FF56C-9691-45B4-A961-24950A2C106C}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		tests\Amazon.Lambda.TestTool.Tests.Shared\Amazon.Lambda.TestTool.Tests.Shared.projitems*{594ee68c-10c0-4a19-9b61-377d0ab2f5ed}*SharedItemsImports = 5
@@ -133,6 +135,10 @@ Global
 		{E57ABB02-E8FC-4011-95D3-E9CB9412EDCB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E57ABB02-E8FC-4011-95D3-E9CB9412EDCB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E57ABB02-E8FC-4011-95D3-E9CB9412EDCB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5E1FF56C-9691-45B4-A961-24950A2C106C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5E1FF56C-9691-45B4-A961-24950A2C106C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5E1FF56C-9691-45B4-A961-24950A2C106C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5E1FF56C-9691-45B4-A961-24950A2C106C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -159,6 +165,7 @@ Global
 		{70AFF681-844A-428C-ABA2-7053E61D39C8} = {28C935E3-4FB4-4B09-A9DB-26A1EB04CDE0}
 		{594EE68C-10C0-4A19-9B61-377D0AB2F5ED} = {28C935E3-4FB4-4B09-A9DB-26A1EB04CDE0}
 		{E57ABB02-E8FC-4011-95D3-E9CB9412EDCB} = {28C935E3-4FB4-4B09-A9DB-26A1EB04CDE0}
+		{5E1FF56C-9691-45B4-A961-24950A2C106C} = {0B078893-2F43-4C0C-88FE-98D0839ED7A9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E6C77567-6F16-4EE3-8743-ADE6B68434FD}

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/Amazon.Lambda.TestTool.Tests.Shared.projitems
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/Amazon.Lambda.TestTool.Tests.Shared.projitems
@@ -20,4 +20,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)SampleRequestTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestUtils.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="$(MSBuildThisFileDirectory)call-valuescontroller-request.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/InvokeFunctionTests.cs
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/InvokeFunctionTests.cs
@@ -146,9 +146,28 @@ namespace Amazon.Lambda.TestTool.Tests
             Assert.NotNull(response.Error);
         }
 
+#if NETCORE_3_1
+        [Fact]
+        public async Task CallValuesControllerInAspNetCoreApp()
+        {
+            var payload = File.ReadAllText("call-valuescontroller-request.txt");
+            var response = await ExecuteFunctionAsync("AspNetCoreAPIExample",
+                "AspNetCoreAPIExample::AspNetCoreAPIExample.LambdaEntryPoint::FunctionHandlerAsync",
+                payload);
+
+            Assert.True(response.IsSuccess);
+            Assert.Contains("value1", response.Response);
+        }
+#endif
+
         private async Task<ExecutionResponse> ExecuteFunctionAsync(string handler, string payload)
         {
-            var buildPath = TestUtils.GetLambdaFunctionBuildPath("FunctionSignatureExamples");
+            return await ExecuteFunctionAsync("FunctionSignatureExamples", handler, payload);
+        }
+
+        private async Task<ExecutionResponse> ExecuteFunctionAsync(string projectName, string handler, string payload)
+        {
+            var buildPath = TestUtils.GetLambdaFunctionBuildPath(projectName);
 
             var runtime = LocalLambdaRuntime.Initialize(buildPath);
             var configInfo = new LambdaFunctionInfo
@@ -165,8 +184,8 @@ namespace Amazon.Lambda.TestTool.Tests
                 Function = function,
                 AWSRegion = "us-west-2",
                 Payload = payload
-            }; 
-            
+            };
+
             var response = await runtime.ExecuteLambdaFunctionAsync(request);
             return response;
         }

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/call-valuescontroller-request.txt
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/call-valuescontroller-request.txt
@@ -1,0 +1,57 @@
+{
+  "body": "{\"test\":\"body\"}",
+  "resource": "/{proxy+}",
+  "path": "/api/values",
+  "httpMethod": "GET",
+  "queryStringParameters": {
+    "foo": "bar"
+  },
+  "pathParameters": {
+    "proxy": "api/values"
+  },
+  "stageVariables": {
+    "baz": "qux"
+  },
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, sdch",
+    "Accept-Language": "en-US,en;q=0.8",
+    "Cache-Control": "max-age=0",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "1234567890.execute-api.{dns_suffix}",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Custom User Agent String",
+    "Via": "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==",
+    "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "123456",
+    "stage": "prod",
+    "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "apiKey": null,
+      "sourceIp": "127.0.0.1",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Custom User Agent String",
+      "user": null
+    },
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "apiId": "1234567890"
+  }
+}

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/AspNetCoreAPIExample.csproj
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/AspNetCoreAPIExample.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AWSProjectType>Lambda</AWSProjectType>
+    <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="5.3.0" />
+  </ItemGroup>
+</Project>

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/Controllers/ValuesController.cs
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/Controllers/ValuesController.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AspNetCoreAPIExample.Controllers
+{
+    [Route("api/[controller]")]
+    public class ValuesController : ControllerBase
+    {
+        IFakeDependency _fakeDependency;
+
+        public ValuesController(IFakeDependency fakeDependency)
+        {
+            _fakeDependency = fakeDependency;
+        }
+
+        // GET api/values
+        [HttpGet]
+        public IEnumerable<string> Get()
+        {
+            return new string[] { "value1", "value2" };
+        }
+
+        // GET api/values/5
+        [HttpGet("{id}")]
+        public string Get(int id)
+        {
+            return "value";
+        }
+
+        // POST api/values
+        [HttpPost]
+        public void Post([FromBody]string value)
+        {
+        }
+
+        // PUT api/values/5
+        [HttpPut("{id}")]
+        public void Put(int id, [FromBody]string value)
+        {
+        }
+
+        // DELETE api/values/5
+        [HttpDelete("{id}")]
+        public void Delete(int id)
+        {
+        }
+    }
+}

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/FakeDependency.cs
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/FakeDependency.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AspNetCoreAPIExample
+{
+    public interface IFakeDependency
+    {
+
+    }
+
+    public class FakeDependency : IFakeDependency
+    {
+    }
+}

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/LambdaEntryPoint.cs
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/LambdaEntryPoint.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace AspNetCoreAPIExample
+{
+    /// <summary>
+    /// This class extends from APIGatewayProxyFunction which contains the method FunctionHandlerAsync which is the 
+    /// actual Lambda function entry point. The Lambda handler field should be set to
+    /// 
+    /// AspNetCoreAPIExample::AspNetCoreAPIExample.LambdaEntryPoint::FunctionHandlerAsync
+    /// </summary>
+    public class LambdaEntryPoint :
+
+        // The base class must be set to match the AWS service invoking the Lambda function. If not Amazon.Lambda.AspNetCoreServer
+        // will fail to convert the incoming request correctly into a valid ASP.NET Core request.
+        //
+        // API Gateway REST API                         -> Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction
+        // API Gateway HTTP API payload version 1.0     -> Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction
+        // API Gateway HTTP API payload version 2.0     -> Amazon.Lambda.AspNetCoreServer.APIGatewayHttpApiV2ProxyFunction
+        // Application Load Balancer                    -> Amazon.Lambda.AspNetCoreServer.ApplicationLoadBalancerFunction
+        // 
+        // Note: When using the AWS::Serverless::Function resource with an event type of "HttpApi" then payload version 2.0
+        // will be the default and you must make Amazon.Lambda.AspNetCoreServer.APIGatewayHttpApiV2ProxyFunction the base class.
+
+        Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction
+    {
+        /// <summary>
+        /// The builder has configuration, logging and Amazon API Gateway already configured. The startup class
+        /// needs to be configured in this method using the UseStartup<>() method.
+        /// </summary>
+        /// <param name="builder"></param>
+        protected override void Init(IWebHostBuilder builder)
+        {
+            builder
+                .UseStartup<Startup>();
+        }
+
+        /// <summary>
+        /// Use this override to customize the services registered with the IHostBuilder. 
+        /// 
+        /// It is recommended not to call ConfigureWebHostDefaults to configure the IWebHostBuilder inside this method.
+        /// Instead customize the IWebHostBuilder in the Init(IWebHostBuilder) overload.
+        /// </summary>
+        /// <param name="builder"></param>
+        protected override void Init(IHostBuilder builder)
+        {
+        }
+    }
+}

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/LocalEntryPoint.cs
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/LocalEntryPoint.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace AspNetCoreAPIExample
+{
+    /// <summary>
+    /// The Main function can be used to run the ASP.NET Core application locally using the Kestrel webserver.
+    /// </summary>
+    public class LocalEntryPoint
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/Readme.md
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/Readme.md
@@ -1,0 +1,69 @@
+# ASP.NET Core Web API Serverless Application
+
+This project shows how to run an ASP.NET Core Web API project as an AWS Lambda exposed through Amazon API Gateway. The NuGet package [Amazon.Lambda.AspNetCoreServer](https://www.nuget.org/packages/Amazon.Lambda.AspNetCoreServer) contains a Lambda function that is used to translate requests from API Gateway into the ASP.NET Core framework and then the responses from ASP.NET Core back to API Gateway.
+
+
+For more information about how the Amazon.Lambda.AspNetCoreServer package works and how to extend its behavior view its [README](https://github.com/aws/aws-lambda-dotnet/blob/master/Libraries/src/Amazon.Lambda.AspNetCoreServer/README.md) file in GitHub.
+
+
+### Configuring for API Gateway HTTP API ###
+
+API Gateway supports the original REST API and the new HTTP API. In addition HTTP API supports 2 different
+payload formats. When using the 2.0 format the base class of `LambdaEntryPoint` must be `Amazon.Lambda.AspNetCoreServer.APIGatewayHttpApiV2ProxyFunction`.
+For the 1.0 payload format the base class is the same as REST API which is `Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction`.
+**Note:** when using the `AWS::Serverless::Function` CloudFormation resource with an event type of `HttpApi` the default payload
+format is 2.0 so the base class of `LambdaEntryPoint` must be `Amazon.Lambda.AspNetCoreServer.APIGatewayHttpApiV2ProxyFunction`.
+
+
+### Configuring for Application Load Balancer ###
+
+To configure this project to handle requests from an Application Load Balancer instead of API Gateway change
+the base class of `LambdaEntryPoint` from `Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction` to 
+`Amazon.Lambda.AspNetCoreServer.ApplicationLoadBalancerFunction`.
+
+### Project Files ###
+
+* serverless.template - an AWS CloudFormation Serverless Application Model template file for declaring your Serverless functions and other AWS resources
+* aws-lambda-tools-defaults.json - default argument settings for use with Visual Studio and command line deployment tools for AWS
+* LambdaEntryPoint.cs - class that derives from **Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction**. The code in 
+this file bootstraps the ASP.NET Core hosting framework. The Lambda function is defined in the base class.
+Change the base class to **Amazon.Lambda.AspNetCoreServer.ApplicationLoadBalancerFunction** when using an 
+Application Load Balancer.
+* LocalEntryPoint.cs - for local development this contains the executable Main function which bootstraps the ASP.NET Core hosting framework with Kestrel, as for typical ASP.NET Core applications.
+* Startup.cs - usual ASP.NET Core Startup class used to configure the services ASP.NET Core will use.
+* web.config - used for local development.
+* Controllers\ValuesController - example Web API controller
+
+You may also have a test project depending on the options selected.
+
+## Here are some steps to follow from Visual Studio:
+
+To deploy your Serverless application, right click the project in Solution Explorer and select *Publish to AWS Lambda*.
+
+To view your deployed application open the Stack View window by double-clicking the stack name shown beneath the AWS CloudFormation node in the AWS Explorer tree. The Stack View also displays the root URL to your published application.
+
+## Here are some steps to follow to get started from the command line:
+
+Once you have edited your template and code you can deploy your application using the [Amazon.Lambda.Tools Global Tool](https://github.com/aws/aws-extensions-for-dotnet-cli#aws-lambda-amazonlambdatools) from the command line.
+
+Install Amazon.Lambda.Tools Global Tools if not already installed.
+```
+    dotnet tool install -g Amazon.Lambda.Tools
+```
+
+If already installed check if new version is available.
+```
+    dotnet tool update -g Amazon.Lambda.Tools
+```
+
+Execute unit tests
+```
+    cd "AspNetCoreAPIExample/test/AspNetCoreAPIExample.Tests"
+    dotnet test
+```
+
+Deploy application
+```
+    cd "AspNetCoreAPIExample/src/AspNetCoreAPIExample"
+    dotnet lambda deploy-serverless
+```

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/Startup.cs
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/Startup.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.HttpsPolicy;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace AspNetCoreAPIExample
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public static IConfiguration Configuration { get; private set; }
+
+        // This method gets called by the runtime. Use this method to add services to the container
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddScoped<IFakeDependency, FakeDependency>();
+            services.AddControllers();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseHttpsRedirection();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+                endpoints.MapGet("/", async context =>
+                {
+                    await context.Response.WriteAsync("Welcome to running ASP.NET Core on AWS Lambda");
+                });
+            });
+        }
+    }
+}

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/appsettings.Development.json
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/appsettings.Development.json
@@ -1,0 +1,5 @@
+{
+  "AWS": {
+    "Region": "DefaultRegion"
+  }
+}

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/appsettings.json
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/appsettings.json
@@ -1,0 +1,7 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information"
+    }
+  }
+}

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/aws-lambda-tools-defaults.json
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/aws-lambda-tools-defaults.json
@@ -1,0 +1,15 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+    "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+    "dotnet lambda help",
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+  "profile": "default",
+  "region": "us-west-2",
+  "configuration": "Release",
+  "framework": "netcoreapp3.1",
+  "s3-prefix": "AspNetCoreAPIExample/",
+  "template": "serverless.template",
+  "template-parameters": ""
+}

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/serverless.template
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/AspNetCoreAPIExample/serverless.template
@@ -1,0 +1,47 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Transform": "AWS::Serverless-2016-10-31",
+  "Description": "An AWS Serverless Application that uses the ASP.NET Core framework running in Amazon Lambda.",
+  "Parameters": {},
+  "Conditions": {},
+  "Resources": {
+    "AspNetCoreFunction": {
+      "Type": "AWS::Serverless::Function",
+      "Properties": {
+        "Handler": "AspNetCoreAPIExample::AspNetCoreAPIExample.LambdaEntryPoint::FunctionHandlerAsync",
+        "Runtime": "dotnetcore3.1",
+        "CodeUri": "",
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Role": null,
+        "Policies": [
+          "AWSLambda_FullAccess"
+        ],
+        "Events": {
+          "ProxyResource": {
+            "Type": "Api",
+            "Properties": {
+              "Path": "/{proxy+}",
+              "Method": "ANY"
+            }
+          },
+          "RootResource": {
+            "Type": "Api",
+            "Properties": {
+              "Path": "/",
+              "Method": "ANY"
+            }
+          }
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "ApiURL": {
+      "Description": "API endpoint URL for Prod environment",
+      "Value": {
+        "Fn::Sub": "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+      }
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/659

*Description of changes:*
This fix makes it so that the when assemblies from ASP.NET Core are loaded into the test tool they are being loaded into the Test Tool's AssemblyLoadContext for the Lambda function instead of relying the Default AssemblyLoadContext. The code change was all in the `LambdaAssemblyLoadContext`. The rest of the code is adding a new test case and example function.

If we don't do this the IServiceCollection and corresponding IServiceProvider will be create in the Default AssemblyLoadContext. The IServiceCollection is passed into the developer's code which is loaded in the Test Tool's AssemblyLoadContext. The app registers services into the IServiceCollection loading up types from their respective Assemblies. Those types and assemblies are loaded into the Test Tool's AssemblyLoadContext. When the app is done registering services it passes the IServiceCollection back to ASP.NET Core which attempts to resolve all of the services into the IServiceProvider all happening in the Default AssemblyLoadContext. The Default AssemblyLoadContext doesn't know anything about the types from the Test Tool's AssemblyLoadContext and so it fails to resolves them.

Now with this fix all of the work for from ASP.NET Core creating the IServiceCollection happens in the Test Tool's AssemblyLoadContext so the services can be resolved.





By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
