### PR TITLE
Test augmentation to verify the behavior of RemoveOrphanedLambdaFunctions

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Writers/JsonWriter.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Writers/JsonWriter.cs
@@ -40,8 +40,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Writers
             var lastProperty = pathList.LastOrDefault();
             if (string.IsNullOrEmpty((lastProperty)))
             {
-                throw new InvalidOperationException(
-                    "Cannot set a token at {jsonPath} because the terminal property is null or empty");
+                throw new InvalidOperationException($"Cannot set a token at {jsonPath} because the terminal property is null or empty");
             }
             var currentNode = _rootNode;
 

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/CloudFormationJsonWriterTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/CloudFormationJsonWriterTests.cs
@@ -178,6 +178,19 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
                                     ],
                                     'Handler': 'MyAssembly::MyNamespace.MyType::Handler'
                                   }
+                                },
+                                'MethodNotCreatedFromAnnotationsPackage': {
+                                  'Type': 'AWS::Serverless::Function',
+                                  'Properties': {
+                                    'Runtime': 'dotnetcore3.1',
+                                    'CodeUri': '',
+                                    'MemorySize': 128,
+                                    'Timeout': 100,
+                                    'Policies': [
+                                      'AWSLambdaBasicExecutionRole'
+                                    ],
+                                    'Handler': 'MyAssembly::MyNamespace.MyType::Handler'
+                                  }
                                 }
                               }
                             }";
@@ -194,6 +207,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
             var rootToken = JObject.Parse(mockFileSystem.File.ReadAllText(ServerlessTemplateFilePath));
             Assert.Null(rootToken["Resources"]["ObsoleteMethod"]);
             Assert.NotNull(rootToken["Resources"]["NewMethod"]);
+            Assert.NotNull(rootToken["Resources"]["MethodNotCreatedFromAnnotationsPackage"]);
         }
 
         private MockFileSystem GetMockFileSystem(string originalContent)


### PR DESCRIPTION
*Description of changes:*
This PR makes the `RemoveOrphanedLambdaFunctions` test more robust by verifying that lambda functions that are created **without** the `Amazon.Lambda.Annotations` are not erroneously deleted from the serverless template.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
