### PR TITLE
fix: resolve Newtonsoft.Json by using explicit version

### DIFF
--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.47" />
         <PackageReference Include="System.Memory" Version="4.5.4" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Manual resolution is required due to two sources of Newtonsoft. One from generators, another from APIGatewayEvents.

This is only applicable for test project. I don't see same behavior in sample app.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
