### PR TITLE
fix: return 400 instead 200 for validation errors

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.cs
@@ -963,7 +963,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
                         {""Content-Type"", ""application/json""},
                         {""x-amzn-ErrorType"", ""ValidationException""}
                     },
-                    StatusCode = 200
+                    StatusCode = 400
                 };
             }
 

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.tt
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.tt
@@ -361,7 +361,7 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
                         {"Content-Type", "application/json"},
                         {"x-amzn-ErrorType", "ValidationException"}
                     },
-                    StatusCode = 200
+                    StatusCode = 400
                 };
             }
 

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ComplexCalculator_Subtract_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ComplexCalculator_Subtract_Generated.g.cs
@@ -42,7 +42,7 @@ namespace TestServerlessApp
                         {"Content-Type", "application/json"},
                         {"x-amzn-ErrorType", "ValidationException"}
                     },
-                    StatusCode = 200
+                    StatusCode = 400
                 };
             }
 

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Greeter_SayHelloAsync_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Greeter_SayHelloAsync_Generated.g.cs
@@ -52,7 +52,7 @@ namespace TestServerlessApp
                         {"Content-Type", "application/json"},
                         {"x-amzn-ErrorType", "ValidationException"}
                     },
-                    StatusCode = 200
+                    StatusCode = 400
                 };
             }
 

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Greeter_SayHello_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Greeter_SayHello_Generated.g.cs
@@ -51,7 +51,7 @@ namespace TestServerlessApp
                         {"Content-Type", "application/json"},
                         {"x-amzn-ErrorType", "ValidationException"}
                     },
-                    StatusCode = 200
+                    StatusCode = 400
                 };
             }
 

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Add_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Add_Generated.g.cs
@@ -72,7 +72,7 @@ namespace TestServerlessApp
                         {"Content-Type", "application/json"},
                         {"x-amzn-ErrorType", "ValidationException"}
                     },
-                    StatusCode = 200
+                    StatusCode = 400
                 };
             }
 

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_DivideAsync_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_DivideAsync_Generated.g.cs
@@ -73,7 +73,7 @@ namespace TestServerlessApp
                         {"Content-Type", "application/json"},
                         {"x-amzn-ErrorType", "ValidationException"}
                     },
-                    StatusCode = 200
+                    StatusCode = 400
                 };
             }
 

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Multiply_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Multiply_Generated.g.cs
@@ -72,7 +72,7 @@ namespace TestServerlessApp
                         {"Content-Type", "application/json"},
                         {"x-amzn-ErrorType", "ValidationException"}
                     },
-                    StatusCode = 200
+                    StatusCode = 400
                 };
             }
 

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Subtract_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Subtract_Generated.g.cs
@@ -73,7 +73,7 @@ namespace TestServerlessApp
                         {"Content-Type", "application/json"},
                         {"x-amzn-ErrorType", "ValidationException"}
                     },
-                    StatusCode = 200
+                    StatusCode = 400
                 };
             }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Earlier for validation errors, HTTP status code was returned as 200 which should be 400 instead. This PR fixes the status code to 400.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
