### PR TITLE
Port .NET Core 3.1 RIC PreJit feature to Amazon.Lambda.RuntimeSupport

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/Constants.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/Constants.cs
@@ -4,6 +4,19 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
 {
     internal class Constants
     {
+        internal const string ENVIRONMENT_VARIABLE_AWS_LAMBDA_DOTNET_PREJIT = "AWS_LAMBDA_DOTNET_PREJIT";
+        internal const string ENVIRONMENT_VARIABLE_AWS_LAMBDA_INITIALIZATION_TYPE = "AWS_LAMBDA_INITIALIZATION_TYPE";
+        internal const string ENVIRONMENT_VARIABLE_LANG = "LANG";
+        internal const string AWS_LAMBDA_INITIALIZATION_TYPE_PC = "provisioned-concurrency";
+        internal const string AWS_LAMBDA_INITIALIZATION_TYPE_ON_DEMAND = "on-demand";
+
+        internal enum AwsLambdaDotNetPreJit
+        {
+            Never,
+            Always,
+            ProvisionedConcurrency
+        }
+
         internal const BindingFlags DefaultFlags = BindingFlags.DeclaredOnly | BindingFlags.NonPublic | BindingFlags.Public
                                                    | BindingFlags.Instance | BindingFlags.Static;
     }

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
@@ -18,6 +18,8 @@ using System.Net.Http;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Amazon.Lambda.RuntimeSupport.Bootstrap;
+using Amazon.Lambda.RuntimeSupport.Helpers;
 
 namespace Amazon.Lambda.RuntimeSupport
 {
@@ -111,6 +113,15 @@ namespace Amazon.Lambda.RuntimeSupport
         /// <returns>A Task that represents the operation.</returns>
         public async Task RunAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
+            if(UserCodeInit.IsCallPreJit())
+            {
+                InternalLogger.GetDefaultLogger().LogInformation("PreJit: CultureInfo");
+                UserCodeInit.LoadStringCultureInfo();
+
+                InternalLogger.GetDefaultLogger().LogInformation("PreJit: Amazon.Lambda.Core");
+                UserCodeInit.PreJitAssembly(typeof(Amazon.Lambda.Core.ILambdaContext).Assembly);
+            }
+
             bool doStartInvokeLoop = _initializer == null || await InitializeAsync();
 
             while (doStartInvokeLoop && !cancellationToken.IsCancellationRequested)

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeInit.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeInit.cs
@@ -1,0 +1,196 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq.Expressions;
+using System.Text;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using static Amazon.Lambda.RuntimeSupport.Bootstrap.Constants;
+using Amazon.Lambda.RuntimeSupport.Helpers;
+
+namespace Amazon.Lambda.RuntimeSupport.Bootstrap
+{
+    internal class UserCodeInit
+    {
+        public static bool IsCallPreJit()
+        {
+            string awsLambdaDotNetPreJitStr = Environment.GetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_DOTNET_PREJIT);
+            string awsLambdaInitTypeStr = Environment.GetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_INITIALIZATION_TYPE);
+            AwsLambdaDotNetPreJit awsLambdaDotNetPreJit;
+            bool isParsed = Enum.TryParse(awsLambdaDotNetPreJitStr, true, out awsLambdaDotNetPreJit);
+            if (!isParsed)
+            {
+                awsLambdaDotNetPreJit = AwsLambdaDotNetPreJit.ProvisionedConcurrency;
+            }
+
+            return IsPreJitAll(awsLambdaDotNetPreJit) ||
+                   (IsPCInvoke(awsLambdaInitTypeStr) && IsPreJitPC(awsLambdaDotNetPreJit));
+        }
+
+        private static bool IsPreJitAll(AwsLambdaDotNetPreJit awsLambdaDotNetPreJit)
+        {
+            return AwsLambdaDotNetPreJit.Always.Equals(awsLambdaDotNetPreJit);
+        }
+
+        private static bool IsPCInvoke(string awsLambdaInitTypeStr)
+        {
+            return AWS_LAMBDA_INITIALIZATION_TYPE_PC.Equals(awsLambdaInitTypeStr);
+        }
+
+        private static bool IsPreJitPC(AwsLambdaDotNetPreJit awsLambdaDotNetPreJit)
+        {
+            return AwsLambdaDotNetPreJit.ProvisionedConcurrency.Equals(awsLambdaDotNetPreJit);
+        }
+
+        public static void InitDeserializationAssembly(Expression inputExpression, ParameterExpression inStreamParameter)
+        {
+            if (inputExpression != null)
+            {
+                try
+                {
+                    byte[] byteArray = Encoding.ASCII.GetBytes("''");
+                    using (Stream dummyInStream = new MemoryStream(byteArray))
+                    {
+                        Expression.Lambda(inputExpression, inStreamParameter)
+                            .Compile()
+                            .DynamicInvoke(dummyInStream);
+                    }
+                }
+                catch
+                {
+                    // An exception is expected here because the dummy JSON is unlikely to match POCO
+                }
+            }
+        }
+
+        public static void InitSerializationAssembly(Expression outputExpression, ParameterExpression outStreamParameter, Type customerOutputType)
+        {
+            if (outputExpression == null || customerOutputType == null || customerOutputType == typeof(void))
+                return;
+            try
+            {
+                var customerObjectParameter = Expression.Parameter(customerOutputType, "customerObject");
+                byte[] byteArray = Encoding.ASCII.GetBytes("''");
+                using (Stream dummyInStream = new MemoryStream(byteArray))
+                {
+                    Expression.Lambda(outputExpression, customerObjectParameter, outStreamParameter)
+                        .Compile()
+                        .DynamicInvoke(null, dummyInStream);
+                }
+            }
+            catch
+            {
+                // An exception is expected here because the dummy JSON is unlikely to match POCO
+            }
+        }
+
+        public static void LoadStringCultureInfo()
+        {
+            try
+            {
+                string locale = Environment.GetEnvironmentVariable(ENVIRONMENT_VARIABLE_LANG);
+
+                if (!string.IsNullOrEmpty(locale))
+                {
+                    // The environment variable also has the text encoding (i.e. en_US.UTF-8). .NET 6
+                    // Does not accept culture names with text encoding and throw an exception. 
+                    // To avoid that strip off the text encoding.
+                    if (locale.Contains("."))
+                    {
+                        locale = locale.Substring(0, locale.IndexOf("."));
+                    }
+                    /*A dummy operation on string*/
+                    "Lambdalanguages".ToUpper(new CultureInfo(locale));
+                }
+                else
+                {
+                    /*A dummy operation on string*/
+                    "Lambdalanguages".ToUpper();
+                }
+            }
+            catch (Exception e)
+            {
+                InternalLogger.GetDefaultLogger().LogError(e, "PreJit: Error with LoadStringCultureInfo");
+            }
+        }
+
+        public static void PreJitAssembly(Assembly a)
+        {
+            // Storage to ensure not loading the same assembly twice and optimize calls to GetAssemblies()
+            var loaded = new HashSet<string>();
+
+            PrepareAssembly(a);
+            LoadReferencedAssemblies(a);
+
+            // Filter to avoid loading all the .net framework
+            bool ShouldLoad(string assemblyName)
+            {
+                return !loaded.Contains(assemblyName) && NotNetFramework(assemblyName);
+            }
+
+            bool NotNetFramework(string assemblyName)
+            {
+                return !assemblyName.StartsWith("Microsoft.")
+                       && !assemblyName.StartsWith("System.")
+                       && !assemblyName.StartsWith("Newtonsoft.")
+                       && !assemblyName.StartsWith("netstandard");
+            }
+
+            void PrepareAssembly(Assembly assembly)
+            {
+                foreach (var type in assembly.GetTypes())
+                {
+                    foreach (var method in type.GetMethods(BindingFlags.DeclaredOnly |
+                                                           BindingFlags.NonPublic |
+                                                           BindingFlags.Public | BindingFlags.Instance |
+                                                           BindingFlags.Static))
+                    {
+                        try
+                        {
+                            if (method.IsAbstract)
+                                continue;
+
+                            RuntimeHelpers.PrepareMethod(
+                                method.MethodHandle);
+
+                        }
+                        catch (Exception e)
+                        {
+                            InternalLogger.GetDefaultLogger().LogError(e, "PreJit: Error with PrepareAssembly");
+                        }
+                    }
+                }
+            }
+
+            void LoadReferencedAssemblies(Assembly assembly)
+            {
+
+                foreach (AssemblyName an in assembly.GetReferencedAssemblies().Where(x => ShouldLoad(x.FullName)))
+                {
+                    // Load the assembly and load its dependencies
+                    Assembly loadedAssembly = Assembly.Load(an);
+                    loaded.Add(an.FullName);
+                    PrepareAssembly(loadedAssembly);
+                    LoadReferencedAssemblies(loadedAssembly); // Load the referenced assemblies
+                }
+            }
+        }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeLoader.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeLoader.cs
@@ -124,8 +124,14 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
             var customerSerializerInstance = GetSerializerObject(customerAssembly);
             _logger.LogDebug($"UCL : Constructing invoke delegate");
 
+            var isPreJit = UserCodeInit.IsCallPreJit();
             var builder = new InvokeDelegateBuilder(_logger, _handler, CustomerMethodInfo);
-            _invokeDelegate = builder.ConstructInvokeDelegate(customerObject, customerSerializerInstance);
+            _invokeDelegate = builder.ConstructInvokeDelegate(customerObject, customerSerializerInstance, isPreJit);
+            if (isPreJit)
+            {
+                _logger.LogInformation("PreJit: PrepareDelegate");
+                RuntimeHelpers.PrepareDelegate(_invokeDelegate);
+            }
         }
 
         /// <summary>

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/InternalLogger.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/InternalLogger.cs
@@ -19,6 +19,8 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
 {
     internal class InternalLogger
     {
+        private const string DebuggingEnvironmentVariable = "LAMBDA_RUNTIMESUPPORT_DEBUG";
+
         public static readonly InternalLogger ConsoleLogger = new InternalLogger(Console.WriteLine);
         public static readonly InternalLogger NoOpLogger = new InternalLogger(message => { });
 
@@ -61,6 +63,20 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
         public static InternalLogger GetCustomInternalLogger(Action<string> loggingAction)
         {
             return new InternalLogger(loggingAction);
+        }
+
+        /// <summary>
+        /// Gets the default logger for the environment based on the "LAMBDA_RUNTIMESUPPORT_DEBUG" environment variable
+        /// </summary>
+        /// <returns></returns>
+        public static InternalLogger GetDefaultLogger()
+        {
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(DebuggingEnvironmentVariable)))
+            {
+                return NoOpLogger;
+            }
+
+            return ConsoleLogger;
         }
     }
 }

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/RuntimeSupportInitializer.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/RuntimeSupportInitializer.cs
@@ -16,7 +16,7 @@ namespace Amazon.Lambda.RuntimeSupport
         private readonly string _handler;
         private readonly InternalLogger _logger;
         private readonly RuntimeSupportDebugAttacher _debugAttacher;
-        private const string DebuggingEnvironmentVariable = "LAMBDA_RUNTIMESUPPORT_DEBUG";
+        
 
         /// <summary>
         /// Class constructor that takes a Function Handler and initializes the class.
@@ -28,15 +28,7 @@ namespace Amazon.Lambda.RuntimeSupport
                 throw new ArgumentException("Cannot initialize RuntimeSupportInitializer with a null of empty Function Handler", nameof(handler));
             }
 
-
-            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(DebuggingEnvironmentVariable)))
-            {
-                _logger = InternalLogger.NoOpLogger;
-            }
-            else
-            {
-                _logger = InternalLogger.ConsoleLogger;
-            }
+            _logger = InternalLogger.GetDefaultLogger();
 
             _handler = handler;
             _debugAttacher = new RuntimeSupportDebugAttacher();

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaBootstrapTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaBootstrapTests.cs
@@ -20,6 +20,9 @@ using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
+using Amazon.Lambda.RuntimeSupport.Bootstrap;
+using static Amazon.Lambda.RuntimeSupport.Bootstrap.Constants;
+
 namespace Amazon.Lambda.RuntimeSupport.UnitTests
 {
     /// <summary>
@@ -211,6 +214,49 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
 
             var runtimeLambdaSupportVersion = Version.Parse(versions[1]);
             Assert.True(Version.Parse("1.0.0") <= runtimeLambdaSupportVersion);
+        }
+
+        [Fact]
+        public void IsCallPreJitTest()
+        {
+            Environment.SetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_DOTNET_PREJIT, "ProvisionedConcurrency");
+            Environment.SetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_INITIALIZATION_TYPE,
+                AWS_LAMBDA_INITIALIZATION_TYPE_PC);
+
+            Assert.True(UserCodeInit.IsCallPreJit());
+            Environment.SetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_DOTNET_PREJIT, "ProvisionedConcurrency");
+            Environment.SetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_INITIALIZATION_TYPE,
+                AWS_LAMBDA_INITIALIZATION_TYPE_ON_DEMAND);
+
+            Assert.False(UserCodeInit.IsCallPreJit());
+
+            Environment.SetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_DOTNET_PREJIT, "ProvisionedConcurrency");
+            Environment.SetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_INITIALIZATION_TYPE, null);
+            Assert.False(UserCodeInit.IsCallPreJit());
+
+            Environment.SetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_DOTNET_PREJIT, "Always");
+            Environment.SetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_INITIALIZATION_TYPE, null);
+            Assert.True(UserCodeInit.IsCallPreJit());
+
+            Environment.SetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_DOTNET_PREJIT, "Never");
+            Environment.SetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_INITIALIZATION_TYPE, null);
+            Assert.False(UserCodeInit.IsCallPreJit());
+
+            Environment.SetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_DOTNET_PREJIT, null);
+            Environment.SetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_INITIALIZATION_TYPE, null);
+            Assert.False(UserCodeInit.IsCallPreJit());
+
+            Environment.SetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_DOTNET_PREJIT, null);
+            Environment.SetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_INITIALIZATION_TYPE, AWS_LAMBDA_INITIALIZATION_TYPE_ON_DEMAND);
+            Assert.False(UserCodeInit.IsCallPreJit());
+
+            Environment.SetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_DOTNET_PREJIT, "Never");
+            Environment.SetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_INITIALIZATION_TYPE, null);
+            Assert.False(UserCodeInit.IsCallPreJit());
+
+            Environment.SetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_DOTNET_PREJIT, null);
+            Environment.SetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_INITIALIZATION_TYPE, AWS_LAMBDA_INITIALIZATION_TYPE_PC);
+            Assert.True(UserCodeInit.IsCallPreJit());
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The .NET Core 3.1 managed runtime has the feature that when the `AWS_LAMBDA_DOTNET_PREJIT` environment is set or the Lambda function is being started for provisioned concurrency the RIC will warm up additional parts of the .NET runtime and Assemblies to make the first invoke run faster.

This PR ports that feature from the .NET Core 3.1 RIC to Amazon.Lambda.RuntimeSupport. Most of the code is same as the 3.1 RIC with additionally logging added. The internal logger was also reworked to make it easier to access within Amazon.Lambda.RuntimeSupport.

During testing with the feature I discovered that .NET 6 is less forgiving about the culture names being loaded then .NET Core 3.1 was. The locale prewarmed was being determined by the "LANG" environment variable which contains the text encoding as well (i.e. en_US.UTF-8). With .NET 6 this was throwing an exception because of the suffix .UTF-8. The 3.1 RIC code was modified to strip off the text encoding.

Testing was done with building .NET 6 container image with this version of Amazon.Lambda.RuntimeSupport and doing self contained publish with custom runtimes.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
