### PR TITLE
test: Invoke deployment script during integ test initialization

### DIFF
--- a/Libraries/test/TestServerlessApp.IntegrationTests/Helpers/CommandLineWrapper.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/Helpers/CommandLineWrapper.cs
@@ -1,0 +1,62 @@
+﻿#nullable enable
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TestServerlessApp.IntegrationTests.Helpers
+{
+    public static class CommandLineWrapper
+    {
+        public static async Task Run(string command, string workingDirectory = "", bool redirectIo = true, CancellationToken cancelToken = default)
+        {
+            var processStartInfo = new ProcessStartInfo
+            {
+                FileName = GetSystemShell(),
+                Arguments = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? $"/c {command}" : $"-c \"{command}\"",
+
+                RedirectStandardInput = redirectIo,
+                RedirectStandardOutput = redirectIo,
+                RedirectStandardError = redirectIo,
+                UseShellExecute = false,
+                CreateNoWindow = redirectIo,
+                WorkingDirectory = workingDirectory
+            };
+
+            var process = Process.Start(processStartInfo);
+            if (null == process)
+                throw new Exception("Process.Start failed to return a non-null process");
+
+            if (redirectIo)
+            {
+                process.OutputDataReceived += (sender, e) => Console.WriteLine(e.Data);
+                process.ErrorDataReceived += (sender, e) => Console.WriteLine(e.Data);
+
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+            }
+
+            await process.WaitForExitAsync(cancelToken).ConfigureAwait(false);
+        }
+
+        private static string GetSystemShell()
+        {
+            if (TryGetEnvironmentVariable("COMSPEC", out var comspec))
+                return comspec!;
+
+            if (TryGetEnvironmentVariable("SHELL", out var shell))
+                return shell!;
+
+            // fall back to defaults
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "cmd.exe" : "/bin/sh";
+        }
+
+        private static bool TryGetEnvironmentVariable(string variable, out string? value)
+        {
+            value = Environment.GetEnvironmentVariable(variable);
+
+            return !string.IsNullOrEmpty(value);
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixture.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixture.cs
@@ -30,6 +30,9 @@ namespace TestServerlessApp.IntegrationTests
 
         public IntegrationTestContextFixture()
         {
+            var scriptPath = Path.Combine("..", "..", "..", "DeploymentScript.ps1");
+            CommandLineWrapper.Run($"pwsh {scriptPath}").GetAwaiter().GetResult();
+
             _stackName = GetStackName();
             _bucketName = GetBucketName();
             Assert.False(string.IsNullOrEmpty(_stackName));

--- a/Libraries/test/TestServerlessApp.IntegrationTests/TestServerlessApp.IntegrationTests.csproj
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/TestServerlessApp.IntegrationTests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
+        <OutputType>Library</OutputType>
     </PropertyGroup>
 
     <ItemGroup>
@@ -16,9 +17,5 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
     </ItemGroup>
-
-    <Target Name="DeployTestServerlessApp" BeforeTargets="BeforeBuild">
-        <Exec Command="pwsh DeploymentScript.ps1" IgnoreExitCode="true" />
-    </Target>
 
 </Project>


### PR DESCRIPTION
*Description of changes:*
This PR invokes the `DeploymentScript.ps1` during in the initialization of the integration test to deploy the `TestServerlessApp`.

This is done to avoid performing a deployment every time the integration test project is built.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
