### PR TITLE
feat: expose Lambda method attributes to ILambdaFunctionSerializable …

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/ILambdaFunctionSerializable.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/ILambdaFunctionSerializable.cs
@@ -1,4 +1,7 @@
-﻿namespace Amazon.Lambda.Annotations.SourceGenerator.Models
+﻿using System;
+using System.Collections.Generic;
+
+namespace Amazon.Lambda.Annotations.SourceGenerator.Models
 {
     public interface ILambdaFunctionSerializable
     {
@@ -35,5 +38,11 @@
         /// Resource based policies that grants permissions to access other AWS resources.
         /// </summary>
         string Policies { get; }
+
+        /// <summary>
+        /// List of attributes applied to the Lambda method that are used to generate serverless.template.
+        /// There always exists <see cref="Annotations.LambdaFunctionAttribute"/> in the list.
+        /// </summary>
+        IList<Attribute> Attributes { get; }
     }
 }

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/LambdaFunctionModel.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/LambdaFunctionModel.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes;
 
 namespace Amazon.Lambda.Annotations.SourceGenerator.Models
 {
@@ -47,5 +49,10 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
 
         /// <inheritdoc />
         public string Policies => LambdaMethod.LambdaFunctionAttribute.Data.Policies;
+
+        /// <inheritdoc />
+        public IList<Attribute> Attributes => LambdaMethod.Attributes
+            .Where(model => model is AttributeModel<Attribute>)
+            .Select(model => (model as AttributeModel<Attribute>)?.Data).ToList();
     }
 }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/CloudFormationJsonWriterTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/CloudFormationJsonWriterTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Amazon.Lambda.Annotations.SourceGenerator.FileIO;
 using Amazon.Lambda.Annotations.SourceGenerator.Models;
@@ -233,23 +234,23 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
                                 }
                               }
                             }";
-            
+
             var mockFileManager = GetMockFileManager(originalContent);
             var lambdaFunctionModel = GetLambdaFunctionModel("MyAssembly::MyNamespace.MyType::Handler",
                 "MethodNotCreatedFromAnnotationsPackage", 45, 512, null, "Policy1, Policy2, Policy3");
             var cloudFormationJsonWriter = new CloudFormationJsonWriter(mockFileManager, new JsonWriter());
             var report = GetAnnotationReport(new() {lambdaFunctionModel});
-            
+
             // ACT
             cloudFormationJsonWriter.ApplyReport(report);
-            
+
             // ASSERT
             var rootToken = JObject.Parse(mockFileManager.ReadAllText(ServerlessTemplateFilePath));
-            
+
             Assert.NotNull(rootToken["Resources"]["MethodNotCreatedFromAnnotationsPackage"]);
             Assert.Equal(128, rootToken["Resources"]["MethodNotCreatedFromAnnotationsPackage"]["Properties"]["MemorySize"]); // unchanged
             Assert.Equal(100, rootToken["Resources"]["MethodNotCreatedFromAnnotationsPackage"]["Properties"]["Timeout"]); // unchanged
-            
+
             var policies = rootToken["Resources"]["MethodNotCreatedFromAnnotationsPackage"]["Properties"]["Policies"] as JArray;
             Assert.Equal(1, policies.Count);
             Assert.Equal("AWSLambdaBasicExecutionRole", policies[0]); // unchanged
@@ -297,6 +298,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
             public uint? MemorySize { get; set; }
             public string Role { get; set; }
             public string Policies { get; set; }
+            public IList<Attribute> Attributes { get; set; }
         }
     }
 }


### PR DESCRIPTION
…to allow serverless.template generation

*Issue #, if available:*

*Description of changes:*

This will allow writers to extract attribute information for writing JSON/YAML serverless.templates.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
