### PR TITLE
Update Lambda Test Tool to use the latest version of Amazon.Lambda.Core (2.1.0)

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="YamlDotNet.Signed" Version="5.2.1" />
 

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NETCore31/Amazon.Lambda.TestTool.Tests.NETCore31.csproj
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NETCore31/Amazon.Lambda.TestTool.Tests.NETCore31.csproj
@@ -10,7 +10,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1003

*Description of changes:*
Since the test tool loads up Amazon.Lambda.Core packaged with the test tool we need to make sure it is using the latest version so users using the latest APIs of Amazon.Lambda.Core in their Lambda Function are successful.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
