### PR TITLE
Make sure the embedded manifest is generated for web resources in Lambda test tool

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester31-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester31-pack.csproj
@@ -16,6 +16,8 @@
     <PackageId>Amazon.Lambda.TestTool-3.1</PackageId>
 	<AssemblyName>Amazon.Lambda.TestTool.BlazorTester</AssemblyName>
 	<RootNamespace>Amazon.Lambda.TestTool.BlazorTester</RootNamespace>	
+	<GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
+	<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
   </PropertyGroup>
 	
   <ItemGroup>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester50-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester50-pack.csproj
@@ -15,7 +15,9 @@
     <PackAsTool>true</PackAsTool>
     <PackageId>Amazon.Lambda.TestTool-5.0</PackageId>
 	<AssemblyName>Amazon.Lambda.TestTool.BlazorTester</AssemblyName>
-	<RootNamespace>Amazon.Lambda.TestTool.BlazorTester</RootNamespace>	
+	<RootNamespace>Amazon.Lambda.TestTool.BlazorTester</RootNamespace>
+	<GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>	
+	<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester60-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester60-pack.csproj
@@ -16,6 +16,8 @@
     <PackageId>Amazon.Lambda.TestTool-6.0</PackageId>
 	<AssemblyName>Amazon.Lambda.TestTool.BlazorTester</AssemblyName>
 	<RootNamespace>Amazon.Lambda.TestTool.BlazorTester</RootNamespace>	
+	<GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
+	<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Description of changes:*
The development project file for the test tool had `GenerateEmbeddedFilesManifest` setting in it ensuring the embedded manifest was generated at build time. This was missing in the individual package project files. So if the packaging projects triggered a build after the main solution was built then the embedded manifest not get created.

This PR makes sure all packaging projects generate the manifest.

Also the PR turns of `StaticWebAssetsEnabled` which I believe is what is triggering our issues in the pipeline. Static assets are unnecessary since they are all embedded into the assembly.

I have manually confirmed this works in all 3 versions of the package.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
