### PR TITLE
Remove unnecessary log message

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -142,11 +142,6 @@ namespace Amazon.Lambda.AspNetCoreServer
                 requestFeatures.Scheme = "https";
                 requestFeatures.Method = apiGatewayRequest.HttpMethod;
 
-                if (string.IsNullOrWhiteSpace(apiGatewayRequest?.RequestContext?.DomainName))
-                {
-                    _logger.LogWarning($"Request does not contain domain name information but is derived from {nameof(APIGatewayProxyFunction)}.");
-                }
-
                 string path = null;
                 if (apiGatewayRequest.PathParameters != null && apiGatewayRequest.PathParameters.ContainsKey("proxy") &&
                     !string.IsNullOrEmpty(apiGatewayRequest.Resource))


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/693

*Description of changes:*
This log message was unnecessary and clutter users CloudWatch log streams.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
