### PR TITLE
ci: create nuget package on every push to feature/annotations

### DIFF
--- a/.github/workflows/source-generator-ci.yml
+++ b/.github/workflows/source-generator-ci.yml
@@ -1,6 +1,10 @@
 name: Source Generator CI
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - feature/annotations
+  pull_request:
 
 jobs:
   source-generator-build-pack-test:

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/CloudFormationJsonWriterTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/CloudFormationJsonWriterTests.cs
@@ -252,7 +252,8 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
             Assert.Equal(100, rootToken["Resources"]["MethodNotCreatedFromAnnotationsPackage"]["Properties"]["Timeout"]); // unchanged
 
             var policies = rootToken["Resources"]["MethodNotCreatedFromAnnotationsPackage"]["Properties"]["Policies"] as JArray;
-            Assert.Equal(1, policies.Count);
+            Assert.NotNull(policies);
+            Assert.Single(policies);
             Assert.Equal("AWSLambdaBasicExecutionRole", policies[0]); // unchanged
         }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change allows not only do checks on PRs but also on merge to `feature/annotations` to allow testing nuget package without looking into PRs. Anyone can go any commit and grab the nuget package and use it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
