### PR TITLE
ci: include source generator unit and integ tests in tasks

### DIFF
--- a/buildtools/build.proj
+++ b/buildtools/build.proj
@@ -195,9 +195,11 @@
     </Target>
     <Target Name="run-unit-tests">
         <Exec Command="dotnet test -c $(Configuration)" WorkingDirectory="..\Libraries\test\Amazon.Lambda.RuntimeSupport.Tests\Amazon.Lambda.RuntimeSupport.UnitTests"/>
+        <Exec Command="dotnet test -c $(Configuration)" WorkingDirectory="..\Libraries\test\Amazon.Lambda.Annotations.SourceGenerators.Tests"/>
     </Target>
     <Target Name="run-integ-tests">
         <Exec Command="dotnet test -c $(Configuration)" WorkingDirectory="..\Libraries\test\Amazon.Lambda.RuntimeSupport.Tests\Amazon.Lambda.RuntimeSupport.IntegrationTests"/>
+        <Exec Command="dotnet test -c $(Configuration)" WorkingDirectory="..\Libraries\test\TestServerlessApp.IntegrationTests"/>
     </Target>
     <Target Name="create-nuget-packages-cicd" DependsOnTargets="build-project-packages">
         <Exec Command="$(PackCommand)" WorkingDirectory="..\Libraries\src\%(LibraryName.FileName)"/>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Current publishing pipeline doesn't execute the tests for annotations, unlike other pipeline, lambda pipeline is setup to use msbuild targets, therefore, they must be added explicitly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
