### PR TITLE
chore: move shipped diagnostic rules to AnalyzerReleases.Shipped.md

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/AnalyzerReleases.Shipped.md
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/AnalyzerReleases.Shipped.md
@@ -1,2 +1,13 @@
 ; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+## Release 0.4.2.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+AWSLambda0001 | AWSLambda | Error | Unhandled exception
+AWSLambda0101 | AWSLambdaCSharpGenerator | Error | Multiple LambdaStartup classes not allowed
+AWSLambda0102 | AWSLambdaCSharpGenerator | Error | Multiple events on Lambda function not supported
+AWSLambda0103 | AWSLambdaCSharpGenerator | Info | Generated code

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/AnalyzerReleases.Unshipped.md
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/AnalyzerReleases.Unshipped.md
@@ -1,11 +1,2 @@
 ; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
-
-### New Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
-AWSLambda0001 | AWSLambda | Error | Unhandled exception
-AWSLambda0101 | AWSLambdaCSharpGenerator | Error | Multiple LambdaStartup classes not allowed
-AWSLambda0102 | AWSLambdaCSharpGenerator | Error | Multiple events on Lambda function not supported
-AWSLambda0103 | AWSLambdaCSharpGenerator | Info | Generated code


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

As 0.4.2.0 is out, all the new/updated/removed rules must be moved to `AnalyzerReleases.Shipped.md`. This PR moves `AnalyzerReleases.Unshipped.md` to `AnalyzerReleases.Shipped.md`.

To learn how does the diagnostics release work, check [here](https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md). This link is also part of the Shipped/Unshipped markdown files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
