### PR TITLE
Update targeting to .NET 6

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Amazon.Lambda.Annotations.SourceGenerator.csproj
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Amazon.Lambda.Annotations.SourceGenerator.csproj
@@ -2,16 +2,16 @@
 
   <PropertyGroup>
     <AssemblyVersion>0.1.0.0</AssemblyVersion>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
 
     <!-- This is required to allow copying all the dependencies to bin directory which can be copied after to nuget package based on nuspec -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="System.CodeDom" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
+    <PackageReference Include="System.CodeDom" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/FileIO/DirectoryManager.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/FileIO/DirectoryManager.cs
@@ -10,8 +10,9 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.FileIO
 
         public string GetRelativePath(string relativeTo, string path)
         {
-            var relativePath = Path.GetRelativePath(relativeTo, path);
-            return relativePath.Replace(Path.DirectorySeparatorChar, '/');
+            return ".";
+            //var relativePath = Path.GetRelativePath(relativeTo, path);
+            //return relativePath.Replace(Path.DirectorySeparatorChar, '/');
         }
 
         public string[] GetFiles(string path, string searchPattern, SearchOption searchOption = SearchOption.TopDirectoryOnly)

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/FileIO/DirectoryManager.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/FileIO/DirectoryManager.cs
@@ -1,4 +1,6 @@
+using System;
 using System.IO;
+using System.Text;
 
 namespace Amazon.Lambda.Annotations.SourceGenerator.FileIO
 {
@@ -8,16 +10,65 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.FileIO
 
         public bool Exists(string path) => Directory.Exists(path);
 
+        /// <summary>
+        /// This method mimics the behaviour of <see href="https://docs.microsoft.com/en-us/dotnet/api/system.io.path.getrelativepath?view=net-6.0"/>
+        /// This logic already exists in the aws-extensions-for-dotnet-cli package. <see href="https://github.com/aws/aws-extensions-for-dotnet-cli/blob/9639f8f4902349d289491b290979a3a1671cc0a5/src/Amazon.Common.DotNetCli.Tools/Utilities.cs#L91">see here</see>
+        /// </summary>
         public string GetRelativePath(string relativeTo, string path)
         {
-            return ".";
-            //var relativePath = Path.GetRelativePath(relativeTo, path);
-            //return relativePath.Replace(Path.DirectorySeparatorChar, '/');
+            relativeTo = SanitizePath(relativeTo);
+            path = SanitizePath(path);
+
+            var relativeToDirs = relativeTo.Split('/');
+            var pathDirs = path.Split('/');
+
+            int len = relativeToDirs.Length < pathDirs.Length ? relativeToDirs.Length : pathDirs.Length;
+
+            int lastCommonRoot = -1;
+            int index;
+
+            for (index = 0; index < len && string.Equals(relativeToDirs[index], pathDirs[index], StringComparison.OrdinalIgnoreCase); index++)
+            {
+                lastCommonRoot = index;
+            }
+
+            // The 2 paths don't share a common ancestor. So the closest we can give is the absolute path to the target.
+            if (lastCommonRoot == -1)
+            {
+                return path;
+            }
+
+            StringBuilder relativePath = new StringBuilder();
+            for (index = lastCommonRoot + 1; index < relativeToDirs.Length; index++)
+            {
+                if (relativeToDirs[index].Length > 0) relativePath.Append("../");
+            }
+
+            for (index = lastCommonRoot + 1; index < pathDirs.Length; index++)
+            {
+                relativePath.Append(pathDirs[index]);
+                if(index + 1 < pathDirs.Length)
+                {
+                    relativePath.Append("/");
+                }
+            }
+
+            var result = relativePath.ToString();
+            if (result.EndsWith("/"))
+                result = result.Substring(0, result.Length - 1);
+            return string.IsNullOrEmpty(result) ? "." : result;
         }
 
         public string[] GetFiles(string path, string searchPattern, SearchOption searchOption = SearchOption.TopDirectoryOnly)
         {
             return Directory.GetFiles(path, searchPattern, searchOption);
+        }
+
+        private string SanitizePath(string path)
+        {
+            return path
+                .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)
+                .Replace(Path.DirectorySeparatorChar, '/');
         }
     }
 }

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Generator.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Generator.cs
@@ -27,10 +27,10 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
         public Generator()
         {
 #if DEBUG
-            // if (!Debugger.IsAttached)
-            // {
-            //     Debugger.Launch();
-            // }
+            //if (!Debugger.IsAttached)
+            //{
+            //    Debugger.Launch();
+            //}
 #endif
         }
 

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/LambdaFunctionAttributeDataBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/LambdaFunctionAttributeDataBuilder.cs
@@ -38,9 +38,9 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes
                     data.MemorySize = memorySize;
                 }
 
-                if (pair.Key == nameof(data.PackageType) && pair.Value.Value is PackageTypeEnum packageType)
+                if (pair.Key == nameof(data.PackageType) && pair.Value.Value is int)
                 {
-                    data.PackageType = packageType;
+                    data.PackageType = (LambdaPackageType)pair.Value.Value;
                 }
             }
 

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/ILambdaFunctionSerializable.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/ILambdaFunctionSerializable.cs
@@ -44,7 +44,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
         /// The deployment package type of the Lambda function. The supported values are Zip and Image.
         /// For more information, see <a href="https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-package.html">here</a>
         /// </summary>
-        PackageTypeEnum PackageType { get; }
+        LambdaPackageType PackageType { get; }
 
         /// <summary>
         /// List of attributes applied to the Lambda method that are used to generate serverless.template.

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/LambdaFunctionModel.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/LambdaFunctionModel.cs
@@ -52,7 +52,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
 
         /// <inheritdoc />
         /// The default value is set to Zip
-        public PackageTypeEnum PackageType  => LambdaMethod.LambdaFunctionAttribute.Data.PackageType ?? PackageTypeEnum.Zip;
+        public LambdaPackageType PackageType  => LambdaMethod.LambdaFunctionAttribute.Data.PackageType;
 
         /// <inheritdoc />
         public IList<AttributeModel> Attributes => LambdaMethod.Attributes ?? new List<AttributeModel>();

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Writers/CloudFormationJsonWriter.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Writers/CloudFormationJsonWriter.cs
@@ -107,22 +107,23 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Writers
 
             switch (lambdaFunction.PackageType)
             {
-                case PackageTypeEnum.Zip:
+                case LambdaPackageType.Zip:
                     _jsonWriter.SetToken($"{propertiesPath}.CodeUri", relativeProjectUri);
                     _jsonWriter.SetToken($"{propertiesPath}.Handler", lambdaFunction.Handler);
                     _jsonWriter.RemoveToken($"{propertiesPath}.ImageUri");
                     _jsonWriter.RemoveToken($"{propertiesPath}.ImageConfig");
                     break;
 
-                case PackageTypeEnum.Image:
+                case LambdaPackageType.Image:
                     _jsonWriter.SetToken($"{propertiesPath}.ImageUri", relativeProjectUri);
-                    _jsonWriter.SetToken($"{propertiesPath}.ImageConfig.Command", lambdaFunction.Handler);
+                    _jsonWriter.SetToken($"{propertiesPath}.ImageConfig.Command", new JArray(lambdaFunction.Handler));
                     _jsonWriter.RemoveToken($"{propertiesPath}.Handler");
                     _jsonWriter.RemoveToken($"{propertiesPath}.CodeUri");
+                    _jsonWriter.RemoveToken($"{propertiesPath}.Runtime");
                     break;
 
                 default:
-                    throw new InvalidEnumArgumentException($"The {nameof(lambdaFunction.PackageType)} does not match any supported enums of type {nameof(PackageTypeEnum)}");
+                    throw new InvalidEnumArgumentException($"The {nameof(lambdaFunction.PackageType)} does not match any supported enums of type {nameof(LambdaPackageType)}");
             }
         }
 

--- a/Libraries/src/Amazon.Lambda.Annotations.nuspec
+++ b/Libraries/src/Amazon.Lambda.Annotations.nuspec
@@ -9,17 +9,17 @@
         <projectUrl>https://github.com/aws/aws-lambda-dotnet</projectUrl>
         <license type="expression">Apache-2.0</license>
         <dependencies>
-            <group targetFramework=".netcoreapp3.1"/>
+            <group targetFramework=".net6.0"/>
         </dependencies>
     </metadata>
 
     <files>
         <!-- Dependencies to make sure attributes are available in consuming csproj, this ensures packaged version of customer code have all the dependencies needed. -->
-        <file src="Amazon.Lambda.Annotations\bin\Release\netcoreapp3.1\Amazon.Lambda.Annotations.dll" target="lib/netcoreapp3.1" />
+        <file src="Amazon.Lambda.Annotations\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.dll" target="lib/net6.0" />
 
         <!-- Include every dependency manually for analyzer, whenever a new dependency is added, it has to be added here. -->
-        <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netcoreapp3.1\Amazon.Lambda.Annotations.dll" target="analyzers\dotnet\cs" />
-        <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netcoreapp3.1\Amazon.Lambda.Annotations.SourceGenerator.dll" target="analyzers\dotnet\cs" />
-        <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netcoreapp3.1\Newtonsoft.Json.dll" target="analyzers\dotnet\cs" />
+        <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.dll" target="analyzers\dotnet\cs" />
+        <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.SourceGenerator.dll" target="analyzers\dotnet\cs" />
+        <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netstandard2.0\Newtonsoft.Json.dll" target="analyzers\dotnet\cs" />
     </files>
 </package>

--- a/Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj
+++ b/Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyVersion>0.1.0.0</AssemblyVersion>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/Libraries/src/Amazon.Lambda.Annotations/LambdaFunctionAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/LambdaFunctionAttribute.cs
@@ -36,6 +36,6 @@ namespace Amazon.Lambda.Annotations
         /// The deployment package type of the Lambda function. The supported values are Zip or Image. The default value is Zip.
         /// For more information, see <a href="https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-package.html">here</a>
         /// </summary>
-        public PackageTypeEnum? PackageType {get; set;}
+        public LambdaPackageType PackageType { get; set; }
     }
 }

--- a/Libraries/src/Amazon.Lambda.Annotations/LambdaPackageType.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/LambdaPackageType.cs
@@ -1,0 +1,8 @@
+﻿namespace Amazon.Lambda.Annotations
+{
+    public enum LambdaPackageType
+    {
+        Zip=0,
+        Image=1
+    }
+}

--- a/Libraries/src/Amazon.Lambda.Annotations/PackageTypeEnum.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/PackageTypeEnum.cs
@@ -1,8 +1,0 @@
-﻿namespace Amazon.Lambda.Annotations
-{
-    public enum PackageTypeEnum
-    {
-        Zip,
-        Image
-    }
-}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
@@ -22,15 +22,6 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-		<!--
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" ExcludeAssets="Compile"/>
-        <Reference Include="Microsoft.Extensions.DependencyInjection">
-            <HintPath>$(NuGetPackageRoot)microsoft.extensions.dependencyinjection\6.0.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.dll</HintPath>
-        </Reference>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" ExcludeAssets="Compile"/>
-		<Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions">
-			<HintPath>$(NuGetPackageRoot)microsoft.extensions.dependencyinjection.abstractions\6.0.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
-		</Reference>-->
 	</ItemGroup>
 
     <ItemGroup>

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
@@ -21,8 +21,17 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    </ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+		<!--
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" ExcludeAssets="Compile"/>
+        <Reference Include="Microsoft.Extensions.DependencyInjection">
+            <HintPath>$(NuGetPackageRoot)microsoft.extensions.dependencyinjection\6.0.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+        </Reference>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" ExcludeAssets="Compile"/>
+		<Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions">
+			<HintPath>$(NuGetPackageRoot)microsoft.extensions.dependencyinjection.abstractions\6.0.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+		</Reference>-->
+	</ItemGroup>
 
     <ItemGroup>
         <Content Include="..\TestServerlessApp\**">

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
         <PackageReference Include="Moq" Version="4.16.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="System.Memory" Version="4.5.4" />
@@ -21,7 +21,7 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>
@@ -61,7 +61,7 @@
       <ProjectReference Include="..\..\src\Amazon.Lambda.Annotations.SourceGenerator\Amazon.Lambda.Annotations.SourceGenerator.csproj" />
       <ProjectReference Include="..\..\src\Amazon.Lambda.Annotations\Amazon.Lambda.Annotations.csproj" />
       <ProjectReference Include="..\..\src\Amazon.Lambda.APIGatewayEvents\Amazon.Lambda.APIGatewayEvents.csproj" />
-      <ProjectReference Include="..\..\src\Amazon.Lambda.Core\Amazon.Lambda.Core.csproj" />
+      <ProjectReference Include="..\..\src\Amazon.Lambda.Core\Amazon.Lambda.Core.csproj" AdditionalProperties="TargetFramework=netstandard2.0" />
       <ProjectReference Include="..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
     </ItemGroup>
 

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
@@ -61,6 +61,10 @@
       <ProjectReference Include="..\..\src\Amazon.Lambda.Annotations.SourceGenerator\Amazon.Lambda.Annotations.SourceGenerator.csproj" />
       <ProjectReference Include="..\..\src\Amazon.Lambda.Annotations\Amazon.Lambda.Annotations.csproj" />
       <ProjectReference Include="..\..\src\Amazon.Lambda.APIGatewayEvents\Amazon.Lambda.APIGatewayEvents.csproj" />
+      <!-- 
+	    We need to force using the .NET Standard 2.0 version because the source generator test framework will complain
+		about using newer versions of System.Runtime then it can handle. This is not an issue in a end user scenario.
+	  -->
       <ProjectReference Include="..\..\src\Amazon.Lambda.Core\Amazon.Lambda.Core.csproj" AdditionalProperties="TargetFramework=netstandard2.0" />
       <ProjectReference Include="..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
     </ItemGroup>

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/FileIOTests/DirectoryManagerTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/FileIOTests/DirectoryManagerTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Amazon.Lambda.Annotations.SourceGenerator.FileIO;
+
+namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.FileIOTests
+{
+    public class DirectoryManagerTests
+    {
+        [Theory]
+        [InlineData("C:/CodeBase/Src/MyProject", "C:/CodeBase/Src/MyProject", ".")]
+        [InlineData("C:/CodeBase/Src/MyProject/MyFile.cs", "C:/CodeBase/Src/MyProject/MyFile.cs", ".")]
+        [InlineData("C:/CodeBase/Src/MyProject", "C:/CodeBase/Src/MyProject/MyProject.csproj", "MyProject.csproj")]
+        [InlineData("C:/CodeBase/Src/MyProject", "C:/CodeBase/Src", "..")]
+        [InlineData("C:/CodeBase/Src/MyProject", "C:/CodeBase/Test", "../../Test")]
+        [InlineData("C:/CodeBase/Src/MyProject", "C:/CodeBase/Test/TestApp.csproj", "../../Test/TestApp.csproj")]
+        [InlineData("C:/CodeBase/Src/MyProject", "C:/CodeBase/Src/MyProject/MyFolder/MyResources", "MyFolder/MyResources")]
+        [InlineData("C:/CodeBase/Src/MyProject/MyProject.csproj", "C:/CodeBase/Src/MyProject", "..")]
+        [InlineData("C:/CodeBase/Src/MyProject/MyProject.csproj", "C:/CodeBase/Src", "../..")]
+        [InlineData("MyFolder", "MyFolder", ".")]
+        [InlineData("C:/CodeBase/Src/MyProject/MyProject.csproj", "D:/CodeBase/Src/MyProject/MyProject.csproj", "D:/CodeBase/Src/MyProject/MyProject.csproj")]
+        public void GetRelativePath(string relativeTo, string path, string expectedPath)
+        {
+            var directoryManager = new DirectoryManager();
+            var relativePath = directoryManager.GetRelativePath(relativeTo, path);
+            Assert.Equal(expectedPath, relativePath);
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/complexCalculator.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/complexCalculator.template
@@ -1,4 +1,4 @@
-﻿{
+{
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
   "Resources": {
@@ -11,15 +11,18 @@
         ]
       },
       "Properties": {
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
-        "PackageType": "Zip",
-        "Handler": "TestServerlessApp::TestServerlessApp.ComplexCalculator_Add_Generated::Add",
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.ComplexCalculator_Add_Generated::Add"
+          ]
+        },
         "Events": {
           "RootPost": {
             "Type": "HttpApi",
@@ -41,15 +44,18 @@
         ]
       },
       "Properties": {
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
-        "PackageType": "Zip",
-        "Handler": "TestServerlessApp::TestServerlessApp.ComplexCalculator_Subtract_Generated::Subtract",
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.ComplexCalculator_Subtract_Generated::Subtract"
+          ]
+        },
         "Events": {
           "RootPost": {
             "Type": "HttpApi",

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/greeter.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/greeter.template
@@ -1,4 +1,4 @@
-﻿{
+{
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
   "Resources": {
@@ -11,15 +11,18 @@
         ]
       },
       "Properties": {
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 1024,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
-        "PackageType": "Zip",
-        "Handler": "TestServerlessApp::TestServerlessApp.Greeter_SayHello_Generated::SayHello",
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.Greeter_SayHello_Generated::SayHello"
+          ]
+        },
         "Events": {
           "RootGet": {
             "Type": "HttpApi",
@@ -41,15 +44,18 @@
         ]
       },
       "Properties": {
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 50,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
-        "PackageType": "Zip",
-        "Handler": "TestServerlessApp::TestServerlessApp.Greeter_SayHelloAsync_Generated::SayHelloAsync",
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.Greeter_SayHelloAsync_Generated::SayHelloAsync"
+          ]
+        },
         "Events": {
           "RootGet": {
             "Type": "HttpApi",

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/simpleCalculator.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/simpleCalculator.template
@@ -20,7 +20,7 @@
         "ImageUri": ".",
         "ImageConfig": {
           "Command": [
-            "TestServerlessApp::TestServerlessApp.ComplexCalculator_Subtract_Generated::Subtract"
+            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Add_Generated::Add"
           ]
         },
         "Events": {

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/simpleCalculator.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/simpleCalculator.template
@@ -1,4 +1,4 @@
-﻿{
+{
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
   "Resources": {
@@ -11,15 +11,18 @@
         ]
       },
       "Properties": {
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
-        "PackageType": "Zip",
-        "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Add_Generated::Add",
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.ComplexCalculator_Subtract_Generated::Subtract"
+          ]
+        },
         "Events": {
           "RootGet": {
             "Type": "Api",
@@ -40,15 +43,18 @@
         ]
       },
       "Properties": {
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
-        "PackageType": "Zip",
-        "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Subtract_Generated::Subtract",
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Subtract_Generated::Subtract"
+          ]
+        },
         "Events": {
           "RootGet": {
             "Type": "Api",
@@ -69,15 +75,18 @@
         ]
       },
       "Properties": {
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
-        "PackageType": "Zip",
-        "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Multiply_Generated::Multiply",
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Multiply_Generated::Multiply"
+          ]
+        },
         "Events": {
           "RootGet": {
             "Type": "Api",
@@ -98,15 +107,18 @@
         ]
       },
       "Properties": {
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
-        "PackageType": "Zip",
-        "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_DivideAsync_Generated::DivideAsync",
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.SimpleCalculator_DivideAsync_Generated::DivideAsync"
+          ]
+        },
         "Events": {
           "RootGet": {
             "Type": "Api",
@@ -124,15 +136,18 @@
         "Tool": "Amazon.Lambda.Annotations"
       },
       "Properties": {
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
-        "PackageType": "Zip",
-        "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Pi_Generated::Pi"
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Pi_Generated::Pi"
+          ]
+        }
       }
     },
     "Random": {
@@ -141,15 +156,18 @@
         "Tool": "Amazon.Lambda.Annotations"
       },
       "Properties": {
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
-        "PackageType": "Zip",
-        "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Random_Generated::Random"
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Random_Generated::Random"
+          ]
+        }
       }
     },
     "Randoms": {
@@ -158,15 +176,18 @@
         "Tool": "Amazon.Lambda.Annotations"
       },
       "Properties": {
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
-        "PackageType": "Zip",
-        "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Randoms_Generated::Randoms"
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Randoms_Generated::Randoms"
+          ]
+        }
       }
     }
   }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/CloudFormationJsonWriterTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/CloudFormationJsonWriterTests.cs
@@ -352,7 +352,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
             propertiesToken = rootToken["Resources"]["TestMethod"]["Properties"];
             Assert.Equal("Image", propertiesToken["PackageType"]);
             Assert.Equal(".", propertiesToken["ImageUri"]);
-            Assert.Equal("MyAssembly::MyNamespace.MyType::Handler", propertiesToken["ImageConfig"]["Command"]);
+            Assert.Equal(new JArray("MyAssembly::MyNamespace.MyType::Handler"), propertiesToken["ImageConfig"]["Command"]);
             Assert.Null(propertiesToken["CodeUri"]);
             Assert.Null(propertiesToken["Handler"]);
 

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/CloudFormationJsonWriterTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/CloudFormationJsonWriterTests.cs
@@ -326,7 +326,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
             var mockFileManager = GetMockFileManager(string.Empty);
             var lambdaFunctionModel = GetLambdaFunctionModel("MyAssembly::MyNamespace.MyType::Handler",
                 "TestMethod", 45, 512, null, null);
-            lambdaFunctionModel.PackageType = PackageTypeEnum.Zip;
+            lambdaFunctionModel.PackageType = LambdaPackageType.Zip;
             var cloudFormationJsonWriter = new CloudFormationJsonWriter(mockFileManager, _mockDirectoryManager, _jsonWriter, _diagnosticReporter);
             var report = GetAnnotationReport(new List<ILambdaFunctionSerializable>() {lambdaFunctionModel});
 
@@ -341,7 +341,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
             Assert.Equal("MyAssembly::MyNamespace.MyType::Handler", propertiesToken["Handler"]);
 
             // ARRANGE - Change PackageType to Image
-            lambdaFunctionModel.PackageType = PackageTypeEnum.Image;
+            lambdaFunctionModel.PackageType = LambdaPackageType.Image;
             report = GetAnnotationReport(new List<ILambdaFunctionSerializable>() {lambdaFunctionModel});
 
             // ACT
@@ -357,7 +357,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
             Assert.Null(propertiesToken["Handler"]);
 
             // ARRANGE - Change PackageType back to Zip
-            lambdaFunctionModel.PackageType = PackageTypeEnum.Zip;
+            lambdaFunctionModel.PackageType = LambdaPackageType.Zip;
             report = GetAnnotationReport(new List<ILambdaFunctionSerializable>() {lambdaFunctionModel});
 
             // ACT
@@ -418,7 +418,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
             public string Policies { get; set; }
             public IList<AttributeModel> Attributes { get; set; } = new List<AttributeModel>();
             public string SourceGeneratorVersion { get; set; }
-            public PackageTypeEnum PackageType { get; set; } = PackageTypeEnum.Zip;
+            public LambdaPackageType PackageType { get; set; } = LambdaPackageType.Zip;
         }
     }
 }

--- a/Libraries/test/TestServerlessApp.IntegrationTests/Helpers/CloudWatchHelper.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/Helpers/CloudWatchHelper.cs
@@ -26,7 +26,7 @@ namespace TestServerlessApp.IntegrationTests.Helpers
             {
                 attemptCount += 1;
                 var recentLogEvents = await GetRecentLogEventsAsync(logGroupName, logGroupNamePrefix);
-                if (recentLogEvents.Any(x => string.Equals(x.Message.Trim(), message)))
+                if (recentLogEvents.Any(x => x.Message.Contains(message)))
                     return true;
                 await Task.Delay(StaticHelpers.GetWaitTime(attemptCount));
             }

--- a/Libraries/test/TestServerlessApp.IntegrationTests/Helpers/CommandLineWrapper.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/Helpers/CommandLineWrapper.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -28,16 +29,24 @@ namespace TestServerlessApp.IntegrationTests.Helpers
             if (null == process)
                 throw new Exception("Process.Start failed to return a non-null process");
 
+            var sb = new StringBuilder();
+            DataReceivedEventHandler callback = (object sender, DataReceivedEventArgs e) =>
+            {
+                sb.AppendLine(e.Data);
+                Console.WriteLine(e.Data);
+            };
+
             if (redirectIo)
             {
-                process.OutputDataReceived += (sender, e) => Console.WriteLine(e.Data);
-                process.ErrorDataReceived += (sender, e) => Console.WriteLine(e.Data);
+                process.OutputDataReceived += callback;
+                process.ErrorDataReceived += callback;
 
                 process.BeginOutputReadLine();
                 process.BeginErrorReadLine();
             }
 
             await process.WaitForExitAsync(cancelToken);
+            var log = sb.ToString();
         }
 
         private static string GetSystemShell()

--- a/Libraries/test/TestServerlessApp.IntegrationTests/Helpers/LambdaHelper.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/Helpers/LambdaHelper.cs
@@ -45,6 +45,25 @@ namespace TestServerlessApp.IntegrationTests.Helpers
                 request.Payload = payload;
             return await _lambdaClient.InvokeAsync(request);
         }
+
+        public async Task WaitTillNotPending(List<string> functions)
+        {
+            foreach(var function in functions)
+            {
+                while(true)
+                {
+                    var response = await _lambdaClient.GetFunctionConfigurationAsync(new GetFunctionConfigurationRequest {FunctionName = function });
+                    if(response.State == State.Pending)
+                    {
+                        await Task.Delay(1000);
+                    }
+                    else
+                    {
+                        break;
+                    }
+                } 
+            }
+        }
     }
 
     public class LambdaFunction

--- a/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixture.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Amazon.CloudFormation;
@@ -57,6 +58,8 @@ namespace TestServerlessApp.IntegrationTests
             Assert.Equal(11, LambdaFunctions.Count);
             Assert.False(string.IsNullOrEmpty(RestApiUrlPrefix));
             Assert.False(string.IsNullOrEmpty(RestApiUrlPrefix));
+
+            await LambdaHelper.WaitTillNotPending(LambdaFunctions.Select(x => x.Name).ToList());
         }
 
         public async Task DisposeAsync()

--- a/Libraries/test/TestServerlessApp/ComplexCalculator.cs
+++ b/Libraries/test/TestServerlessApp/ComplexCalculator.cs
@@ -12,7 +12,7 @@ namespace TestServerlessApp
 {
     public class ComplexCalculator
     {
-        [LambdaFunction]
+        [LambdaFunction(PackageType = LambdaPackageType.Image)]
         [HttpApi(HttpMethod.Post, HttpApiVersion.V2, "/ComplexCalculator/Add")]
         public Tuple<double, double> Add([FromBody]string complexNumbers, ILambdaContext context, APIGatewayHttpApiV2ProxyRequest request)
         {
@@ -42,7 +42,7 @@ namespace TestServerlessApp
             return new Tuple<double, double>(result.Real, result.Imaginary);
         }
 
-        [LambdaFunction]
+        [LambdaFunction(PackageType = LambdaPackageType.Image)]
         [HttpApi(HttpMethod.Post, HttpApiVersion.V2, "/ComplexCalculator/Subtract")]
         public Tuple<double, double> Subtract([FromBody]IList<IList<int>> complexNumbers)
         {

--- a/Libraries/test/TestServerlessApp/Dockerfile
+++ b/Libraries/test/TestServerlessApp/Dockerfile
@@ -1,0 +1,13 @@
+FROM public.ecr.aws/lambda/dotnet:6
+
+WORKDIR /var/task
+
+# This COPY command copies the .NET Lambda project's build artifacts from the host machine into the image. 
+# The source of the COPY should match where the .NET Lambda project publishes its build artifacts. If the Lambda function is being built 
+# with the AWS .NET Lambda Tooling, the `--docker-host-build-output-dir` switch controls where the .NET Lambda project
+# will be built. The .NET Lambda project templates default to having `--docker-host-build-output-dir`
+# set in the aws-lambda-tools-defaults.json file to "bin/Release/lambda-publish".
+#
+# Alternatively Docker multi-stage build could be used to build the .NET Lambda project inside the image.
+# For more information on this approach checkout the project's README.md file.
+COPY "bin/Release/lambda-publish"  .

--- a/Libraries/test/TestServerlessApp/Greeter.cs
+++ b/Libraries/test/TestServerlessApp/Greeter.cs
@@ -10,11 +10,11 @@ namespace TestServerlessApp
 {
     public class Greeter
     {
-        [LambdaFunction(Name = "GreeterSayHello", MemorySize = 1024)]
+        [LambdaFunction(Name = "GreeterSayHello", MemorySize = 1024, PackageType = LambdaPackageType.Image)]
         [HttpApi(HttpMethod.Get, HttpApiVersion.V1, "/Greeter/SayHello")]
         public void SayHello([FromQuery(Name = "names")]IEnumerable<string> firstNames, APIGatewayProxyRequest request, ILambdaContext context)
         {
-            context.Logger.Log($"Request {JsonSerializer.Serialize(request)}");
+            context.Logger.LogLine($"Request {JsonSerializer.Serialize(request)}");
 
             if (firstNames == null)
             {
@@ -27,7 +27,7 @@ namespace TestServerlessApp
             }
         }
 
-        [LambdaFunction(Name = "GreeterSayHelloAsync", Timeout = 50)]
+        [LambdaFunction(Name = "GreeterSayHelloAsync", Timeout = 50, PackageType = LambdaPackageType.Image)]
         [HttpApi(HttpMethod.Get, HttpApiVersion.V1, "/Greeter/SayHelloAsync")]
         public async Task SayHelloAsync([FromHeader(Name = "names")]IEnumerable<string> firstNames)
         {

--- a/Libraries/test/TestServerlessApp/SimpleCalculator.cs
+++ b/Libraries/test/TestServerlessApp/SimpleCalculator.cs
@@ -8,7 +8,7 @@ using Amazon.Lambda.Annotations;
 using TestServerlessApp.Services;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+//[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 
 namespace TestServerlessApp
 {

--- a/Libraries/test/TestServerlessApp/SimpleCalculator.cs
+++ b/Libraries/test/TestServerlessApp/SimpleCalculator.cs
@@ -8,7 +8,7 @@ using Amazon.Lambda.Annotations;
 using TestServerlessApp.Services;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-//[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 
 namespace TestServerlessApp
 {

--- a/Libraries/test/TestServerlessApp/SimpleCalculator.cs
+++ b/Libraries/test/TestServerlessApp/SimpleCalculator.cs
@@ -24,14 +24,14 @@ namespace TestServerlessApp
             this._simpleCalculatorService = simpleCalculatorService;
         }
 
-        [LambdaFunction(Name = "SimpleCalculatorAdd")]
+        [LambdaFunction(Name = "SimpleCalculatorAdd", PackageType = LambdaPackageType.Image)]
         [RestApi(HttpMethod.Get, "/SimpleCalculator/Add")]
         public int Add([FromQuery]int x, [FromQuery]int y)
         {
             return _simpleCalculatorService.Add(x, y);
         }
 
-        [LambdaFunction(Name = "SimpleCalculatorSubtract")]
+        [LambdaFunction(Name = "SimpleCalculatorSubtract", PackageType = LambdaPackageType.Image)]
         [RestApi(HttpMethod.Get, "/SimpleCalculator/Subtract")]
         public APIGatewayProxyResponse Subtract([FromHeader]int x, [FromHeader]int y, [FromServices]ISimpleCalculatorService simpleCalculatorService)
         {
@@ -42,34 +42,34 @@ namespace TestServerlessApp
             };
         }
 
-        [LambdaFunction(Name = "SimpleCalculatorMultiply")]
+        [LambdaFunction(Name = "SimpleCalculatorMultiply", PackageType = LambdaPackageType.Image)]
         [RestApi(HttpMethod.Get, "/SimpleCalculator/Multiply/{x}/{y}")]
         public string Multiply(int x, int y)
         {
             return _simpleCalculatorService.Multiply(x, y).ToString();
         }
 
-        [LambdaFunction(Name = "SimpleCalculatorDivideAsync")]
+        [LambdaFunction(Name = "SimpleCalculatorDivideAsync", PackageType = LambdaPackageType.Image)]
         [RestApi(template: "/SimpleCalculator/DivideAsync/{x}/{y}", method: HttpMethod.Get)]
         public async Task<int> DivideAsync([FromRoute(Name = "x")]int first, [FromRoute(Name = "y")]int second)
         {
             return await Task.FromResult(_simpleCalculatorService.Divide(first, second));
         }
 
-        [LambdaFunction(Name = "PI")]
+        [LambdaFunction(Name = "PI", PackageType = LambdaPackageType.Image)]
         public double Pi([FromServices]ISimpleCalculatorService simpleCalculatorService)
         {
             return simpleCalculatorService.PI();
         }
 
-        [LambdaFunction(Name = "Random")]
+        [LambdaFunction(Name = "Random", PackageType = LambdaPackageType.Image)]
         public int Random(int maxValue, ILambdaContext context)
         {
             context.Logger.Log($"Max value: {maxValue}");
             return new Random().Next(maxValue);
         }
 
-        [LambdaFunction(Name = "Randoms")]
+        [LambdaFunction(Name = "Randoms", PackageType = LambdaPackageType.Image)]
         public IList<int> Randoms(RandomsInput input, ILambdaContext context)
         {
             context.Logger.Log($"Count: {input.Count}");

--- a/Libraries/test/TestServerlessApp/TestServerlessApp.csproj
+++ b/Libraries/test/TestServerlessApp/TestServerlessApp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
@@ -13,7 +13,7 @@
     <Content Include="Generated\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Amazon.Lambda.Annotations.SourceGenerator\Amazon.Lambda.Annotations.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />

--- a/Libraries/test/TestServerlessApp/aws-lambda-tools-defaults.json
+++ b/Libraries/test/TestServerlessApp/aws-lambda-tools-defaults.json
@@ -8,10 +8,11 @@
   "profile": "default",
   "region": "us-west-2",
   "configuration": "Release",
-  "framework": "netcoreapp3.1",
+  "framework": "net6.0",
   "s3-prefix": "TestServerlessApp/",
   "template": "serverless.template",
   "template-parameters": "",
+  "docker-host-build-output-dir": "./bin/Release/lambda-publish",
   "s3-bucket": "test-serverless-app",
   "stack-name": "test-serverless-app"
 }

--- a/Libraries/test/TestServerlessApp/serverless.template
+++ b/Libraries/test/TestServerlessApp/serverless.template
@@ -12,9 +12,6 @@
         ]
       },
       "Properties": {
-        "Handler": "TestServerlessApp::TestServerlessApp.Greeter_SayHello_Generated::SayHello",
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 1024,
         "Timeout": 30,
         "Role": null,
@@ -31,38 +28,13 @@
             }
           }
         },
-        "PackageType": "Zip"
-      }
-    },
-    "GreeterSayHelloAsync": {
-      "Type": "AWS::Serverless::Function",
-      "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations",
-        "SyncedEvents": [
-          "RootGet"
-        ]
-      },
-      "Properties": {
-        "Handler": "TestServerlessApp::TestServerlessApp.Greeter_SayHelloAsync_Generated::SayHelloAsync",
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
-        "MemorySize": 256,
-        "Timeout": 50,
-        "Role": null,
-        "Policies": [
-          "AWSLambdaBasicExecutionRole"
-        ],
-        "Events": {
-          "RootGet": {
-            "Type": "HttpApi",
-            "Properties": {
-              "Path": "/Greeter/SayHelloAsync",
-              "Method": "GET",
-              "PayloadFormatVersion": "1.0"
-            }
-          }
-        },
-        "PackageType": "Zip"
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.Greeter_SayHello_Generated::SayHello"
+          ]
+        }
       }
     },
     "SimpleCalculatorAdd": {
@@ -74,9 +46,6 @@
         ]
       },
       "Properties": {
-        "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Add_Generated::Add",
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Role": null,
@@ -92,7 +61,13 @@
             }
           }
         },
-        "PackageType": "Zip"
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Add_Generated::Add"
+          ]
+        }
       }
     },
     "SimpleCalculatorSubtract": {
@@ -104,9 +79,6 @@
         ]
       },
       "Properties": {
-        "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Subtract_Generated::Subtract",
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Role": null,
@@ -122,7 +94,13 @@
             }
           }
         },
-        "PackageType": "Zip"
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Subtract_Generated::Subtract"
+          ]
+        }
       }
     },
     "SimpleCalculatorMultiply": {
@@ -134,9 +112,6 @@
         ]
       },
       "Properties": {
-        "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Multiply_Generated::Multiply",
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Role": null,
@@ -152,7 +127,13 @@
             }
           }
         },
-        "PackageType": "Zip"
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Multiply_Generated::Multiply"
+          ]
+        }
       }
     },
     "SimpleCalculatorDivideAsync": {
@@ -164,9 +145,6 @@
         ]
       },
       "Properties": {
-        "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_DivideAsync_Generated::DivideAsync",
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Role": null,
@@ -182,7 +160,13 @@
             }
           }
         },
-        "PackageType": "Zip"
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.SimpleCalculator_DivideAsync_Generated::DivideAsync"
+          ]
+        }
       }
     },
     "TestServerlessAppComplexCalculatorAddGenerated": {
@@ -194,9 +178,6 @@
         ]
       },
       "Properties": {
-        "Handler": "TestServerlessApp::TestServerlessApp.ComplexCalculator_Add_Generated::Add",
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Role": null,
@@ -213,7 +194,13 @@
             }
           }
         },
-        "PackageType": "Zip"
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.ComplexCalculator_Add_Generated::Add"
+          ]
+        }
       }
     },
     "TestServerlessAppComplexCalculatorSubtractGenerated": {
@@ -225,14 +212,11 @@
         ]
       },
       "Properties": {
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
-        "Handler": "TestServerlessApp::TestServerlessApp.ComplexCalculator_Subtract_Generated::Subtract",
         "Events": {
           "RootPost": {
             "Type": "HttpApi",
@@ -243,7 +227,13 @@
             }
           }
         },
-        "PackageType": "Zip"
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.ComplexCalculator_Subtract_Generated::Subtract"
+          ]
+        }
       }
     },
     "PI": {
@@ -252,15 +242,18 @@
         "Tool": "Amazon.Lambda.Annotations"
       },
       "Properties": {
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
-        "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Pi_Generated::Pi",
-        "PackageType": "Zip"
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Pi_Generated::Pi"
+          ]
+        }
       }
     },
     "Random": {
@@ -269,15 +262,18 @@
         "Tool": "Amazon.Lambda.Annotations"
       },
       "Properties": {
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
-        "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Random_Generated::Random",
-        "PackageType": "Zip"
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Random_Generated::Random"
+          ]
+        }
       }
     },
     "Randoms": {
@@ -286,15 +282,51 @@
         "Tool": "Amazon.Lambda.Annotations"
       },
       "Properties": {
-        "Runtime": "dotnetcore3.1",
-        "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
-        "Handler": "TestServerlessApp::TestServerlessApp.SimpleCalculator_Randoms_Generated::Randoms",
-        "PackageType": "Zip"
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Randoms_Generated::Randoms"
+          ]
+        }
+      }
+    },
+    "GreeterSayHelloAsync": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 50,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "Events": {
+          "RootGet": {
+            "Type": "HttpApi",
+            "Properties": {
+              "Path": "/Greeter/SayHelloAsync",
+              "Method": "GET",
+              "PayloadFormatVersion": "1.0"
+            }
+          }
+        },
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.Greeter_SayHelloAsync_Generated::SayHelloAsync"
+          ]
+        }
       }
     }
   },


### PR DESCRIPTION
*Description of changes:*
Update Amazon.Lambda.Annotations to target .NET 6. Since we now have a .NET 6 container image update integ tests to use that. Fixed a issues discovered while doing end to end testing.
* Rename PackageTypeEnum to LambdaPackageType
* Fix issue with PackageTypeEnum being marked as nullable which is not allowed for named attribute parameters
* Fix issue with the enum conversion from attribute data to source generator model. Source generator was seeing the enum attribute data as just an int.
* Both Amazon.Lambda.Annotations and Amazon.Lambda.Annotations.SourceGenerator target netstandard2.0 which is required for source generators to work due to .NET Framework requirements in VS>
* Removed `Runtime` field in serverless.template file when using `Image` based packaging.
* Fix setting Image->Command in serverless.template to be an array which is required for CloudFormation.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
