### PR TITLE
fix: Add GetRelativePath method to DirectoryManager class

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/FileIO/DirectoryManager.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/FileIO/DirectoryManager.cs
@@ -1,4 +1,6 @@
+using System;
 using System.IO;
+using System.Text;
 
 namespace Amazon.Lambda.Annotations.SourceGenerator.FileIO
 {
@@ -8,16 +10,65 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.FileIO
 
         public bool Exists(string path) => Directory.Exists(path);
 
+        /// <summary>
+        /// This method mimics the behaviour of <see href="https://docs.microsoft.com/en-us/dotnet/api/system.io.path.getrelativepath?view=net-6.0"/>
+        /// This logic already exists in the aws-extensions-for-dotnet-cli package. <see href="https://github.com/aws/aws-extensions-for-dotnet-cli/blob/9639f8f4902349d289491b290979a3a1671cc0a5/src/Amazon.Common.DotNetCli.Tools/Utilities.cs#L91">see here</see>
+        /// </summary>
         public string GetRelativePath(string relativeTo, string path)
         {
-            return ".";
-            //var relativePath = Path.GetRelativePath(relativeTo, path);
-            //return relativePath.Replace(Path.DirectorySeparatorChar, '/');
+            relativeTo = SanitizePath(relativeTo);
+            path = SanitizePath(path);
+
+            var relativeToDirs = relativeTo.Split('/');
+            var pathDirs = path.Split('/');
+
+            int len = relativeToDirs.Length < pathDirs.Length ? relativeToDirs.Length : pathDirs.Length;
+
+            int lastCommonRoot = -1;
+            int index;
+
+            for (index = 0; index < len && string.Equals(relativeToDirs[index], pathDirs[index], StringComparison.OrdinalIgnoreCase); index++)
+            {
+                lastCommonRoot = index;
+            }
+
+            // The 2 paths don't share a common ancestor. So the closest we can give is the absolute path to the target.
+            if (lastCommonRoot == -1)
+            {
+                return path;
+            }
+
+            StringBuilder relativePath = new StringBuilder();
+            for (index = lastCommonRoot + 1; index < relativeToDirs.Length; index++)
+            {
+                if (relativeToDirs[index].Length > 0) relativePath.Append("../");
+            }
+
+            for (index = lastCommonRoot + 1; index < pathDirs.Length; index++)
+            {
+                relativePath.Append(pathDirs[index]);
+                if(index + 1 < pathDirs.Length)
+                {
+                    relativePath.Append("/");
+                }
+            }
+
+            var result = relativePath.ToString();
+            if (result.EndsWith("/"))
+                result = result.Substring(0, result.Length - 1);
+            return string.IsNullOrEmpty(result) ? "." : result;
         }
 
         public string[] GetFiles(string path, string searchPattern, SearchOption searchOption = SearchOption.TopDirectoryOnly)
         {
             return Directory.GetFiles(path, searchPattern, searchOption);
+        }
+
+        private string SanitizePath(string path)
+        {
+            return path
+                .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)
+                .Replace(Path.DirectorySeparatorChar, '/');
         }
     }
 }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/FileIOTests/DirectoryManagerTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/FileIOTests/DirectoryManagerTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Amazon.Lambda.Annotations.SourceGenerator.FileIO;
+
+namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.FileIOTests
+{
+    public class DirectoryManagerTests
+    {
+        [Theory]
+        [InlineData("C:/CodeBase/Src/MyProject", "C:/CodeBase/Src/MyProject", ".")]
+        [InlineData("C:/CodeBase/Src/MyProject/MyFile.cs", "C:/CodeBase/Src/MyProject/MyFile.cs", ".")]
+        [InlineData("C:/CodeBase/Src/MyProject", "C:/CodeBase/Src/MyProject/MyProject.csproj", "MyProject.csproj")]
+        [InlineData("C:/CodeBase/Src/MyProject", "C:/CodeBase/Src", "..")]
+        [InlineData("C:/CodeBase/Src/MyProject", "C:/CodeBase/Test", "../../Test")]
+        [InlineData("C:/CodeBase/Src/MyProject", "C:/CodeBase/Test/TestApp.csproj", "../../Test/TestApp.csproj")]
+        [InlineData("C:/CodeBase/Src/MyProject", "C:/CodeBase/Src/MyProject/MyFolder/MyResources", "MyFolder/MyResources")]
+        [InlineData("C:/CodeBase/Src/MyProject/MyProject.csproj", "C:/CodeBase/Src/MyProject", "..")]
+        [InlineData("C:/CodeBase/Src/MyProject/MyProject.csproj", "C:/CodeBase/Src", "../..")]
+        [InlineData("MyFolder", "MyFolder", ".")]
+        [InlineData("C:/CodeBase/Src/MyProject/MyProject.csproj", "D:/CodeBase/Src/MyProject/MyProject.csproj", "D:/CodeBase/Src/MyProject/MyProject.csproj")]
+        public void GetRelativePath(string relativeTo, string path, string expectedPath)
+        {
+            var directoryManager = new DirectoryManager();
+            var relativePath = directoryManager.GetRelativePath(relativeTo, path);
+            Assert.Equal(expectedPath, relativePath);
+        }
+    }
+}


### PR DESCRIPTION
*Description of changes:*
The `Amazon.Lambda.Annotations.SourceGenerator` project targets `netstandard2.0`

`netstandard2.0` does not have the `Path.GetRelativePath` method as part `System.IO`. It was introduced as part of `netstandard2.1`.

This PR adds the `GetRelativePath` as part of the `DirectoryManager` class. This method mimics the behavior of the [built-in API](https://docs.microsoft.com/en-us/dotnet/api/system.io.path.getrelativepath?view=net-6.0)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
