### PR TITLE
Add AWS_EXECUTION_ENV, Dockerfile tidy-up

### DIFF
--- a/LambdaRuntimeDockerfiles/Images/net5/amd64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net5/amd64/Dockerfile
@@ -2,6 +2,8 @@
 
 ARG ASPNET_VERSION=5.0.12
 ARG ASPNET_SHA512=0529f23ffa651ac2c2807b70d6e5034f6ae4c88204afdaaa76965ef604d6533f9440d68d9f2cdd3a9f2ca37e9140e6c61a9f9207d430c71140094c7d5c33bf79
+
+ARG LAMBDA_RUNTIME_NAME=dotnet5
 ARG AMAZON_LINUX=public.ecr.aws/lambda/provided:al2
 
 FROM $AMAZON_LINUX AS base
@@ -23,13 +25,6 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
     && rm aspnetcore.tar.gz
 
 
-FROM base as final
-ARG ASPNET_VERSION
-
-ENV DOTNET_VERSION $ASPNET_VERSION
-
-COPY --from=builder-net5 ["/dotnet", "/var/lang/bin"]
-
 FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS builder
 WORKDIR /src
 COPY ["Libraries/src/Amazon.Lambda.RuntimeSupport", "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/"]
@@ -39,15 +34,29 @@ RUN dotnet restore "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambd
 WORKDIR "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport"
 RUN dotnet build "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net5.0 --runtime linux-x64 -c Release -o /app/build
 
+
 FROM builder AS publish
 RUN dotnet publish "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net5.0 -f net5.0 --runtime linux-x64 --self-contained false -p:PublishReadyToRun=true -c Release -o /app/publish
 RUN apt-get update && apt-get install -y dos2unix
-RUN dos2unix /app/publish/bootstrap.sh
+RUN dos2unix /app/publish/bootstrap.sh && \
+    mv /app/publish/bootstrap.sh /app/publish/bootstrap && \
+    chmod +x /app/publish/bootstrap
 
-FROM final
-WORKDIR /var/task
+# Generate runtime-release file
+ARG LAMBDA_RUNTIME_NAME
+RUN export BUILD_TIMESTAMP=$(printf '%x' $(date +%s)) && \
+    export LOGGING_PROTOCOL="LOGGING=amzn-stdout-tlv" && \
+    export LAMBDA_RUNTIME_NAME="LAMBDA_RUNTIME_NAME=${LAMBDA_RUNTIME_NAME}" && \
+    echo "NAME=dotnet\nVERSION=${ASPNET_VERSION}-${BUILD_TIMESTAMP}\n${LOGGING_PROTOCOL}\n${LAMBDA_RUNTIME_NAME}\n" > /app/publish/runtime-release
+
+
+FROM base
+
+ARG ASPNET_VERSION
 
 ENV \
+    # Export .NET version as environment variable
+    DOTNET_VERSION=$ASPNET_VERSION \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Lambda is opinionated about installing tooling under /var
@@ -57,9 +66,7 @@ ENV \
     # Disable Microsoft's telemetry collection
     DOTNET_CLI_TELEMETRY_OPTOUT=true
 
-COPY --from=publish /app/publish /var/runtime
-
-COPY --from=publish /app/publish/bootstrap.sh /var/runtime/bootstrap
-RUN chmod +x /var/runtime/bootstrap
+COPY --from=builder-net5    /dotnet         ${DOTNET_ROOT}
+COPY --from=publish         /app/publish    ${LAMBDA_RUNTIME_DIR}
 
 # Entrypoint is inherited from public.ecr.aws/lambda/provided

--- a/LambdaRuntimeDockerfiles/Images/net6/amd64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net6/amd64/Dockerfile
@@ -3,6 +3,7 @@
 ARG ASPNET_VERSION=6.0.0
 ARG ASPNET_SHA512=6a1ae878efdc9f654e1914b0753b710c3780b646ac160fb5a68850b2fd1101675dc71e015dbbea6b4fcf1edac0822d3f7d470e9ed533dd81d0cfbcbbb1745c6c
 
+ARG LAMBDA_RUNTIME_NAME=dotnet6
 ARG AMAZON_LINUX=public.ecr.aws/lambda/provided:al2
 
 FROM $AMAZON_LINUX AS base
@@ -24,13 +25,6 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
     && rm aspnetcore.tar.gz
 
 
-FROM base as final
-ARG ASPNET_VERSION
-
-ENV DOTNET_VERSION $ASPNET_VERSION
-
-COPY --from=builder-net6 ["/dotnet", "/var/lang/bin"]
-
 FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS builder
 WORKDIR /src
 COPY ["Libraries/src/Amazon.Lambda.RuntimeSupport", "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/"]
@@ -40,15 +34,29 @@ RUN dotnet restore "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambd
 WORKDIR "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport"
 RUN dotnet build "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net6.0 --runtime linux-x64 -c Release -o /app/build
 
+
 FROM builder AS publish
 RUN dotnet publish "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net6.0 -f net6.0 --runtime linux-x64 --self-contained false -p:PublishReadyToRun=true -c Release -o /app/publish
 RUN apt-get update && apt-get install -y dos2unix
-RUN dos2unix /app/publish/bootstrap.sh
+RUN dos2unix /app/publish/bootstrap.sh && \
+    mv /app/publish/bootstrap.sh /app/publish/bootstrap && \
+    chmod +x /app/publish/bootstrap
 
-FROM final
-WORKDIR /var/task
+# Generate runtime-release file
+ARG LAMBDA_RUNTIME_NAME
+RUN export BUILD_TIMESTAMP=$(printf '%x' $(date +%s)) && \
+    export LOGGING_PROTOCOL="LOGGING=amzn-stdout-tlv" && \
+    export LAMBDA_RUNTIME_NAME="LAMBDA_RUNTIME_NAME=${LAMBDA_RUNTIME_NAME}" && \
+    echo "NAME=dotnet\nVERSION=${ASPNET_VERSION}-${BUILD_TIMESTAMP}\n${LOGGING_PROTOCOL}\n${LAMBDA_RUNTIME_NAME}\n" > /app/publish/runtime-release
+
+
+FROM base
+
+ARG ASPNET_VERSION
 
 ENV \
+    # Export .NET version as environment variable
+    DOTNET_VERSION=$ASPNET_VERSION \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Lambda is opinionated about installing tooling under /var
@@ -58,9 +66,7 @@ ENV \
     # Disable Microsoft's telemetry collection
     DOTNET_CLI_TELEMETRY_OPTOUT=true
 
-COPY --from=publish /app/publish /var/runtime
-
-RUN mv /var/runtime/bootstrap.sh /var/runtime/bootstrap && \
-    chmod +x /var/runtime/bootstrap
+COPY --from=builder-net6    /dotnet         ${DOTNET_ROOT}
+COPY --from=publish         /app/publish    ${LAMBDA_RUNTIME_DIR}
 
 # Entrypoint is inherited from public.ecr.aws/lambda/provided

--- a/LambdaRuntimeDockerfiles/Images/net6/arm64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net6/arm64/Dockerfile
@@ -2,15 +2,16 @@
 
 ARG ASPNET_VERSION=6.0.0
 ARG ASPNET_SHA512=e61eade344b686180b8a709229d6b3180ea6f085523e5e4e4b0d23dd00cf9edce3e51a920c986b1bab7d04d8cab5aae219c3b533b6feb84b32a02810936859b0
+
+ARG ICU_VERSION=68.1
 ARG ICU_MD5=6a99b541ea01f271257b121a4433c7c0
 
+ARG LAMBDA_RUNTIME_NAME=dotnet6
 ARG AMAZON_LINUX=public.ecr.aws/lambda/provided:al2
 
 FROM $AMAZON_LINUX AS base
 
 FROM base AS builder-libicu
-ARG ICU_MD5
-
 WORKDIR /
 
 # Install depedencies to extract and build ICU library
@@ -22,17 +23,20 @@ RUN yum install -d1 -y \
 
 # Download, validate and extract ICU library
 # https://github.com/unicode-org/icu/releases/tag/release-68-1
-RUN curl -SL https://github.com/unicode-org/icu/releases/download/release-68-1/icu4c-68_1-src.tgz -o icu-src.tgz \
+ARG ICU_VERSION
+ARG ICU_MD5
+RUN curl -SL https://github.com/unicode-org/icu/releases/download/release-${ICU_VERSION//./-}/icu4c-${ICU_VERSION//./_}-src.tgz -o icu-src.tgz \
     && echo "$ICU_MD5  icu-src.tgz" | md5sum -c - \
     && tar -xzf icu-src.tgz \
     && rm icu-src.tgz
 
 # Build ICU library
-RUN mkdir ~/libicu
+RUN mkdir /libicu
 WORKDIR /icu/source/
 RUN ./configure --prefix=/libicu \
     && make \
     && make install
+
 
 FROM base AS builder-net6
 ARG ASPNET_VERSION
@@ -51,19 +55,6 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
     && rm aspnetcore.tar.gz
 
 
-FROM base as final
-ARG ASPNET_VERSION
-
-ENV DOTNET_VERSION $ASPNET_VERSION
-
-# Copy native dependencies
-COPY --from=builder-libicu /libicu /usr/share/libicu
-
-# Setup path
-ENV LD_LIBRARY_PATH="/usr/share/libicu/lib:${LD_LIBRARY_PATH}"
-
-COPY --from=builder-net6 ["/dotnet", "/var/lang/bin"]
-
 FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS builder
 WORKDIR /src
 COPY ["Libraries/src/Amazon.Lambda.RuntimeSupport", "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/"]
@@ -73,15 +64,32 @@ RUN dotnet restore "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambd
 WORKDIR "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport"
 RUN dotnet build "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net6.0 --runtime linux-arm64 -c Release -o /app/build
 
+
 FROM builder AS publish
 RUN dotnet publish "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net6.0 -f net6.0 --runtime linux-arm64 --self-contained false -p:PublishReadyToRun=true -c Release -o /app/publish
 RUN apt-get update && apt-get install -y dos2unix
-RUN dos2unix /app/publish/bootstrap.sh
+RUN dos2unix /app/publish/bootstrap.sh && \
+    mv /app/publish/bootstrap.sh /app/publish/bootstrap && \
+    chmod +x /app/publish/bootstrap
 
-FROM final
-WORKDIR /var/task
+# Copy native dependencies
+COPY --from=builder-libicu  /libicu         /app/publish
+
+# Generate runtime-release file
+ARG LAMBDA_RUNTIME_NAME
+RUN export BUILD_TIMESTAMP=$(printf '%x' $(date +%s)) && \
+    export LOGGING_PROTOCOL="LOGGING=amzn-stdout-tlv" && \
+    export LAMBDA_RUNTIME_NAME="LAMBDA_RUNTIME_NAME=${LAMBDA_RUNTIME_NAME}" && \
+    echo "NAME=dotnet\nVERSION=${ASPNET_VERSION}-${BUILD_TIMESTAMP}\n${LOGGING_PROTOCOL}\n${LAMBDA_RUNTIME_NAME}\n" > /app/publish/runtime-release
+
+
+FROM base
+
+ARG ASPNET_VERSION
 
 ENV \
+    # Export .NET version as environment variable
+    DOTNET_VERSION=$ASPNET_VERSION \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Lambda is opinionated about installing tooling under /var
@@ -91,9 +99,7 @@ ENV \
     # Disable Microsoft's telemetry collection
     DOTNET_CLI_TELEMETRY_OPTOUT=true
 
-COPY --from=publish /app/publish /var/runtime
-
-RUN mv /var/runtime/bootstrap.sh /var/runtime/bootstrap && \
-    chmod +x /var/runtime/bootstrap
+COPY --from=builder-net6    /dotnet         ${DOTNET_ROOT}
+COPY --from=publish         /app/publish    ${LAMBDA_RUNTIME_DIR}
 
 # Entrypoint is inherited from public.ecr.aws/lambda/provided

--- a/LambdaRuntimeDockerfiles/sample/Sample/Dockerfile
+++ b/LambdaRuntimeDockerfiles/sample/Sample/Dockerfile
@@ -2,16 +2,19 @@ ARG AWS_LAMBDA_VERSION=local
 
 FROM aws-lambda-dotnet:$AWS_LAMBDA_VERSION AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim as build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim as build
 COPY . /Sample
 
 WORKDIR /Sample
 
 RUN dotnet build "Sample.csproj" -o /app/build
 
+
 FROM build AS publish
 RUN dotnet publish "Sample.csproj" -c Release -o /app/publish
 
+
 FROM base AS final
-WORKDIR /var/task
-COPY --from=publish /app/publish .
+COPY --from=publish /app/publish ${LAMBDA_TASK_ROOT}
+# ref. https://docs.aws.amazon.com/lambda/latest/dg/csharp-handler.html#csharp-handler-signatures
+CMD [ "Sample::Sample.Function::FunctionHandler" ]

--- a/LambdaRuntimeDockerfiles/sample/Sample/Sample.csproj
+++ b/LambdaRuntimeDockerfiles/sample/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Context/LambdaEnvironment.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Context/LambdaEnvironment.cs
@@ -33,6 +33,7 @@ namespace Amazon.Lambda.RuntimeSupport
         internal const string EnvVarServerHostAndPort = "AWS_LAMBDA_RUNTIME_API";
         internal const string EnvVarTraceId = "_X_AMZN_TRACE_ID";
         
+        internal const string AwsLambdaDotnetCustomRuntime = "AWS_Lambda_dotnet_custom";
         internal const string AmazonLambdaRuntimeSupportMarker = "amazonlambdaruntimesupport";
 
         private IEnvironmentVariables _environmentVariables;
@@ -58,7 +59,7 @@ namespace Amazon.Lambda.RuntimeSupport
         {
 
             var envValue = _environmentVariables.GetEnvironmentVariable(EnvVarExecutionEnvironment);
-            if (!string.IsNullOrEmpty(envValue) && !envValue.Contains(AmazonLambdaRuntimeSupportMarker))
+            if (!string.IsNullOrEmpty(envValue) && envValue.Equals(AwsLambdaDotnetCustomRuntime))
             {
                 var assemblyVersion = typeof(LambdaBootstrap).Assembly
                     .GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false)


### PR DESCRIPTION
*Description of changes:*
- Update sample project for net6
- Add `runtime-release` file
- Move net6 arm64 `libicu` to `/var/runtime`
- Refactor net5 and net6 Dockerfiles for consistency
- Export `AWS_EXECUTION_ENV` in `bootstrap`
- Only append RuntimeSupport marker if using custom dotnet runtime
   - eg. `AWS_EXECUTION_ENV=AWS_Lambda_dotnet_custom_amazonlambdaruntimesupport_1.5.0`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
