### PR TITLE
Check for Metatdata Before Modifying the Serverless Template

### DIFF
--- a/Libraries/test/TestServerlessApp/serverless.template
+++ b/Libraries/test/TestServerlessApp/serverless.template
@@ -5,6 +5,9 @@
   "Resources": {
     "GreeterSayHello": {
       "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations"
+      },
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.Greeter_SayHello_Generated::SayHello",
         "Runtime": "dotnetcore3.1",
@@ -29,6 +32,9 @@
     },
     "GreeterSayHelloAsync": {
       "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations"
+      },
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.Greeter_SayHelloAsync_Generated::SayHelloAsync",
         "Runtime": "dotnetcore3.1",
@@ -53,6 +59,9 @@
     },
     "SimpleCalculatorAdd": {
       "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations"
+      },
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Add_Generated::Add",
         "Runtime": "dotnetcore3.1",
@@ -76,6 +85,9 @@
     },
     "SimpleCalculatorSubtract": {
       "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations"
+      },
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Subtract_Generated::Subtract",
         "Runtime": "dotnetcore3.1",
@@ -99,6 +111,9 @@
     },
     "SimpleCalculatorMultiply": {
       "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations"
+      },
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Multiply_Generated::Multiply",
         "Runtime": "dotnetcore3.1",
@@ -122,6 +137,9 @@
     },
     "SimpleCalculatorDivideAsync": {
       "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations"
+      },
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_DivideAsync_Generated::DivideAsync",
         "Runtime": "dotnetcore3.1",
@@ -145,6 +163,9 @@
     },
     "TestServerlessAppComplexCalculatorAddGenerated": {
       "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations"
+      },
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.ComplexCalculator_Add_Generated::Add",
         "Runtime": "dotnetcore3.1",


### PR DESCRIPTION
*Description of changes:*
This PR does the following
* Prevents the `CloudFormationJsonWriter` from modifying functions that were not created using the `Amazon.Lambda.Annotation` package.
* Add Metadata to existing functions in the `TestServerlessApp` to indicate that they were created using the `Amazon.Lambda.Annotation` package


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
