### PR TITLE
Fix typo in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -26,7 +26,7 @@ labels: feature-request, needs-triage
 <!--- If feature is environment-specific (targeting specific version, Windows only, etc.) please indicate requirements here -->
 
 * [ ] :wave: I may be able to implement this feature request
-* [ ] :warning: This feature might incur a breaking change <!-- NOTE: Please do not submit a PR before recieving feedback. In order to maintain stability, breaking changes are only added in major versions, so this change may not be merged --> 
+* [ ] :warning: This feature might incur a breaking change <!-- NOTE: Please do not submit a PR before receiving feedback. In order to maintain stability, breaking changes are only added in major versions, so this change may not be merged --> 
 
 ---
 


### PR DESCRIPTION
*Description of changes:*

Fix typo in GitHub template comment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
