### PR TITLE
feat: Add support for PackageType in JSON serverless template

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Amazon.Lambda.Annotations.SourceGenerator.csproj
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Amazon.Lambda.Annotations.SourceGenerator.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyVersion>0.1.0.0</AssemblyVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
-    <!-- This is required to allow copying all the dependnceis to bin directory which can be copied after to nuget package based on nuspec -->
+    <!-- This is required to allow copying all the dependencies to bin directory which can be copied after to nuget package based on nuspec -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/FileIO/IDirectoryManager.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/FileIO/IDirectoryManager.cs
@@ -7,5 +7,6 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.FileIO
         string GetDirectoryName(string path);
         string[] GetFiles(string path, string searchPattern, SearchOption searchOption = SearchOption.TopDirectoryOnly);
         bool Exists(string path);
+        string GetRelativePath(string relativeTo, string path);
     }
 }

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Generator.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Generator.cs
@@ -98,7 +98,8 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
                 }
 
                 annotationReport.CloudFormationTemplatePath = templateFinder.FindCloudFormationTemplate(projectRootDirectory);
-                var cloudFormationJsonWriter = new CloudFormationJsonWriter(_fileManager, _jsonWriter, diagnosticReporter);
+                annotationReport.ProjectRootDirectory = projectRootDirectory;
+                var cloudFormationJsonWriter = new CloudFormationJsonWriter(_fileManager, _directoryManager,_jsonWriter, diagnosticReporter);
                 cloudFormationJsonWriter.ApplyReport(annotationReport);
             }
             catch (Exception e)

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/AnnotationReport.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/AnnotationReport.cs
@@ -6,5 +6,6 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
     {
         public IList<ILambdaFunctionSerializable> LambdaFunctions { get; } = new List<ILambdaFunctionSerializable>();
         public string CloudFormationTemplatePath{ get; set; }
+        public string  ProjectRootDirectory { get; set; }
     }
 }

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/LambdaFunctionAttributeDataBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/LambdaFunctionAttributeDataBuilder.cs
@@ -37,6 +37,11 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes
                 {
                     data.MemorySize = memorySize;
                 }
+
+                if (pair.Key == nameof(data.PackageType) && pair.Value.Value is PackageTypeEnum packageType)
+                {
+                    data.PackageType = packageType;
+                }
             }
 
             return data;

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/ILambdaFunctionSerializable.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/ILambdaFunctionSerializable.cs
@@ -41,6 +41,12 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
         string Policies { get; }
 
         /// <summary>
+        /// The deployment package type of the Lambda function. The supported values are Zip and Image.
+        /// For more information, see <a href="https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-package.html">here</a>
+        /// </summary>
+        PackageTypeEnum PackageType { get; }
+
+        /// <summary>
         /// List of attributes applied to the Lambda method that are used to generate serverless.template.
         /// There always exists <see cref="Annotations.LambdaFunctionAttribute"/> in the list.
         /// </summary>

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/LambdaFunctionModel.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/LambdaFunctionModel.cs
@@ -51,6 +51,10 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
         public string Policies => LambdaMethod.LambdaFunctionAttribute.Data.Policies;
 
         /// <inheritdoc />
+        /// The default value is set to Zip
+        public PackageTypeEnum PackageType  => LambdaMethod.LambdaFunctionAttribute.Data.PackageType ?? PackageTypeEnum.Zip;
+
+        /// <inheritdoc />
         public IList<AttributeModel> Attributes => LambdaMethod.Attributes ?? new List<AttributeModel>();
 
         /// <inheritdoc />

--- a/Libraries/src/Amazon.Lambda.Annotations.nuspec
+++ b/Libraries/src/Amazon.Lambda.Annotations.nuspec
@@ -9,17 +9,17 @@
         <projectUrl>https://github.com/aws/aws-lambda-dotnet</projectUrl>
         <license type="expression">Apache-2.0</license>
         <dependencies>
-            <group targetFramework=".NETStandard2.0"/>
+            <group targetFramework=".netcoreapp3.1"/>
         </dependencies>
     </metadata>
 
     <files>
         <!-- Dependencies to make sure attributes are available in consuming csproj, this ensures packaged version of customer code have all the dependencies needed. -->
-        <file src="Amazon.Lambda.Annotations\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.dll" target="lib/netstandard2.0" />
+        <file src="Amazon.Lambda.Annotations\bin\Release\netcoreapp3.1\Amazon.Lambda.Annotations.dll" target="lib/netcoreapp3.1" />
 
         <!-- Include every dependency manually for analyzer, whenever a new dependency is added, it has to be added here. -->
-        <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.dll" target="analyzers\dotnet\cs" />
-        <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.SourceGenerator.dll" target="analyzers\dotnet\cs" />
-        <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netstandard2.0\Newtonsoft.Json.dll" target="analyzers\dotnet\cs" />
+        <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netcoreapp3.1\Amazon.Lambda.Annotations.dll" target="analyzers\dotnet\cs" />
+        <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netcoreapp3.1\Amazon.Lambda.Annotations.SourceGenerator.dll" target="analyzers\dotnet\cs" />
+        <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netcoreapp3.1\Newtonsoft.Json.dll" target="analyzers\dotnet\cs" />
     </files>
 </package>

--- a/Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj
+++ b/Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyVersion>0.1.0.0</AssemblyVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/Libraries/src/Amazon.Lambda.Annotations/LambdaFunctionAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/LambdaFunctionAttribute.cs
@@ -31,5 +31,11 @@ namespace Amazon.Lambda.Annotations
         /// Resource based policies that grants permissions to access other AWS resources.
         /// </summary>
         public string Policies { get; set; }
+
+        /// <summary>
+        /// The deployment package type of the Lambda function. The supported values are Zip or Image. The default value is Zip.
+        /// For more information, see <a href="https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-package.html">here</a>
+        /// </summary>
+        public PackageTypeEnum? PackageType {get; set;}
     }
 }

--- a/Libraries/src/Amazon.Lambda.Annotations/PackageTypeEnum.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/PackageTypeEnum.cs
@@ -1,0 +1,8 @@
+﻿namespace Amazon.Lambda.Annotations
+{
+    public enum PackageTypeEnum
+    {
+        Zip,
+        Image
+    }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/complexCalculator.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/complexCalculator.template
@@ -12,12 +12,13 @@
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
+        "PackageType": "Zip",
         "Handler": "TestServerlessApp::TestServerlessApp.ComplexCalculator_Add_Generated::Add",
         "Events": {
           "RootPost": {
@@ -41,12 +42,13 @@
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
+        "PackageType": "Zip",
         "Handler": "TestServerlessApp::TestServerlessApp.ComplexCalculator_Subtract_Generated::Subtract",
         "Events": {
           "RootPost": {

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/greeter.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/greeter.template
@@ -12,12 +12,13 @@
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 1024,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
+        "PackageType": "Zip",
         "Handler": "TestServerlessApp::TestServerlessApp.Greeter_SayHello_Generated::SayHello",
         "Events": {
           "RootGet": {
@@ -41,12 +42,13 @@
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 50,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
+        "PackageType": "Zip",
         "Handler": "TestServerlessApp::TestServerlessApp.Greeter_SayHelloAsync_Generated::SayHelloAsync",
         "Events": {
           "RootGet": {

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/simpleCalculator.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/simpleCalculator.template
@@ -12,12 +12,13 @@
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
+        "PackageType": "Zip",
         "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Add_Generated::Add",
         "Events": {
           "RootGet": {
@@ -40,12 +41,13 @@
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
+        "PackageType": "Zip",
         "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Subtract_Generated::Subtract",
         "Events": {
           "RootGet": {
@@ -68,12 +70,13 @@
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
+        "PackageType": "Zip",
         "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Multiply_Generated::Multiply",
         "Events": {
           "RootGet": {
@@ -96,12 +99,13 @@
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
+        "PackageType": "Zip",
         "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_DivideAsync_Generated::DivideAsync",
         "Events": {
           "RootGet": {
@@ -121,12 +125,13 @@
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
+        "PackageType": "Zip",
         "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Pi_Generated::Pi"
       }
     },
@@ -137,12 +142,13 @@
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
+        "PackageType": "Zip",
         "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Random_Generated::Random"
       }
     },
@@ -153,12 +159,13 @@
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
+        "PackageType": "Zip",
         "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Randoms_Generated::Randoms"
       }
     }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/InMemoryDirectoryManager.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/InMemoryDirectoryManager.cs
@@ -1,12 +1,11 @@
-using System.IO;
+﻿using System.IO;
+using Amazon.Lambda.Annotations.SourceGenerator.FileIO;
 
-namespace Amazon.Lambda.Annotations.SourceGenerator.FileIO
+namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
 {
-    public class DirectoryManager : IDirectoryManager
+    public class InMemoryDirectoryManager : IDirectoryManager
     {
         public string GetDirectoryName(string path) => Path.GetDirectoryName(path);
-
-        public bool Exists(string path) => Directory.Exists(path);
 
         public string GetRelativePath(string relativeTo, string path)
         {
@@ -16,7 +15,12 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.FileIO
 
         public string[] GetFiles(string path, string searchPattern, SearchOption searchOption = SearchOption.TopDirectoryOnly)
         {
-            return Directory.GetFiles(path, searchPattern, searchOption);
+            throw new System.NotImplementedException();
+        }
+
+        public bool Exists(string path)
+        {
+            throw new System.NotImplementedException();
         }
     }
 }

--- a/Libraries/test/TestServerlessApp/serverless.template
+++ b/Libraries/test/TestServerlessApp/serverless.template
@@ -14,7 +14,7 @@
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.Greeter_SayHello_Generated::SayHello",
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 1024,
         "Timeout": 30,
         "Role": null,
@@ -30,7 +30,8 @@
               "PayloadFormatVersion": "1.0"
             }
           }
-        }
+        },
+        "PackageType": "Zip"
       }
     },
     "GreeterSayHelloAsync": {
@@ -44,7 +45,7 @@
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.Greeter_SayHelloAsync_Generated::SayHelloAsync",
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 50,
         "Role": null,
@@ -60,7 +61,8 @@
               "PayloadFormatVersion": "1.0"
             }
           }
-        }
+        },
+        "PackageType": "Zip"
       }
     },
     "SimpleCalculatorAdd": {
@@ -74,7 +76,7 @@
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Add_Generated::Add",
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Role": null,
@@ -89,7 +91,8 @@
               "Method": "GET"
             }
           }
-        }
+        },
+        "PackageType": "Zip"
       }
     },
     "SimpleCalculatorSubtract": {
@@ -103,7 +106,7 @@
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Subtract_Generated::Subtract",
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Role": null,
@@ -118,7 +121,8 @@
               "Method": "GET"
             }
           }
-        }
+        },
+        "PackageType": "Zip"
       }
     },
     "SimpleCalculatorMultiply": {
@@ -132,7 +136,7 @@
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Multiply_Generated::Multiply",
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Role": null,
@@ -147,7 +151,8 @@
               "Method": "GET"
             }
           }
-        }
+        },
+        "PackageType": "Zip"
       }
     },
     "SimpleCalculatorDivideAsync": {
@@ -161,7 +166,7 @@
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_DivideAsync_Generated::DivideAsync",
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Role": null,
@@ -176,7 +181,8 @@
               "Method": "GET"
             }
           }
-        }
+        },
+        "PackageType": "Zip"
       }
     },
     "TestServerlessAppComplexCalculatorAddGenerated": {
@@ -190,7 +196,7 @@
       "Properties": {
         "Handler": "TestServerlessApp::TestServerlessApp.ComplexCalculator_Add_Generated::Add",
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Role": null,
@@ -206,14 +212,21 @@
               "PayloadFormatVersion": "2.0"
             }
           }
-        }
+        },
+        "PackageType": "Zip"
       }
     },
     "TestServerlessAppComplexCalculatorSubtractGenerated": {
       "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootPost"
+        ]
+      },
       "Properties": {
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
@@ -229,7 +242,8 @@
               "PayloadFormatVersion": "2.0"
             }
           }
-        }
+        },
+        "PackageType": "Zip"
       }
     },
     "PI": {
@@ -239,13 +253,14 @@
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
-        "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Pi_Generated::Pi"
+        "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Pi_Generated::Pi",
+        "PackageType": "Zip"
       }
     },
     "Random": {
@@ -255,13 +270,14 @@
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
-        "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Random_Generated::Random"
+        "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Random_Generated::Random",
+        "PackageType": "Zip"
       }
     },
     "Randoms": {
@@ -271,13 +287,14 @@
       },
       "Properties": {
         "Runtime": "dotnetcore3.1",
-        "CodeUri": "",
+        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
-        "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Randoms_Generated::Randoms"
+        "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Randoms_Generated::Randoms",
+        "PackageType": "Zip"
       }
     }
   },


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5528

*Description of changes:*
feat: Add support for PackageType in JSON serverless template
This PR also performs a minor refactor to the `CloudFormationJsonWriter` class.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
