### PR TITLE
Delete Redundant Event Attributes Entries from serverless.template

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/LambdaFunctionModel.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/LambdaFunctionModel.cs
@@ -51,6 +51,6 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
         public string Policies => LambdaMethod.LambdaFunctionAttribute.Data.Policies;
 
         /// <inheritdoc />
-        public IList<AttributeModel> Attributes => LambdaMethod.Attributes;
+        public IList<AttributeModel> Attributes => LambdaMethod.Attributes ?? new List<AttributeModel>();
     }
 }

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Writers/CloudFormationJsonWriter.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Writers/CloudFormationJsonWriter.cs
@@ -83,27 +83,48 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Writers
                 _jsonWriter.RemoveToken($"{propertiesPath}.Role");
             }
             
-            if (lambdaFunction.Attributes != null && lambdaFunction.Attributes.Any())
-                ProcessLambdaFunctionAttributes(lambdaFunction);
+            ProcessLambdaFunctionEvents(lambdaFunction);
         }
 
-        private void ProcessLambdaFunctionAttributes(ILambdaFunctionSerializable lambdaFunction)
+        private void ProcessLambdaFunctionEvents(ILambdaFunctionSerializable lambdaFunction)
         {
+            var currentSyncedEvents = new List<string>();
+            string eventName;
+            
             foreach (var attributeModel in lambdaFunction.Attributes)
             {
                 switch (attributeModel)
                 {
                     case AttributeModel<HttpApiAttribute> httpApiAttributeModel:
-                        ProcessHttpApiAttribute(lambdaFunction, httpApiAttributeModel.Data);
+                        eventName = ProcessHttpApiAttribute(lambdaFunction, httpApiAttributeModel.Data);
+                        currentSyncedEvents.Add(eventName);
                         break;
                     case AttributeModel<RestApiAttribute> restApiAttributeModel:
-                        ProcessRestApiAttribute(lambdaFunction, restApiAttributeModel.Data);
+                        eventName = ProcessRestApiAttribute(lambdaFunction, restApiAttributeModel.Data);
+                        currentSyncedEvents.Add(eventName);
                         break;
                 }
             }
+
+            var eventsPath = $"Resources.{lambdaFunction.Name}.Properties.Events";
+            var syncedEventsMetadataPath = $"Resources.{lambdaFunction.Name}.Metadata.SyncedEvents";
+            
+            if (_jsonWriter.GetToken(syncedEventsMetadataPath, new JArray()) is JArray previousSyncedEvents)
+            {
+                foreach (var previousEventName in previousSyncedEvents.Select(x => x.ToObject<string>()))
+                {
+                    if (!currentSyncedEvents.Contains(previousEventName))
+                        _jsonWriter.RemoveToken($"{eventsPath}.{previousEventName}");
+                }
+            }
+
+            if (currentSyncedEvents.Any())
+                _jsonWriter.SetToken(syncedEventsMetadataPath, new JArray(currentSyncedEvents));
+            else
+                _jsonWriter.RemoveToken(syncedEventsMetadataPath);
         }
 
-        private void ProcessRestApiAttribute(ILambdaFunctionSerializable lambdaFunction, RestApiAttribute restApiAttribute)
+        private string ProcessRestApiAttribute(ILambdaFunctionSerializable lambdaFunction, RestApiAttribute restApiAttribute)
         {
             var eventPath = $"Resources.{lambdaFunction.Name}.Properties.Events";
             var methodName = restApiAttribute.Method.ToString();
@@ -112,9 +133,11 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Writers
             _jsonWriter.SetToken($"{methodPath}.Type", "Api");
             _jsonWriter.SetToken($"{methodPath}.Properties.Path", restApiAttribute.Template);
             _jsonWriter.SetToken($"{methodPath}.Properties.Method", methodName.ToUpper());
+
+            return $"Root{methodName}";
         }
 
-        private void ProcessHttpApiAttribute(ILambdaFunctionSerializable lambdaFunction, HttpApiAttribute httpApiAttribute)
+        private string ProcessHttpApiAttribute(ILambdaFunctionSerializable lambdaFunction, HttpApiAttribute httpApiAttribute)
         {
             var eventPath = $"Resources.{lambdaFunction.Name}.Properties.Events";
             var methodName = httpApiAttribute.Method.ToString();
@@ -125,6 +148,8 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Writers
             _jsonWriter.SetToken($"{methodPath}.Properties.Path", httpApiAttribute.Template);
             _jsonWriter.SetToken($"{methodPath}.Properties.Method", methodName.ToUpper());
             _jsonWriter.SetToken($"{methodPath}.Properties.PayloadFormatVersion", version);
+            
+            return $"Root{methodName}";
         }
         
         private void ApplyLambdaFunctionDefaults(string lambdaFunctionPath, string propertiesPath)

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/complexCalculator.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/complexCalculator.template
@@ -5,7 +5,10 @@
     "TestServerlessAppComplexCalculatorAddGenerated": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations"
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootPost"
+        ]
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",
@@ -31,7 +34,10 @@
     "TestServerlessAppComplexCalculatorSubtractGenerated": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations"
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootPost"
+        ]
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/greeter.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/greeter.template
@@ -5,7 +5,10 @@
     "GreeterSayHello": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations"
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",
@@ -31,7 +34,10 @@
     "GreeterSayHelloAsync": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations"
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/simpleCalculator.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/simpleCalculator.template
@@ -5,7 +5,10 @@
     "SimpleCalculatorAdd": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations"
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",
@@ -30,7 +33,10 @@
     "SimpleCalculatorSubtract": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations"
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",
@@ -55,7 +61,10 @@
     "SimpleCalculatorMultiply": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations"
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",
@@ -80,7 +89,10 @@
     "SimpleCalculatorDivideAsync": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations"
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",

--- a/Libraries/test/TestServerlessApp/serverless.template
+++ b/Libraries/test/TestServerlessApp/serverless.template
@@ -6,7 +6,10 @@
     "GreeterSayHello": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations"
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
       },
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.Greeter_SayHello_Generated::SayHello",
@@ -33,7 +36,10 @@
     "GreeterSayHelloAsync": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations"
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
       },
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.Greeter_SayHelloAsync_Generated::SayHelloAsync",
@@ -60,7 +66,10 @@
     "SimpleCalculatorAdd": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations"
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
       },
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Add_Generated::Add",
@@ -86,7 +95,10 @@
     "SimpleCalculatorSubtract": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations"
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
       },
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Subtract_Generated::Subtract",
@@ -112,7 +124,10 @@
     "SimpleCalculatorMultiply": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations"
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
       },
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Multiply_Generated::Multiply",
@@ -138,7 +153,10 @@
     "SimpleCalculatorDivideAsync": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations"
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
       },
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_DivideAsync_Generated::DivideAsync",
@@ -164,7 +182,10 @@
     "TestServerlessAppComplexCalculatorAddGenerated": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations"
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootPost"
+        ]
       },
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.ComplexCalculator_Add_Generated::Add",


### PR DESCRIPTION
*Description of changes:*
When a customer changes their event attributes (for ex, changing from HTTP GET attribute to a HTTP POST attribute) the previous attributes are still retained in the `severless.template`.

This PR addresses this issue by adding new metadata called `SyncedEvents` which maintains a list of events that are created by the `Amazon.Lambda.Annotations` package

On every compilation of the target application, currently synced events are compared with the previous ones and redundant entries are deleted.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
