### PR TITLE
Tighten (and tidy) up bootstrap.sh

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/bootstrap.sh
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/bootstrap.sh
@@ -5,10 +5,15 @@
 # These files are used to add the end-user assembly into context and make the code reachable to the dotnet process
 # Since the file names are not known in advance, we use this shell script to find the files and pass them to the dotnet process as parameters
 # You can improve cold-start performance by setting the LAMBDA_DOTNET_MAIN_ASSEMBLY environment variable and specifying the assembly name
-USER_LAMBDA_BINARIES_DIR="/var/task"
-if [ ! -d "${USER_LAMBDA_BINARIES_DIR}" ]; then
-  echo "Error: .NET binaries for Lambda function are not correctly installed in the ${USER_LAMBDA_BINARIES_DIR} directory of the image when the image was built. The ${USER_LAMBDA_BINARIES_DIR} directory is missing." 1>&2
-  exit 1
+# LAMBDA_TASK_ROOT is inherited from the Lambda execution environment/base image as "/var/task", but can be overridden for use in custom images.
+if [ -z "${LAMBDA_TASK_ROOT}" ]; then
+  echo "Error: Environment variable LAMBDA_TASK_ROOT needs to be defined in order for the Lambda Runtime to load the function handler to be executed." 1>&2
+  exit 101
+fi
+
+if [ ! -d "${LAMBDA_TASK_ROOT}" ] | [ -z "$(ls -A ${LAMBDA_TASK_ROOT})" ]; then
+  echo "Error: .NET binaries for Lambda function are not correctly installed in the ${LAMBDA_TASK_ROOT} directory of the image when the image was built. The ${LAMBDA_TASK_ROOT} directory is missing." 1>&2
+  exit 102
 fi
 
 # Get version of Lambda .NET runtime if available
@@ -28,40 +33,52 @@ elif [ -n "${_HANDLER}" ]; then
   LAMBDA_HANDLER="${_HANDLER}"
 else
   echo "Error: No Lambda Handler function was specified." 1>&2
-  exit 1
+  exit 103
 fi
 
-if [[ $(expr index "${LAMBDA_HANDLER}" ":") == 0 ]]; then
-  EXECUTABLE_ASSEMBLY="${USER_LAMBDA_BINARIES_DIR}"/"${LAMBDA_HANDLER}"
+HANDLER_COL_INDEX=$(expr index "${LAMBDA_HANDLER}" ":")
+
+if [[ "${HANDLER_COL_INDEX}" == 0 ]]; then
+  EXECUTABLE_ASSEMBLY="${LAMBDA_TASK_ROOT}/${LAMBDA_HANDLER}"
   if [[ "${EXECUTABLE_ASSEMBLY}" != *.dll ]]; then
     EXECUTABLE_ASSEMBLY="${EXECUTABLE_ASSEMBLY}.dll"
   fi
 
   if [ ! -f "${EXECUTABLE_ASSEMBLY}" ]; then
     echo "Error: executable assembly ${EXECUTABLE_ASSEMBLY} was not found." 1>&2
-    exit 1
+    exit 104
   fi
 
   DOTNET_ARGS+=("${EXECUTABLE_ASSEMBLY}")
 else
-  ASSEMBLY_NAME="${LAMBDA_DOTNET_MAIN_ASSEMBLY}"
-  if [ -z "${ASSEMBLY_NAME}" ]; then
-    DEPS_FILE=$(find "${USER_LAMBDA_BINARIES_DIR}" -name \*.deps.json -print)
-    if [ -z "${DEPS_FILE}" ]; then
-      echo "Error: .NET binaries for Lambda function are not correctly installed in the ${USER_LAMBDA_BINARIES_DIR} directory of the image when the image was built. The ${USER_LAMBDA_BINARIES_DIR} directory is missing the required .deps.json file." 1>&2
-      exit 1
-    fi
-    RUNTIMECONFIG_FILE=$(find "${USER_LAMBDA_BINARIES_DIR}" -name \*.runtimeconfig.json -print)
-    if [ -z "${RUNTIMECONFIG_FILE}" ]; then
-      echo "Error: .NET binaries for Lambda function are not correctly installed in the ${USER_LAMBDA_BINARIES_DIR} directory of the image when the image was built. The ${USER_LAMBDA_BINARIES_DIR} directory is missing the required .runtimeconfig.json file." 1>&2
-      exit 1
+  if [ -n "${LAMBDA_DOTNET_MAIN_ASSEMBLY}" ]; then
+    if [[ "${LAMBDA_DOTNET_MAIN_ASSEMBLY}" == *.dll ]]; then
+      ASSEMBLY_NAME="${LAMBDA_DOTNET_MAIN_ASSEMBLY::-4}"
+    else
+      ASSEMBLY_NAME="${LAMBDA_DOTNET_MAIN_ASSEMBLY}"
     fi
   else
-    if [[ "${ASSEMBLY_NAME}" == *.dll ]]; then
-      ASSEMBLY_NAME="${ASSEMBLY_NAME::-4}"
+    ASSEMBLY_NAME="${LAMBDA_HANDLER::${HANDLER_COL_INDEX}-1}"
+  fi
+
+  DEPS_FILE="${LAMBDA_TASK_ROOT}/${ASSEMBLY_NAME}.deps.json"
+  if ! [ -f "${DEPS_FILE}" ]; then
+    DEPS_FILES=("${LAMBDA_TASK_ROOT}"/*.deps.json)
+    if [ "${#DEPS_FILES[@]}" -ne 1 ]; then
+      echo "Error: .NET binaries for Lambda function are not correctly installed in the ${LAMBDA_TASK_ROOT} directory of the image when the image was built. The ${LAMBDA_TASK_ROOT} directory is missing the required .deps.json file." 1>&2
+      exit 105
     fi
-    DEPS_FILE="${USER_LAMBDA_BINARIES_DIR}/${ASSEMBLY_NAME}.deps.json"
-    RUNTIMECONFIG_FILE="${USER_LAMBDA_BINARIES_DIR}/${ASSEMBLY_NAME}.runtimeconfig.json"
+    DEPS_FILE="${DEPS_FILES[1]}"
+  fi
+  
+  RUNTIMECONFIG_FILE="${LAMBDA_TASK_ROOT}/${ASSEMBLY_NAME}.runtimeconfig.json"
+  if ! [ -f "${RUNTIMECONFIG_FILE}" ]; then
+    RUNTIMECONFIG_FILES=("${LAMBDA_TASK_ROOT}"/*.deps.json)
+    if [ "${#RUNTIMECONFIG_FILES[@]}" -ne 1 ]; then
+      echo "Error: .NET binaries for Lambda function are not correctly installed in the ${LAMBDA_TASK_ROOT} directory of the image when the image was built. The ${LAMBDA_TASK_ROOT} directory is missing the required .runtimeconfig.json file." 1>&2
+      exit 106
+    fi
+    RUNTIMECONFIG_FILE="${RUNTIMECONFIG_FILES[1]}"
   fi
 
   DOTNET_ARGS+=("--depsfile" "${DEPS_FILE}"


### PR DESCRIPTION
*Description of changes:*
1. Use `LAMBDA_TASK_ROOT` instead of new variable `USER_LAMBDA_BINARIES_DIR`
1. Look for specific .deps.json and .runtimeconfig.json files based on the assembly name instead of dynamically looking for all occurrences of `*.deps.json` and `*.runtimeconfig.json` in `LAMBDA_TASK_ROOT`
1. Add fallback to look for single occurrence of *.deps.json and *.runtimeconfig.json if not using the assembly name
1. Make exit codes unique across the bootstrap script
1. Rewrite conditionals when `LAMBDA_HANDLER` is not an executable assembly (contains `::`)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
