### PR TITLE
Correct json property names for Cognito identity properties in lambda normj/runtimesupport-cognito-fix

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Context/CognitoIdentity.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Context/CognitoIdentity.cs
@@ -31,10 +31,10 @@ namespace Amazon.Lambda.RuntimeSupport
             if (!string.IsNullOrWhiteSpace(json))
             {
                 var jsonData = JsonMapper.ToObject(json);
-                if (jsonData["identityId"] != null)
-                    result.IdentityId = jsonData["identityId"].ToString();
-                if (jsonData["identityPoolId"] != null)
-                    result.IdentityPoolId = jsonData["identityPoolId"].ToString();
+                if (jsonData["cognitoIdentityId"] != null)
+                    result.IdentityId = jsonData["cognitoIdentityId"].ToString();
+                if (jsonData["cognitoIdentityPoolId"] != null)
+                    result.IdentityPoolId = jsonData["cognitoIdentityPoolId"].ToString();
             }
 
             return result;

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/BaseCustomRuntimeTest.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/BaseCustomRuntimeTest.cs
@@ -143,6 +143,7 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
                     BucketName = bucketName
                 };
                 await s3Client.PutBucketAsync(putBucketRequest);
+                await Task.Delay(10000);
             }
 
             // write or overwrite deployment package
@@ -199,7 +200,7 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
             };
             await lambdaClient.UpdateFunctionConfigurationAsync(updateFunctionConfigurationRequest);
             // Wait for eventual consistency of function change.
-            Thread.Sleep(3000);
+            await Task.Delay(3000);
         }
 
         protected async Task CreateFunctionAsync(IAmazonLambda lambdaClient, string bucketName)
@@ -243,6 +244,7 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
                     }
                 }
             }
+            await Task.Delay(5000);
 
             if (!created)
             {

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/Amazon.Lambda.RuntimeSupport.UnitTests.csproj
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/Amazon.Lambda.RuntimeSupport.UnitTests.csproj
@@ -5,9 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/CognitoIdentity.json
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/CognitoIdentity.json
@@ -1,4 +1,4 @@
 ﻿{
-  "identityId": "Id1",
-  "identityPoolId": "Pool1"
+  "cognitoIdentityId": "Id1",
+  "cognitoIdentityPoolId": "Pool1"
 }


### PR DESCRIPTION
*Description of changes:*
The Amazon.Lambda.RuntimeSupport package was using the incorrect json properties for mashaling the Cognito properties into the lambda context object.

Also did a few tweaks to make the test more reliable and work in VS 2022.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
