### PR TITLE
fix: remove HttpApiVersion from required parameters

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Generator.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Generator.cs
@@ -112,6 +112,9 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
             {
                 // this is a generator failure, report this as error
                 diagnosticReporter.Report(Diagnostic.Create(DiagnosticDescriptors.UnhandledException, Location.None, e.PrettyPrint()));
+#if DEBUG
+                throw;
+#endif
             }
         }
 

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/HttpApiAttributeBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/HttpApiAttributeBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 
 namespace Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes
@@ -7,16 +8,19 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes
     {
         public static HttpApiAttribute Build(AttributeData att)
         {
-            if (att.ConstructorArguments.Length != 3)
+            if (att.ConstructorArguments.Length != 2)
             {
-                throw new NotSupportedException($"{TypeFullNames.HttpApiAttribute} must have constructor with 3 arguments.");
+                throw new NotSupportedException($"{TypeFullNames.HttpApiAttribute} must have constructor with 2 arguments.");
             }
 
             var method = (HttpMethod)att.ConstructorArguments[0].Value;
-            var version = (HttpApiVersion)att.ConstructorArguments[1].Value;
-            var template = att.ConstructorArguments[2].Value as string;
+            var template = att.ConstructorArguments[1].Value as string;
+            var version = att.NamedArguments.FirstOrDefault(arg => arg.Key == "Version").Value.Value;
 
-            var data = new HttpApiAttribute(method, version, template);
+            var data = new HttpApiAttribute(method, template)
+            {
+                Version = version == null ? HttpApiVersion.V2 : (HttpApiVersion)version
+            };
             return data;
         }
     }

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/GeneratedMethodModelBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/GeneratedMethodModelBuilder.cs
@@ -99,10 +99,10 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
                 throw new InvalidOperationException($"{TypeFullNames.HttpApiAttribute} must have a constructor with parameter.");
             }
 
-            var versionArgument = httpApiAttribute.ConstructorArguments[1];
+            var versionArgument = httpApiAttribute.NamedArguments.FirstOrDefault(arg => arg.Key == "Version").Value;
             if (versionArgument.Type == null)
             {
-                throw new InvalidOperationException($"{versionArgument.Type} type cannot be null for {TypeFullNames.HttpApiAttribute}.");
+                return HttpApiVersion.V2;
             }
 
             if (!versionArgument.Type.Equals(context.Compilation.GetTypeByMetadataName(TypeFullNames.HttpApiVersion), SymbolEqualityComparer.Default))

--- a/Libraries/src/Amazon.Lambda.Annotations/HttpApiAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/HttpApiAttribute.cs
@@ -5,13 +5,12 @@ namespace Amazon.Lambda.Annotations
     [AttributeUsage(AttributeTargets.Method)]
     public class HttpApiAttribute : Attribute
     {
-        public HttpApiVersion Version { get; set; }
+        public HttpApiVersion Version { get; set; } = HttpApiVersion.V2;
         public string Template { get; set;  }
         public HttpMethod Method { get; set; }
 
-        public HttpApiAttribute(HttpMethod method, HttpApiVersion version, string template)
+        public HttpApiAttribute(HttpMethod method, string template)
         {
-            Version = version;
             Template = template;
             Method = method;
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/CloudFormationJsonWriterTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/CloudFormationJsonWriterTests.cs
@@ -277,7 +277,10 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
                 "TestMethod", 45, 512, null, null);
             var httpAttributeModel = new AttributeModel<HttpApiAttribute>()
             {
-                Data = new HttpApiAttribute(HttpMethod.Get, HttpApiVersion.V1, "/Calculator/Add")
+                Data = new HttpApiAttribute(HttpMethod.Get, "/Calculator/Add")
+                {
+                    Version = HttpApiVersion.V1
+                }
             };
             lambdaFunctionModel.Attributes = new List<AttributeModel>() {httpAttributeModel};
             var cloudFormationJsonWriter = new CloudFormationJsonWriter(mockFileManager, _mockDirectoryManager, _jsonWriter, _diagnosticReporter);
@@ -299,7 +302,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
             // ARRANGE - CHANGE TO A HTTP POST METHOD
             httpAttributeModel = new AttributeModel<HttpApiAttribute>()
             {
-                Data = new HttpApiAttribute(HttpMethod.Post, HttpApiVersion.V2, "/Calculator/Add")
+                Data = new HttpApiAttribute(HttpMethod.Post, "/Calculator/Add")
             };
             lambdaFunctionModel.Attributes = new List<AttributeModel>() {httpAttributeModel};
 

--- a/Libraries/test/TestServerlessApp/ComplexCalculator.cs
+++ b/Libraries/test/TestServerlessApp/ComplexCalculator.cs
@@ -13,7 +13,7 @@ namespace TestServerlessApp
     public class ComplexCalculator
     {
         [LambdaFunction(PackageType = LambdaPackageType.Image)]
-        [HttpApi(HttpMethod.Post, HttpApiVersion.V2, "/ComplexCalculator/Add")]
+        [HttpApi(HttpMethod.Post, "/ComplexCalculator/Add")]
         public Tuple<double, double> Add([FromBody]string complexNumbers, ILambdaContext context, APIGatewayHttpApiV2ProxyRequest request)
         {
             context.Logger.Log($"Request {JsonSerializer.Serialize(request)}");
@@ -43,7 +43,7 @@ namespace TestServerlessApp
         }
 
         [LambdaFunction(PackageType = LambdaPackageType.Image)]
-        [HttpApi(HttpMethod.Post, HttpApiVersion.V2, "/ComplexCalculator/Subtract")]
+        [HttpApi(HttpMethod.Post, "/ComplexCalculator/Subtract")]
         public Tuple<double, double> Subtract([FromBody]IList<IList<int>> complexNumbers)
         {
             if (complexNumbers.Count() != 2)

--- a/Libraries/test/TestServerlessApp/Greeter.cs
+++ b/Libraries/test/TestServerlessApp/Greeter.cs
@@ -11,7 +11,7 @@ namespace TestServerlessApp
     public class Greeter
     {
         [LambdaFunction(Name = "GreeterSayHello", MemorySize = 1024, PackageType = LambdaPackageType.Image)]
-        [HttpApi(HttpMethod.Get, HttpApiVersion.V1, "/Greeter/SayHello")]
+        [HttpApi(HttpMethod.Get, "/Greeter/SayHello", Version = HttpApiVersion.V1)]
         public void SayHello([FromQuery(Name = "names")]IEnumerable<string> firstNames, APIGatewayProxyRequest request, ILambdaContext context)
         {
             context.Logger.LogLine($"Request {JsonSerializer.Serialize(request)}");
@@ -28,7 +28,7 @@ namespace TestServerlessApp
         }
 
         [LambdaFunction(Name = "GreeterSayHelloAsync", Timeout = 50, PackageType = LambdaPackageType.Image)]
-        [HttpApi(HttpMethod.Get, HttpApiVersion.V1, "/Greeter/SayHelloAsync")]
+        [HttpApi(HttpMethod.Get, "/Greeter/SayHelloAsync", Version = HttpApiVersion.V1)]
         public async Task SayHelloAsync([FromHeader(Name = "names")]IEnumerable<string> firstNames)
         {
             if (firstNames == null)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Initially it was decided to keep the Version as required parameter so that when a new version of HTTP API introduced, there won't be a breaking change because customers are always choosing which version to use.

After some discussions on use case and simplicity, it has been decided that by default Version is set to 2 and can be overridden if customer wants. The main reason for the decision is convenience, ideally customer shouldn't worry about the payload version (structure) as long as they can get the desired parameters from the payload.

Hence, Version is now a named parameter which can optionally be set. This also puts `HttpApi` attribute in parity with `RestApi` attribute because they share similar constructor signature.

If we ever get new version of HTTP payload, it will be released as a breaking change with major version bump.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
