### PR TITLE
Rename /bootstrap.sh to /var/runtime/bootstrap in .NET 6 Lambda base image

### DIFF
--- a/LambdaRuntimeDockerfiles/Images/net6/amd64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net6/amd64/Dockerfile
@@ -60,8 +60,7 @@ ENV \
 
 COPY --from=publish /app/publish /var/runtime
 
-COPY --from=publish /app/publish/bootstrap.sh /
-RUN rm -f /var/runtime/bootstrap.sh && \
-    chmod +x /bootstrap.sh
+RUN mv /var/runtime/bootstrap.sh /var/runtime/bootstrap && \
+    chmod +x /var/runtime/bootstrap
 
-ENTRYPOINT ["/bootstrap.sh"]
+ENTRYPOINT ["/var/runtime/bootstrap"]

--- a/LambdaRuntimeDockerfiles/Images/net6/arm64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net6/arm64/Dockerfile
@@ -93,8 +93,7 @@ ENV \
 
 COPY --from=publish /app/publish /var/runtime
 
-COPY --from=publish /app/publish/bootstrap.sh /
-RUN rm -f /var/runtime/bootstrap.sh && \
-    chmod +x /bootstrap.sh
+RUN mv /var/runtime/bootstrap.sh /var/runtime/bootstrap && \
+    chmod +x /var/runtime/bootstrap
 
-ENTRYPOINT ["/bootstrap.sh"]
+ENTRYPOINT ["/var/runtime/bootstrap"]


### PR DESCRIPTION
*Description of changes:*
To match other language base images the name of bootstrap this PR renames the `/bootstrap.sh` to `/var/runtime/bootstrap`. This is done for both the amd64 and arm64 images.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
