### PR TITLE
feat: add support for FromBody attribute

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.cs
@@ -638,6 +638,60 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
                 }
 
             }
+            else if (parameter.Attributes.Any(att => att.Type.FullName == TypeFullNames.FromBodyAttribute))
+            {
+                // string parameter does not need to be de-serialized
+                if (parameter.Type.IsString())
+                {
+ 
+            
+            #line default
+            #line hidden
+            this.Write("            var ");
+            
+            #line 218 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(parameter.Name));
+            
+            #line default
+            #line hidden
+            this.Write(" = request.Body;\r\n\r\n");
+            
+            #line 220 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+
+                }
+                else
+                {
+ 
+            
+            #line default
+            #line hidden
+            this.Write("            var ");
+            
+            #line 225 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(parameter.Name));
+            
+            #line default
+            #line hidden
+            this.Write(" = ");
+            
+            #line 225 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(_model.Serializer));
+            
+            #line default
+            #line hidden
+            this.Write(".Deserialize<");
+            
+            #line 225 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(parameter.Type.FullName));
+            
+            #line default
+            #line hidden
+            this.Write(">(request.Body);\r\n\r\n");
+            
+            #line 227 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+
+                }
+            }
         }
 
         if (_model.LambdaMethod.ReturnsVoidOrTask)
@@ -648,34 +702,34 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("            ");
             
-            #line 217 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 235 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.IsAsync ? "await " : ""));
             
             #line default
             #line hidden
             
-            #line 217 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 235 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.ContainingType.Name.ToCamelCase()));
             
             #line default
             #line hidden
             this.Write(".");
             
-            #line 217 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 235 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.Name));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 217 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 235 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(parameters));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 218 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 236 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
         }
         else
@@ -686,34 +740,34 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("            var response = ");
             
-            #line 223 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 241 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.IsAsync ? "await " : ""));
             
             #line default
             #line hidden
             
-            #line 223 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 241 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.ContainingType.Name.ToCamelCase()));
             
             #line default
             #line hidden
             this.Write(".");
             
-            #line 223 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 241 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.Name));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 223 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 241 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(parameters));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 224 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 242 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
         }
 
@@ -725,7 +779,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("            return response;\r\n");
             
-            #line 231 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 249 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
         }
         else
@@ -740,7 +794,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("\r\n            var body = response.ToString();\r\n");
             
-            #line 242 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 260 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
                 }
                 else if (_model.LambdaMethod.ReturnType.IsString())
@@ -755,14 +809,14 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("\r\n            var body = ");
             
-            #line 252 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 270 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.Serializer));
             
             #line default
             #line hidden
             this.Write(".Serialize(response);\r\n");
             
-            #line 253 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 271 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
                 }
             }
@@ -772,14 +826,14 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("\r\n            return new ");
             
-            #line 258 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 276 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.GeneratedMethod.ResponseType.Name));
             
             #line default
             #line hidden
             this.Write("\r\n            {\r\n");
             
-            #line 260 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 278 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
             if (!_model.LambdaMethod.ReturnsVoidOrTask)
             {
@@ -789,7 +843,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("                Body = ");
             
-            #line 264 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 282 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.ReturnType.IsString() ? "response" : "body"));
             
             #line default
@@ -797,14 +851,14 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             this.Write(",\r\n                Headers = new Dictionary<string, string>\r\n                {\r\n " +
                     "                   {\"Content-Type\", ");
             
-            #line 267 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 285 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.ReturnType.IsString() ? "\"text/plain\"" : "\"application/json\""));
             
             #line default
             #line hidden
             this.Write("}\r\n                },\r\n");
             
-            #line 269 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 287 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
             }
 
@@ -813,7 +867,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("                StatusCode = 200\r\n            };\r\n");
             
-            #line 274 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 292 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
         }
     }

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.tt
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.tt
@@ -209,6 +209,24 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
                 }
 
             }
+            else if (parameter.Attributes.Any(att => att.Type.FullName == TypeFullNames.FromBodyAttribute))
+            {
+                // string parameter does not need to be de-serialized
+                if (parameter.Type.IsString())
+                {
+ #>
+            var <#= parameter.Name #> = request.Body;
+
+<#
+                }
+                else
+                {
+ #>
+            var <#= parameter.Name #> = <#= _model.Serializer #>.Deserialize<<#= parameter.Type.FullName #>>(request.Body);
+
+<#
+                }
+            }
         }
 
         if (_model.LambdaMethod.ReturnsVoidOrTask)

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/TypeFullNames.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/TypeFullNames.cs
@@ -16,6 +16,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
         public const string LambdaFunctionAttribute = "Amazon.Lambda.Annotations.LambdaFunctionAttribute";
         public const string FromQueryAttribute = "Amazon.Lambda.Annotations.FromQueryAttribute";
         public const string FromHeaderAttribute = "Amazon.Lambda.Annotations.FromHeaderAttribute";
+        public const string FromBodyAttribute = "Amazon.Lambda.Annotations.FromBodyAttribute";
         public const string FromServiceAttribute = "Amazon.Lambda.Annotations.FromServicesAttribute";
         public const string IEnumerable = "System.Collections.IEnumerable";
     }

--- a/Libraries/src/Amazon.Lambda.Annotations/FromBodyAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/FromBodyAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Amazon.Lambda.Annotations
+{
+    [AttributeUsage(AttributeTargets.Parameter)]
+    public class FromBodyAttribute : Attribute
+    {
+    }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ComplexCalculator_Subtract_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ComplexCalculator_Subtract_Generated.g.cs
@@ -6,20 +6,20 @@ using Amazon.Lambda.APIGatewayEvents;
 
 namespace TestServerlessApp
 {
-    public class ComplexCalculator_Add_Generated
+    public class ComplexCalculator_Subtract_Generated
     {
         private readonly ComplexCalculator complexCalculator;
 
-        public ComplexCalculator_Add_Generated()
+        public ComplexCalculator_Subtract_Generated()
         {
             complexCalculator = new ComplexCalculator();
         }
 
-        public APIGatewayHttpApiV2ProxyResponse Add(APIGatewayHttpApiV2ProxyRequest request, ILambdaContext context)
+        public APIGatewayHttpApiV2ProxyResponse Subtract(APIGatewayHttpApiV2ProxyRequest request, ILambdaContext context)
         {
-            var complexNumbers = request.Body;
+            var complexNumbers = System.Text.Json.JsonSerializer.Deserialize<System.Collections.Generic.IList<System.Collections.Generic.IList<int>>>(request.Body);
 
-            var response = complexCalculator.Add(complexNumbers);
+            var response = complexCalculator.Subtract(complexNumbers);
 
             var body = System.Text.Json.JsonSerializer.Serialize(response);
 

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
@@ -105,6 +105,11 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                             typeof(SourceGenerator.Generator),
                             "ComplexCalculator_Add_Generated.g.cs",
                             SourceText.From(File.ReadAllText(Path.Combine("Snapshots", "ComplexCalculator_Add_Generated.g.cs")), Encoding.UTF8, SourceHashAlgorithm.Sha256)
+                        ),
+                        (
+                            typeof(SourceGenerator.Generator),
+                            "ComplexCalculator_Subtract_Generated.g.cs",
+                            SourceText.From(File.ReadAllText(Path.Combine("Snapshots", "ComplexCalculator_Subtract_Generated.g.cs")), Encoding.UTF8, SourceHashAlgorithm.Sha256)
                         )
                     }
                 }

--- a/Libraries/test/TestServerlessApp/ComplexCalculator.cs
+++ b/Libraries/test/TestServerlessApp/ComplexCalculator.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
+using System.Threading;
 using Amazon.Lambda.Annotations;
 
 namespace TestServerlessApp
@@ -8,12 +11,58 @@ namespace TestServerlessApp
     {
         [LambdaFunction]
         [HttpApi(HttpApiVersion.V2)]
-        public Tuple<double, double> Add()
+        public Tuple<double, double> Add([FromBody]string complexNumbers)
         {
-            var c1 = new Complex(4, 2);
-            var c2 = new Complex(2, 4);
+            var components = complexNumbers.Split(";");
+            if (components.Length != 2)
+            {
+                throw new ArgumentException(@$"Complex numbers must be in format ""1,2;3,4"", but found ""{complexNumbers}""");
+            }
+
+            var firstComponent = components[0].Split(",");
+            if (firstComponent.Count() != 2)
+            {
+                throw new ArgumentException(@$"Complex number must be in format ""1,2"", but found ""{firstComponent}""");
+            }
+
+            var secondComponent = components[1].Split(",");
+            if (secondComponent.Count() != 2)
+            {
+                throw new ArgumentException(@$"Complex number must be in format ""1,2"", but found ""{secondComponent}""");
+            }
+
+            var c1 = new Complex(int.Parse(firstComponent[0]), int.Parse(firstComponent[1]));
+            var c2 = new Complex(int.Parse(secondComponent[0]), int.Parse(secondComponent[1]));
+            var result = c1 + c2;
+            return new Tuple<double, double>(result.Real, result.Imaginary);
+        }
+
+        [LambdaFunction]
+        [HttpApi(HttpApiVersion.V2)]
+        public Tuple<double, double> Subtract([FromBody]IList<IList<int>> complexNumbers)
+        {
+            if (complexNumbers.Count() != 2)
+            {
+                throw new ArgumentException("There must be two complex numbers");
+            }
+
+            var firstComponent = complexNumbers[0];
+            if (firstComponent.Count() != 2)
+            {
+                throw new ArgumentException(@$"Complex number must be in format [1,2], but found ""{firstComponent}""");
+            }
+
+            var secondComponent = complexNumbers[1];
+            if (secondComponent.Count() != 2)
+            {
+                throw new ArgumentException(@$"Complex number must be in format [1,2], but found ""{secondComponent}""");
+            }
+
+            var c1 = new Complex(firstComponent[0], firstComponent[1]);
+            var c2 = new Complex(secondComponent[0], secondComponent[1]);
             var result = c1 + c2;
             return new Tuple<double, double>(result.Real, result.Imaginary);
         }
     }
+
 }

--- a/Libraries/test/TestServerlessApp/serverless.template
+++ b/Libraries/test/TestServerlessApp/serverless.template
@@ -177,11 +177,34 @@
           "AWSLambdaBasicExecutionRole"
         ],
         "Events": {
-          "RootGet": {
+          "RootPost": {
             "Type": "HttpApi",
             "Properties": {
               "Path": "/ComplexCalculator/Add",
-              "Method": "GET",
+              "Method": "POST",
+              "PayloadFormatVersion": "2.0"
+            }
+          }
+        }
+      }
+    },
+    "TestServerlessAppComplexCalculatorSubtractGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Properties": {
+        "Runtime": "dotnetcore3.1",
+        "CodeUri": "",
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "Handler": "TestServerlessApp::TestServerlessApp.ComplexCalculator_Subtract_Generated::Subtract",
+        "Events": {
+          "RootPost": {
+            "Type": "HttpApi",
+            "Properties": {
+              "Path": "/ComplexCalculator/Subtract",
+              "Method": "POST",
               "PayloadFormatVersion": "2.0"
             }
           }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- [x] add support for FromBody attribute. Like response return, anything other than string requires de-serialization.
**Example 1**
```csharp
[LambdaFunction]
[HttpApi(HttpApiVersion.V2)]
public Tuple<double, double> Add([FromBody]string complexNumbers)
{
...
}
```
translates to
```csharp
public APIGatewayHttpApiV2ProxyResponse Add(APIGatewayHttpApiV2ProxyRequest request, ILambdaContext context)
{
    var complexNumbers = request.Body;

    var response = complexCalculator.Add(complexNumbers);

    var body = System.Text.Json.JsonSerializer.Serialize(response);

    return new APIGatewayHttpApiV2ProxyResponse
    {
        Body = body,
        Headers = new Dictionary<string, string>
        {
            {"Content-Type", "application/json"}
        },
        StatusCode = 200
    };
}
```

ComplexCalculator/Add
body: 
```
1,2;3,4
```
response:
```json
{
    "Item1": 4,
    "Item2": 6
}
```
**Example 2** 
```csharp
[LambdaFunction]
[HttpApi(HttpApiVersion.V2)]
public Tuple<double, double> Subtract([FromBody]IList<IList<int>> complexNumbers)
{
...
}
```
translates to
```csharp
public APIGatewayHttpApiV2ProxyResponse Subtract(APIGatewayHttpApiV2ProxyRequest request, ILambdaContext context)
{
    var complexNumbers = System.Text.Json.JsonSerializer.Deserialize<System.Collections.Generic.IList<System.Collections.Generic.IList<int>>>(request.Body);

    var response = complexCalculator.Subtract(complexNumbers);

    var body = System.Text.Json.JsonSerializer.Serialize(response);

    return new APIGatewayHttpApiV2ProxyResponse
    {
        Body = body,
        Headers = new Dictionary<string, string>
        {
            {"Content-Type", "application/json"}
        },
        StatusCode = 200
    };
}
```

ComplexCalculator/Subtract
body
```json
[
    [4,6],
    [7,8]
]
```
output
```json
{
    "Item1": 11,
    "Item2": 14
}
```

- [x] Test 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
