### PR TITLE
fix: removing InternalCustomResponseExceptionHandling in ASP.NET core…

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction.cs
@@ -51,10 +51,6 @@ namespace Amazon.Lambda.AspNetCoreServer
             _hostServices = hostedServices;
         }
 
-        private protected override void InternalCustomResponseExceptionHandling(APIGatewayHttpApiV2ProxyResponse apiGatewayResponse, ILambdaContext lambdaContext, Exception ex)
-        {
-            apiGatewayResponse.SetHeaderValues("ErrorType", ex.GetType().Name, false);
-        }
 
         /// <summary>
         /// Convert the JSON document received from API Gateway into the InvokeFeatures object.

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -99,10 +99,6 @@ namespace Amazon.Lambda.AspNetCoreServer
             _hostServices = hostedServices;
         }
 
-        private protected override void InternalCustomResponseExceptionHandling(APIGatewayProxyResponse apiGatewayResponse, ILambdaContext lambdaContext, Exception ex)
-        {
-            apiGatewayResponse.MultiValueHeaders["ErrorType"] = new List<string> { ex.GetType().Name };
-        }
 
 
         /// <summary>

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
@@ -530,11 +530,6 @@ namespace Amazon.Lambda.AspNetCoreServer
                 }
                 var response = this.MarshallResponse(features, lambdaContext, defaultStatusCode);
 
-                if (ex != null)
-                {
-                    InternalCustomResponseExceptionHandling(response, lambdaContext, ex);
-                }
-
                 if (features.ResponseCompletedEvents != null)
                 {
                     await features.ResponseCompletedEvents.ExecuteAsync();
@@ -548,11 +543,6 @@ namespace Amazon.Lambda.AspNetCoreServer
             }
         }
 
-
-        private protected virtual void InternalCustomResponseExceptionHandling(TRESPONSE lambdaReponse, ILambdaContext lambdaContext, Exception ex)
-        {
-
-        }
 
         /// <summary>
         /// This method is called after the IWebHost is created from the IWebHostBuilder and the services have been configured. The

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
@@ -202,20 +202,6 @@ namespace Amazon.Lambda.AspNetCoreServer
             return response;
         }
 
-        private protected override void InternalCustomResponseExceptionHandling(ApplicationLoadBalancerResponse lambdaResponse, ILambdaContext lambdaContext, Exception ex)
-        {
-            var errorName = ex.GetType().Name;
-
-            if (this._multiHeaderValuesEnabled)
-            {
-                lambdaResponse.MultiValueHeaders.Add(new KeyValuePair<string, IList<string>>("ErrorType", new List<string> { errorName }));
-            }
-            else
-            {
-                lambdaResponse.Headers.Add(new KeyValuePair<string, string>("ErrorType", errorName));
-            }
-        }
-
         private string GetSingleHeaderValue(ApplicationLoadBalancerRequest request, string headerName)
         {
             if (this._multiHeaderValuesEnabled)


### PR DESCRIPTION
fix: removing InternalCustomResponseExceptionHandling in ASP.NET core server that resulted in implementation details being leaked.

*Issue #, if available:* 886

*Description of changes:*
The default behavior of ASP.NET core when an unhandled exception is thrown in a controller is to respond with the type of exception in an HTTP header. This is done by the ```InternalCustomResponseExceptionHandling``` method. This leaks implementation details. Per [this comment](https://github.com/aws/aws-lambda-dotnet/issues/886#issuecomment-877416642) I have removed that behavior.

Prior to this, overriding this behavior required override the ```ProcessRequest``` method that called the ```InternalCustomResponseExceptionHandling``` method since the latter is private protected. This PR does not change this behavior. One still has to override ```ProcessRequest``` in order to change behavior on unhandled exceptions.

[x] I have run the tests and they pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
