### PR TITLE
Lambda exceptions written to log stream

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
@@ -145,6 +145,7 @@ namespace Amazon.Lambda.RuntimeSupport
             }
             catch (Exception exception)
             {
+                WriteUnhandledExceptionToLog(exception);
                 await Client.ReportInitializationErrorAsync(exception);
                 throw;
             }
@@ -164,6 +165,7 @@ namespace Amazon.Lambda.RuntimeSupport
                 }
                 catch (Exception exception)
                 {
+                    WriteUnhandledExceptionToLog(exception);
                     await Client.ReportInvocationErrorAsync(invocation.LambdaContext.AwsRequestId, exception);
                 }
 
@@ -197,6 +199,13 @@ namespace Amazon.Lambda.RuntimeSupport
             var client = new HttpClient();
             client.DefaultRequestHeaders.Add("User-Agent", userAgentString);
             return client;
+        }
+
+        private void WriteUnhandledExceptionToLog(Exception exception)
+        {
+            // Console.Error.WriteLine are redirected to the IConsoleLoggerWriter which 
+            // will take care of writing to the function's log stream.
+            Console.Error.WriteLine(exception);
         }
 
         #region IDisposable Support

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/CustomRuntimeTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/CustomRuntimeTests.cs
@@ -102,6 +102,10 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
                 JObject exception = (JObject)JsonConvert.DeserializeObject(await sr.ReadToEndAsync());
                 Assert.Equal(expectedErrorType, exception["errorType"].ToString());
                 Assert.Equal(expectedErrorMessage, exception["errorMessage"].ToString());
+
+                var log = System.Text.UTF8Encoding.UTF8.GetString(Convert.FromBase64String(invokeResponse.LogResult));
+                var logExpectedException = expectedErrorType != "Function.ResponseSizeTooLarge" ? expectedErrorType : "RuntimeApiClientException";
+                Assert.Contains(logExpectedException, log);
             }
         }
 


### PR DESCRIPTION
*Description of changes:*
This PR updates Amazon.Lambda.RuntimeSupport to have unhandled exceptions from the Lambda function be written to the function's log stream. This matches the behavior of .NET Core 3.1 managed runtime.

For example a Lambda function like this
```csharp
public static async Task<string> FunctionHandler(string input, ILambdaContext context)
{
    ThrowTest(input);
    return await Task.FromResult(input?.ToUpper());
}

public static void ThrowTest(string input)
{
    if(string.Equals(input, "fail", StringComparison.OrdinalIgnoreCase))
    {
        try
        {
            throw new ArgumentException(nameof(input));
        }
        catch(Exception e)
        {
            throw new ApplicationException("You caused a failure", e);
        }
    }
}
```

Now writes the following to the log stream
```
START RequestId: 3e2fbf0c-1482-4d13-93b8-e6f4fc705d3f Version: $LATEST
2021-12-10T08:20:59.274Z	3e2fbf0c-1482-4d13-93b8-e6f4fc705d3f	fail	System.ApplicationException: You caused a failure
---> System.ArgumentException: input
at CustomRuntimeTest.Function.ThrowTest(String input) in C:\Users\normj\source\repos\CustomRuntimeTest\CustomRuntimeTest\Function.cs:line 45
--- End of inner exception stack trace ---
at CustomRuntimeTest.Function.ThrowTest(String input) in C:\Users\normj\source\repos\CustomRuntimeTest\CustomRuntimeTest\Function.cs:line 49
at CustomRuntimeTest.Function.FunctionHandler(String input, ILambdaContext context) in C:\Users\normj\source\repos\CustomRuntimeTest\CustomRuntimeTest\Function.cs:line 35
at Amazon.Lambda.RuntimeSupport.HandlerWrapper.<>c__DisplayClass26_0`2.<<GetHandlerWrapper>b__0>d.MoveNext() in C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.RuntimeSupport\Bootstrap\HandlerWrapper.cs:line 383
--- End of stack trace from previous location ---
at Amazon.Lambda.RuntimeSupport.LambdaBootstrap.InvokeOnceAsync(CancellationToken cancellationToken) in C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.RuntimeSupport\Bootstrap\LambdaBootstrap.cs:line 163
END RequestId: 3e2fbf0c-1482-4d13-93b8-e6f4fc705d3f
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
