### PR TITLE
Fix issue with ASP.NET Core Lambda functions that have internal errors to correctly return 500 status code

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
@@ -495,7 +495,7 @@ namespace Amazon.Lambda.AspNetCoreServer
                     }
 
                     _logger.LogError(sb.ToString());
-                    defaultStatusCode = 500;
+                    ((IHttpResponseFeature)features).StatusCode = 500;
                 }
                 catch (ReflectionTypeLoadException rex)
                 {
@@ -516,14 +516,14 @@ namespace Amazon.Lambda.AspNetCoreServer
                     }
 
                     _logger.LogError(sb.ToString());
-                    defaultStatusCode = 500;
+                    ((IHttpResponseFeature)features).StatusCode = 500;
                 }
                 catch (Exception e)
                 {
                     ex = e;
                     if (rethrowUnhandledError) throw;
                     _logger.LogError($"Unknown error responding to request: {this.ErrorReport(e)}");
-                    defaultStatusCode = 500;
+                    ((IHttpResponseFeature)features).StatusCode = 500;
                 }
 
                 if (features.ResponseStartingEvents != null)

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Amazon.Lambda.AspNetCoreServer.csproj
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Amazon.Lambda.AspNetCoreServer.csproj
@@ -6,7 +6,7 @@
     <Description>Amazon.Lambda.AspNetCoreServer makes it easy to run ASP.NET Core Web API applications as AWS Lambda functions.</Description>
     <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.AspNetCoreServer</AssemblyTitle>
-    <VersionPrefix>6.0.2</VersionPrefix>
+    <VersionPrefix>6.0.3</VersionPrefix>
     <AssemblyName>Amazon.Lambda.AspNetCoreServer</AssemblyName>
     <PackageId>Amazon.Lambda.AspNetCoreServer</PackageId>
     <PackageTags>AWS;Amazon;Lambda;aspnetcore</PackageTags>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/884

*Description of changes:*
The previous PR [858](https://github.com/aws/aws-lambda-dotnet/pull/858) changed the default HTTP status code to 200 to fix issues with ASP.NET Core middleware. That change had unintended consequences of interfering with exceptions logic when in the ProcessRequest method which sends the request into ASP.NET Core. 

The original logic was catching any exceptions and if the status code was not set then set the status code to 500. Since the previous PR always sets the status code to default to 200 then it would never get set to 500 if there was an exception.

Since an exception should only be caught by the ProcessRequest method if nothing handled it in ASP.NET Core then the status code should always be set to 500 if an exception is caught. This is what is being done in this PR to explicitly set the status code if an exception is caught.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
