### PR TITLE
Re-use base image's entrypoint, refactor bootstrap script

### DIFF
--- a/LambdaRuntimeDockerfiles/Images/net5/amd64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net5/amd64/Dockerfile
@@ -59,10 +59,7 @@ ENV \
 
 COPY --from=publish /app/publish /var/runtime
 
-COPY --from=publish /app/publish/bootstrap.sh /
-RUN rm -f /var/runtime/bootstrap.sh && \
-    chmod +x /bootstrap.sh && \
-	# Keep the legacy name lambda-entrypoint.sh for the bootstrap script for existing CloudFormation templates referencing it
-	cp /bootstrap.sh /lambda-entrypoint.sh
+COPY --from=publish /app/publish/bootstrap.sh /var/runtime/bootstrap
+RUN chmod +x /var/runtime/bootstrap
 
-ENTRYPOINT ["/bootstrap.sh"]
+# Entrypoint is inherited from public.ecr.aws/lambda/provided

--- a/LambdaRuntimeDockerfiles/Images/net6/amd64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net6/amd64/Dockerfile
@@ -63,4 +63,4 @@ COPY --from=publish /app/publish /var/runtime
 RUN mv /var/runtime/bootstrap.sh /var/runtime/bootstrap && \
     chmod +x /var/runtime/bootstrap
 
-ENTRYPOINT ["/var/runtime/bootstrap"]
+# Entrypoint is inherited from public.ecr.aws/lambda/provided

--- a/LambdaRuntimeDockerfiles/Images/net6/arm64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net6/arm64/Dockerfile
@@ -96,4 +96,4 @@ COPY --from=publish /app/publish /var/runtime
 RUN mv /var/runtime/bootstrap.sh /var/runtime/bootstrap && \
     chmod +x /var/runtime/bootstrap
 
-ENTRYPOINT ["/var/runtime/bootstrap"]
+# Entrypoint is inherited from public.ecr.aws/lambda/provided

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/bootstrap.sh
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/bootstrap.sh
@@ -5,50 +5,77 @@
 # These files are used to add the end-user assembly into context and make the code reachable to the dotnet process
 # Since the file names are not known in advance, we use this shell script to find the files and pass them to the dotnet process as parameters
 # You can improve cold-start performance by setting the LAMBDA_DOTNET_MAIN_ASSEMBLY environment variable and specifying the assembly name
-USER_LAMBDA_BINARIES_DIR="/var/task/"
-if [ ! -d "$USER_LAMBDA_BINARIES_DIR" ]; then
-    echo "Error: .NET binaries for Lambda function are not correctly installed in the $USER_LAMBDA_BINARIES_DIR directory of the image when the image was built. The $USER_LAMBDA_BINARIES_DIR directory is missing." 1>&2
-	exit 1
+USER_LAMBDA_BINARIES_DIR="/var/task"
+if [ ! -d "${USER_LAMBDA_BINARIES_DIR}" ]; then
+  echo "Error: .NET binaries for Lambda function are not correctly installed in the ${USER_LAMBDA_BINARIES_DIR} directory of the image when the image was built. The ${USER_LAMBDA_BINARIES_DIR} directory is missing." 1>&2
+  exit 1
 fi
 
-if [[ `expr index  "$1" ":"` == 0 ]]; then
-  EXECUTABLE_ASSEMBLY=$1
-  if [[ "$EXECUTABLE_ASSEMBLY" != *.dll ]]; then
+DOTNET_BIN="/var/lang/bin/dotnet"
+DOTNET_EXEC="exec"
+DOTNET_ARGS=()
+
+LAMBDA_HANDLER=""
+# Command-line parameter has precedence over "_HANDLER" environment variable
+if [ ! -z "${1}" ]; then
+  LAMBDA_HANDLER="${1}"
+elif [ ! -z "${_HANDLER}" ]; then
+  LAMBDA_HANDLER="${_HANDLER}"
+else
+  echo "Error: No Lambda Handler function was specified." 1>&2
+  exit 1
+fi
+
+if [[ `expr index "${LAMBDA_HANDLER}" ":"` == 0 ]]; then
+  EXECUTABLE_ASSEMBLY="${USER_LAMBDA_BINARIES_DIR}"/"${LAMBDA_HANDLER}"
+  if [[ "${EXECUTABLE_ASSEMBLY}" != *.dll ]]; then
     EXECUTABLE_ASSEMBLY="${EXECUTABLE_ASSEMBLY}.dll"
   fi
 
-  if [ ! -f "${USER_LAMBDA_BINARIES_DIR}/${EXECUTABLE_ASSEMBLY}" ]; then
-      echo "Error: executable assembly $EXECUTABLE_ASSEMBLY was not found." 1>&2
-      exit 1
+  if [ ! -f "${EXECUTABLE_ASSEMBLY}" ]; then
+    echo "Error: executable assembly ${EXECUTABLE_ASSEMBLY} was not found." 1>&2
+    exit 1
   fi
-  if [ -z "${AWS_LAMBDA_RUNTIME_API}" ]; then
-    exec /usr/local/bin/aws-lambda-rie /var/lang/bin/dotnet exec "${USER_LAMBDA_BINARIES_DIR}/${EXECUTABLE_ASSEMBLY}"
-  else
-    /var/lang/bin/dotnet exec "${USER_LAMBDA_BINARIES_DIR}/${EXECUTABLE_ASSEMBLY}"
-  fi
+
+  DOTNET_ARGS+=("${EXECUTABLE_ASSEMBLY}")
 else
   ASSEMBLY_NAME="${LAMBDA_DOTNET_MAIN_ASSEMBLY}"
-  if [ -z "$ASSEMBLY_NAME" ]; then
+  if [ -z "${ASSEMBLY_NAME}" ]; then
     DEPS_FILE=`find "${USER_LAMBDA_BINARIES_DIR}" -name \*.deps.json -print`
-    if [ -z "$DEPS_FILE" ]; then
-      echo "Error: .NET binaries for Lambda function are not correctly installed in the $USER_LAMBDA_BINARIES_DIR directory of the image when the image was built. The $USER_LAMBDA_BINARIES_DIR directory is missing the required .deps.json file." 1>&2
+    if [ -z "${DEPS_FILE}" ]; then
+      echo "Error: .NET binaries for Lambda function are not correctly installed in the ${USER_LAMBDA_BINARIES_DIR} directory of the image when the image was built. The ${USER_LAMBDA_BINARIES_DIR} directory is missing the required .deps.json file." 1>&2
       exit 1
     fi
     RUNTIMECONFIG_FILE=`find "${USER_LAMBDA_BINARIES_DIR}" -name \*.runtimeconfig.json -print`
-    if [ -z "$RUNTIMECONFIG_FILE" ]; then
-      echo "Error: .NET binaries for Lambda function are not correctly installed in the $USER_LAMBDA_BINARIES_DIR directory of the image when the image was built. The $USER_LAMBDA_BINARIES_DIR directory is missing the required .runtimeconfig.json file." 1>&2
+    if [ -z "${RUNTIMECONFIG_FILE}" ]; then
+      echo "Error: .NET binaries for Lambda function are not correctly installed in the ${USER_LAMBDA_BINARIES_DIR} directory of the image when the image was built. The ${USER_LAMBDA_BINARIES_DIR} directory is missing the required .runtimeconfig.json file." 1>&2
       exit 1
     fi
   else
-    if [[ "$ASSEMBLY_NAME" == *.dll ]]; then
+    if [[ "${ASSEMBLY_NAME}" == *.dll ]]; then
       ASSEMBLY_NAME="${ASSEMBLY_NAME::-4}"
     fi
-    DEPS_FILE="${USER_LAMBDA_BINARIES_DIR}${ASSEMBLY_NAME}.deps.json"
-    RUNTIMECONFIG_FILE="${USER_LAMBDA_BINARIES_DIR}${ASSEMBLY_NAME}.runtimeconfig.json"
+    DEPS_FILE="${USER_LAMBDA_BINARIES_DIR}/${ASSEMBLY_NAME}.deps.json"
+    RUNTIMECONFIG_FILE="${USER_LAMBDA_BINARIES_DIR}/${ASSEMBLY_NAME}.runtimeconfig.json"
   fi
-  if [ -z "${AWS_LAMBDA_RUNTIME_API}" ]; then
-    exec /usr/local/bin/aws-lambda-rie /var/lang/bin/dotnet exec --depsfile $DEPS_FILE --runtimeconfig $RUNTIMECONFIG_FILE /var/runtime/Amazon.Lambda.RuntimeSupport.dll $1
-  else
-    /var/lang/bin/dotnet exec --depsfile $DEPS_FILE --runtimeconfig $RUNTIMECONFIG_FILE /var/runtime/Amazon.Lambda.RuntimeSupport.dll $1
+
+  DOTNET_ARGS+=("--depsfile" "${DEPS_FILE}"
+                "--runtimeconfig" "${RUNTIMECONFIG_FILE}"
+                "/var/runtime/Amazon.Lambda.RuntimeSupport.dll" "${LAMBDA_HANDLER}")
+fi
+
+# To support runtime wrapper scripts
+# https://docs.aws.amazon.com/lambda/latest/dg/runtimes-modify.html#runtime-wrapper
+if [ -z "${AWS_LAMBDA_EXEC_WRAPPER}" ]; then
+  exec "${DOTNET_BIN}" "${DOTNET_EXEC}" "${DOTNET_ARGS[@]}"
+else
+  if [ ! -f "${AWS_LAMBDA_EXEC_WRAPPER}" ]; then
+    echo "${AWS_LAMBDA_EXEC_WRAPPER}: does not exist"
+    exit 127
   fi
+  if [ ! -x "${AWS_LAMBDA_EXEC_WRAPPER}" ]; then
+    echo "${AWS_LAMBDA_EXEC_WRAPPER}: is not an executable"
+    exit 126
+  fi
+  exec -- "${AWS_LAMBDA_EXEC_WRAPPER}" "${DOTNET_BIN}" "${DOTNET_EXEC}" "${DOTNET_ARGS[@]}"
 fi


### PR DESCRIPTION
*Description of changes:*

### 1. Refactor `net5` and `net6` bootstrap scripts to `/var/runtime/bootstrap`

This is in order to make use of the `provided` image's bundled `/lambda-entrypoint.sh` entrypoint. The script also handles deciding whether or not the bootstrap should run through the RIE.

This is what `/lambda-entrypoint.sh` looks like:
```
#!/bin/sh
# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.

if [ $# -ne 1 ]; then
  echo "entrypoint requires the handler name to be the first argument" 1>&2
  exit 142
fi
export _HANDLER="$1"

RUNTIME_ENTRYPOINT=/var/runtime/bootstrap
if [ -z "${AWS_LAMBDA_RUNTIME_API}" ]; then
  exec /usr/local/bin/aws-lambda-rie $RUNTIME_ENTRYPOINT
else
  exec $RUNTIME_ENTRYPOINT
fi
```

### 2. Allow handler to be specified with `_HANDLER` 

`_HANDLER` will be used if the first command-line argument is not specified. This is to support running through `/lambda-entrypoint.sh` which does not pass the handler string in as a command-line argument, but as an environment variable.


### 3. Add support for exec wrapper scripts

ref. https://docs.aws.amazon.com/lambda/latest/dg/runtimes-modify.html#runtime-wrapper

This is controlled by users through the `AWS_LAMBDA_EXEC_WRAPPER` environment variable in order to hook into the runtime's start command line arguments.


-----------

## Testing

Built base images locally (tagged as `dotnet5` and `dotnet6`) and used those in Lambda container image functions:
```Dockerfile
# intermediate build stages omitted
FROM dotnet5

COPY --from=build-image /build/build_artifacts/ /var/task/

CMD ["HelloWorld::HelloWorld.Function::FunctionHandler"]
```

And invoked successfully both locally and in the cloud.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*
