### PR TITLE
Adding SQSBatchResponse class to support partial success for SQS batches

### DIFF
--- a/Libraries/src/Amazon.Lambda.SQSEvents/Amazon.Lambda.SQSEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.SQSEvents/Amazon.Lambda.SQSEvents.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>Amazon Lambda .NET Core support - SQSEvents package.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.SQSEvents</AssemblyTitle>
     <VersionPrefix>2.0.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.SQSEvents</AssemblyName>

--- a/Libraries/src/Amazon.Lambda.SQSEvents/SQSBatchResponse.cs
+++ b/Libraries/src/Amazon.Lambda.SQSEvents/SQSBatchResponse.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Amazon.Lambda.SQSEvents
+{
+    /// This class can be used as the return type for Lambda functions that have partially
+    /// succeeded by supplying a list of message IDs that have failed to process.
+    /// https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
+    [DataContract]
+    public class SQSBatchResponse
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="SQSBatchResponse"/>
+        /// </summary>
+        public SQSBatchResponse()
+            : this(new List<BatchItemFailure>())
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="SQSBatchResponse"/>
+        /// </summary>
+        /// <param name="batchItemFailures">A list of batch item failures</param>
+        public SQSBatchResponse(List<BatchItemFailure> batchItemFailures)
+        {
+            BatchItemFailures = batchItemFailures;
+        }
+
+        /// <summary>
+        /// Gets or sets the message failures within the batch failures
+        /// </summary>
+        [DataMember(Name = "batchItemFailures")]
+#if NETCOREAPP3_1
+        [System.Text.Json.Serialization.JsonPropertyName("batchItemFailures")]
+#endif
+        public List<BatchItemFailure> BatchItemFailures { get; set; }
+
+        /// <summary>
+        /// Class representing a SQS message item failure
+        /// </summary>
+        [DataContract]
+        public class BatchItemFailure
+        {
+            /// <summary>
+            /// MessageId that failed processing
+            /// </summary>
+            [DataMember(Name = "itemIdentifier")]
+#if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("itemIdentifier")]
+#endif
+            public string ItemIdentifier { get; set; }
+        }
+    }
+}

--- a/Libraries/test/EventsTests.Shared/EventsTests.Shared.projitems
+++ b/Libraries/test/EventsTests.Shared/EventsTests.Shared.projitems
@@ -39,6 +39,7 @@
     <Content Include="$(MSBuildThisFileDirectory)simple-email-event-lambda.json" />
     <Content Include="$(MSBuildThisFileDirectory)simple-email-event-s3.json" />
     <Content Include="$(MSBuildThisFileDirectory)sns-event.json" />
+    <Content Include="$(MSBuildThisFileDirectory)sqs-response.json" />
     <Content Include="$(MSBuildThisFileDirectory)sqs-event.json" />
   </ItemGroup>
   <ItemGroup>

--- a/Libraries/test/EventsTests.Shared/sqs-response.json
+++ b/Libraries/test/EventsTests.Shared/sqs-response.json
@@ -1,0 +1,10 @@
+﻿{
+  "batchItemFailures": [
+    {
+      "itemIdentifier": "MessageID_1"
+    },
+    {
+      "itemIdentifier": "MessageID_2"
+    }
+  ]
+}


### PR DESCRIPTION
*Issue #, if available: #1033 

*Description of changes: Adding SQSBatchResponse class to support partial success for SQS batches.  See https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
