### PR TITLE
[PS Lambda] Add support for passing in AWSAccessKeyId, AWSSecretKey, AWSSessionToken and Architecture

### DIFF
--- a/PowerShell/Module/AWSLambdaPSCore.psd1
+++ b/PowerShell/Module/AWSLambdaPSCore.psd1
@@ -12,7 +12,7 @@
 RootModule = 'AWSLambdaPSCore.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.1.0.0'
+ModuleVersion = '2.2.0.0'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core'

--- a/PowerShell/Module/Public/New-AWSPowerShellLambdaPackage.ps1
+++ b/PowerShell/Module/Public/New-AWSPowerShellLambdaPackage.ps1
@@ -36,6 +36,9 @@
     .PARAMETER ScriptPath
     The path to the PowerShell script file to be published to AWS Lambda.
 
+    .PARAMETER Architecture
+    The architecture of the Lambda function. Valid values: x86_64 or arm64. Default is x86_64
+        
     .PARAMETER StagingDirectory
     Optional parameter to set the directory where the AWS Lambda package bundle for a standalone script deployment
     will be created. If not set the system temp directory will be used.
@@ -83,7 +86,11 @@ function New-AWSPowerShellLambdaPackage
         [String]$OutputPackage,
 
         [Parameter()]
-        [string[]]$ModuleRepository
+        [string[]]$ModuleRepository,  
+
+        [Parameter()]
+        [ValidateSet('x86_64', 'arm64')]
+        [string]$Architecture      
     )
 
     _validateDotnetInstall
@@ -179,7 +186,7 @@ function New-AWSPowerShellLambdaPackage
 
     Write-Host "Creating deployment package at $OutputPackage"
 
-    _packageProject -OutputPackage $OutputPackage -BuildDirectory $_buildDirectory
+    _packageProject -OutputPackage $OutputPackage -BuildDirectory $_buildDirectory -FunctionArchitecture $Architecture
 
     if ($PSCmdlet.ParameterSetName -eq 'PackageScript')
     {

--- a/PowerShell/Module/Public/Publish-AWSPowerShellLambda.ps1
+++ b/PowerShell/Module/Public/Publish-AWSPowerShellLambda.ps1
@@ -53,6 +53,9 @@
     .PARAMETER Memory
     The amount of memory, in MB, your Lambda function is given when it executes inside AWS Lambda.
 
+    .PARAMETER Architecture
+    The architecture of the Lambda function. Valid values: x86_64 or arm64. Default is x86_64
+
     .PARAMETER Layer
     The Lambda layers to include with the Lambda function.
 
@@ -73,6 +76,15 @@
 
     .PARAMETER ProfileName
     The AWS credentials profile to use when publishing to AWS Lambda. If not set environment credentials will be used.
+
+    .PARAMETER AWSAccessKeyId
+    The AWS access key id. Used when setting credentials explicitly instead of using ProfileName.
+
+    .PARAMETER AWSSecretKey
+    The AWS secret key. Used when setting credentials explicitly instead of using ProfileName.
+
+    .PARAMETER AWSSessionToken
+    The AWS session token. Used when setting credentials explicitly instead of using ProfileName.
 
     .PARAMETER ProjectDirectory
     The directory containing the AWS Lambda PowerShell project to publish.
@@ -170,6 +182,15 @@ function Publish-AWSPowerShellLambda
         [string]$ProfileName,
 
         [Parameter()]
+        [string]$AWSAccessKeyId,
+
+        [Parameter()]
+        [string]$AWSSecretKey,
+
+        [Parameter()]
+        [string]$AWSSessionToken,
+
+        [Parameter()]
         [string]$Region,
 
         [Parameter()]
@@ -177,6 +198,10 @@ function Publish-AWSPowerShellLambda
 
         [Parameter()]
         [int]$Memory,
+
+        [Parameter()]
+        [ValidateSet('x86_64', 'arm64')]
+        [string]$Architecture,
 
         [Parameter()]
         [int]$Timeout,
@@ -313,9 +338,13 @@ function Publish-AWSPowerShellLambda
         FunctionHandler        = $_handler
         PowerShellFunction     = $PowerShellFunctionHandler
         Profile                = $ProfileName
+        AWSAccessKeyId         = $AWSAccessKeyId
+        AWSSecretKey           = $AWSSecretKey
+        AWSSessionToken        = $AWSSessionToken
         Region                 = $Region
         FunctionRole           = $IAMRoleArn
         FunctionMemory         = $Memory
+        FunctionArchitecture   = $Architecture
         FunctionLayer          = $Layer
         FunctionTimeout        = $Timeout
         PublishNewVersion      = $PublishNewVersion


### PR DESCRIPTION
*Description of changes:*
Update the list of parameters that can be passed into the publish cmdlet to allow users to pass explicit credentials and also set function architecture allowing ARM64 support. The `New-AWSPowerShellLambdaPackage` cmdlet which is used to create just a zip file of the PS Lambda function was updated to include ARM support.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
