### PR TITLE
test: Update integration tests to use IAsyncLifetime

### DIFF
--- a/Libraries/test/TestServerlessApp.IntegrationTests/Helpers/CommandLineWrapper.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/Helpers/CommandLineWrapper.cs
@@ -9,7 +9,7 @@ namespace TestServerlessApp.IntegrationTests.Helpers
 {
     public static class CommandLineWrapper
     {
-        public static async Task Run(string command, string workingDirectory = "", bool redirectIo = true, CancellationToken cancelToken = default)
+        public static async Task RunAsync(string command, string workingDirectory = "", bool redirectIo = true, CancellationToken cancelToken = default)
         {
             var processStartInfo = new ProcessStartInfo
             {
@@ -37,7 +37,7 @@ namespace TestServerlessApp.IntegrationTests.Helpers
                 process.BeginErrorReadLine();
             }
 
-            await process.WaitForExitAsync(cancelToken).ConfigureAwait(false);
+            await process.WaitForExitAsync(cancelToken);
         }
 
         private static string GetSystemShell()


### PR DESCRIPTION
*Description of changes:*
Update integration tests to use `IAsyncLifetime`. This allows the test initialization and disposal to happen asynchronously. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
