### PR TITLE
add necessary dynamodb permissions 

### DIFF
--- a/Blueprints/BlueprintDefinitions/netcore2.1/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/Blog.cs
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/Blog.cs
@@ -2,11 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Amazon.DynamoDBv2.DataModel;
 
 namespace BlueprintBaseName._1
 {
     public class Blog
     {
+        [DynamoDBHashKey]
         public string Id { get; set; }
         public string Name { get; set; }
         public string Content { get; set; }

--- a/Blueprints/BlueprintDefinitions/netcore2.1/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore2.1/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/serverless.template
@@ -59,7 +59,8 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambda_FullAccess"
+          "AWSLambda_FullAccess",
+          "AmazonDynamoDBFullAccess"
         ],
         "Environment": {
           "Variables": {
@@ -98,7 +99,8 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambda_FullAccess"
+          "AWSLambda_FullAccess",
+          "AmazonDynamoDBFullAccess"
         ],
         "Environment": {
           "Variables": {
@@ -137,7 +139,8 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambda_FullAccess"
+          "AWSLambda_FullAccess",
+          "AmazonDynamoDBFullAccess"
         ],
         "Environment": {
           "Variables": {
@@ -176,7 +179,8 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambda_FullAccess"
+          "AWSLambda_FullAccess",
+          "AmazonDynamoDBFullAccess"
         ],
         "Environment": {
           "Variables": {

--- a/Blueprints/BlueprintDefinitions/netcore3.1/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/Blog.cs
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/Blog.cs
@@ -2,11 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Amazon.DynamoDBv2.DataModel;
 
 namespace BlueprintBaseName._1
 {
     public class Blog
     {
+        [DynamoDBHashKey]
         public string Id { get; set; }
         public string Name { get; set; }
         public string Content { get; set; }

--- a/Blueprints/BlueprintDefinitions/netcore3.1/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/serverless.template
@@ -59,7 +59,8 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambda_FullAccess"
+          "AWSLambda_FullAccess",
+          "AmazonDynamoDBFullAccess"
         ],
         "Environment": {
           "Variables": {
@@ -98,7 +99,8 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambda_FullAccess"
+          "AWSLambda_FullAccess",
+          "AmazonDynamoDBFullAccess"
         ],
         "Environment": {
           "Variables": {
@@ -137,7 +139,8 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambda_FullAccess"
+          "AWSLambda_FullAccess",
+          "AmazonDynamoDBFullAccess"
         ],
         "Environment": {
           "Variables": {
@@ -176,7 +179,8 @@
         "Timeout": 30,
         "Role": null,
         "Policies": [
-          "AWSLambda_FullAccess"
+          "AWSLambda_FullAccess",
+          "AmazonDynamoDBFullAccess"
         ],
         "Environment": {
           "Variables": {


### PR DESCRIPTION
*Issue #, if available:*
#852 

*Description of changes:*

Adds necessary dynamodb permissions to blueprint.

Fixes:

```
"Message":"User: arn:aws:sts::8xxxxxxxxx4:assumed-role/example-GetBlogsRole-TF8JQS710Q8H/example-GetBlogs-2K8167JQPX14 is not authorized to perform:
     | dynamodb:DescribeTable on resource:
     | arn:aws:dynamodb:us-west-2:8xxxxxxxxx4table/example-BlogTable-1QOLWPD4OM63Y"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
