### PR TITLE
Fix typos in help messages

### DIFF
--- a/LambdaRuntimeDockerfiles/Infrastructure/bootstrap.ps1
+++ b/LambdaRuntimeDockerfiles/Infrastructure/bootstrap.ps1
@@ -11,10 +11,10 @@ param (
     [Parameter(Mandatory = $false, HelpMessage = "ECR URI to store Stage images.")]
     [string] $StageEcr,
 
-    [Parameter(Mandatory = $false, HelpMessage = "Semicolon seperated ECR URIs to store Beta images.")]
+    [Parameter(Mandatory = $false, HelpMessage = "Semicolon separated ECR URIs to store Beta images.")]
     [string] $BetaEcrs,
 
-    [Parameter(Mandatory = $false, HelpMessage = "Semicolon seperated ECR URIs to store Prod images.")]
+    [Parameter(Mandatory = $false, HelpMessage = "Semicolon separated ECR URIs to store Prod images.")]
     [string] $ProdEcrs,
 
     [Parameter(Mandatory = $true, HelpMessage = "ECR repository name for Stage, Beta and Prod images.")]

--- a/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/DockerBuild/build.ps1
+++ b/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/DockerBuild/build.ps1
@@ -8,7 +8,7 @@ param (
     [Parameter(HelpMessage = "Final image tag to push.")]
     [string] $ImageTag,
 
-    [Parameter(HelpMessage = "Image archtecture")]
+    [Parameter(HelpMessage = "Image architecture")]
     [string] $Architecture,
                           
     [Parameter(HelpMessage = ".NET version")]

--- a/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/DockerImageManifest/build.ps1
+++ b/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/DockerImageManifest/build.ps1
@@ -8,10 +8,10 @@ param (
     [Parameter(HelpMessage = "Final image tag to push.")]
     [string] $MultiArchImageTag,
 
-    [Parameter(HelpMessage = "Image archtectures")]
+    [Parameter(HelpMessage = "Image architectures")]
     [string] $Arm64ImageTag,
 
-    [Parameter(HelpMessage = "Image archtectures")]
+    [Parameter(HelpMessage = "Image architectures")]
     [string] $Amd64ImageTag,
 
     [Parameter(HelpMessage = "Indicates whether to include an Arm64 image in the manifest")]

--- a/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/DockerPush/build.ps1
+++ b/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/DockerPush/build.ps1
@@ -1,5 +1,5 @@
 param (
-    [Parameter(HelpMessage = "Soruce ECR containing source docker image.")]
+    [Parameter(HelpMessage = "Source ECR containing source docker image.")]
     [string] $SourceEcr,
 
     [Parameter(HelpMessage = "Tag of the source image.")]
@@ -8,7 +8,7 @@ param (
     [Parameter(HelpMessage = "Tag of the source image.")]
     [string]  $Arm64ImageTag,
 
-    [Parameter(HelpMessage = "Semicolon seperated list of destincation ECR to push source image.")]
+    [Parameter(HelpMessage = "Semicolon separated list of destincation ECR to push source image.")]
     [string] $DestinationEcrs,
 
     [Parameter(HelpMessage = "Tag of the destination image.")]

--- a/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/SmokeTests/build.ps1
+++ b/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/SmokeTests/build.ps1
@@ -1,5 +1,5 @@
 param (
-    [Parameter(HelpMessage = "Soruce ECR containing source docker image.")]
+    [Parameter(HelpMessage = "Source ECR containing source docker image.")]
     [string] $SourceEcr,
 
     [Parameter(HelpMessage = "Tag of the source image.")]


### PR DESCRIPTION
*Description of changes:*
Scanning through the changes of 31850ac7050035a8e49cd272c933d6e6a15032e2 I noticed some typos.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
