### PR TITLE
Resolves issue 936 - build.ps1 doesn't work with PowerShell version 5.1

### DIFF
--- a/LambdaRuntimeDockerfiles/build.ps1
+++ b/LambdaRuntimeDockerfiles/build.ps1
@@ -23,12 +23,12 @@ try
     # so it can include the Amazon.Lambda.RuntimeSupport project in its Docker Build Context
     Push-Location $PSScriptRoot\..   
 
-    if (Test-Path -Path (Join-Path $PWD '.\LambdaRuntimeDockerfiles\Images\' $TargetFramework $Architecture 'Dockerfile') -PathType Leaf)
+    if (Test-Path -Path (Join-Path $PWD -ChildPath '.\LambdaRuntimeDockerfiles\Images\' | Join-Path -ChildPath $TargetFramework | Join-Path -ChildPath  $Architecture | Join-Path -ChildPath 'Dockerfile') -PathType Leaf)
     {
         $Tag = "dot$TargetFramework.0-runtime:base-image-$Architecture"
 
         Write-Status "Building $TargetFramework base image: $Tag"
-        docker build -f (Join-Path $PWD '.\LambdaRuntimeDockerfiles\Images\' $TargetFramework $Architecture 'Dockerfile') -t $Tag .
+        docker build -f (Join-Path $PWD -ChildPath '.\LambdaRuntimeDockerfiles\Images\' | Join-Path -ChildPath $TargetFramework | Join-Path -ChildPath  $Architecture | Join-Path -ChildPath 'Dockerfile') -t $Tag .
     }
 }
 finally


### PR DESCRIPTION
*Issue #936:* build.ps1 doesn't work with PowerShell version 5.1

*Description of changes:*
Changed the `Join-Path` command to be compatible with PowerShell 5.1. 

Tested changes on PowerShell 5.1 (Windows), PowerShell 7.0.8 (Windows), and PowerShell 7.1.5 (Linux).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
