### PR TITLE
Changed data type of LexCurrentIntent.NluIntentConfidenceScore to Nullable<double> for LexEvent

### DIFF
--- a/Libraries/src/Amazon.Lambda.LexEvents/Amazon.Lambda.LexEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.LexEvents/Amazon.Lambda.LexEvents.csproj
@@ -6,7 +6,7 @@
     <Description>Amazon Lambda .NET Core support - Amazon Lex package.</Description>
     <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.LexEvents</AssemblyTitle>
-    <VersionPrefix>2.2.0</VersionPrefix>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.LexEvents</AssemblyName>
     <PackageId>Amazon.Lambda.LexEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda;Lex</PackageTags>

--- a/Libraries/src/Amazon.Lambda.LexEvents/LexEvent.cs
+++ b/Libraries/src/Amazon.Lambda.LexEvents/LexEvent.cs
@@ -136,7 +136,7 @@ namespace Amazon.Lambda.LexEvents
             /// <summary>
             /// Gets and sets the property NluIntentConfidence.
             /// </summary>
-            public float NluIntentConfidenceScore { get; set; }
+            public double? NluIntentConfidenceScore { get; set; }
 
 
 

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -1050,6 +1050,7 @@ namespace Amazon.Lambda.Tests
                 Assert.Equal("value2", lexEvent.CurrentIntent.Slots["slot name2"]);
                 Assert.Equal("None, Confirmed, or Denied (intent confirmation, if configured)", lexEvent.CurrentIntent.ConfirmationStatus);
                 Assert.Equal("Text used to process the request", lexEvent.InputTranscript);
+                Assert.Null(lexEvent.CurrentIntent.NluIntentConfidenceScore);
 
                 Assert.Equal(2, lexEvent.RequestAttributes.Count);
                 Assert.Equal("value1", lexEvent.RequestAttributes["key1"]);
@@ -1064,6 +1065,9 @@ namespace Amazon.Lambda.Tests
 
                 Assert.Equal("intent-name", lexEvent.AlternativeIntents[0].Name);
                 Assert.Equal(5.5, lexEvent.AlternativeIntents[0].NluIntentConfidenceScore);
+
+                Assert.Equal("intent-name", lexEvent.AlternativeIntents[1].Name);
+                Assert.Null(lexEvent.AlternativeIntents[1].NluIntentConfidenceScore);
 
                 Assert.Equal("Name", lexEvent.RecentIntentSummaryView[0].IntentName);
                 Assert.Equal("Label", lexEvent.RecentIntentSummaryView[0].CheckpointLabel);

--- a/Libraries/test/EventsTests.Shared/lex-event.json
+++ b/Libraries/test/EventsTests.Shared/lex-event.json
@@ -48,6 +48,31 @@
         }
       },
       "confirmationStatus": "None, Confirmed, or Denied (intent confirmation, if configured)"
+    },
+    {
+      "name": "intent-name",
+      "nluIntentConfidenceScore": null,
+      "slots": {
+        "slot name1": "value",
+        "slot name2": "value"
+      },
+      "slotDetails": {
+        "slot name1": {
+          "resolutions": [
+            { "value": "resolved value" },
+            { "value": "resolved value" }
+          ],
+          "originalValue": "original text"
+        },
+        "slot name2": {
+          "resolutions": [
+            { "value1": "resolved value" },
+            { "value2": "resolved value" }
+          ],
+          "originalValue": "original text"
+        }
+      },
+      "confirmationStatus": "None, Confirmed, or Denied (intent confirmation, if configured)"
     }
   ],
   "bot": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changed data type of LexCurrentIntent.NluIntentConfidenceScore to Nullable<double> for LexEvent.

___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
