### PR TITLE
fix: Task being added second time on a 0-event Lambda function which …

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/TypeModel.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/TypeModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Amazon.Lambda.Annotations.SourceGenerator.Models
 {
@@ -33,6 +34,29 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
         /// Returns empty when there are not type arguments
         /// </summary>
         public IList<TypeModel> TypeArguments { get; set; }
+
+
+        /// <summary>
+        /// Gets type argument of the <see cref="Task{TResult}"/> type.
+        /// If the type is not a generic or <see cref="Task{TResult}"/> type, returns null.
+        /// </summary>
+        public string TaskTypeArgument
+        {
+            get
+            {
+                if (!IsGenericType)
+                {
+                    return null;
+                }
+
+                if (!FullName.StartsWith($"{TypeFullNames.Task}<"))
+                {
+                    return null;
+                }
+
+                return TypeArguments[0].FullName;
+            }
+        }
 
         /// <summary>
         /// True, if the type implements IEnumerable interface.

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.cs
@@ -189,19 +189,13 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             this.Write("        }\r\n\r\n        public ");
             
             #line 66 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.IsAsync ? "async Task<" : ""));
+            this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.IsAsync ? "async " : ""));
             
             #line default
             #line hidden
             
             #line 66 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.GeneratedMethod.ReturnType.FullName));
-            
-            #line default
-            #line hidden
-            
-            #line 66 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.IsAsync ? ">" : ""));
             
             #line default
             #line hidden
@@ -951,7 +945,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
                     "     if (validationErrors.Any())\r\n            {\r\n                return new ");
             
             #line 356 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(_model.GeneratedMethod.ReturnType.Name));
+            this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.IsAsync ? _model.GeneratedMethod.ReturnType.TaskTypeArgument : _model.GeneratedMethod.ReturnType.FullName));
             
             #line default
             #line hidden
@@ -1106,7 +1100,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             this.Write("\r\n            return new ");
             
             #line 415 "C:\Users\jangirg\source\repos\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(_model.GeneratedMethod.ReturnType.Name));
+            this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.IsAsync ? _model.GeneratedMethod.ReturnType.TaskTypeArgument : _model.GeneratedMethod.ReturnType.FullName));
             
             #line default
             #line hidden

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.tt
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.tt
@@ -63,7 +63,7 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
 #>
         }
 
-        public <#= _model.LambdaMethod.IsAsync ? "async Task<" : "" #><#= _model.GeneratedMethod.ReturnType.FullName #><#= _model.LambdaMethod.IsAsync ? ">" : "" #> <#= _model.LambdaMethod.Name #>(<#= string.Join(", ", _model.GeneratedMethod.Parameters.Select(p => $"{p.Type.FullName} {p.Name}")) #>)
+        public <#= _model.LambdaMethod.IsAsync ? "async " : "" #><#= _model.GeneratedMethod.ReturnType.FullName #> <#= _model.LambdaMethod.Name #>(<#= string.Join(", ", _model.GeneratedMethod.Parameters.Select(p => $"{p.Type.FullName} {p.Name}")) #>)
         {
 <#
     if (_model.LambdaMethod.UsingDependencyInjection)
@@ -353,7 +353,7 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
             // return 400 Bad Request if there exists a validation error
             if (validationErrors.Any())
             {
-                return new <#= _model.GeneratedMethod.ReturnType.Name #>
+                return new <#= _model.LambdaMethod.IsAsync ? _model.GeneratedMethod.ReturnType.TaskTypeArgument : _model.GeneratedMethod.ReturnType.FullName #>
                 {
                     Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
                     Headers = new Dictionary<string, string>
@@ -412,7 +412,7 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
             }
 #>
 
-            return new <#= _model.GeneratedMethod.ReturnType.Name #>
+            return new <#= _model.LambdaMethod.IsAsync ? _model.GeneratedMethod.ReturnType.TaskTypeArgument : _model.GeneratedMethod.ReturnType.FullName #>
             {
 <#
             if (!_model.LambdaMethod.ReturnsVoidOrTask)

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/TypeFullNames.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/TypeFullNames.cs
@@ -23,6 +23,8 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
         public const string FromServiceAttribute = "Amazon.Lambda.Annotations.FromServicesAttribute";
         public const string ILambdaContext = "Amazon.Lambda.Core.ILambdaContext";
         public const string IEnumerable = "System.Collections.IEnumerable";
+        public const string Task1 = "System.Threading.Tasks.Task`1";
+        public const string Task = "System.Threading.Tasks.Task";
 
         public static HashSet<string> Requests = new HashSet<string>
         {

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ComplexCalculator_Add_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ComplexCalculator_Add_Generated.g.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Text;
 using Amazon.Lambda.Core;
-using Amazon.Lambda.APIGatewayEvents;
 
 namespace TestServerlessApp
 {
@@ -25,7 +24,7 @@ namespace TestServerlessApp
 
             var body = System.Text.Json.JsonSerializer.Serialize(response);
 
-            return new APIGatewayHttpApiV2ProxyResponse
+            return new Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyResponse
             {
                 Body = body,
                 Headers = new Dictionary<string, string>

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ComplexCalculator_Subtract_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ComplexCalculator_Subtract_Generated.g.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Text;
 using Amazon.Lambda.Core;
-using Amazon.Lambda.APIGatewayEvents;
 
 namespace TestServerlessApp
 {
@@ -34,7 +33,7 @@ namespace TestServerlessApp
             // return 400 Bad Request if there exists a validation error
             if (validationErrors.Any())
             {
-                return new APIGatewayHttpApiV2ProxyResponse
+                return new Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyResponse
                 {
                     Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
                     Headers = new Dictionary<string, string>
@@ -50,7 +49,7 @@ namespace TestServerlessApp
 
             var body = System.Text.Json.JsonSerializer.Serialize(response);
 
-            return new APIGatewayHttpApiV2ProxyResponse
+            return new Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyResponse
             {
                 Body = body,
                 Headers = new Dictionary<string, string>

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Greeter_SayHelloAsync_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Greeter_SayHelloAsync_Generated.g.cs
@@ -2,9 +2,7 @@
 using System.Linq;
 using System.Collections.Generic;
 using System.Text;
-using System.Threading.Tasks;
 using Amazon.Lambda.Core;
-using Amazon.Lambda.APIGatewayEvents;
 
 namespace TestServerlessApp
 {
@@ -18,7 +16,7 @@ namespace TestServerlessApp
             greeter = new Greeter();
         }
 
-        public async Task<Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse> SayHelloAsync(Amazon.Lambda.APIGatewayEvents.APIGatewayProxyRequest request, Amazon.Lambda.Core.ILambdaContext context)
+        public async System.Threading.Tasks.Task<Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse> SayHelloAsync(Amazon.Lambda.APIGatewayEvents.APIGatewayProxyRequest request, Amazon.Lambda.Core.ILambdaContext context)
         {
             var validationErrors = new List<string>();
 
@@ -44,7 +42,7 @@ namespace TestServerlessApp
             // return 400 Bad Request if there exists a validation error
             if (validationErrors.Any())
             {
-                return new APIGatewayProxyResponse
+                return new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
                 {
                     Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
                     Headers = new Dictionary<string, string>
@@ -58,7 +56,7 @@ namespace TestServerlessApp
 
             await greeter.SayHelloAsync(firstNames);
 
-            return new APIGatewayProxyResponse
+            return new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
             {
                 StatusCode = 200
             };

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Greeter_SayHello_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Greeter_SayHello_Generated.g.cs
@@ -1,9 +1,8 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Text;
 using Amazon.Lambda.Core;
-using Amazon.Lambda.APIGatewayEvents;
 
 namespace TestServerlessApp
 {
@@ -43,7 +42,7 @@ namespace TestServerlessApp
             // return 400 Bad Request if there exists a validation error
             if (validationErrors.Any())
             {
-                return new APIGatewayProxyResponse
+                return new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
                 {
                     Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
                     Headers = new Dictionary<string, string>
@@ -57,7 +56,7 @@ namespace TestServerlessApp
 
             greeter.SayHello(firstNames, request, context);
 
-            return new APIGatewayProxyResponse
+            return new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
             {
                 StatusCode = 200
             };

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Add_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Add_Generated.g.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Amazon.Lambda.Core;
-using Amazon.Lambda.APIGatewayEvents;
 
 namespace TestServerlessApp
 {
@@ -64,7 +63,7 @@ namespace TestServerlessApp
             // return 400 Bad Request if there exists a validation error
             if (validationErrors.Any())
             {
-                return new APIGatewayProxyResponse
+                return new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
                 {
                     Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
                     Headers = new Dictionary<string, string>
@@ -80,7 +79,7 @@ namespace TestServerlessApp
 
             var body = response.ToString();
 
-            return new APIGatewayProxyResponse
+            return new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
             {
                 Body = body,
                 Headers = new Dictionary<string, string>

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_DivideAsync_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_DivideAsync_Generated.g.cs
@@ -2,10 +2,8 @@
 using System.Linq;
 using System.Collections.Generic;
 using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Amazon.Lambda.Core;
-using Amazon.Lambda.APIGatewayEvents;
 
 namespace TestServerlessApp
 {
@@ -27,7 +25,7 @@ namespace TestServerlessApp
             serviceProvider = services.BuildServiceProvider();
         }
 
-        public async Task<Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse> DivideAsync(Amazon.Lambda.APIGatewayEvents.APIGatewayProxyRequest request, Amazon.Lambda.Core.ILambdaContext context)
+        public async System.Threading.Tasks.Task<Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse> DivideAsync(Amazon.Lambda.APIGatewayEvents.APIGatewayProxyRequest request, Amazon.Lambda.Core.ILambdaContext context)
         {
             // Create a scope for every request,
             // this allows creating scoped dependencies without creating a scope manually.
@@ -65,7 +63,7 @@ namespace TestServerlessApp
             // return 400 Bad Request if there exists a validation error
             if (validationErrors.Any())
             {
-                return new APIGatewayProxyResponse
+                return new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
                 {
                     Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
                     Headers = new Dictionary<string, string>
@@ -81,7 +79,7 @@ namespace TestServerlessApp
 
             var body = System.Text.Json.JsonSerializer.Serialize(response);
 
-            return new APIGatewayProxyResponse
+            return new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
             {
                 Body = body,
                 Headers = new Dictionary<string, string>

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Multiply_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Multiply_Generated.g.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Amazon.Lambda.Core;
-using Amazon.Lambda.APIGatewayEvents;
 
 namespace TestServerlessApp
 {
@@ -64,7 +63,7 @@ namespace TestServerlessApp
             // return 400 Bad Request if there exists a validation error
             if (validationErrors.Any())
             {
-                return new APIGatewayProxyResponse
+                return new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
                 {
                     Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
                     Headers = new Dictionary<string, string>
@@ -78,7 +77,7 @@ namespace TestServerlessApp
 
             var response = simpleCalculator.Multiply(x, y);
 
-            return new APIGatewayProxyResponse
+            return new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
             {
                 Body = response,
                 Headers = new Dictionary<string, string>

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Random_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Random_Generated.g.cs
@@ -25,14 +25,14 @@ namespace TestServerlessApp
             serviceProvider = services.BuildServiceProvider();
         }
 
-        public int Random(int maxValue, Amazon.Lambda.Core.ILambdaContext context)
+        public async System.Threading.Tasks.Task<int> Random(int maxValue, Amazon.Lambda.Core.ILambdaContext context)
         {
             // Create a scope for every request,
             // this allows creating scoped dependencies without creating a scope manually.
             using var scope = serviceProvider.CreateScope();
             var simpleCalculator = scope.ServiceProvider.GetRequiredService<SimpleCalculator>();
 
-            return simpleCalculator.Random(maxValue, context);
+            return await simpleCalculator.Random(maxValue, context);
         }
 
         private static void SetExecutionEnvironment()

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Subtract_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Subtract_Generated.g.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Amazon.Lambda.Core;
-using Amazon.Lambda.APIGatewayEvents;
 
 namespace TestServerlessApp
 {
@@ -65,7 +64,7 @@ namespace TestServerlessApp
             // return 400 Bad Request if there exists a validation error
             if (validationErrors.Any())
             {
-                return new APIGatewayProxyResponse
+                return new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
                 {
                     Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
                     Headers = new Dictionary<string, string>

--- a/Libraries/test/TestServerlessApp/SimpleCalculator.cs
+++ b/Libraries/test/TestServerlessApp/SimpleCalculator.cs
@@ -63,10 +63,11 @@ namespace TestServerlessApp
         }
 
         [LambdaFunction(Name = "Random", PackageType = LambdaPackageType.Image)]
-        public int Random(int maxValue, ILambdaContext context)
+        public async Task<int> Random(int maxValue, ILambdaContext context)
         {
             context.Logger.Log($"Max value: {maxValue}");
-            return new Random().Next(maxValue);
+            var value = new Random().Next(maxValue);
+            return await Task.FromResult(value);
         }
 
         [LambdaFunction(Name = "Randoms", PackageType = LambdaPackageType.Image)]


### PR DESCRIPTION
*Issue #, if available:*

- [x] Fixes #1058 

*Description of changes:*
The issue was due to always wrapping return type to Task when original method is async. This doesn't work for Lambda functions which has 0-events, because their return type can be a Task which is simply delegated to the Lambda runtime without any return type conversion.

Ex. for a API Gateway based Lambda, return type always be API Gateway response type or `Task'1`
but in case of 0-event Lambda, original method return type can be `Task'1` which is again wrapped in `Task'1` in T4 template.

This change changes how return type is generated and now ReturnType property of generated method solely controls the code generation. When an API Gateway Lambda return a `Task'1`, it creates a generic response type, otherwise non-generic response type.

For 0-event based Lambda, there is no action required because their types are already have all the required information.

- [x] Updated the test case to cover the scenario.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
