### PR TITLE
Reference APIGatewayEvents project in Annotations

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.nuspec
+++ b/Libraries/src/Amazon.Lambda.Annotations.nuspec
@@ -21,10 +21,12 @@
 
         <!-- Dependencies to make sure attributes are available in consuming csproj, this ensures packaged version of customer code have all the dependencies needed. -->
         <file src="Amazon.Lambda.Annotations\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.dll" target="lib/net6.0" />
+        <file src="Amazon.Lambda.APIGatewayEvents\bin\Release\netstandard2.0\Amazon.Lambda.APIGatewayEvents.dll" target="lib/net6.0" />
 
         <!-- Include every dependency manually for analyzer, whenever a new dependency is added, it has to be added here. -->
         <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.dll" target="analyzers\dotnet\cs" />
         <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.SourceGenerator.dll" target="analyzers\dotnet\cs" />
         <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netstandard2.0\Newtonsoft.Json.dll" target="analyzers\dotnet\cs" />
+        <file src="Amazon.Lambda.APIGatewayEvents\bin\Release\netstandard2.0\Amazon.Lambda.APIGatewayEvents.dll" target="analyzers\dotnet\cs" />
     </files>
 </package>

--- a/Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj
+++ b/Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj
@@ -5,4 +5,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Amazon.Lambda.APIGatewayEvents\Amazon.Lambda.APIGatewayEvents.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
*Issue #1052:*

Resolves #1052 by adding a reference to `Amazon.Lambda.APIGatewayEvents` to the `Amazon.Lambda.Annotations` project.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
