### PR TITLE
fix: replace .NET 3.1 with 5.0 in CI to build test app

### DIFF
--- a/.github/workflows/source-generator-ci.yml
+++ b/.github/workflows/source-generator-ci.yml
@@ -41,10 +41,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET 3.1
+    - name: Setup .NET 5.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.x
+        dotnet-version: 5.0.x
     - name: Restore dependencies
       run: dotnet restore Libraries/test/TestServerlessApp/TestServerlessApp.csproj
     - name: Build


### PR DESCRIPTION
*Issue #, if available:*
Source generator is not working for sample app in CI.

*Description of changes:*
The issue was because of using .NET 3.1 SDK, to compile a .NET Core 3.1 using source generator, .NET SDK must be 5.0 or above.

To verify, go to Checks -> Source Generator CI ->test-app-build-result, download the uploaded artifacts from CI and open TestServerlessApp.dll. 

![image](https://user-images.githubusercontent.com/8882380/139733390-6bbcc186-0038-4b8f-bda0-66c197f87f8e.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
