### PR TITLE
Rename HttpMethod to LambdaHttpMethod

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/HttpApiAttributeBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/HttpApiAttributeBuilder.cs
@@ -13,7 +13,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes
                 throw new NotSupportedException($"{TypeFullNames.HttpApiAttribute} must have constructor with 2 arguments.");
             }
 
-            var method = (HttpMethod)att.ConstructorArguments[0].Value;
+            var method = (LambdaHttpMethod)att.ConstructorArguments[0].Value;
             var template = att.ConstructorArguments[1].Value as string;
             var version = att.NamedArguments.FirstOrDefault(arg => arg.Key == "Version").Value.Value;
 

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/RestApiAttributeBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/RestApiAttributeBuilder.cs
@@ -15,7 +15,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes
                 throw new NotSupportedException($"{TypeFullNames.RestApiAttribute} must have constructor with 2 arguments.");
             }
 
-            var method = (HttpMethod)att.ConstructorArguments[0].Value;
+            var method = (LambdaHttpMethod)att.ConstructorArguments[0].Value;
             var template = att.ConstructorArguments[1].Value as string;
 
             var data = new RestApiAttribute(method, template);

--- a/Libraries/src/Amazon.Lambda.Annotations/HttpApiAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/HttpApiAttribute.cs
@@ -7,9 +7,9 @@ namespace Amazon.Lambda.Annotations
     {
         public HttpApiVersion Version { get; set; } = HttpApiVersion.V2;
         public string Template { get; set;  }
-        public HttpMethod Method { get; set; }
+        public LambdaHttpMethod Method { get; set; }
 
-        public HttpApiAttribute(HttpMethod method, string template)
+        public HttpApiAttribute(LambdaHttpMethod method, string template)
         {
             Template = template;
             Method = method;

--- a/Libraries/src/Amazon.Lambda.Annotations/LambdaHttpMethod.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/LambdaHttpMethod.cs
@@ -1,6 +1,6 @@
 namespace Amazon.Lambda.Annotations
 {
-    public enum HttpMethod
+    public enum LambdaHttpMethod
     {
         Any,
         Get,

--- a/Libraries/src/Amazon.Lambda.Annotations/RestApiAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/RestApiAttribute.cs
@@ -6,9 +6,9 @@ namespace Amazon.Lambda.Annotations
     public class RestApiAttribute : Attribute
     {
         public string Template { get; set;  }
-        public HttpMethod Method { get; set; }
+        public LambdaHttpMethod Method { get; set; }
 
-        public RestApiAttribute(HttpMethod method, string template)
+        public RestApiAttribute(LambdaHttpMethod method, string template)
         {
             Template = template;
             Method = method;

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/CloudFormationJsonWriterTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/CloudFormationJsonWriterTests.cs
@@ -277,7 +277,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
                 "TestMethod", 45, 512, null, null);
             var httpAttributeModel = new AttributeModel<HttpApiAttribute>()
             {
-                Data = new HttpApiAttribute(HttpMethod.Get, "/Calculator/Add")
+                Data = new HttpApiAttribute(LambdaHttpMethod.Get, "/Calculator/Add")
                 {
                     Version = HttpApiVersion.V1
                 }
@@ -302,7 +302,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
             // ARRANGE - CHANGE TO A HTTP POST METHOD
             httpAttributeModel = new AttributeModel<HttpApiAttribute>()
             {
-                Data = new HttpApiAttribute(HttpMethod.Post, "/Calculator/Add")
+                Data = new HttpApiAttribute(LambdaHttpMethod.Post, "/Calculator/Add")
             };
             lambdaFunctionModel.Attributes = new List<AttributeModel>() {httpAttributeModel};
 

--- a/Libraries/test/TestServerlessApp/ComplexCalculator.cs
+++ b/Libraries/test/TestServerlessApp/ComplexCalculator.cs
@@ -13,7 +13,7 @@ namespace TestServerlessApp
     public class ComplexCalculator
     {
         [LambdaFunction(PackageType = LambdaPackageType.Image)]
-        [HttpApi(HttpMethod.Post, "/ComplexCalculator/Add")]
+        [HttpApi(LambdaHttpMethod.Post, "/ComplexCalculator/Add")]
         public Tuple<double, double> Add([FromBody]string complexNumbers, ILambdaContext context, APIGatewayHttpApiV2ProxyRequest request)
         {
             context.Logger.Log($"Request {JsonSerializer.Serialize(request)}");
@@ -43,7 +43,7 @@ namespace TestServerlessApp
         }
 
         [LambdaFunction(PackageType = LambdaPackageType.Image)]
-        [HttpApi(HttpMethod.Post, "/ComplexCalculator/Subtract")]
+        [HttpApi(LambdaHttpMethod.Post, "/ComplexCalculator/Subtract")]
         public Tuple<double, double> Subtract([FromBody]IList<IList<int>> complexNumbers)
         {
             if (complexNumbers.Count() != 2)

--- a/Libraries/test/TestServerlessApp/Greeter.cs
+++ b/Libraries/test/TestServerlessApp/Greeter.cs
@@ -11,7 +11,7 @@ namespace TestServerlessApp
     public class Greeter
     {
         [LambdaFunction(Name = "GreeterSayHello", MemorySize = 1024, PackageType = LambdaPackageType.Image)]
-        [HttpApi(HttpMethod.Get, "/Greeter/SayHello", Version = HttpApiVersion.V1)]
+        [HttpApi(LambdaHttpMethod.Get, "/Greeter/SayHello", Version = HttpApiVersion.V1)]
         public void SayHello([FromQuery(Name = "names")]IEnumerable<string> firstNames, APIGatewayProxyRequest request, ILambdaContext context)
         {
             context.Logger.LogLine($"Request {JsonSerializer.Serialize(request)}");
@@ -28,7 +28,7 @@ namespace TestServerlessApp
         }
 
         [LambdaFunction(Name = "GreeterSayHelloAsync", Timeout = 50, PackageType = LambdaPackageType.Image)]
-        [HttpApi(HttpMethod.Get, "/Greeter/SayHelloAsync", Version = HttpApiVersion.V1)]
+        [HttpApi(LambdaHttpMethod.Get, "/Greeter/SayHelloAsync", Version = HttpApiVersion.V1)]
         public async Task SayHelloAsync([FromHeader(Name = "names")]IEnumerable<string> firstNames)
         {
             if (firstNames == null)

--- a/Libraries/test/TestServerlessApp/SimpleCalculator.cs
+++ b/Libraries/test/TestServerlessApp/SimpleCalculator.cs
@@ -25,14 +25,14 @@ namespace TestServerlessApp
         }
 
         [LambdaFunction(Name = "SimpleCalculatorAdd", PackageType = LambdaPackageType.Image)]
-        [RestApi(HttpMethod.Get, "/SimpleCalculator/Add")]
+        [RestApi(LambdaHttpMethod.Get, "/SimpleCalculator/Add")]
         public int Add([FromQuery]int x, [FromQuery]int y)
         {
             return _simpleCalculatorService.Add(x, y);
         }
 
         [LambdaFunction(Name = "SimpleCalculatorSubtract", PackageType = LambdaPackageType.Image)]
-        [RestApi(HttpMethod.Get, "/SimpleCalculator/Subtract")]
+        [RestApi(LambdaHttpMethod.Get, "/SimpleCalculator/Subtract")]
         public APIGatewayProxyResponse Subtract([FromHeader]int x, [FromHeader]int y, [FromServices]ISimpleCalculatorService simpleCalculatorService)
         {
             return new APIGatewayProxyResponse
@@ -43,14 +43,14 @@ namespace TestServerlessApp
         }
 
         [LambdaFunction(Name = "SimpleCalculatorMultiply", PackageType = LambdaPackageType.Image)]
-        [RestApi(HttpMethod.Get, "/SimpleCalculator/Multiply/{x}/{y}")]
+        [RestApi(LambdaHttpMethod.Get, "/SimpleCalculator/Multiply/{x}/{y}")]
         public string Multiply(int x, int y)
         {
             return _simpleCalculatorService.Multiply(x, y).ToString();
         }
 
         [LambdaFunction(Name = "SimpleCalculatorDivideAsync", PackageType = LambdaPackageType.Image)]
-        [RestApi(template: "/SimpleCalculator/DivideAsync/{x}/{y}", method: HttpMethod.Get)]
+        [RestApi(template: "/SimpleCalculator/DivideAsync/{x}/{y}", method: LambdaHttpMethod.Get)]
         public async Task<int> DivideAsync([FromRoute(Name = "x")]int first, [FromRoute(Name = "y")]int second)
         {
             return await Task.FromResult(_simpleCalculatorService.Divide(first, second));


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1053

*Description of changes:*
Rename the `HttpMethod` enum to `LambdaHttpMethod` to avoid ambigituty with `System.Net.Http.HttpMethod`. This is especially important for .NET 6 which has implicit usings for `System.Net.Http`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
