### PR TITLE
ci: use static Configuration and TargetFramework in nuspec

### DIFF
--- a/.github/workflows/source-generator-ci.yml
+++ b/.github/workflows/source-generator-ci.yml
@@ -26,10 +26,10 @@ jobs:
         dotnet restore Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
     - name: Build
       run: |
-        dotnet build Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj --no-restore
-        dotnet build Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj --no-restore
+        dotnet build Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj --no-restore --configuration Release
+        dotnet build Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj --no-restore --configuration Release
     - name: Pack
-      run: dotnet pack Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj -p:NuspecFile=../Amazon.Lambda.Annotations.nuspec --no-build --output "PackResults"
+      run: dotnet pack Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj -p:NuspecFile=../Amazon.Lambda.Annotations.nuspec --no-build --configuration Release --output "PackResults"
     - name: Upload pack results
       uses: actions/upload-artifact@v2
       with:
@@ -38,7 +38,7 @@ jobs:
       # Use always() to always run this step to publish test results when there are test failures
       if: ${{ always() }}
     - name: Test
-      run:  dotnet test Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj --no-build --verbosity normal --logger trx --results-directory "TestResults"
+      run:  dotnet test Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj --no-build --configuration Release --verbosity normal --logger trx --results-directory "TestResults"
     - name: Upload test results
       uses: actions/upload-artifact@v2
       with:
@@ -60,7 +60,7 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore Libraries/test/TestServerlessApp/TestServerlessApp.csproj
     - name: Build
-      run: dotnet build Libraries/test/TestServerlessApp/TestServerlessApp.csproj --no-restore
+      run: dotnet build Libraries/test/TestServerlessApp/TestServerlessApp.csproj --no-restore --configuration Release
     - name: Upload built assemblies
       uses: actions/upload-artifact@v2
       with:

--- a/Libraries/src/Amazon.Lambda.Annotations.nuspec
+++ b/Libraries/src/Amazon.Lambda.Annotations.nuspec
@@ -15,11 +15,11 @@
 
     <files>
         <!-- Dependencies to make sure attributes are available in consuming csproj, this ensures packaged version of customer code have all the dependencies needed. -->
-        <file src="Amazon.Lambda.Annotations\bin\$configuration$\$targetFramework$\Amazon.Lambda.Annotations.dll" target="lib/netstandard2.0" />
+        <file src="Amazon.Lambda.Annotations\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.dll" target="lib/netstandard2.0" />
 
         <!-- Include every dependency manually for analyzer, whenever a new dependency is added, it has to be added here. -->
-        <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\$configuration$\$targetFramework$\Amazon.Lambda.Annotations.dll" target="analyzers\dotnet\cs" />
-        <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\$configuration$\$targetFramework$\Amazon.Lambda.Annotations.SourceGenerator.dll" target="analyzers\dotnet\cs" />
-        <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\$configuration$\$targetFramework$\Newtonsoft.Json.dll" target="analyzers\dotnet\cs" />
+        <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.dll" target="analyzers\dotnet\cs" />
+        <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.SourceGenerator.dll" target="analyzers\dotnet\cs" />
+        <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netstandard2.0\Newtonsoft.Json.dll" target="analyzers\dotnet\cs" />
     </files>
 </package>

--- a/Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj
+++ b/Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj
@@ -4,11 +4,4 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
-  <Target Name="SetNuspecProperties" BeforeTargets="GenerateNuspec">
-    <PropertyGroup>
-      <NuspecProperties>$(NuspecProperties);configuration=$(Configuration)</NuspecProperties>
-      <NuspecProperties>$(NuspecProperties);targetFramework=$(TargetFramework)</NuspecProperties>
-    </PropertyGroup>
-  </Target>
-
 </Project>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I realized that release CodePipeline doesn't have support for configuration and target framework passing from outside. It simply executes `nuget pack "path/to/nuspec"`. There isn't a great way to pass defaults there I chose to fix the nuspec to make it compatible with the CodePipeline.

This change also updates the CI which now builds with Release configuration otherwise `dotnet pack` will fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
