### PR TITLE
Add X-Ray Cause JSON to error response in Amazon.Lambda.RuntimeSupport

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/InternalClientAdapted.custom.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/InternalClientAdapted.custom.cs
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+
+namespace Amazon.Lambda.RuntimeSupport
+{
+    internal partial interface IInternalRuntimeApiClient
+    {
+        /// <summary>
+        /// This is a copy of the generated Error2Async method but adds support for the unmodeled header `Lambda-Runtime-Function-XRay-Error-Cause`.
+        /// </summary>
+        /// <param name="awsRequestId"></param>
+        /// <param name="lambda_Runtime_Function_Error_Type"></param>
+        /// <param name="errorJson"></param>
+        /// <param name="xrayCause"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        System.Threading.Tasks.Task<SwaggerResponse<StatusResponse>> ErrorWithXRayCauseAsync(string awsRequestId, string lambda_Runtime_Function_Error_Type, string errorJson, string xrayCause, System.Threading.CancellationToken cancellationToken);
+    }
+
+    internal partial class InternalRuntimeApiClient : IInternalRuntimeApiClient
+    {
+        const int MAX_HEADER_SIZE_BYTES = 1024 * 1024;
+
+        /// <summary>
+        /// This is a copy of the generated Error2Async method but adds support for the unmodeled header `Lambda-Runtime-Function-XRay-Error-Cause`.
+        /// </summary>
+        /// <param name="awsRequestId"></param>
+        /// <param name="lambda_Runtime_Function_Error_Type"></param>
+        /// <param name="errorJson"></param>
+        /// <param name="xrayCause"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async System.Threading.Tasks.Task<SwaggerResponse<StatusResponse>> ErrorWithXRayCauseAsync(string awsRequestId, string lambda_Runtime_Function_Error_Type, string errorJson, string xrayCause, System.Threading.CancellationToken cancellationToken)
+        {
+            if (awsRequestId == null)
+                throw new System.ArgumentNullException("awsRequestId");
+
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/runtime/invocation/{AwsRequestId}/error");
+            urlBuilder_.Replace("{AwsRequestId}", System.Uri.EscapeDataString(ConvertToString(awsRequestId, System.Globalization.CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    if (lambda_Runtime_Function_Error_Type != null)
+                        request_.Headers.TryAddWithoutValidation("Lambda-Runtime-Function-Error-Type", ConvertToString(lambda_Runtime_Function_Error_Type, System.Globalization.CultureInfo.InvariantCulture));
+
+                    // This is the unmodeled X-Ray header to report back the cause of errors.
+                    if (xrayCause != null && System.Text.Encoding.UTF8.GetByteCount(xrayCause) < MAX_HEADER_SIZE_BYTES)
+                    {
+                        // Headers can not have newlines. The X-Ray JSON writer should not have put any in but do a final check of newlines.
+                        xrayCause = xrayCause.Replace("\r\n", "").Replace("\n", "");
+
+                        try
+                        {
+                            request_.Headers.Add("Lambda-Runtime-Function-XRay-Error-Cause", xrayCause);
+                        }
+                        catch
+                        {
+                            // Don't prevent reporting errors to Lambda if there are any issues adding the X-Ray cause JSON as a header.
+                        }
+                    }
+
+                    using (var content_ = new System.Net.Http.StringContent(errorJson))
+                    {
+                        content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(ErrorContentType);
+                        request_.Content = content_;
+                        request_.Method = new System.Net.Http.HttpMethod("POST");
+                        request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                        PrepareRequest(client_, request_, urlBuilder_);
+                        var url_ = urlBuilder_.ToString();
+                        request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+                        PrepareRequest(client_, request_, url_);
+
+                        var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                        try
+                        {
+                            var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                            if (response_.Content != null && response_.Content.Headers != null)
+                            {
+                                foreach (var item_ in response_.Content.Headers)
+                                    headers_[item_.Key] = item_.Value;
+                            }
+
+                            ProcessResponse(client_, response_);
+
+                            var status_ = ((int)response_.StatusCode).ToString();
+                            if (status_ == "202")
+                            {
+                                var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                                var result_ = default(StatusResponse);
+                                try
+                                {
+                                    result_ = ThirdParty.Json.LitJson.JsonMapper.ToObject<StatusResponse>(responseData_);
+                                    return new SwaggerResponse<StatusResponse>((int)response_.StatusCode, headers_, result_);
+                                }
+                                catch (System.Exception exception_)
+                                {
+                                    throw new RuntimeApiClientException("Could not deserialize the response body.", (int)response_.StatusCode, responseData_, headers_, exception_);
+                                }
+                            }
+                            else
+                            if (status_ == "400")
+                            {
+                                var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                                var result_ = default(ErrorResponse);
+                                try
+                                {
+                                    result_ = ThirdParty.Json.LitJson.JsonMapper.ToObject<ErrorResponse>(responseData_);
+                                }
+                                catch (System.Exception exception_)
+                                {
+                                    throw new RuntimeApiClientException("Could not deserialize the response body.", (int)response_.StatusCode, responseData_, headers_, exception_);
+                                }
+                                throw new RuntimeApiClientException<ErrorResponse>("Bad Request", (int)response_.StatusCode, responseData_, headers_, result_, null);
+                            }
+                            else
+                            if (status_ == "403")
+                            {
+                                var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                                var result_ = default(ErrorResponse);
+                                try
+                                {
+                                    result_ = ThirdParty.Json.LitJson.JsonMapper.ToObject<ErrorResponse>(responseData_);
+                                }
+                                catch (System.Exception exception_)
+                                {
+                                    throw new RuntimeApiClientException("Could not deserialize the response body.", (int)response_.StatusCode, responseData_, headers_, exception_);
+                                }
+                                throw new RuntimeApiClientException<ErrorResponse>("Forbidden", (int)response_.StatusCode, responseData_, headers_, result_, null);
+                            }
+                            else
+                            if (status_ == "500")
+                            {
+                                var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                                throw new RuntimeApiClientException("Container error. Non-recoverable state. Runtime should exit promptly.\n", (int)response_.StatusCode, responseData_, headers_, null);
+                            }
+                            else
+                            if (status_ != "200" && status_ != "204")
+                            {
+                                var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                                throw new RuntimeApiClientException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", (int)response_.StatusCode, responseData_, headers_, null);
+                            }
+
+                            return new SwaggerResponse<StatusResponse>((int)response_.StatusCode, headers_, default(StatusResponse));
+                        }
+                        finally
+                        {
+                            if (response_ != null)
+                                response_.Dispose();
+                        }
+                    }
+                }
+            }
+            finally
+            {
+            }
+        }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/RuntimeApiClient.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/RuntimeApiClient.cs
@@ -134,7 +134,11 @@ namespace Amazon.Lambda.RuntimeSupport
                 throw new ArgumentNullException(nameof(exception));
 
             var exceptionInfo = ExceptionInfo.GetExceptionInfo(exception);
-            return _internalClient.Error2Async(awsRequestId, exceptionInfo.ErrorType, LambdaJsonExceptionWriter.WriteJson(exceptionInfo), cancellationToken);
+
+            var exceptionInfoJson = LambdaJsonExceptionWriter.WriteJson(exceptionInfo);
+            var exceptionInfoXRayJson = LambdaXRayExceptionWriter.WriteJson(exceptionInfo);
+
+            return _internalClient.ErrorWithXRayCauseAsync(awsRequestId, exceptionInfo.ErrorType, exceptionInfoJson, exceptionInfoXRayJson, cancellationToken);
         }
 
         /// <summary>

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/ExceptionHandling/LambdaXRayExceptionWriter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/ExceptionHandling/LambdaXRayExceptionWriter.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Amazon.Lambda.RuntimeSupport
+{
+    internal class LambdaXRayExceptionWriter
+    {
+        private const int INDENT_SIZE = 2;
+        private const string EXCEPTION = "exceptions";
+        private const string WORKING_DIR = "working_directory";
+        private const string PATHS = "paths";
+        private const string ERROR_MESSAGE = "message";
+        private const string ERROR_TYPE = "type";
+        private const string STACK_TRACE = "stack";
+        private const string STACK_FRAME_METHOD = "label";
+        private const string STACK_FRAME_FILE = "path";
+        private const string STACK_FRAME_LINE = "line";
+
+
+        public static string WriteJson(ExceptionInfo ex)
+        {
+            string workingDir = JsonExceptionWriterHelpers.EscapeStringForJson(System.IO.Directory.GetCurrentDirectory());
+            string exceptionTxt = CreateExceptionJson(ex, 1);
+
+            string workingDirJson = TabString($"\"{WORKING_DIR}\": \"{workingDir}\"", 1);
+            string exceptionJson = TabString($"\"{EXCEPTION}\": [ {exceptionTxt} ]", 1);
+
+            var paths = new string[0];
+            // Build the paths list by getting all the unique file names in the stack trace elements
+            if (ex.StackFrames != null)
+            {
+                paths = (
+                    from sf in ex.StackFrames
+                    where sf.Path != null
+                    select "\"" + JsonExceptionWriterHelpers.EscapeStringForJson(sf.Path) + "\""
+                ).Distinct().ToArray();
+            }
+
+            StringBuilder pathsBuilder = new StringBuilder();
+            pathsBuilder.Append(TabString($"\"{PATHS}\": ", 1));
+            pathsBuilder.Append(CombinePartsIntoJsonObject(2, '[', ']', paths));
+            string pathsJson = pathsBuilder.ToString();
+
+            // Add each non-null element to the json elements list
+            string[] jsonElements = GetNonNullElements(workingDirJson, exceptionJson, pathsJson);
+            return CombinePartsIntoJsonObject(1, '{', '}', jsonElements.ToArray());
+        }
+
+        private static string CreateExceptionJson(ExceptionInfo ex, int tab)
+        {
+
+            // Grab the elements we want to capture
+            string message = JsonExceptionWriterHelpers.EscapeStringForJson(ex.ErrorMessage);
+            string type = JsonExceptionWriterHelpers.EscapeStringForJson(ex.ErrorType);
+            var stackTrace = ex.StackFrames;
+
+            // Create the JSON lines for each non-null element
+            string messageJson = null;
+            if (message != null)
+            {
+                // Trim important for Aggregate Exceptions, whose
+                // message contains multiple lines by default
+                messageJson = TabString($"\"{ERROR_MESSAGE}\": \"{message}\"", tab + 1);
+            }
+
+            string typeJson = TabString($"\"{ERROR_TYPE}\": \"{type}\"", tab + 1);
+            string stackTraceJson = GetStackTraceJson(stackTrace, tab + 1);
+
+            // Add each non-null element to the json elements list
+            string[] jsonElements = GetNonNullElements(typeJson, messageJson, stackTraceJson);
+            return CombinePartsIntoJsonObject(tab + 1, '{', '}', jsonElements);
+        }
+
+        // Craft the JSON element (ex: "stack": [ {...}, {...} ]) for the stack trace
+        private static string GetStackTraceJson(StackFrameInfo[] stackTrace, int tab)
+        {
+            // Null stack trace means the entire stack trace json should be null, and therefore not included
+            if (stackTrace == null)
+            {
+                return null;
+            }
+
+            // Convert each ExceptionStackFrameResponse object to string using CreateStackFrameJson
+            string[] stackTraceElements = (
+                    from frame in stackTrace
+                    where frame != null
+                    select CreateStackFrameJson(frame, tab + 1)
+                ).ToArray();
+
+            // If there aren't any frames, return null and therefore don't include the stack trace
+            if (stackTraceElements.Length == 0)
+            {
+                return null;
+            }
+
+            // Create JSON property name and create the JSON array holding each element
+            StringBuilder stackTraceBuilder = new StringBuilder();
+            stackTraceBuilder.Append(TabString($"\"{STACK_TRACE}\": ", tab));
+            stackTraceBuilder.Append(CombinePartsIntoJsonObject(tab + 1, '[', ']', stackTraceElements));
+            return stackTraceBuilder.ToString();
+        }
+
+        // Craft JSON object {...} for a particular stack frame
+        private static string CreateStackFrameJson(StackFrameInfo stackFrame, int tab)
+        {
+            string file = JsonExceptionWriterHelpers.EscapeStringForJson(stackFrame.Path);
+            string label = JsonExceptionWriterHelpers.EscapeStringForJson(stackFrame.Label);
+            int line = stackFrame.Line;
+
+            string fileJson = null;
+            string lineJson = null;
+            if (file != null)
+            {
+                fileJson = TabString($"\"{STACK_FRAME_FILE}\": \"{file}\"", tab);
+                lineJson = TabString($"\"{STACK_FRAME_LINE}\": {line}", tab);
+            }
+
+            string labelJson = null;
+            if (label != null)
+            {
+                labelJson = TabString($"\"{STACK_FRAME_METHOD}\": \"{label}\"", tab);
+            }
+
+            string[] jsonElements = GetNonNullElements(fileJson, labelJson, lineJson);
+            return CombinePartsIntoJsonObject(tab, '{', '}', jsonElements);
+        }
+
+        private static string TabString(string str, int tabDepth)
+        {
+            if (tabDepth == 0) return str;
+
+            StringBuilder stringBuilder = new StringBuilder();
+            for (int x = 0; x < tabDepth * INDENT_SIZE; x++)
+            {
+                stringBuilder.Append(" ");
+            }
+            stringBuilder.Append(str);
+
+            return stringBuilder.ToString();
+        }
+
+        private static string CombinePartsIntoJsonObject(int tab, char openChar, char closeChar, params string[] parts)
+        {
+            string jsonBody = string.Join(",", parts);
+
+            StringBuilder jsonBuilder = new StringBuilder();
+            jsonBuilder.Append(TabString(openChar.ToString(), tab));
+            jsonBuilder.Append(jsonBody);
+            jsonBuilder.Append(TabString(closeChar.ToString(), tab));
+            return jsonBuilder.ToString();
+        }
+
+        private static string[] GetNonNullElements(params string[] elements)
+        {
+            return (from x in elements where x != null select x).ToArray();
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaExceptionHandlingTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaExceptionHandlingTests.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Xunit;
+
+namespace Amazon.Lambda.RuntimeSupport.UnitTests
+{
+    public class LambdaExceptionHandlingTests
+    {
+        [Fact]
+        public void WriteJsonForUserCodeException()
+        {
+            Exception exception = null;
+            try
+            {
+                ThrowTest();
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            var exceptionInfo = ExceptionInfo.GetExceptionInfo(exception);
+            var json = LambdaXRayExceptionWriter.WriteJson(exceptionInfo);
+            Assert.NotNull(json);
+            Assert.DoesNotMatch("\r\n", json);
+            Assert.DoesNotMatch("\n", json);
+
+            var jsonDocument = JsonDocument.Parse(json);
+
+            JsonElement jsonElement;
+            Assert.True(jsonDocument.RootElement.TryGetProperty("working_directory", out jsonElement));
+            Assert.Equal(JsonValueKind.String, jsonElement.ValueKind);
+            Assert.True(jsonElement.GetString().Length > 0);
+
+            Assert.True(jsonDocument.RootElement.TryGetProperty("exceptions", out jsonElement));
+            Assert.Equal(JsonValueKind.Array, jsonElement.ValueKind);
+
+            jsonElement = jsonElement.EnumerateArray().First();
+            Assert.Equal("ApplicationException", jsonElement.GetProperty("type").GetString());
+            Assert.Equal("This is a fake Exception", jsonElement.GetProperty("message").GetString());
+
+            jsonElement = jsonElement.GetProperty("stack").EnumerateArray().First();
+            Assert.True(jsonElement.GetProperty("path").GetString().Length > 0);
+            Assert.Equal("LambdaExceptionHandlingTests.ThrowTest", jsonElement.GetProperty("label").GetString());
+            Assert.True(jsonElement.GetProperty("line").GetInt32() > 0);
+
+            Assert.True(jsonDocument.RootElement.TryGetProperty("paths", out jsonElement));
+            Assert.Equal(JsonValueKind.Array, jsonElement.ValueKind);
+
+            var paths = jsonElement.EnumerateArray().ToArray();
+            Assert.Single(paths);
+            Assert.Contains("LambdaExceptionHandlingTests.cs", paths[0].GetString());
+        }
+
+
+        private void ThrowTest()
+        {
+            throw new ApplicationException("This is a fake Exception");
+        }
+    }
+}


### PR DESCRIPTION
*Description of changes:*
This PR ports the .NET Core 3.1 RIC `LambdaXRayExceptionWriter` to Amazon.Lambda.RuntimeSupport allowing the X-Ray cause section to be allowed to the X-Ray trace. The below image shows a snippet of the X-Ray cause in the X-Ray console.

![image](https://user-images.githubusercontent.com/1653751/144738228-841e98aa-228c-45c0-a5e0-8ad49cb7e2c9.png)

Since Amazon.Lambda.RuntimeSupport uses the HTTP API and the X-Ray cause JSON is passed in the `Lambda-Runtime-Function-XRay-Error-Cause` HTTP headers no newlines can be part of the JSON document. So `LambdaXRayExceptionWriter` was tweaked from the .NET Core 3.1 RIC to make sure newlines were not added.

Amazon.Lambda.RuntimeSupport generates a HTTP client using NSwag and Lambda's OpenAPI doc for the Runtime API. The OpenAPI doc does not model `Lambda-Runtime-Function-XRay-Error-Cause` header. The generated HTTP client is partial class so I copied the existing error reporting method into a new `ErrorWithXRayCauseAsync` and added a few lines to add the X-Ray header.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
