### PR TITLE
Added missing System.Text.Json.Serialization.JsonPropertyName attribute for some properties in KinesisAnalyticsFirehoseInputPreprocessingEvent and KinesisAnalyticsStreamsInputPreprocessingEvent classes.

### DIFF
--- a/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/Amazon.Lambda.KinesisAnalyticsEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/Amazon.Lambda.KinesisAnalyticsEvents.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <Description>Amazon Lambda .NET Core support - Amazon Kinesis Analytics package.</Description>
     <AssemblyTitle>Amazon.Lambda.KinesisAnalyticsEvents</AssemblyTitle>
-    <VersionPrefix>2.2.0</VersionPrefix>
+    <VersionPrefix>2.2.1</VersionPrefix>
     <AssemblyName>Amazon.Lambda.KinesisAnalyticsEvents</AssemblyName>
     <PackageId>Amazon.Lambda.KinesisAnalyticsEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda;KinesisAnalytics</PackageTags>

--- a/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsFirehoseInputPreprocessingEvent.cs
+++ b/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsFirehoseInputPreprocessingEvent.cs
@@ -69,6 +69,9 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The record metadata.
             /// </value>
             [DataMember(Name = "kinesisFirehoseRecordMetadata")]
+#if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("kinesisFirehoseRecordMetadata")]
+#endif
             public KinesisFirehoseRecordMetadata RecordMetadata { get; set; }
 
             /// <summary>
@@ -81,6 +84,9 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
                 /// The approximate time the record was sent to Kinesis Firehose.
                 /// </summary>
                 [IgnoreDataMember]
+#if NETCOREAPP3_1
+                [System.Text.Json.Serialization.JsonIgnore]
+#endif
                 public DateTime ApproximateArrivalTimestamp
                 {
                     get
@@ -94,6 +100,9 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
                 /// The approximate time the record was sent to Kinesis Firehose in epoch.
                 /// </summary>
                 [DataMember(Name = "approximateArrivalTimestamp")]
+#if NETCOREAPP3_1
+                [System.Text.Json.Serialization.JsonPropertyName("approximateArrivalTimestamp")]
+#endif
                 public long ApproximateArrivalEpoch { get; set; }
 
             }
@@ -105,6 +114,9 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The base64 encoded data.
             /// </value>
             [DataMember(Name = "data")]
+#if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("data")]
+#endif
             public string Base64EncodedData { get; set; }
 
             /// <summary>

--- a/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsStreamsInputPreprocessingEvent.cs
+++ b/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsStreamsInputPreprocessingEvent.cs
@@ -68,6 +68,9 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The record metadata.
             /// </value>
             [DataMember(Name = "kinesisStreamRecordMetadata")]
+#if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("kinesisStreamRecordMetadata")]
+#endif
             public KinesisStreamRecordMetadata RecordMetadata { get; set; }
 
             /// <summary>
@@ -98,6 +101,9 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
                 /// The approximate time the record was sent to Kinesis Steam.
                 /// </summary>
                 [IgnoreDataMember]
+#if NETCOREAPP3_1
+                [System.Text.Json.Serialization.JsonIgnore]
+#endif
                 public DateTime ApproximateArrivalTimestamp
                 {
                     get
@@ -111,6 +117,9 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
                 /// The approximate time the record was sent to Kinesis stream in epoch.
                 /// </summary>
                 [DataMember(Name = "approximateArrivalTimestamp")]
+#if NETCOREAPP3_1
+                [System.Text.Json.Serialization.JsonPropertyName("approximateArrivalTimestamp")]
+#endif
                 public long ApproximateArrivalEpoch { get; set; }
 
                 /// <summary>

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -1309,6 +1309,59 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
+        public void KinesisAnalyticsStreamsInputProcessingEventTest(Type serializerType)
+        {
+            var serializer = Activator.CreateInstance(serializerType) as ILambdaSerializer;
+            using (var fileStream = LoadJsonTestFile("kinesis-analytics-streamsinputpreprocessing-event.json"))
+            {
+                var kinesisAnalyticsEvent = serializer.Deserialize<KinesisAnalyticsStreamsInputPreprocessingEvent>(fileStream);
+                Assert.Equal("00540a87-5050-496a-84e4-e7d92bbaf5e2", kinesisAnalyticsEvent.InvocationId);
+                Assert.Equal("arn:aws:kinesis:us-east-1:AAAAAAAAAAAA:stream/lambda-test", kinesisAnalyticsEvent.StreamArn);
+                Assert.Equal("arn:aws:kinesisanalytics:us-east-1:12345678911:application/lambda-test", kinesisAnalyticsEvent.ApplicationArn);
+                Assert.Equal(1, kinesisAnalyticsEvent.Records.Count);
+
+                Assert.Equal("49572672223665514422805246926656954630972486059535892482", kinesisAnalyticsEvent.Records[0].RecordId);
+                Assert.Equal("aGVsbG8gd29ybGQ=", kinesisAnalyticsEvent.Records[0].Base64EncodedData);
+
+                Assert.NotNull(kinesisAnalyticsEvent.Records[0].RecordMetadata);
+                Assert.Equal("shardId-000000000003", kinesisAnalyticsEvent.Records[0].RecordMetadata.ShardId);
+                Assert.Equal("7400791606", kinesisAnalyticsEvent.Records[0].RecordMetadata.PartitionKey);
+                Assert.Equal("49572672223665514422805246926656954630972486059535892482", kinesisAnalyticsEvent.Records[0].RecordMetadata.SequenceNumber);
+                Assert.Equal(1520280173, kinesisAnalyticsEvent.Records[0].RecordMetadata.ApproximateArrivalEpoch);
+            }
+        }
+
+        [Theory]
+        [InlineData(typeof(JsonSerializer))]
+#if NETCOREAPP_3_1        
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+#endif
+        public void KinesisAnalyticsFirehoseInputProcessingEventTest(Type serializerType)
+        {
+            var serializer = Activator.CreateInstance(serializerType) as ILambdaSerializer;
+            using (var fileStream = LoadJsonTestFile("kinesis-analytics-firehoseinputpreprocessing-event.json"))
+            {
+                var kinesisAnalyticsEvent = serializer.Deserialize<KinesisAnalyticsFirehoseInputPreprocessingEvent>(fileStream);
+                Assert.Equal("00540a87-5050-496a-84e4-e7d92bbaf5e2", kinesisAnalyticsEvent.InvocationId);
+                Assert.Equal("arn:aws:firehose:us-east-1:AAAAAAAAAAAA:deliverystream/lambda-test", kinesisAnalyticsEvent.StreamArn);
+                Assert.Equal("arn:aws:kinesisanalytics:us-east-1:12345678911:application/lambda-test", kinesisAnalyticsEvent.ApplicationArn);
+                Assert.Equal(1, kinesisAnalyticsEvent.Records.Count);
+
+                Assert.Equal("49572672223665514422805246926656954630972486059535892482", kinesisAnalyticsEvent.Records[0].RecordId);
+                Assert.Equal("aGVsbG8gd29ybGQ=", kinesisAnalyticsEvent.Records[0].Base64EncodedData);
+
+                Assert.NotNull(kinesisAnalyticsEvent.Records[0].RecordMetadata);
+                Assert.Equal(1520280173, kinesisAnalyticsEvent.Records[0].RecordMetadata.ApproximateArrivalEpoch);
+            }
+        }
+
+        [Theory]
+        [InlineData(typeof(JsonSerializer))]
+#if NETCOREAPP_3_1        
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+#endif
         public void CloudWatchLogEvent(Type serializerType)
         {
             var serializer = Activator.CreateInstance(serializerType) as ILambdaSerializer;

--- a/Libraries/test/EventsTests.Shared/EventsTests.Shared.projitems
+++ b/Libraries/test/EventsTests.Shared/EventsTests.Shared.projitems
@@ -18,10 +18,12 @@
     <Content Include="$(MSBuildThisFileDirectory)ecs-container-state-change-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)ecs-task-state-change-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)http-api-v2-request.json" />
+    <Content Include="$(MSBuildThisFileDirectory)kinesis-analytics-firehoseinputpreprocessing-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)kinesis-analytics-inputpreprocessing-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)kinesis-analytics-inputpreprocessing-response.json" />
     <Content Include="$(MSBuildThisFileDirectory)kinesis-analytics-outputdelivery-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)kinesis-analytics-outputdelivery-response.json" />
+    <Content Include="$(MSBuildThisFileDirectory)kinesis-analytics-streamsinputpreprocessing-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)kinesis-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)kinesis-firehose-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)kinesis-firehose-response.json" />

--- a/Libraries/test/EventsTests.Shared/kinesis-analytics-firehoseinputpreprocessing-event.json
+++ b/Libraries/test/EventsTests.Shared/kinesis-analytics-firehoseinputpreprocessing-event.json
@@ -1,0 +1,14 @@
+﻿{
+  "invocationId": "00540a87-5050-496a-84e4-e7d92bbaf5e2",
+  "applicationArn": "arn:aws:kinesisanalytics:us-east-1:12345678911:application/lambda-test",
+  "streamArn": "arn:aws:firehose:us-east-1:AAAAAAAAAAAA:deliverystream/lambda-test",
+  "records": [
+    {
+      "recordId": "49572672223665514422805246926656954630972486059535892482",
+      "data": "aGVsbG8gd29ybGQ=",
+      "kinesisFirehoseRecordMetadata": {
+        "approximateArrivalTimestamp": 1520280173
+      }
+    }
+  ]
+}

--- a/Libraries/test/EventsTests.Shared/kinesis-analytics-streamsinputpreprocessing-event.json
+++ b/Libraries/test/EventsTests.Shared/kinesis-analytics-streamsinputpreprocessing-event.json
@@ -1,0 +1,17 @@
+﻿{
+  "invocationId": "00540a87-5050-496a-84e4-e7d92bbaf5e2",
+  "applicationArn": "arn:aws:kinesisanalytics:us-east-1:12345678911:application/lambda-test",
+  "streamArn": "arn:aws:kinesis:us-east-1:AAAAAAAAAAAA:stream/lambda-test",
+  "records": [
+    {
+      "recordId": "49572672223665514422805246926656954630972486059535892482",
+      "data": "aGVsbG8gd29ybGQ=",
+      "kinesisStreamRecordMetadata": {
+        "shardId": "shardId-000000000003",
+        "partitionKey": "7400791606",
+        "sequenceNumber": "49572672223665514422805246926656954630972486059535892482",
+        "approximateArrivalTimestamp": 1520280173
+      }
+    }
+  ]
+}


### PR DESCRIPTION
*Issue #:* #862 

*Description of changes:*
Added missing System.Text.Json.Serialization.JsonPropertyName attribute for some properties in KinesisAnalyticsFirehoseInputPreprocessingEvent and KinesisAnalyticsStreamsInputPreprocessingEvent classes.

___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
