### PR TITLE
fix: return early if there are no Lambda functions to process

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Generator.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Generator.cs
@@ -46,6 +46,12 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
                     return;
                 }
 
+                // If there are no Lambda methods, return early
+                if (!receiver.LambdaMethods.Any())
+                {
+                    return;
+                }
+
                 var semanticModelProvider = new SemanticModelProvider(context);
                 if (receiver.StartupClasses.Count > 1)
                 {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently in a project where there doesn't exist a Lambda function, the generator fails at writing the serverless.template due to missing information. This change allows to exit early if there doesn't exist a Lambda function and also output a info diagnostics to let customers know that they should add a `LambdaFunction` attribute in order to start consuming the generator.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
