### PR TITLE
AspNetCoreServer: make adding exception detail to http response opt-in

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
@@ -171,6 +171,13 @@ namespace Amazon.Lambda.AspNetCoreServer
             _responseContentEncodingForContentEncoding[contentEncoding] = encoding;
         }
 
+        /// <summary>
+        /// If true, information about unhandled exceptions thrown during request processing
+        /// will be included in the HTTP response.
+        /// Defaults to false
+        /// </summary>
+        public bool IncludeUnhandledExceptionDetailInResponse { get; set;  }
+
 
         /// <summary>
         /// Method to initialize the web builder before starting the web host. In a typical Web API this is similar to the main function. 
@@ -532,7 +539,7 @@ namespace Amazon.Lambda.AspNetCoreServer
                 }
                 var response = this.MarshallResponse(features, lambdaContext, defaultStatusCode);
 
-                if (ex != null)
+                if (ex != null && IncludeUnhandledExceptionDetailInResponse)
                 {
                     InternalCustomResponseExceptionHandling(response, lambdaContext, ex);
                 }

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
@@ -132,16 +132,25 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
         }
 
         [Theory]
-        [InlineData("values-get-aggregateerror-apigateway-request.json", "AggregateException")]
-        [InlineData("values-get-typeloaderror-apigateway-request.json", "ReflectionTypeLoadException")]
-        public async Task TestEnhancedExceptions(string requestFileName, string expectedExceptionType)
+        [InlineData("values-get-aggregateerror-apigateway-request.json", "AggregateException", true)]
+        [InlineData("values-get-typeloaderror-apigateway-request.json", "ReflectionTypeLoadException", true)]
+        [InlineData("values-get-aggregateerror-apigateway-request.json", "AggregateException", false)]
+        [InlineData("values-get-typeloaderror-apigateway-request.json", "ReflectionTypeLoadException", false)]
+        public async Task TestEnhancedExceptions(string requestFileName, string expectedExceptionType, bool configureApiToReturnExceptionDetail)
         {
-            var response = await this.InvokeAPIGatewayRequest(requestFileName);
+            var response = await this.InvokeAPIGatewayRequest(requestFileName, configureApiToReturnExceptionDetail);
 
             Assert.Equal(500, response.StatusCode);
             Assert.Equal(string.Empty, response.Body);
-            Assert.True(response.MultiValueHeaders.ContainsKey("ErrorType"));
-            Assert.Equal(expectedExceptionType, response.MultiValueHeaders["ErrorType"][0]);
+            if (configureApiToReturnExceptionDetail)
+            {
+                Assert.True(response.MultiValueHeaders.ContainsKey("ErrorType"));
+                Assert.Equal(expectedExceptionType, response.MultiValueHeaders["ErrorType"][0]);
+            }
+            else
+            {
+                Assert.False(response.MultiValueHeaders.ContainsKey("ErrorType"));
+            }
         }
 
         [Fact]
@@ -416,19 +425,21 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
             Assert.Equal("Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceProviderEngineScope", response.Body);
         }
 
-        private async Task<APIGatewayProxyResponse> InvokeAPIGatewayRequest(string fileName)
+        private async Task<APIGatewayProxyResponse> InvokeAPIGatewayRequest(string fileName, bool configureApiToReturnExceptionDetail = false)
         {
-            return await InvokeAPIGatewayRequest(new TestLambdaContext(), fileName);
+            return await InvokeAPIGatewayRequest(new TestLambdaContext(), fileName, configureApiToReturnExceptionDetail);
         }
 
-        private async Task<APIGatewayProxyResponse> InvokeAPIGatewayRequest(TestLambdaContext context, string fileName)
+        private async Task<APIGatewayProxyResponse> InvokeAPIGatewayRequest(TestLambdaContext context, string fileName, bool configureApiToReturnExceptionDetail = false)
         {
-            return await InvokeAPIGatewayRequestWithContent(context, GetRequestContent(fileName));
+            return await InvokeAPIGatewayRequestWithContent(context, GetRequestContent(fileName), configureApiToReturnExceptionDetail);
         }
 
-        private async Task<APIGatewayProxyResponse> InvokeAPIGatewayRequestWithContent(TestLambdaContext context, string requestContent)
+        private async Task<APIGatewayProxyResponse> InvokeAPIGatewayRequestWithContent(TestLambdaContext context, string requestContent, bool configureApiToReturnExceptionDetail = false)
         {
             var lambdaFunction = new ApiGatewayLambdaFunction();
+            if (configureApiToReturnExceptionDetail)
+                lambdaFunction.IncludeUnhandledExceptionDetailInResponse = true;
             var requestStream = new MemoryStream(System.Text.UTF8Encoding.UTF8.GetBytes(requestContent));
 #if NETCOREAPP_2_1
             var request = new Amazon.Lambda.Serialization.Json.JsonSerializer().Deserialize<APIGatewayProxyRequest>(requestStream);


### PR DESCRIPTION
*Issue #, if available:*
#886

*Description of changes:*
Current behaviour of AspNetCoreServer when an exception is thrown during request processing is to include details of that exception - specifically its type-name - in the HTTP response.
This seems insecure, so this change makes that something that must be opted-in to - by default, exception detail will not be returned in the response.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
