### PR TITLE
feat: add support for FromHeader attribute

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/AttributeModelBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/AttributeModelBuilder.cs
@@ -34,6 +34,15 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes
                     Type = TypeModelBuilder.Build(att.AttributeClass, context)
                 };
             }
+            else if (att.AttributeClass.Equals(context.Compilation.GetTypeByMetadataName(TypeFullNames.FromHeaderAttribute), SymbolEqualityComparer.Default))
+            {
+                var data = FromHeaderAttributeBuilder.Build(att);
+                model = new AttributeModel<FromHeaderAttribute>
+                {
+                    Data = data,
+                    Type = TypeModelBuilder.Build(att.AttributeClass, context)
+                };
+            }
             else if (att.AttributeClass.Equals(context.Compilation.GetTypeByMetadataName(TypeFullNames.HttpApiAttribute), SymbolEqualityComparer.Default))
             {
                 var data = HttpApiAttributeBuilder.Build(att);

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/FromHeaderAttributeBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/FromHeaderAttributeBuilder.cs
@@ -1,0 +1,24 @@
+using Microsoft.CodeAnalysis;
+
+namespace Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes
+{
+    /// <summary>
+    /// Builder for <see cref="FromHeaderAttribute"/>.
+    /// </summary>
+    public class FromHeaderAttributeBuilder
+    {
+        public static FromHeaderAttribute Build(AttributeData att)
+        {
+            var data = new FromHeaderAttribute();
+            foreach (var pair in att.NamedArguments)
+            {
+                if (pair.Key == nameof(data.Name) && pair.Value.Value is string value)
+                {
+                    data.Name = value;
+                }
+            }
+
+            return data;
+        }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.tt
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.tt
@@ -79,6 +79,8 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
     if (_model.LambdaMethod.Events.Contains(EventType.API))
     {
         var parameters = string.Join(", ", _model.LambdaMethod.Parameters.Select(p => p.Name));
+        var restApiAttribute = _model.LambdaMethod.Attributes.FirstOrDefault(att => att.Type.FullName == TypeFullNames.RestApiAttribute);
+        var httpApiAttribute = _model.LambdaMethod.Attributes.FirstOrDefault(att => att.Type.FullName == TypeFullNames.HttpApiAttribute) as AttributeModel<HttpApiAttribute>;
         foreach (var parameter in _model.LambdaMethod.Parameters)
         {
             if (parameter.Attributes.Any(att => att.Type.FullName == TypeFullNames.FromServiceAttribute))
@@ -89,8 +91,6 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
             }
             else if (parameter.Attributes.Any(att => att.Type.FullName == TypeFullNames.FromQueryAttribute))
             {
-                var restApiAttribute = _model.LambdaMethod.Attributes.FirstOrDefault(att => att.Type.FullName == TypeFullNames.RestApiAttribute);
-                var httpApiAttribute = _model.LambdaMethod.Attributes.FirstOrDefault(att => att.Type.FullName == TypeFullNames.HttpApiAttribute) as AttributeModel<HttpApiAttribute>;
                 var fromQueryAttribute = parameter.Attributes.First(att => att.Type.FullName == TypeFullNames.FromQueryAttribute) as AttributeModel<FromQueryAttribute>;
 
                 // Use parameter name as key, if Name has not specified explicitly in the attribute definition.
@@ -143,6 +143,66 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
             if (request.<#= queryStringParameters #>?.ContainsKey("<#= parameterKey #>") == true)
             {
                 <#= parameter.Name #> = (<#= parameter.Type.FullName #>)Convert.ChangeType(request.<#= queryStringParameters #>["<#= parameterKey #>"], typeof(<#= parameter.Type.FullName #>));
+            }
+
+<#
+                }
+
+            }
+            else if (parameter.Attributes.Any(att => att.Type.FullName == TypeFullNames.FromHeaderAttribute))
+            {
+                var fromHeaderAttribute = parameter.Attributes.First(att => att.Type.FullName == TypeFullNames.FromHeaderAttribute) as AttributeModel<FromHeaderAttribute>;
+
+                // Use parameter name as key, if Name has not specified explicitly in the attribute definition.
+                var headerKey = fromHeaderAttribute?.Data?.Name ?? parameter.Name;
+
+                var headers = "Headers";
+
+#>
+            var <#= parameter.Name #> = default(<#= parameter.Type.FullName #>);
+<#
+
+                if (parameter.Type.IsEnumerable && parameter.Type.IsGenericType)
+                {
+                    // In HTTP API V2 multiple values for the same header are represented via comma separated string
+                    // Therefore, it is required to split the string to convert to an enumerable
+                    // and convert individual item to target data type.
+                    var commaSplit = "";
+                    if (httpApiAttribute?.Data.Version == HttpApiVersion.V2)
+                    {
+                        commaSplit = @".Split("","")";
+                    }
+
+                    // HTTP API V1 and Rest API, multiple values for the same header are provided
+                    // dedicated dictionary of string key and list value.
+                    if (restApiAttribute != null || httpApiAttribute?.Data.Version == HttpApiVersion.V1)
+                    {
+                        headers = "MultiValueHeaders";
+                    }
+
+                    if (parameter.Type.TypeArguments.Count != 1)
+                    {
+                        throw new NotSupportedException("Only one type argument is supported for generic types.");
+                    }
+
+                    // Generic types are mapped using Select statement to the target parameter type argument.
+                    var typeArgument = parameter.Type.TypeArguments.First();
+                    var select = $".Select(q => ({typeArgument.FullName})Convert.ChangeType(q, typeof({typeArgument.FullName}))).ToList()";
+#>
+            if (request.<#= headers #>?.ContainsKey("<#= headerKey #>") == true)
+            {
+                <#= parameter.Name #> = request.<#= headers #>["<#= headerKey #>"]<#= commaSplit #><#= select #>;
+            }
+
+<#
+                }
+                else
+                {
+                    // Non-generic types are mapped directly to the target parameter.
+#>
+            if (request.<#= headers #>?.ContainsKey("<#= headerKey #>") == true)
+            {
+                <#= parameter.Name #> = (<#= parameter.Type.FullName #>)Convert.ChangeType(request.<#= headers #>["<#= headerKey #>"], typeof(<#= parameter.Type.FullName #>));
             }
 
 <#

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/TypeFullNames.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/TypeFullNames.cs
@@ -15,6 +15,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
         public const string HttpApiVersion = "Amazon.Lambda.Annotations.HttpApiVersion";
         public const string LambdaFunctionAttribute = "Amazon.Lambda.Annotations.LambdaFunctionAttribute";
         public const string FromQueryAttribute = "Amazon.Lambda.Annotations.FromQueryAttribute";
+        public const string FromHeaderAttribute = "Amazon.Lambda.Annotations.FromHeaderAttribute";
         public const string FromServiceAttribute = "Amazon.Lambda.Annotations.FromServicesAttribute";
         public const string IEnumerable = "System.Collections.IEnumerable";
     }

--- a/Libraries/src/Amazon.Lambda.Annotations/FromHeaderAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/FromHeaderAttribute.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Amazon.Lambda.Annotations
+{
+    [AttributeUsage(AttributeTargets.Parameter)]
+    public class FromHeaderAttribute : Attribute, INamedAttribute
+    {
+        public string Name { get; set; }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Greeter_SayHelloAsync_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Greeter_SayHelloAsync_Generated.g.cs
@@ -18,7 +18,13 @@ namespace TestServerlessApp
 
         public async Task<APIGatewayProxyResponse> SayHelloAsync(APIGatewayProxyRequest request, ILambdaContext context)
         {
-            await greeter.SayHelloAsync();
+            var firstNames = default(System.Collections.Generic.IEnumerable<string>);
+            if (request.Headers?.ContainsKey("names") == true)
+            {
+                firstNames = request.Headers["names"].Split(",").Select(q => (string)Convert.ChangeType(q, typeof(string))).ToList();
+            }
+
+            await greeter.SayHelloAsync(firstNames);
 
             return new APIGatewayProxyResponse
             {

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Subtract_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Subtract_Generated.g.cs
@@ -31,8 +31,20 @@ namespace TestServerlessApp
             using var scope = serviceProvider.CreateScope();
             var simpleCalculator = scope.ServiceProvider.GetRequiredService<SimpleCalculator>();
 
+            var x = default(int);
+            if (request.Headers?.ContainsKey("x") == true)
+            {
+                x = (int)Convert.ChangeType(request.Headers["x"], typeof(int));
+            }
+
+            var y = default(int);
+            if (request.Headers?.ContainsKey("y") == true)
+            {
+                y = (int)Convert.ChangeType(request.Headers["y"], typeof(int));
+            }
+
             var simpleCalculatorService = scope.ServiceProvider.GetRequiredService<TestServerlessApp.Services.ISimpleCalculatorService>();
-            var response = simpleCalculator.Subtract(simpleCalculatorService);
+            var response = simpleCalculator.Subtract(x, y, simpleCalculatorService);
             return response;
         }
     }

--- a/Libraries/test/TestServerlessApp/Greeter.cs
+++ b/Libraries/test/TestServerlessApp/Greeter.cs
@@ -24,9 +24,17 @@ namespace TestServerlessApp
 
         [LambdaFunction(Name = "GreeterSayHelloAsync", Timeout = 50)]
         [HttpApi(HttpApiVersion.V1)]
-        public async Task SayHelloAsync()
+        public async Task SayHelloAsync([FromHeader(Name = "names")]IEnumerable<string> firstNames)
         {
-            Console.WriteLine("Hello");
+            if (firstNames == null)
+            {
+                return;
+            }
+
+            foreach (var firstName in firstNames)
+            {
+                Console.WriteLine($"Hello {firstName}");
+            }
             await Task.CompletedTask;
         }
     }

--- a/Libraries/test/TestServerlessApp/SimpleCalculator.cs
+++ b/Libraries/test/TestServerlessApp/SimpleCalculator.cs
@@ -31,12 +31,12 @@ namespace TestServerlessApp
 
         [LambdaFunction(Name = "SimpleCalculatorSubtract")]
         [RestApi]
-        public APIGatewayProxyResponse Subtract([FromServices]ISimpleCalculatorService simpleCalculatorService)
+        public APIGatewayProxyResponse Subtract([FromHeader]int x, [FromHeader]int y, [FromServices]ISimpleCalculatorService simpleCalculatorService)
         {
             return new APIGatewayProxyResponse
             {
                 StatusCode = 200,
-                Body = simpleCalculatorService.Subtract(4, 2).ToString()
+                Body = simpleCalculatorService.Subtract(x, y).ToString()
             };
         }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- [x] add support for FromHeader parameter attribute

Example 1
```csharp
[LambdaFunction(Name = "GreeterSayHelloAsync", Timeout = 50)]
[HttpApi(HttpApiVersion.V1)]
public async Task SayHelloAsync([FromHeader(Name = "names")]IEnumerable<string> firstNames)
{
    if (firstNames == null)
    {
        return;
    }

    foreach (var firstName in firstNames)
    {
        Console.WriteLine($"Hello {firstName}");
    }
    await Task.CompletedTask;
}
```
translates to
```csharp
public async Task<APIGatewayProxyResponse> SayHelloAsync(APIGatewayProxyRequest request, ILambdaContext context)
{
    var firstNames = default(System.Collections.Generic.IEnumerable<string>);
    if (request.Headers?.ContainsKey("names") == true)
    {
        firstNames = request.Headers["names"].Split(",").Select(q => (string)Convert.ChangeType(q, typeof(string))).ToList();
    }

    await greeter.SayHelloAsync(firstNames);

    return new APIGatewayProxyResponse
    {
        StatusCode = 200
    };
}
```
Path: `Greeter/SayHelloAsync`
Header: `names:foo,bar`

Example 2
```csharp
[LambdaFunction(Name = "SimpleCalculatorSubtract")]
[RestApi]
public APIGatewayProxyResponse Subtract([FromHeader]int x, [FromHeader]int y, [FromServices]ISimpleCalculatorService simpleCalculatorService)
{
    return new APIGatewayProxyResponse
    {
        StatusCode = 200,
        Body = simpleCalculatorService.Subtract(x, y).ToString()
    };
}
```
translates to
```csharp
public APIGatewayProxyResponse Subtract(APIGatewayProxyRequest request, ILambdaContext context)
{
    // Create a scope for every request,
    // this allows creating scoped dependencies without creating a scope manually.
    using var scope = serviceProvider.CreateScope();
    var simpleCalculator = scope.ServiceProvider.GetRequiredService<SimpleCalculator>();

    var x = default(int);
    if (request.Headers?.ContainsKey("x") == true)
    {
        x = (int)Convert.ChangeType(request.Headers["x"], typeof(int));
    }

    var y = default(int);
    if (request.Headers?.ContainsKey("y") == true)
    {
        y = (int)Convert.ChangeType(request.Headers["y"], typeof(int));
    }

    var simpleCalculatorService = scope.ServiceProvider.GetRequiredService<TestServerlessApp.Services.ISimpleCalculatorService>();
    var response = simpleCalculator.Subtract(x, y, simpleCalculatorService);
    return response;
}
```

- [x] Test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
