### PR TITLE
test: Add integration test for TestServerlessApp

### DIFF
--- a/.github/workflows/source-generator-ci.yml
+++ b/.github/workflows/source-generator-ci.yml
@@ -24,14 +24,26 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 5.0.x
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.CI_AWS_ACCESS_KEY_SECRET }}
+        aws-region: us-west-2
+        role-to-assume: ${{ secrets.CI_TEST_RUNNER_ROLE }}
+        role-duration-seconds: 3600
+        role-session-name: test-runner
+        role-skip-session-tagging: true
     - name: Restore dependencies
       run: |
         dotnet restore Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj
         dotnet restore Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
+        dotnet restore Libraries/test/TestServerlessApp.IntegrationTests/TestServerlessApp.IntegrationTests.csproj
     - name: Build
       run: |
         dotnet build Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj --no-restore --configuration Release
         dotnet build Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj --no-restore --configuration Release
+        dotnet build Libraries/test/TestServerlessApp.IntegrationTests/TestServerlessApp.IntegrationTests.csproj --no-restore --configuration Release
     - name: Pack
       run: dotnet pack Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj -p:NuspecFile=../Amazon.Lambda.Annotations.nuspec --no-build --configuration Release --output "PackResults"
     - name: Upload pack results
@@ -42,7 +54,9 @@ jobs:
       # Use always() to always run this step to publish test results when there are test failures
       if: ${{ always() }}
     - name: Test
-      run:  dotnet test Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj --no-build --configuration Release --verbosity normal --logger trx --results-directory "TestResults"
+      run: |
+        dotnet test Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj --no-build --configuration Release --verbosity normal --logger trx --results-directory "TestResults"
+        dotnet test Libraries/test/TestServerlessApp.IntegrationTests/TestServerlessApp.IntegrationTests.csproj --no-build --configuration Release --verbosity normal --logger trx --results-directory "TestResults"
     - name: Upload test results
       uses: actions/upload-artifact@v2
       with:

--- a/Libraries/Libraries.sln
+++ b/Libraries/Libraries.sln
@@ -114,6 +114,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.Lambda.Annotations",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.Lambda.Annotations.SourceGenerator", "src\Amazon.Lambda.Annotations.SourceGenerator\Amazon.Lambda.Annotations.SourceGenerator.csproj", "{3C617909-D61F-4AA8-B11C-4C9ECC865D75}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestServerlessApp.IntegrationTests", "test\TestServerlessApp.IntegrationTests\TestServerlessApp.IntegrationTests.csproj", "{2D956162-04BE-402E-9487-AE785AA14DE4}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		test\EventsTests.Shared\EventsTests.Shared.projitems*{44e9d925-b61d-4234-97b7-61424c963ba6}*SharedItemsImports = 5
@@ -305,6 +307,10 @@ Global
 		{3C617909-D61F-4AA8-B11C-4C9ECC865D75}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3C617909-D61F-4AA8-B11C-4C9ECC865D75}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3C617909-D61F-4AA8-B11C-4C9ECC865D75}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2D956162-04BE-402E-9487-AE785AA14DE4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2D956162-04BE-402E-9487-AE785AA14DE4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2D956162-04BE-402E-9487-AE785AA14DE4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2D956162-04BE-402E-9487-AE785AA14DE4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -359,6 +365,7 @@ Global
 		{D76F2C74-3D7F-4DB3-BA1A-F2EA14749253} = {1DE4EE60-45BA-4EF7-BE00-B9EB861E4C69}
 		{ADA9AF37-A8C1-47E6-BBBD-5C7E49C26C0E} = {AAB54E74-20B1-42ED-BC3D-CE9F7BC7FD12}
 		{3C617909-D61F-4AA8-B11C-4C9ECC865D75} = {AAB54E74-20B1-42ED-BC3D-CE9F7BC7FD12}
+		{2D956162-04BE-402E-9487-AE785AA14DE4} = {1DE4EE60-45BA-4EF7-BE00-B9EB861E4C69}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {503678A4-B8D1-4486-8915-405A3E9CF0EB}

--- a/Libraries/test/TestServerlessApp.IntegrationTests/ComplexCalculator.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/ComplexCalculator.cs
@@ -1,0 +1,42 @@
+﻿using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace TestServerlessApp.IntegrationTests
+{
+    [Collection("Integration Tests")]
+    public class ComplexCalculator
+    {
+        private readonly IntegrationTestContextFixture _fixture;
+
+        public ComplexCalculator(IntegrationTestContextFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task Add_FromBodyAsString_ReturnsJson()
+        {
+            var response = await _fixture.HttpClient.PostAsync($"{_fixture.HttpApiUrlPrefix}/ComplexCalculator/Add", new StringContent("1,2;3,4"));
+            response.EnsureSuccessStatusCode();
+            var responseJson = JObject.Parse(await response.Content.ReadAsStringAsync());
+            Assert.Equal(4, responseJson["Item1"]);
+            Assert.Equal(6, responseJson["Item2"]);
+        }
+
+        [Fact]
+        public async Task Subtract_FromBodyAsList_ReturnsJson()
+        {
+            var json = JsonConvert.SerializeObject(new[,] { { 1, 2 }, { 3, 4 } });
+            var data = new StringContent(json, Encoding.UTF8, "application/json");
+            var response = await _fixture.HttpClient.PostAsync($"{_fixture.HttpApiUrlPrefix}/ComplexCalculator/Subtract", data);
+            response.EnsureSuccessStatusCode();
+            var responseJson = JObject.Parse(await response.Content.ReadAsStringAsync());
+            Assert.Equal(-2, responseJson["Item1"]);
+            Assert.Equal(-2, responseJson["Item2"]);
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp.IntegrationTests/DeploymentScript.ps1
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/DeploymentScript.ps1
@@ -1,0 +1,38 @@
+$ErrorActionPreference = 'Stop'
+try
+{
+    Push-Location $PSScriptRoot
+    $guid = New-Guid
+    $suffix = $guid.ToString().Split('-') | Select-Object -First 1
+    $identifier = "test-serverless-app-" + $suffix
+    cd ..\TestServerlessApp
+
+    # Replace bucket name in aws-lambda-tools-defaults.json
+    $line = Get-Content .\aws-lambda-tools-defaults.json | Select-String s3-bucket | Select-Object -ExpandProperty Line
+    $content = Get-Content .\aws-lambda-tools-defaults.json
+    $content | ForEach-Object {$_ -replace $line, "`"s3-bucket`" : `"$identifier`","} | Set-Content .\aws-lambda-tools-defaults.json
+
+    # Replace stack name in aws-lambda-tools-defaults.json
+    $line = Get-Content .\aws-lambda-tools-defaults.json | Select-String stack-name | Select-Object -ExpandProperty Line
+    $content = Get-Content .\aws-lambda-tools-defaults.json
+    $content | ForEach-Object {$_ -replace $line, "`"stack-name`" : `"$identifier`""} | Set-Content .\aws-lambda-tools-defaults.json
+
+    dotnet tool install -g Amazon.Lambda.Tools
+    Write-Host "Creating S3 Bucket $identifier"
+    aws s3 mb s3://$identifier
+    if (!$?)
+    {
+        throw "Failed to create the following bucket: $identifier"
+    }
+    dotnet restore
+    Write-Host "Creating CloudFormation Stack $identifier"
+    dotnet lambda deploy-serverless
+    if (!$?)
+    {
+        throw "Failed to create the following CloudFormation stack: $identifier"
+    }
+}
+finally
+{
+    Pop-Location
+}

--- a/Libraries/test/TestServerlessApp.IntegrationTests/Greeter.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/Greeter.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace TestServerlessApp.IntegrationTests
+{
+    [Collection("Integration Tests")]
+    public class Greeter
+    {
+        private readonly IntegrationTestContextFixture _fixture;
+
+        public Greeter(IntegrationTestContextFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task SayHello_FromQuery_LogsToCloudWatch()
+        {
+            var response = await _fixture.HttpClient.GetAsync($"{_fixture.HttpApiUrlPrefix}/Greeter/SayHello?names=Alice&names=Bob");
+            response.EnsureSuccessStatusCode();
+            var lambdaFunctionName = _fixture.LambdaFunctions.FirstOrDefault(x => string.Equals(x.LogicalId, "GreeterSayHello"))?.Name;
+            Assert.False(string.IsNullOrEmpty(lambdaFunctionName));
+            var logGroupName = _fixture.CloudWatchHelper.GetLogGroupName(lambdaFunctionName);
+            Assert.True(await _fixture.CloudWatchHelper.MessageExistsInRecentLogEventsAsync("Hello Alice", logGroupName, logGroupName));
+            Assert.True(await _fixture.CloudWatchHelper.MessageExistsInRecentLogEventsAsync("Hello Bob", logGroupName, logGroupName));
+        }
+
+        [Fact]
+        public async Task SayHelloAsync_FromHeader_LogsToCloudWatch()
+        {
+            var httpRequestMessage = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get,
+                RequestUri = new Uri($"{_fixture.HttpApiUrlPrefix}/Greeter/SayHelloAsync"),
+                Headers = {{ "names", new List<string>{"Alice", "Bob"}}}
+            };
+            var response = _fixture.HttpClient.SendAsync(httpRequestMessage).Result;
+            response.EnsureSuccessStatusCode();
+            var lambdaFunctionName = _fixture.LambdaFunctions.FirstOrDefault(x => string.Equals(x.LogicalId, "GreeterSayHelloAsync"))?.Name;
+            Assert.False(string.IsNullOrEmpty(lambdaFunctionName));
+            var logGroupName = _fixture.CloudWatchHelper.GetLogGroupName(lambdaFunctionName);
+            Assert.True(await _fixture.CloudWatchHelper.MessageExistsInRecentLogEventsAsync("Hello Alice, Bob", logGroupName, logGroupName));
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp.IntegrationTests/Helpers/CloudFormationHelper.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/Helpers/CloudFormationHelper.cs
@@ -1,0 +1,75 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Amazon.CloudFormation;
+using Amazon.CloudFormation.Model;
+
+namespace TestServerlessApp.IntegrationTests.Helpers
+{
+    public class CloudFormationHelper
+    {
+        private readonly IAmazonCloudFormation _cloudFormationClient;
+
+        public CloudFormationHelper(IAmazonCloudFormation cloudFormationClient)
+        {
+            _cloudFormationClient = cloudFormationClient;
+        }
+
+        public async Task<StackStatus> GetStackStatusAsync(string stackName)
+        {
+            var stack = await GetStackAsync(stackName);
+            return stack?.StackStatus;
+        }
+
+        public async Task<bool> IsDeletedAsync(string stackName)
+        {
+            var attemptCount = 0;
+            const int maxAttempts = 5;
+
+            while (attemptCount < maxAttempts)
+            {
+                attemptCount += 1;
+                if (! await StackExistsAsync(stackName))
+                    return true;
+                await Task.Delay(StaticHelpers.GetWaitTime(attemptCount));
+            }
+            return false;
+        }
+
+        public async Task DeleteStackAsync(string stackName)
+        {
+            if (!await StackExistsAsync(stackName))
+                return;
+
+            await _cloudFormationClient.DeleteStackAsync(new DeleteStackRequest {StackName = stackName});
+        }
+
+        public async Task<string> GetOutputValueAsync(string stackName, string outputKey)
+        {
+            var stack = await GetStackAsync(stackName);
+            return stack?.Outputs.FirstOrDefault(x => string.Equals(x.OutputKey, outputKey))?.OutputValue;
+        }
+
+        private async Task<Stack> GetStackAsync(string stackName)
+        {
+            if (!await StackExistsAsync(stackName))
+                return null;
+
+            var response = await _cloudFormationClient.DescribeStacksAsync(new DescribeStacksRequest {StackName = stackName});
+            return response.Stacks.Count == 0 ? null : response.Stacks[0];
+        }
+
+        private async Task<bool> StackExistsAsync(string stackName)
+        {
+            try
+            {
+                await _cloudFormationClient.DescribeStacksAsync(new DescribeStacksRequest {StackName = stackName});
+            }
+            catch (AmazonCloudFormationException exception) when (exception.ErrorCode.Equals("ValidationError") && exception.Message.Equals($"Stack with id {stackName} does not exist"))
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp.IntegrationTests/Helpers/CloudWatchHelper.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/Helpers/CloudWatchHelper.cs
@@ -1,0 +1,87 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.CloudWatchLogs;
+using Amazon.CloudWatchLogs.Model;
+
+namespace TestServerlessApp.IntegrationTests.Helpers
+{
+    public class CloudWatchHelper
+    {
+        private readonly IAmazonCloudWatchLogs _cloudWatchlogsClient;
+
+        public CloudWatchHelper(IAmazonCloudWatchLogs cloudWatchlogsClient)
+        {
+            _cloudWatchlogsClient = cloudWatchlogsClient;
+        }
+
+        public string GetLogGroupName(string lambdaFunctionName) => $"/aws/lambda/{lambdaFunctionName}";
+
+        public async Task<bool> MessageExistsInRecentLogEventsAsync(string message, string logGroupName, string logGroupNamePrefix)
+        {
+            var attemptCount = 0;
+            const int maxAttempts = 5;
+
+            while (attemptCount < maxAttempts)
+            {
+                attemptCount += 1;
+                var recentLogEvents = await GetRecentLogEventsAsync(logGroupName, logGroupNamePrefix);
+                if (recentLogEvents.Any(x => string.Equals(x.Message.Trim(), message)))
+                    return true;
+                await Task.Delay(StaticHelpers.GetWaitTime(attemptCount));
+            }
+
+            return false;
+        }
+
+        private async Task<List<OutputLogEvent>> GetRecentLogEventsAsync(string logGroupName, string logGroupNamePrefix)
+        {
+            var latestLogStreamName = await GetLatestLogStreamNameAsync(logGroupName, logGroupNamePrefix);
+            var logEvents = await GetLogEventsAsync(logGroupName, latestLogStreamName);
+            return logEvents;
+        }
+
+        private async Task<string> GetLatestLogStreamNameAsync(string logGroupName, string logGroupNamePrefix)
+        {
+            var attemptCount = 0;
+            const int maxAttempts = 5;
+
+            while (attemptCount < maxAttempts)
+            {
+                attemptCount += 1;
+                if (await LogGroupExistsAsync(logGroupName, logGroupNamePrefix))
+                    break;
+                await Task.Delay(StaticHelpers.GetWaitTime(attemptCount));
+            }
+
+            var response =  await _cloudWatchlogsClient.DescribeLogStreamsAsync(
+                new DescribeLogStreamsRequest
+                {
+                    LogGroupName = logGroupName,
+                    Descending = true,
+                    Limit = 1
+                });
+
+            return response.LogStreams.FirstOrDefault()?.LogStreamName;
+        }
+
+        private async Task<List<OutputLogEvent>> GetLogEventsAsync(string logGroupName, string logStreamName)
+        {
+            var response = await _cloudWatchlogsClient.GetLogEventsAsync(
+                new GetLogEventsRequest
+                {
+                    LogGroupName = logGroupName,
+                    LogStreamName = logStreamName,
+                    Limit = 10
+                });
+
+            return response.Events;
+        }
+
+        private async Task<bool> LogGroupExistsAsync(string logGroupName, string logGroupNamePrefix)
+        {
+            var response = await _cloudWatchlogsClient.DescribeLogGroupsAsync(new DescribeLogGroupsRequest{LogGroupNamePrefix = logGroupNamePrefix});
+            return response.LogGroups.Any(x => string.Equals(x.LogGroupName, logGroupName));
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp.IntegrationTests/Helpers/LambdaHelper.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/Helpers/LambdaHelper.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.Lambda;
+using Amazon.Lambda.Model;
+
+namespace TestServerlessApp.IntegrationTests.Helpers
+{
+    public class LambdaHelper
+    {
+        private readonly IAmazonLambda _lambdaClient;
+
+        public LambdaHelper(IAmazonLambda lambdaClient)
+        {
+            _lambdaClient = lambdaClient;
+        }
+
+        public async Task<List<LambdaFunction>> FilterByCloudFormationStackAsync(string stackName)
+        {
+            const string stackNameKey = "aws:cloudformation:stack-name";
+            const string logicalIdKey = "aws:cloudformation:logical-id";
+            var lambdaFunctions = new List<LambdaFunction>();
+            var response = await _lambdaClient.ListFunctionsAsync(new ListFunctionsRequest());
+
+            foreach (var function in response.Functions)
+            {
+                var tags = (await _lambdaClient.ListTagsAsync(new ListTagsRequest {Resource = function.FunctionArn})).Tags;
+                if (tags.ContainsKey(stackNameKey) && string.Equals(tags[stackNameKey], stackName))
+                {
+                    var lambdaFunction = new LambdaFunction
+                    {
+                        LogicalId = tags[logicalIdKey],
+                        Name = function.FunctionName
+                    };
+                    lambdaFunctions.Add(lambdaFunction);
+                }
+            }
+
+            return lambdaFunctions;
+        }
+
+        public async Task<InvokeResponse> InvokeFunctionAsync(string functionName, string payload = null)
+        {
+            var request = new InvokeRequest {FunctionName = functionName};
+            if (!string.IsNullOrEmpty(payload))
+                request.Payload = payload;
+            return await _lambdaClient.InvokeAsync(request);
+        }
+    }
+
+    public class LambdaFunction
+    {
+        public string LogicalId { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/Libraries/test/TestServerlessApp.IntegrationTests/Helpers/S3Helper.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/Helpers/S3Helper.cs
@@ -1,0 +1,37 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Amazon.S3;
+using Amazon.S3.Model;
+
+namespace TestServerlessApp.IntegrationTests.Helpers
+{
+    public class S3Helper
+    {
+        private readonly IAmazonS3 _s3Client;
+
+        public S3Helper(IAmazonS3 s3Client)
+        {
+            _s3Client = s3Client;
+        }
+
+        public async Task DeleteBucketAsync(string bucketName)
+        {
+            if (!await BucketExistsAsync(bucketName))
+                return;
+
+            var response = await _s3Client.ListObjectsAsync(new ListObjectsRequest{BucketName = bucketName});
+            foreach (var s3Object in response.S3Objects)
+            {
+                await _s3Client.DeleteObjectAsync(new DeleteObjectRequest {BucketName = bucketName, Key = s3Object.Key});
+            }
+
+            await _s3Client.DeleteBucketAsync(new DeleteBucketRequest {BucketName = bucketName});
+        }
+
+        public async Task<bool> BucketExistsAsync(string bucketName)
+        {
+            var response = await _s3Client.ListBucketsAsync(new ListBucketsRequest());
+            return response.Buckets.Any(x => x.BucketName.Equals(bucketName));
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp.IntegrationTests/Helpers/StaticHelpers.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/Helpers/StaticHelpers.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace TestServerlessApp.IntegrationTests.Helpers
+{
+    public static class StaticHelpers
+    {
+        public static TimeSpan GetWaitTime(int attemptCount)
+        {
+            var waitTime = Math.Pow(2, attemptCount) * 5;
+            return TimeSpan.FromSeconds(waitTime);
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixture.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixture.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Amazon.CloudFormation;
+using Amazon.CloudWatchLogs;
+using Amazon.Lambda;
+using Amazon.S3;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using TestServerlessApp.IntegrationTests.Helpers;
+using Xunit;
+
+namespace TestServerlessApp.IntegrationTests
+{
+    public class IntegrationTestContextFixture : IDisposable
+    {
+        private readonly string _stackName;
+        private readonly string _bucketName;
+        private readonly CloudFormationHelper _cloudFormationHelper;
+        private readonly S3Helper _s3Helper;
+
+        public readonly LambdaHelper LambdaHelper;
+        public readonly CloudWatchHelper CloudWatchHelper;
+        public readonly string RestApiUrlPrefix;
+        public readonly string HttpApiUrlPrefix;
+        public readonly List<LambdaFunction> LambdaFunctions;
+        public readonly HttpClient HttpClient;
+
+        public IntegrationTestContextFixture()
+        {
+            _stackName = GetStackName();
+            _bucketName = GetBucketName();
+            Assert.False(string.IsNullOrEmpty(_stackName));
+            Assert.False(string.IsNullOrEmpty(_bucketName));
+
+            _cloudFormationHelper = new CloudFormationHelper(new AmazonCloudFormationClient());
+            _s3Helper = new S3Helper(new AmazonS3Client());
+            LambdaHelper = new LambdaHelper(new AmazonLambdaClient());
+            CloudWatchHelper = new CloudWatchHelper(new AmazonCloudWatchLogsClient());
+            RestApiUrlPrefix = _cloudFormationHelper.GetOutputValueAsync(_stackName, "RestApiURL").GetAwaiter().GetResult();
+            HttpApiUrlPrefix = _cloudFormationHelper.GetOutputValueAsync(_stackName, "HttpApiURL").GetAwaiter().GetResult();
+            LambdaFunctions = LambdaHelper.FilterByCloudFormationStackAsync(_stackName).GetAwaiter().GetResult();
+            HttpClient = new HttpClient();
+
+            Assert.Equal(StackStatus.CREATE_COMPLETE, _cloudFormationHelper.GetStackStatusAsync(_stackName).GetAwaiter().GetResult());
+            Assert.True(_s3Helper.BucketExistsAsync(_bucketName).GetAwaiter().GetResult());
+            Assert.Equal(11, LambdaFunctions.Count);
+            Assert.False(string.IsNullOrEmpty(RestApiUrlPrefix));
+            Assert.False(string.IsNullOrEmpty(RestApiUrlPrefix));
+        }
+
+        private string GetStackName()
+        {
+            var filePath = Path.Combine("..", "..", "..", "..", "TestServerlessApp", "aws-lambda-tools-defaults.json");
+            var token = JObject.Parse(File.ReadAllText(filePath))["stack-name"];
+            return token.ToObject<string>();
+        }
+
+        private string GetBucketName()
+        {
+            var filePath = Path.Combine("..", "..", "..", "..", "TestServerlessApp", "aws-lambda-tools-defaults.json");
+            var token = JObject.Parse(File.ReadAllText(filePath))["s3-bucket"];
+            return token.ToObject<string>();
+        }
+
+        private async Task CleanUpAsync()
+        {
+            await _cloudFormationHelper.DeleteStackAsync(_stackName);
+            Assert.True(await _cloudFormationHelper.IsDeletedAsync(_stackName), $"The stack '{_stackName}' still exists and will have to be manually deleted from the AWS console.");
+
+            await _s3Helper.DeleteBucketAsync(_bucketName);
+            Assert.False(await _s3Helper.BucketExistsAsync(_bucketName), $"The bucket '{_bucketName}' still exists and will have to be manually deleted from the AWS console.");
+
+            var filePath = Path.Combine("..", "..", "..", "..", "TestServerlessApp", "aws-lambda-tools-defaults.json");
+            var token = JObject.Parse(await File.ReadAllTextAsync(filePath));
+            token["s3-bucket"] = "test-serverless-app";
+            token["stack-name"] = "test-serverless-app";
+            await File.WriteAllTextAsync(filePath, token.ToString(Formatting.Indented));
+        }
+
+        public void Dispose()
+        {
+            CleanUpAsync().GetAwaiter().GetResult();
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixtureCollection.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixtureCollection.cs
@@ -1,0 +1,9 @@
+﻿using Xunit;
+
+namespace TestServerlessApp.IntegrationTests
+{
+    [CollectionDefinition("Integration Tests")]
+    public class IntegrationTestContextFixtureCollection : ICollectionFixture<IntegrationTestContextFixture>
+    {
+    }
+}

--- a/Libraries/test/TestServerlessApp.IntegrationTests/SimpleCalculator.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/SimpleCalculator.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace TestServerlessApp.IntegrationTests
+{
+    [Collection("Integration Tests")]
+    public class SimpleCalculator
+    {
+        private readonly IntegrationTestContextFixture _fixture;
+
+        public SimpleCalculator(IntegrationTestContextFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task Add_FromQuery_ReturnsIntAsString()
+        {
+            var response = await _fixture.HttpClient.GetAsync($"{_fixture.RestApiUrlPrefix}/SimpleCalculator/Add?x=2&y=4");
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("6", await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task Subtract_FromHeader_ReturnsIntAsString()
+        {
+            var httpRequestMessage = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get,
+                RequestUri = new Uri($"{_fixture.RestApiUrlPrefix}/SimpleCalculator/Subtract"),
+                Headers = {{ "x", "10" }, {"y", "2"}}
+            };
+            var response = await _fixture.HttpClient.SendAsync(httpRequestMessage);
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("8", await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task Multiply_FromPath_ReturnsIntAsString()
+        {
+            var response = await _fixture.HttpClient.GetAsync($"{_fixture.RestApiUrlPrefix}/SimpleCalculator/Multiply/2/10");
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("20", await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task DivideAsync_FromPath_ReturnsIntAsString()
+        {
+            var response = await _fixture.HttpClient.GetAsync($"{_fixture.RestApiUrlPrefix}/SimpleCalculator/DivideAsync/50/5");
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("10", await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task Pi_NoPayload_ReturnsDoubleAsString()
+        {
+            var lambdaFunctionName = _fixture.LambdaFunctions.FirstOrDefault(x => string.Equals(x.LogicalId, "PI"))?.Name;
+            Assert.False(string.IsNullOrEmpty(lambdaFunctionName));
+            var invokeResponse = await _fixture.LambdaHelper.InvokeFunctionAsync(lambdaFunctionName);
+            Assert.Equal(200, invokeResponse.StatusCode);
+            var responsePayload = await new StreamReader(invokeResponse.Payload).ReadToEndAsync();
+            Assert.Equal("3.141592653589793", responsePayload);
+        }
+
+        [Fact]
+        public async Task Random_IntAsStringPayload_ReturnsRandomIntLessThanPayload()
+        {
+            var lambdaFunctionName = _fixture.LambdaFunctions.FirstOrDefault(x => string.Equals(x.LogicalId, "Random"))?.Name;
+            Assert.False(string.IsNullOrEmpty(lambdaFunctionName));
+            var invokeResponse = await _fixture.LambdaHelper.InvokeFunctionAsync(lambdaFunctionName, "1000");
+            Assert.Equal(200, invokeResponse.StatusCode);
+            var responsePayload = await new StreamReader(invokeResponse.Payload).ReadToEndAsync();
+            Assert.True(int.TryParse(responsePayload, out var result));
+            Assert.True(result < 1000);
+        }
+
+        [Fact]
+        public async Task Randoms_JsonPayload_ReturnsListOfInt()
+        {
+            var lambdaFunctionName = _fixture.LambdaFunctions.FirstOrDefault(x => string.Equals(x.LogicalId, "Randoms"))?.Name;
+            Assert.False(string.IsNullOrEmpty(lambdaFunctionName));
+            var invokeResponse = await _fixture.LambdaHelper.InvokeFunctionAsync(lambdaFunctionName, "{\"count\": 5, \"maxValue\": 1000}");
+            Assert.Equal(200, invokeResponse.StatusCode);
+            var responsePayload = await new StreamReader(invokeResponse.Payload).ReadToEndAsync();
+            var responseArray = responsePayload.Trim(new[] {'[', ']'}).Split(',').Select(int.Parse).ToList();
+            Assert.Equal(5, responseArray.Count);
+            Assert.True(responseArray.All(x => x < 1000));
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp.IntegrationTests/TestServerlessApp.IntegrationTests.csproj
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/TestServerlessApp.IntegrationTests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.5.38" />
+        <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.1.70" />
+        <PackageReference Include="AWSSDK.Lambda" Version="3.7.4.21" />
+        <PackageReference Include="AWSSDK.S3" Version="3.7.4.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <Target Name="DeployTestServerlessApp" BeforeTargets="BeforeBuild">
+        <Exec Command="pwsh DeploymentScript.ps1" IgnoreExitCode="true" />
+    </Target>
+
+</Project>

--- a/Libraries/test/TestServerlessApp/ComplexCalculator.cs
+++ b/Libraries/test/TestServerlessApp/ComplexCalculator.cs
@@ -65,7 +65,7 @@ namespace TestServerlessApp
 
             var c1 = new Complex(firstComponent[0], firstComponent[1]);
             var c2 = new Complex(secondComponent[0], secondComponent[1]);
-            var result = c1 + c2;
+            var result = c1 - c2;
             return new Tuple<double, double>(result.Real, result.Imaginary);
         }
     }

--- a/Libraries/test/TestServerlessApp/aws-lambda-tools-defaults.json
+++ b/Libraries/test/TestServerlessApp/aws-lambda-tools-defaults.json
@@ -1,18 +1,17 @@
-
 {
-    "Information" : [
-        "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
-        "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
-        "dotnet lambda help",
-        "All the command line options for the Lambda command can be specified in this file."
-    ],
-    "profile"     : "default",
-    "region"      : "us-west-2",
-    "configuration" : "Release",
-    "framework"     : "netcoreapp3.1",
-    "s3-prefix"     : "TestServerlessApp/",
-    "template"      : "serverless.template",
-    "template-parameters" : "",
-    "s3-bucket"           : "jangirg-test-serverless-app",
-    "stack-name"          : "test-serverless-app"
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+    "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+    "dotnet lambda help",
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+  "profile": "default",
+  "region": "us-west-2",
+  "configuration": "Release",
+  "framework": "netcoreapp3.1",
+  "s3-prefix": "TestServerlessApp/",
+  "template": "serverless.template",
+  "template-parameters": "",
+  "s3-bucket": "test-serverless-app",
+  "stack-name": "test-serverless-app"
 }

--- a/Libraries/test/TestServerlessApp/serverless.template
+++ b/Libraries/test/TestServerlessApp/serverless.template
@@ -282,10 +282,16 @@
     }
   },
   "Outputs": {
-    "ApiURL": {
-      "Description": "API endpoint URL for Prod environment",
+    "RestApiURL": {
+      "Description": "Rest API endpoint URL for Prod environment",
       "Value": {
-        "Fn::Sub": "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+        "Fn::Sub": "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod"
+      }
+    },
+    "HttpApiURL": {
+      "Description": "HTTP API endpoint URL for Prod environment",
+      "Value": {
+        "Fn::Sub": "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.amazonaws.com"
       }
     }
   }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5506

*Description of changes:*
This PR adds integration test for `TestServerlessApp`. 

The tests suite first deploys all Lambda functions that are part of the the `serverless.template`. These functions are then invoked using one of the following three techniques:
1. Rest API URL backed by APIGateway
2. HTTP API URL backed by APIGateway
3. Direct invocation using the AWS SDK for .NET

The invocation response for each Lambda function is compared against the expected results. 
**Note** - Not all Lambda functions return a payload as part of the response object. Instead, these Lambda functions log to CloudWatch and we assert on the appropriate log message. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
