### PR TITLE
Update VS 2022 container image blueprints to .NET 6

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2017/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -17,7 +17,7 @@
     <None Include="serverless.template" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2017/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2017/AspNetCoreWebApp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/AspNetCoreWebApp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,7 +7,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2017/CustomRuntimeFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/CustomRuntimeFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -15,7 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.4.0" />
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.6.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2017/CustomRuntimeFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/CustomRuntimeFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -9,7 +9,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.4.0" />
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.6.0" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
   </ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.5.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.6.1" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabels/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabels/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.5.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.6.1" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.5.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.6.1" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.5.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.6.1" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,7 +7,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.94" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.2.1" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />

--- a/Blueprints/BlueprintDefinitions/vs2017/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Giraffe" Version="3.4.0" />
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppHandlers.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.94" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.2.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.94" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.94" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.2.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.94" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -17,6 +17,6 @@
     <None Include="serverless.template" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -17,6 +17,6 @@
     <None Include="serverless.template" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,6 +7,6 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,6 +7,6 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebApp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebApp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,7 +7,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="wwwroot\images\" />

--- a/Blueprints/BlueprintDefinitions/vs2019/CustomRuntimeFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/CustomRuntimeFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -15,7 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.4.0" />
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.6.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2019/CustomRuntimeFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/CustomRuntimeFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -8,7 +8,6 @@
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
-  
   <!-- 
   When publishing Lambda functions for ARM64 to the provided.al2 runtime a newer version of libicu needs to be included
   in the deployment bundle because .NET requires a newer version of libicu then is preinstalled with Amazon Linux 2.
@@ -17,9 +16,8 @@
     <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2.0.9" />
     <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
   </ItemGroup>
-	
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.4.0" />
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.6.0" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
   </ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.5.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.6.1" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabels/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabels/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.5.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.6.1" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.5.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.6.1" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.5.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.6.1" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,7 +7,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.94" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.2.1" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />

--- a/Blueprints/BlueprintDefinitions/vs2019/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Giraffe" Version="3.4.0" />
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppHandlers.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.94" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.2.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.94" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.94" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.2.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.94" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/WebSocketAPIServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/WebSocketAPIServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />
-    <PackageReference Include="AWSSDK.ApiGatewayManagementApi" Version="3.7.0.93" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.94" />
+    <PackageReference Include="AWSSDK.ApiGatewayManagementApi" Version="3.7.0.106" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.2.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -17,6 +17,6 @@
     <None Include="serverless.template" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -17,6 +17,6 @@
     <None Include="serverless.template" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
   "display-name": "ASP.NET Core Web API (Container Image)",
   "system-name": "AspNetCoreWebAPI",
-  "description": "Serverless ASP.NET Core 5 Web API packaged as a container image.",
+  "description": "Serverless ASP.NET Core 6 Web API packaged as a container image.",
   "sort-order": 150,
   "hidden-tags": [
     "F#",

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/.template.config/template.json
@@ -6,7 +6,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Lambda ASP.NET Core Web API (.NET 5 Container Image)",
+  "name": "Lambda ASP.NET Core Web API (.NET 6 Container Image)",
   "identity": "AWS.Lambda.Serverless.Image.AspNetCoreWebAPI.FSharp",
   "groupIdentity": "AWS.Lambda.Serverless.Image.AspNetCoreWebAPI",
   "shortName": "serverless.image.AspNetCoreWebAPI",

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -17,6 +17,6 @@
     <None Include="serverless.template" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
@@ -17,6 +17,6 @@
     <None Include="serverless.template" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/Dockerfile
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:5.0
+FROM public.ecr.aws/lambda/dotnet:6
 
 WORKDIR /var/task
 

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -41,12 +41,12 @@ has a **COPY** command which copies the value from the directory pointed to by `
 image.
 
 Alternatively the Docker file could be written to use [multi-stage](https://docs.docker.com/develop/develop-images/multistage-build/) builds and 
-have the .NET project built inside the container. Below is an example of building .NET 5 project inside the image.
+have the .NET project built inside the container. Below is an example of building the .NET project inside the image.
 
 ```dockerfile
-FROM public.ecr.aws/lambda/dotnet:5.0 AS base
+FROM public.ecr.aws/lambda/dotnet:6 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim as build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.csproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.csproj"

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/serverless.template
@@ -9,9 +9,6 @@
       "Properties": {
         "PackageType": "Image",
         "ImageConfig": {
-          "EntryPoint": [
-            "/lambda-entrypoint.sh"
-          ],
           "Command": [
             "BlueprintBaseName.1::BlueprintBaseName._1.LambdaEntryPoint::FunctionHandlerAsync"
           ]

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <EnableDefaultContentItems>False</EnableDefaultContentItems>
   </PropertyGroup>
   <ItemGroup>
@@ -17,9 +17,9 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\BlueprintBaseName.1\BlueprintBaseName.1.fsproj" />

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/test/BlueprintBaseName.1.Tests/ValuesControllerTests.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/test/BlueprintBaseName.1.Tests/ValuesControllerTests.fs
@@ -25,6 +25,3 @@ module ValuesControllerTests =
         Assert.True(response.MultiValueHeaders.ContainsKey("Content-Type"))
         Assert.Equal("application/json; charset=utf-8", response.MultiValueHeaders.Item("Content-Type").[0])
     }
-
-    [<EntryPoint>]
-    let main _ = 0

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": "ASP.NET Core 5 (Container Image)",
+  "display-name": "ASP.NET Core 6 (Container Image)",
   "system-name": "AspNetCoreWebAPIImage",
-  "description": "Serverless ASP.NET Core 5 Web API packaged as a container image.",
+  "description": "Serverless ASP.NET Core 6 Web API packaged as a container image.",
   "sort-order": 165,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/.template.config/template.json
@@ -6,7 +6,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Lambda ASP.NET Core Web API (.NET 5 Container Image)",
+  "name": "Lambda ASP.NET Core Web API (.NET 6 Container Image)",
   "identity": "AWS.Lambda.Serverless.Image.AspNetCoreWebAPI.CSharp",
   "groupIdentity": "AWS.Lambda.Serverless.Image.AspNetCoreWebAPI",
   "shortName": "serverless.image.AspNetCoreWebAPI",

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,6 +7,6 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/Dockerfile
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:5.0
+FROM public.ecr.aws/lambda/dotnet:6
 
 WORKDIR /var/task
 

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/Readme.md
@@ -48,12 +48,12 @@ has a **COPY** command which copies the value from the directory pointed to by `
 image.
 
 Alternatively the Docker file could be written to use [multi-stage](https://docs.docker.com/develop/develop-images/multistage-build/) builds and 
-have the .NET project built inside the container. Below is an example of building .NET 5 project inside the image.
+have the .NET project built inside the container. Below is an example of building the .NET project inside the image.
 
 ```dockerfile
-FROM public.ecr.aws/lambda/dotnet:5.0 AS base
+FROM public.ecr.aws/lambda/dotnet:6 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim as build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.csproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.csproj"

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/serverless.template
@@ -10,9 +10,6 @@
       "Properties": {
         "PackageType": "Image",
         "ImageConfig": {
-          "EntryPoint": [
-            "/lambda-entrypoint.sh"
-          ],
           "Command": [
             "BlueprintBaseName.1::BlueprintBaseName._1.LambdaEntryPoint::FunctionHandlerAsync"
           ]

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <EnableDefaultContentItems>False</EnableDefaultContentItems>
   </PropertyGroup>
   <ItemGroup>
@@ -17,10 +17,10 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\BlueprintBaseName.1\BlueprintBaseName.1.csproj" />

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,6 +7,6 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,6 +7,6 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebApp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebApp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,7 +7,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="wwwroot\images\" />

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebApp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebApp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,7 +7,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="wwwroot\images\" />

--- a/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -6,7 +6,6 @@
     <AssemblyName>bootstrap</AssemblyName>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-
     <!-- 
 		Enable trimming to reduce package size of self contained publish which can reduce cold starts. Trimming alters
 		the .NET assemblies put in the deployment package. Additional runtime testing is required to make sure trimming
@@ -14,10 +13,8 @@
     
 	<PublishTrimmed>true</PublishTrimmed>
 	-->
-
     <!-- Generate ready to run images during publishing to improvement cold starts. -->
     <PublishReadyToRun>true</PublishReadyToRun>
-        
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />
@@ -25,7 +22,6 @@
   <ItemGroup>
     <Content Include="aws-lambda-tools-defaults.json" />
   </ItemGroup>
-  
   <!-- 
   When publishing Lambda functions for ARM64 to the provided.al2 runtime a newer version of libicu needs to be included
   in the deployment bundle because .NET requires a newer version of libicu then is preinstalled with Amazon Linux 2.
@@ -34,10 +30,9 @@
     <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2.0.9" />
     <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
   </ItemGroup>
-  
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.4.0" />
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.6.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,7 +7,6 @@
     <AssemblyName>bootstrap</AssemblyName>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-
     <!-- 
 		Enable trimming to reduce package size of self contained publish which can reduce cold starts. Trimming alters
 		the .NET assemblies put in the deployment package. Additional runtime testing is required to make sure trimming
@@ -15,12 +14,9 @@
     
 	<PublishTrimmed>true</PublishTrimmed>
 	-->
-
     <!-- Generate ready to run images during publishing to improvement cold starts. -->
     <PublishReadyToRun>true</PublishReadyToRun>
-
   </PropertyGroup>
-  
   <!-- 
   When publishing Lambda functions for ARM64 to the provided.al2 runtime a newer version of libicu needs to be included
   in the deployment bundle because .NET requires a newer version of libicu then is preinstalled with Amazon Linux 2.
@@ -28,10 +24,9 @@
   <ItemGroup Condition="'$(RuntimeIdentifier)' == 'linux-arm64'">
     <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2.0.9" />
     <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
-  </ItemGroup>  
-  
+  </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.4.0" />
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.6.0" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
   </ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.5.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.6.1" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.5.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.6.1" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.5.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.6.1" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.5.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.6.1" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />

--- a/Blueprints/BlueprintDefinitions/vs2022/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,7 +7,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.94" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.2.1" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": ".NET 5 (Container Image)",
+  "display-name": ".NET 6 (Container Image)",
   "system-name": "EmptyImageFunction",
-  "description": "A .NET 5 Lambda function packaged as a container image.",
+  "description": "A .NET 6 Lambda function packaged as a container image.",
   "sort-order": 101,
   "hidden-tags": [
     "F#",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Function"
   ],
-  "name": "Lambda Empty Function (.NET 5 Container Image)",
+  "name": "Lambda Empty Function (.NET 6 Container Image)",
   "identity": "AWS.Lambda.Function.Image.Empty.FSharp",
   "groupIdentity": "AWS.Lambda.Function.Image.Empty",
   "shortName": "lambda.image.EmptyFunction",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/Dockerfile
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:5.0
+FROM public.ecr.aws/lambda/dotnet:6
 
 WORKDIR /var/task
 

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -19,12 +19,12 @@ has a **COPY** command which copies the value from the directory pointed to by `
 image.
 
 Alternatively the Docker file could be written to use [multi-stage](https://docs.docker.com/develop/develop-images/multistage-build/) builds and 
-have the .NET project built inside the container. Below is an example of building .NET 5 project inside the image.
+have the .NET project built inside the container. Below is an example of building the .NET project inside the image.
 
 ```dockerfile
-FROM public.ecr.aws/lambda/dotnet:5.0 AS base
+FROM public.ecr.aws/lambda/dotnet:6 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim as build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.fsproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.fsproj"

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="FunctionTest.fs" />
@@ -10,10 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\BlueprintBaseName.1\BlueprintBaseName.1.fsproj" />

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
@@ -16,6 +16,3 @@ module FunctionTest =
         let upperCase = lambdaFunction.FunctionHandler "hello world" context
 
         Assert.Equal("HELLO WORLD", upperCase)
-
-    [<EntryPoint>]
-    let main _ = 0

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": ".NET 5 (Container Image)",
+  "display-name": ".NET 6 (Container Image)",
   "system-name": "EmptyImageFunction",
-  "description": "A .NET 5 Lambda function packaged as a container image.",
+  "description": "A .NET 6 Lambda function packaged as a container image.",
   "sort-order": 101,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Function"
   ],
-  "name": "Lambda Empty Function (.NET 5 Container Image)",
+  "name": "Lambda Empty Function (.NET 6 Container Image)",
   "identity": "AWS.Lambda.Function.Image.Empty.CSharp",
   "groupIdentity": "AWS.Lambda.Function.Image.Empty",
   "shortName": "lambda.image.EmptyFunction",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/Dockerfile
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:5.0
+FROM public.ecr.aws/lambda/dotnet:6
 
 WORKDIR /var/task
 

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/Readme.md
@@ -19,12 +19,12 @@ has a **COPY** command which copies the value from the directory pointed to by `
 image.
 
 Alternatively the Docker file could be written to use [multi-stage](https://docs.docker.com/develop/develop-images/multistage-build/) builds and 
-have the .NET project built inside the container. Below is an example of building .NET 5 project inside the image.
+have the .NET project built inside the container. Below is an example of building the .NET project inside the image.
 
 ```dockerfile
-FROM public.ecr.aws/lambda/dotnet:5.0 AS base
+FROM public.ecr.aws/lambda/dotnet:6 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim as build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.csproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.csproj"

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\BlueprintBaseName.1\BlueprintBaseName.1.csproj" />

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": ".NET 5 (Container Image) Serverless Application",
+  "display-name": ".NET 6 (Container Image) Serverless Application",
   "system-name": "EmptyImageServerless",
-  "description": ".NET 5 Lambda function packaged as a container image and deploy through AWS CloudFormation.",
+  "description": ".NET 6 Lambda function packaged as a container image and deploy through AWS CloudFormation.",
   "sort-order": 125,
   "hidden-tags": [
     "F#",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Lambda Empty Serverless (.NET 5 Container Image)",
+  "name": "Lambda Empty Serverless (.NET 6 Container Image)",
   "identity": "AWS.Lambda.Serverless.Image.Empty.FSharp",
   "groupIdentity": "AWS.Lambda.Image.Serverless.Empty",
   "shortName": "serverless.image.EmptyServerless",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/Dockerfile
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:5.0
+FROM public.ecr.aws/lambda/dotnet:6
 
 WORKDIR /var/task
 

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -21,7 +21,7 @@ type Functions() =
     /// <returns></returns>
     member __.Get (request: APIGatewayProxyRequest) (context: ILambdaContext) =
         sprintf "Request: %s" request.Path
-        |> context.Logger.LogLine
+        |> context.Logger.LogInformation
 
         APIGatewayProxyResponse(
             StatusCode = int HttpStatusCode.OK,

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -21,12 +21,12 @@ has a **COPY** command which copies the value from the directory pointed to by `
 image.
 
 Alternatively the Docker file could be written to use [multi-stage](https://docs.docker.com/develop/develop-images/multistage-build/) builds and 
-have the .NET project built inside the container. Below is an example of building .NET 5 project inside the image.
+have the .NET project built inside the container. Below is an example of building the .NET project inside the image.
 
 ```dockerfile
-FROM public.ecr.aws/lambda/dotnet:5.0 AS base
+FROM public.ecr.aws/lambda/dotnet:6 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim as build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.csproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.csproj"

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/serverless.template
@@ -8,9 +8,6 @@
       "Properties": {
         "PackageType": "Image",
         "ImageConfig": {
-          "EntryPoint": [
-            "/lambda-entrypoint.sh"
-          ],
           "Command": [
             "BlueprintBaseName.1::BlueprintBaseName._1.Functions::Get"
           ]

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="FunctionTest.fs" />
@@ -11,9 +11,9 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\BlueprintBaseName.1\BlueprintBaseName.1.fsproj" />

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
@@ -18,6 +18,3 @@ module FunctionTest =
 
         Assert.Equal(200, response.StatusCode)
         Assert.Equal("Hello AWS Serverless", response.Body)
-
-    [<EntryPoint>]
-    let main _ = 0

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": ".NET 5 (Container Image) Serverless Application",
+  "display-name": ".NET 6 (Container Image) Serverless Application",
   "system-name": "EmptyImageServerless",
-  "description": ".NET 5 Lambda function packaged as a container image and deploy through AWS CloudFormation.",
+  "description": ".NET 6 Lambda function packaged as a container image and deploy through AWS CloudFormation.",
   "sort-order": 125,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Lambda Empty Serverless (.NET 5 Container Image)",
+  "name": "Lambda Empty Serverless (.NET 6 Container Image)",
   "identity": "AWS.Lambda.Serverless.Image.Empty.CSharp",
   "groupIdentity": "AWS.Lambda.Image.Serverless.Empty",
   "shortName": "serverless.image.EmptyServerless",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/Dockerfile
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:5.0
+FROM public.ecr.aws/lambda/dotnet:6
 
 WORKDIR /var/task
 

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/Function.cs
@@ -29,7 +29,7 @@ namespace BlueprintBaseName._1
         /// <returns>The API Gateway response.</returns>
         public APIGatewayProxyResponse Get(APIGatewayProxyRequest request, ILambdaContext context)
         {
-            context.Logger.LogLine("Get Request\n");
+            context.Logger.LogInformation("Get Request\n");
 
             var response = new APIGatewayProxyResponse
             {

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/Readme.md
@@ -21,12 +21,12 @@ has a **COPY** command which copies the value from the directory pointed to by `
 image.
 
 Alternatively the Docker file could be written to use [multi-stage](https://docs.docker.com/develop/develop-images/multistage-build/) builds and 
-have the .NET project built inside the container. Below is an example of building .NET 5 project inside the image.
+have the .NET project built inside the container. Below is an example of building the .NET project inside the image.
 
 ```dockerfile
-FROM public.ecr.aws/lambda/dotnet:5.0 AS base
+FROM public.ecr.aws/lambda/dotnet:6 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim as build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.csproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.csproj"

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/serverless.template
@@ -8,9 +8,6 @@
       "Properties": {
         "PackageType": "Image",
         "ImageConfig": {
-          "EntryPoint": [
-            "/lambda-entrypoint.sh"
-          ],
           "Command": [
             "BlueprintBaseName.1::BlueprintBaseName._1.Functions::Get"
           ]

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\BlueprintBaseName.1\BlueprintBaseName.1.csproj" />

--- a/Blueprints/BlueprintDefinitions/vs2022/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Giraffe" Version="3.4.0" />
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppHandlers.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Giraffe" Version="3.4.0" />
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppHandlers.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.94" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.2.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.94" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.94" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.2.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.94" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.4.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />
-    <PackageReference Include="AWSSDK.ApiGatewayManagementApi" Version="3.7.0.93" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.94" />
+    <PackageReference Include="AWSSDK.ApiGatewayManagementApi" Version="3.7.0.106" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.2.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/template.nuspec
+++ b/Blueprints/BlueprintDefinitions/vs2022/template.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Amazon.Lambda.Templates</id>
-    <version>5.6.0</version>
+    <version>5.7.0</version>
     <authors>Amazon Web Services</authors>
     <tags>AWS Amazon Lambda</tags>
     <description>AWS Lambda templates for Microsoft Template Engine accessible with the dotnet CLI's new command</description>

--- a/buildtools/build.proj
+++ b/buildtools/build.proj
@@ -55,7 +55,8 @@
         <MakeDir Directories="../Deployment/BlueprintGenerationTests/DotnetNew/vs2022"/>
         <MakeDir Directories="../Deployment/BlueprintGenerationTests/DotnetNew/vs2019"/>
         <Copy SourceFiles="@(DeploymentNuGetConfig)" DestinationFolder="../Deployment" />
-				
+		
+        <Exec Command="dotnet new -u Blueprints\BlueprintDefinitions\vs2022" WorkingDirectory="..\" IgnoreExitCode="true" />		
         <Exec Command="dotnet new -i Blueprints\BlueprintDefinitions\vs2022" WorkingDirectory="..\"/>
 		
 		<MSBuild Projects="$(MSBuildProjectFile)" Targets="run-blueprint-dotnetnew" Properties="TemplateName=lambda.image.EmptyFunction;ProjectName=ImageEmptyFunctionC;Lang=C#;Version=vs2022"/>
@@ -99,6 +100,7 @@
         <MSBuild Projects="$(MSBuildProjectFile)" Targets="run-blueprint-dotnetnew" Properties="TemplateName=serverless.StepFunctionsHelloWorld;ProjectName=StepFunctionsHelloWorldC;Lang=C#;Version=vs2022"/>
         <MSBuild Projects="$(MSBuildProjectFile)" Targets="run-blueprint-dotnetnew" Properties="TemplateName=serverless.StepFunctionsHelloWorld;ProjectName=StepFunctionsHelloWorldF;Lang=F#;Version=vs2022"/>				
 		
+		<Exec Command="dotnet new -u Blueprints\BlueprintDefinitions\vs2019" WorkingDirectory="..\" IgnoreExitCode="true" />
         <Exec Command="dotnet new -i Blueprints\BlueprintDefinitions\vs2019" WorkingDirectory="..\"/>
 		
 		<MSBuild Projects="$(MSBuildProjectFile)" Targets="run-blueprint-dotnetnew" Properties="TemplateName=lambda.image.EmptyFunction;ProjectName=ImageEmptyFunctionC;Lang=C#;Version=vs2019"/>


### PR DESCRIPTION
*Description of changes:*
Update all of the VS 2022 container image blueprints to .NET 6 in anticipation of the base image being released.

Changes:
* Update all template.json files to call out .NET 6. This file is used as the description in the .NET CLI `new` command
* Update all blueprint-manifest.json files to call out .NET 6. This file is used as the description in VS project wizard
* Update references of public.ecr.aws/lambda/dotnet:5.0 to public.ecr.aws/lambda/dotnet:6.0
* Update references of mcr.microsoft.com/dotnet/sdk:5.0-buster-slim to mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim
* Update all `TargetFramework` elements to `net6.0`
* Remove ImageConfig.EntryPoint element in serverless.template. This was added for the initial release of image support and CloudFormation had an issue when only Command was set. This work around is no longer needed.
* In test projects update to latest test packages
* In F# test projects remove unnecessary `main` method since the test projects are class library. .NET 6 makes this a compile error to leave it in
* Make build script more resilient by force uninstalling the templates before installing and executing them.

The changes were tested by manually and running the build target `test-blueprints-dotnew` which creates each templates and make sure they compile.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
