### PR TITLE
Fix deadlock issue in Amazon.Lambda.RuntimeSupport while logging

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Amazon.Lambda.AspNetCoreServer.csproj
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Amazon.Lambda.AspNetCoreServer.csproj
@@ -25,17 +25,8 @@
     <ProjectReference Include="..\Amazon.Lambda.APIGatewayEvents\Amazon.Lambda.APIGatewayEvents.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
-    <ProjectReference Include="..\Amazon.Lambda.Serialization.Json\Amazon.Lambda.Serialization.Json.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="System.IO.Pipelines" version="4.7.2">
-      <IncludeAssets>compile</IncludeAssets>
-    </PackageReference>
     <ProjectReference Include="..\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
   </ItemGroup>
 

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/HostBuilderExtensions.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/HostBuilderExtensions.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Extensions.Hosting
                                 }
                                 else
                                 {
+                                    logging.ClearProviders();
                                     logging.AddLambdaLogger(hostingContext.Configuration, "Logging");
                                 }
                             })

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/BaseCustomRuntimeTest.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/BaseCustomRuntimeTest.cs
@@ -199,8 +199,15 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
                 }
             };
             await lambdaClient.UpdateFunctionConfigurationAsync(updateFunctionConfigurationRequest);
+
             // Wait for eventual consistency of function change.
-            await Task.Delay(3000);
+            var getConfigurationRequest = new GetFunctionConfigurationRequest { FunctionName = FunctionName };
+            GetFunctionConfigurationResponse getConfigurationResponse = null;
+            do
+            {
+                await Task.Delay(1000);
+                getConfigurationResponse = await lambdaClient.GetFunctionConfigurationAsync(getConfigurationRequest);
+            } while (getConfigurationResponse.State == State.Pending);
         }
 
         protected async Task CreateFunctionAsync(IAmazonLambda lambdaClient, string bucketName)
@@ -217,7 +224,8 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
                 },
                 Handler = "PingAsync",
                 MemorySize = 512,
-                Runtime = Runtime.Provided,
+                Timeout = 30,
+                Runtime = Runtime.ProvidedAl2,
                 Role = ExecutionRoleArn
             };
 

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/CustomRuntimeTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/CustomRuntimeTests.cs
@@ -54,6 +54,7 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
                 {
                     roleAlreadyExisted = await PrepareTestResources(s3Client, lambdaClient, iamClient);
 
+                    await RunTestSuccessAsync(lambdaClient, "LoggingStressTest", "not-used", "LoggingStressTest-success");
                     await RunLoggingTestAsync(lambdaClient, "LoggingTest", null);
                     await RunLoggingTestAsync(lambdaClient, "LoggingTest", "debug");
                     await RunUnformattedLoggingTestAsync(lambdaClient, "LoggingTest");


### PR DESCRIPTION
*Description of changes:*
This PR fixes an issue when both Console.WriteX and ILambdaLogger are used for logging in different threads it can trigger a deadlock. 

## How was the issue detected?
This was detected with the ASP.NET Core blueprints which have both the Lambda logger and Console Logger added to the log provider. The ASP.NET Core console logger uses a background task to push log messages to the console. Initially the problem showed that the Lambda functions were timing out. After figuring out the issue was with logging I was able to reproduce this issue with a simple logging stress test which has been added to our integration tests.

## How does the deadlock happen?
For .NET 6 we introduced the `LogLevelLoggerWriter` which is where ILambdaLogger sends log message to format the log message and perform the log level determination. It also captures all Console.WriteX and Console.Error.WriteX to make sure they are formatted. 

To capture stdout and stderr `Console.SetOut` and `Console.SetError` are called passing in our own `TextWriter`. Our TextWriter wraps around the original TextWriters that `Console.Out` and `Console.Error` are using. That gives us a chance to format the console messages before forwarding on the log message to the original console `TextWriter`.

The TextWriters that `Console.Out` and `Console.Error` are set to our synchronized `TextWriters` meaning only one thread can make a call through them at a time. When Amazon.Lambda.RuntimeSupport sets new TextWriters using the `Console.SetOut` and `Console.SetError` those commands wrap around the passed in TextWriters with a synchronized TextWriter. This was the unexpected behavior that triggers the deadlock.

This means with a call to Console.WriteX 2 locks are acquired. Once for the synchronized TextWriter created to wrap around our TextWriter and then a second lock when calling to the original TextWriter Console.Out was set to. When using the logging commands from `ILambdaLogger` it is only acquiring the one lock for calling the original TextWriter Console.Out was set to. With `ILambdaLogger` skipping the first lock but Console.WriteX getting 2 locks this can trigger a deadlock writing to the stdout and stderror.

## How to fix the issue?
To fix the issue we need to make sure all code paths get the same locks. This fix makes sure before writing to the original TextWriter that our TextWriter is wrapping we have also lock on Console.Out or Console.Error just like the Console.WriteX commands do.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
