### PR TITLE
ci: remove git config for line endings

### DIFF
--- a/.github/workflows/source-generator-ci.yml
+++ b/.github/workflows/source-generator-ci.yml
@@ -11,9 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Set git to use CRLF
-    # Without CRLF, source generator test add space at beginning
-      run: git config --global core.autocrlf true
 
     - uses: actions/checkout@v2
     - name: Setup .NET 3.1

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Extensions/StringExtensions.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Extensions/StringExtensions.cs
@@ -26,4 +26,14 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Extensions
             return $"{e.Message}{e.StackTrace}{PrettyPrint(e.InnerException)}";
         }
     }
+
+    public static class EnvironmentExtensions
+    {
+        public static string ToEnvironmentLineEndings(this string str)
+        {
+            return str.Replace("\r\n", Environment.NewLine).
+                Replace("\n", Environment.NewLine).
+                Replace("\r\r\n", Environment.NewLine);
+        }
+    }
 }

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Generator.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Generator.cs
@@ -91,7 +91,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
                     }
 
                     var template = new LambdaFunctionTemplate(model);
-                    var sourceText = template.TransformText();
+                    var sourceText = template.TransformText().ToEnvironmentLineEndings();
                     context.AddSource($"{model.GeneratedMethod.ContainingType.Name}.g.cs", SourceText.From(sourceText, Encoding.UTF8, SourceHashAlgorithm.Sha256));
 
                     // report every generated file to build output

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplateCode.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplateCode.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using Amazon.Lambda.Annotations.SourceGenerator.Models;
 

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using Amazon.Lambda.Annotations.SourceGenerator.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
@@ -15,7 +16,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
         [Fact]
         public async Task Greeter()
         {
-            var expectedTemplateContent = NormalizeNewLines(File.ReadAllText(Path.Combine("Snapshots", "ServerlessTemplates", "greeter.template")));
+            var expectedTemplateContent = File.ReadAllText(Path.Combine("Snapshots", "ServerlessTemplates", "greeter.template")).ToEnvironmentLineEndings();
 
             await new VerifyCS.Test
             {
@@ -50,13 +51,13 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
             }.RunAsync();
 
             var actualTemplateContent = File.ReadAllText(Path.Combine("TestServerlessApp", "serverless.template"));
-            Assert.Equal(expectedTemplateContent, actualTemplateContent);
+            Assert.Equal(expectedTemplateContent.ToEnvironmentLineEndings(), actualTemplateContent);
         }
 
         [Fact]
         public async Task SimpleCalculator()
         {
-            var expectedTemplateContent = NormalizeNewLines(File.ReadAllText(Path.Combine("Snapshots", "ServerlessTemplates", "simpleCalculator.template")));
+            var expectedTemplateContent = File.ReadAllText(Path.Combine("Snapshots", "ServerlessTemplates", "simpleCalculator.template")).ToEnvironmentLineEndings();
 
             await new VerifyCS.Test
             {
@@ -125,13 +126,13 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
             }.RunAsync();
 
             var actualTemplateContent = File.ReadAllText(Path.Combine("TestServerlessApp", "serverless.template"));
-            Assert.Equal(NormalizeNewLines(expectedTemplateContent), actualTemplateContent);
+            Assert.Equal(expectedTemplateContent.ToEnvironmentLineEndings(), actualTemplateContent);
         }
 
         [Fact]
         public async Task ComplexCalculator()
         {
-            var expectedTemplateContent = NormalizeNewLines(File.ReadAllText(Path.Combine("Snapshots", "ServerlessTemplates", "complexCalculator.template")));
+            var expectedTemplateContent = File.ReadAllText(Path.Combine("Snapshots", "ServerlessTemplates", "complexCalculator.template")).ToEnvironmentLineEndings();
 
             await new VerifyCS.Test
             {
@@ -167,14 +168,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
             }.RunAsync();
 
             var actualTemplateContent = File.ReadAllText(Path.Combine("TestServerlessApp", "serverless.template"));
-            Assert.Equal(NormalizeNewLines(expectedTemplateContent), actualTemplateContent);
-        }
-
-        private string NormalizeNewLines(string expectedTemplateContent)
-        {
-            return expectedTemplateContent.Replace("\r\n", Environment.NewLine).
-                Replace("\n", Environment.NewLine).
-                Replace("\r\r\n", Environment.NewLine);
+            Assert.Equal(expectedTemplateContent.ToEnvironmentLineEndings(), actualTemplateContent);
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
T4 template cs files can have platform specific line endings which can result in inconsistent line end endings on NT vs unix systems. This change allows to generate C# code for platform specific and doesn't require a git config to pass unit tests that relies on string matching.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
