### PR TITLE
Automate ASP.NET Core version update

### DIFF
--- a/.github/workflows/update-Dockerfiles.yml
+++ b/.github/workflows/update-Dockerfiles.yml
@@ -1,0 +1,94 @@
+name: Update Dockerfiles
+
+on:
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      NET_5_AMD64:
+        description: ".NET 5 AMD64"
+        type: boolean
+        required: true
+        default: "true"
+      NET_6_AMD64:
+        description: ".NET 6 AMD64"
+        type: boolean
+        required: true
+        default: "true"
+      NET_6_ARM64:
+        description: ".NET 6 ARM64"
+        type: boolean
+        required: true
+        default: "true"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      NET_5_AMD64_Dockerfile: "LambdaRuntimeDockerfiles/Images/net5/amd64/Dockerfile"
+      NET_6_AMD64_Dockerfile: "LambdaRuntimeDockerfiles/Images/net6/amd64/Dockerfile"
+      NET_6_ARM64_Dockerfile: "LambdaRuntimeDockerfiles/Images/net6/arm64/Dockerfile"
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Update .NET 5 AMD64
+        id: update-net5-amd64
+        shell: pwsh
+        run: |
+          .\LambdaRuntimeDockerfiles/update-dockerfile.ps1 -Dockerfile ${{ env.NET_5_AMD64_Dockerfile }}
+        if: ${{ github.event.inputs.NET_5_AMD64 == 'true' }}
+
+      - name: Update .NET 6 AMD64
+        id: update-net6-amd64
+        shell: pwsh
+        run: |
+          .\LambdaRuntimeDockerfiles/update-dockerfile.ps1 -Dockerfile ${{ env.NET_6_AMD64_Dockerfile }}
+        if: ${{ github.event.inputs.NET_6_AMD64 == 'true' }}
+
+      - name: Update .NET 6 ARM64
+        id: update-net6-arm64
+        shell: pwsh
+        run: |
+          .\LambdaRuntimeDockerfiles/update-dockerfile.ps1 -Dockerfile ${{ env.NET_6_ARM64_Dockerfile }}
+        if: ${{ github.event.inputs.NET_6_ARM64 == 'true' }}
+
+      # Update Dockerfiles if newer version of ASP.NET Core is available
+      - name: Commit and Push
+        id: commit-push
+        shell: pwsh
+        run: |
+          git config --global user.email "github-aws-sdk-dotnet-automation@amazon.com"
+          git config --global user.name "aws-sdk-dotnet-automation"
+          $suffix=Get-Date -Format yyyy-mm-dd-HH-mm
+          $branch="chore/update-Dockerfiles-${suffix}"
+          git checkout -b $branch
+          git add "**/*Dockerfile"
+          git commit -m "chore: ASP.NET Core version update in Dockerfiles"
+          git push origin $branch
+          echo "::set-output name=BRANCH::$branch"
+
+      # Create a Pull Request from the pushed branch
+      - name: Pull Request
+        id: pull-request
+        if: ${{ steps.commit-push.outputs.BRANCH }}
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: ${{ steps.commit-push.outputs.BRANCH }}
+          destination_branch: "master"
+          pr_title: 'chore: ASP.NET Core version update in Dockerfiles'
+          pr_body: "This PR updates the Dockerfiles to use the latest ASP.NET Core version.
+            Verify listed Dockerfiles that they have correct version and matching SHA512 checksum for ASP.NET Core runtime.
+            \n\nAll .NET versions https://dotnet.microsoft.com/en-us/download/dotnet
+            \n\n*Description of changes:*
+            \n${{ format
+                (
+                  '{0}\n{1}\n{2}',
+                  join(steps.update-net5-amd64.outputs.*, '\n'),
+                  join(steps.update-net6-amd64.outputs.*, '\n'),
+                  join(steps.update-net6-arm64.outputs.*, '\n')
+                )
+            }}"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_label: "auto-pr"

--- a/LambdaRuntimeDockerfiles/update-dockerfile.ps1
+++ b/LambdaRuntimeDockerfiles/update-dockerfile.ps1
@@ -1,0 +1,79 @@
+# This script allows to update Dockerfiles with next ASP.NET Core patch version.
+# It greps the current version from Dockerfile, increment the patch version and fetches checksum file from Microsoft server.
+# If checksum file is available, it will update the Dockerfile next version and its checksum.
+# NOTE: This scripts only updates patch version by incrementing the next patch version.
+# If Microsoft ever releases a minor version, this needs to updated accordingly to include minor version.
+
+param ([Parameter(Mandatory)]$DockerfilePath)
+
+# Updates the Dockerfile with next ASP.NET Core version and checksum512 hash if available
+function Update-Dockerfile ([string]$DockerfilePath) {
+    Write-Host "Updating $DockerfilePath with next ASP.NET Core version"
+
+    $nextVersion = Get-NextASPNETVersion -DockerfilePath $DockerfilePath
+
+    $checksumFilePath = "${nextVersion}-checksum.txt"
+
+    $checksumUri = "https://dotnetcli.blob.core.windows.net/dotnet/checksums/${nextVersion}-sha.txt"
+    Write-Host "Downloading checksums from $checksumUri"
+
+    Invoke-WebRequest -Uri $checksumUri -OutFile $checksumFilePath
+
+    $arch = Get-Architecture -DockerfilePath $DockerfilePath
+
+    $artifact = "aspnetcore-runtime-${nextVersion}-linux-${arch}.tar.gz"
+    $checksum = Get-Checksum -Artifact $artifact -DockerfilePath $checksumFilePath
+
+    (Get-Content $DockerfilePath) -replace 'ARG ASPNET_VERSION=.*', "ARG ASPNET_VERSION=${nextVersion}" -replace 'ARG ASPNET_SHA512=.*', "ARG ASPNET_SHA512=${checksum}" | Out-File $DockerfilePath
+
+    Write-Host "Updated ${path} to ${nextVersion}."
+
+    # This allows checksumring the $DockerfilePath variable between steps
+    # which is needed to update the description of the PR
+    Write-Host "::set-output name=${path}::- Updated ${path} to ${nextVersion}<br> - Artifact: ${artifact}<br> - Checksum Source: ${checksumUri}"
+}
+
+# Returns Checksum of given ASP.NET Core version from the give Checksum file
+function Get-Checksum ([string]$artifact, [string]$DockerfilePath) {
+    $line = Select-String -Path $DockerfilePath -Pattern $artifact | Select-Object -Property Line -ExpandProperty Line
+    Write-Host $line
+
+    $checksum = $line.Split(" ")[0]
+    return $checksum
+}
+
+# Returns the architecture of the Dockerfile by checking the path of Dockerfile
+function Get-Architecture ([string]$DockerfilePath) {
+    if ($DockerfilePath.Contains("amd64")) {
+        return "x64"
+    } elseif ($DockerfilePath.Contains("arm64")) {
+        return "arm64"
+    } else {
+        throw "Unsupported architecture"
+    }
+}
+
+# Returns the next ASP.NET version to be updated in the Dockerfile
+function Get-NextASPNETVersion ([string]$DockerfilePath) {
+    $line = Select-String -Path $DockerfilePath -Pattern "ARG ASPNET_VERSION=" | Select-Object -Property Line -ExpandProperty Line
+    $currentVersion = $line.Split("=")[1]
+    Write-Host "Current ASPNET version: ${currentVersion}"
+
+    $nextVersion = Update-PatchVersion -Version $currentVersion
+    Write-Host "Next ASPNET version: ${nextVersion}"
+
+    return $nextVersion
+}
+
+# Returns the next patch version of the given version
+function Update-PatchVersion ([string]$version) {
+    $components = $version.Split(".");
+    $major = $components[0];
+    $minor = $components[1];
+    $patch = $components[2];
+    $patch = [int]$patch + 1;
+    $newVersion = $major + "." + $minor + "." + $patch;
+    return $newVersion;
+}
+
+Update-Dockerfile $DockerfilePath


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR sets up automation for updating the Dockerfiles with the latest version of ASP.NET Core version available for .NET 5 and .NET 6. This will allow us to push image updates quicker and reduce Ops load.

On a successful run, the workflow will create a PR similar to https://github.com/ganeshnj/aws-lambda-dotnet/pull/38 which further needs to be merged to push newer images. https://github.com/ganeshnj/aws-lambda-dotnet/pull/38 is for demo only, once this PR is merged, https://github.com/ganeshnj/aws-lambda-dotnet/pull/38 will be discarded and a new PR will be created.

Screenshot 
![image](https://user-images.githubusercontent.com/8882380/147784095-2a9f47dc-9ef9-464f-a171-3a95bd3889dd.png)


Testing performed

- [x] When there are no new versions available, actions succeeds without executing PR step (https://github.com/ganeshnj/aws-lambda-dotnet/runs/4622876309)
- [x] When a new version available, a PR https://github.com/ganeshnj/aws-lambda-dotnet/pull/38 is created

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
