### PR TITLE
Added support for reporting batch item failures when processing streams for DynamoDBEvent.

### DIFF
--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents/Amazon.Lambda.DynamoDBEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents/Amazon.Lambda.DynamoDBEvents.csproj
@@ -3,10 +3,10 @@
   <Import Project="..\..\..\buildtools\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <Description>Amazon Lambda .NET Core support - DynamoDBEvents package.</Description>
     <AssemblyTitle>Amazon.Lambda.DynamoDBEvents</AssemblyTitle>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.DynamoDBEvents</AssemblyName>
     <PackageId>Amazon.Lambda.DynamoDBEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents/StreamsEventResponse.cs
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents/StreamsEventResponse.cs
@@ -1,0 +1,38 @@
+﻿namespace Amazon.Lambda.DynamoDBEvents
+{
+    using System.Collections.Generic;
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// This class is used as the return type for AWS Lambda functions that are invoked by DynamoDB to report batch item failures.
+    /// https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html#services-ddb-batchfailurereporting
+    /// </summary>
+    [DataContract]
+    public class StreamsEventResponse
+    {
+        /// <summary>
+        /// A list of records which failed processing. Returning the first record which failed would retry all remaining records from the batch.
+        /// </summary>
+        [DataMember(Name = "batchItemFailures", EmitDefaultValue = false)]
+#if NETCOREAPP3_1
+        [System.Text.Json.Serialization.JsonPropertyName("batchItemFailures")]
+#endif
+        public IList<BatchItemFailure> BatchItemFailures { get; set; }
+
+        /// <summary>
+        /// The class representing the BatchItemFailure.
+        /// </summary>
+        [DataContract]
+        public class BatchItemFailure
+        {
+            /// <summary>
+            /// Sequence number of the record which failed processing.
+            /// </summary>
+            [DataMember(Name = "itemIdentifier", EmitDefaultValue = false)]
+#if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("itemIdentifier")]
+#endif
+            public string ItemIdentifier { get; set; }
+        }
+    }
+}

--- a/Libraries/test/EventsTests.Shared/EventsTests.Shared.projitems
+++ b/Libraries/test/EventsTests.Shared/EventsTests.Shared.projitems
@@ -14,6 +14,7 @@
     <Content Include="$(MSBuildThisFileDirectory)batch-job-state-change-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)cognito-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)config-event.json" />
+    <Content Include="$(MSBuildThisFileDirectory)dynamodb-batchitemfailures-response.json" />
     <Content Include="$(MSBuildThisFileDirectory)dynamodb-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)ecs-container-state-change-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)ecs-task-state-change-event.json" />

--- a/Libraries/test/EventsTests.Shared/dynamodb-batchitemfailures-response.json
+++ b/Libraries/test/EventsTests.Shared/dynamodb-batchitemfailures-response.json
@@ -1,0 +1,7 @@
+﻿{
+  "batchItemFailures": [
+    {
+      "itemIdentifier": "1405400000000002063282832"
+    }
+  ]
+}


### PR DESCRIPTION
*Issue #:* Fixes #903 

*Description of changes:*
- Added support for reporting batch item failures when processing streams for DynamoDBEvent.
- Added `netcoreapp3.1` for `Amazon.Lambda.DynamoDBEvents`.

___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
