### PR TITLE
Add new page for testing executable assembly Lambda functions

### DIFF
--- a/Tools/LambdaTestTool/aws-lambda-test-tool-netcore.sln
+++ b/Tools/LambdaTestTool/aws-lambda-test-tool-netcore.sln
@@ -38,6 +38,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCoreAPIExample", "tests\LambdaFunctions\netcore31\AspNetCoreAPIExample\AspNetCoreAPIExample.csproj", "{5E1FF56C-9691-45B4-A961-24950A2C106C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.Lambda.TestTool.BlazorTester.Tests", "tests\Amazon.Lambda.TestTool.BlazorTester.Tests\Amazon.Lambda.TestTool.BlazorTester.Tests.csproj", "{0CA7DDC6-A1C5-467C-9CBF-8B4290D56D4A}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		tests\Amazon.Lambda.TestTool.Tests.Shared\Amazon.Lambda.TestTool.Tests.Shared.projitems*{70aff681-844a-428c-aba2-7053e61d39c8}*SharedItemsImports = 13
@@ -88,6 +90,10 @@ Global
 		{5E1FF56C-9691-45B4-A961-24950A2C106C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5E1FF56C-9691-45B4-A961-24950A2C106C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5E1FF56C-9691-45B4-A961-24950A2C106C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0CA7DDC6-A1C5-467C-9CBF-8B4290D56D4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0CA7DDC6-A1C5-467C-9CBF-8B4290D56D4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0CA7DDC6-A1C5-467C-9CBF-8B4290D56D4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0CA7DDC6-A1C5-467C-9CBF-8B4290D56D4A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -106,6 +112,7 @@ Global
 		{70AFF681-844A-428C-ABA2-7053E61D39C8} = {28C935E3-4FB4-4B09-A9DB-26A1EB04CDE0}
 		{E57ABB02-E8FC-4011-95D3-E9CB9412EDCB} = {28C935E3-4FB4-4B09-A9DB-26A1EB04CDE0}
 		{5E1FF56C-9691-45B4-A961-24950A2C106C} = {0B078893-2F43-4C0C-88FE-98D0839ED7A9}
+		{0CA7DDC6-A1C5-467C-9CBF-8B4290D56D4A} = {28C935E3-4FB4-4B09-A9DB-26A1EB04CDE0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E6C77567-6F16-4EE3-8743-ADE6B68434FD}

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Constants.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Constants.cs
@@ -13,6 +13,13 @@ namespace Amazon.Lambda.TestTool.BlazorTester
 #else
         Update for new target framework!!!
 #endif
+      
+        public const string ResponseSuccessStyle = "white-space: pre-wrap; height: min-content; font-size: 75%; color: black"; 
+        public const string ResponseErrorStyle = "white-space: pre-wrap; height: min-content; font-size: 75%; color: red";
+            
+        public const string ResponseSuccessStyleSizeConstraint = "white-space: pre-wrap; height: 300px; font-size: 75%; color: black"; 
+        public const string ResponseErrorStyleSizeConstraint = "white-space: pre-wrap; height: 300px; font-size: 75%; color: red";
+          
 
         public const string LINK_GITHUB_TEST_TOOL = "https://github.com/aws/aws-lambda-dotnet/tree/master/Tools/LambdaTestTool";
         public const string LINK_GITHUB_TEST_TOOL_INSTALL_AND_RUN = "https://github.com/aws/aws-lambda-dotnet/tree/master/Tools/LambdaTestTool#installing-and-running";

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Controllers/RuntimeApiController.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Controllers/RuntimeApiController.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Amazon.Lambda.TestTool.BlazorTester.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Amazon.Lambda.TestTool.BlazorTester.Controllers
+{
+#if NET6_0_OR_GREATER
+    public class RuntimeApiController : ControllerBase
+    {
+        private const string HEADER_BREAK = "-----------------------------------";
+        private readonly IRuntimeApiDataStore _runtimeApiDataStore;
+
+        public RuntimeApiController(IRuntimeApiDataStore runtimeApiDataStore)
+        {
+            _runtimeApiDataStore = runtimeApiDataStore;
+        }
+
+        [HttpPost("/runtime/test-event")]
+        [HttpPost("/2015-03-31/functions/function/invocations")]
+        public async Task<IActionResult> PostTestEvent()
+        {
+            using var reader = new StreamReader(Request.Body);
+            var testEvent = await reader.ReadToEndAsync();
+            _runtimeApiDataStore.QueueEvent(testEvent);
+
+            return Accepted();
+        }
+        
+        [HttpPost("/2018-06-01/runtime/init/error")]
+        public IActionResult PostInitError([FromHeader(Name = "Lambda-Runtime-Function-Error-Type")] string errorType, [FromBody] string error)
+        {
+            Console.Error.WriteLine("Init Error Type: " + errorType);
+            Console.Error.WriteLine(error);
+            Console.Error.WriteLine("-----------------------------------");
+            return Accepted(new StatusResponse{Status = "success"});
+        }
+        
+        [HttpGet("/2018-06-01/runtime/invocation/next")]
+        public async Task GetNextInvocation()
+        {
+            IEventContainer activeEvent;
+            while (!_runtimeApiDataStore.TryActivateEvent(out activeEvent))
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+            }
+
+            Console.WriteLine(HEADER_BREAK);
+            Console.WriteLine($"Next invocation returned: {activeEvent.AwsRequestId}");
+            
+            Response.Headers["Lambda-Runtime-Aws-Request-Id"] = activeEvent.AwsRequestId;
+            Response.Headers["Lambda-Runtime-Trace-Id"] = Guid.NewGuid().ToString();
+            Response.Headers["Lambda-Runtime-Invoked-Function-Arn"] = activeEvent.FunctionArn;
+            Response.StatusCode = 200;
+
+            if (activeEvent.EventJson?.Length != 0)
+            {
+                // The event is written directly to the response stream to avoid ASP.NET Core attempting any
+                // encoding on content passed in the Ok() method.
+                Response.Headers["Content-Type"] = "application/json";
+                var buffer = UTF8Encoding.UTF8.GetBytes(activeEvent.EventJson);
+                await Response.Body.WriteAsync(buffer, 0, buffer.Length);
+                Response.Body.Close();
+            }
+        }
+        
+        [HttpPost("/2018-06-01/runtime/invocation/{awsRequestId}/response")]
+        public async Task<IActionResult> PostInvocationResponse(string awsRequestId)
+        {
+            using var reader = new StreamReader(Request.Body);
+            var response = await reader.ReadToEndAsync();
+            
+            _runtimeApiDataStore.ReportSuccess(awsRequestId, response);
+            
+            Console.WriteLine(HEADER_BREAK);
+            Console.WriteLine($"Response for request {awsRequestId}");
+            Console.WriteLine(response);
+
+            return Accepted(new StatusResponse{Status = "success"});
+        }
+
+        [HttpPost("/2018-06-01/runtime/invocation/{awsRequestId}/error")]
+        public async Task<IActionResult> PostError(string awsRequestId, [FromHeader(Name = "Lambda-Runtime-Function-Error-Type")] string errorType)
+        {
+            using var reader = new StreamReader(Request.Body);
+            var errorBody = await reader.ReadToEndAsync();
+            
+            _runtimeApiDataStore.ReportError(awsRequestId, errorType, errorBody);
+            await Console.Error.WriteLineAsync(HEADER_BREAK);
+            await Console.Error.WriteLineAsync($"Request {awsRequestId} Error Type: {errorType}");
+            await Console.Error.WriteLineAsync(errorBody);
+            
+            return Accepted(new StatusResponse{Status = "success"});
+        }
+    }
+    
+    internal class StatusResponse
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("status")]
+        public string Status { get; set; }
+    }
+#endif
+}

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Controllers/RuntimeApiController.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Controllers/RuntimeApiController.cs
@@ -34,7 +34,7 @@ namespace Amazon.Lambda.TestTool.BlazorTester.Controllers
         {
             Console.Error.WriteLine("Init Error Type: " + errorType);
             Console.Error.WriteLine(error);
-            Console.Error.WriteLine("-----------------------------------");
+            Console.Error.WriteLine(HEADER_BREAK);
             return Accepted(new StatusResponse{Status = "success"});
         }
         

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Documentation.razor
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Documentation.razor
@@ -1,4 +1,6 @@
 @page "/documentation"
+@using Microsoft.AspNetCore.Http;
+@inject IHttpContextAccessor httpContextAccessor;
 
 <h1 style="padding: 15px">@Constants.PRODUCT_NAME</h1>
 <hr />
@@ -16,6 +18,44 @@
     The easiest way to use this tool is with Visual Studio and the <a href="@Constants.LINK_VS_TOOLKIT_MARKETPLACE" target="_blank">AWS Toolkit for Visual Studio</a>
     which will automatically configure this tool when a .NET Core Lambda project is opened in Visual Studio. For how to setup this tool for other IDE like Visual Studio for Code or Rider from JetBrains check
     click <a href="@Constants.LINK_GITHUB_TEST_TOOL_INSTALL_AND_RUN" target="_blank">here.</a>
+</p>
+
+<h2>Test Executable Assembly Functions</h2>
+<p>
+    .NET Lambda functions can be written as an executable assembly. This is done for Lambda functions using custom runtime or using .NET top level statements. These functions include the 
+    Lambda runtime client implemented in the Amazon.Lambda.RuntimeSupport NuGet package. In an executable assembly function the Lambda runtime client is initialized and connects to a 
+    local REST endpoint for Lambda events to process.
+</p>
+<p>
+    The <b>Executable Assembly</b> page in this tool hosts a local Lambda runtime API for the Lambda runtime client to connect to. On this page you can queue events for the Lambda 
+    function to process.
+</p>
+<h4>Connect Executable Assembly Functions</h4>
+<p>
+    To test Lambda function built as an executable assembly the environment variable <b>AWS_LAMBDA_RUNTIME_API</b> must be set to 
+    <b>localhost:@httpContextAccessor.HttpContext.Connection.LocalPort</b>. This will tell Amazon.Lambda.RuntimeSupport to connect to this instance of the test tool for Lambda
+    events to process. To configure AWS credentials and region for the function the environment variables <b>AWS_PROFILE</b> and <b>AWS_REGION</b> can be set. 
+</p>
+<p>
+    Here is an example of a .NET executable assembly Lambda function's <i>launchSettings.json</i> file used in Visual Studio for debugging that connects to the test tool and 
+    sets the profile and region.
+    <pre>
+{
+  "profiles": {
+    "Lambda Runtime API": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "AWS_LAMBDA_RUNTIME_API": "localhost:5050"
+        "AWS_PROFILE": "test-profile"
+        "AWS_REGION": "us-west-2"
+      }
+    }
+  }
+}
+    </pre>
+<h4>Programmatically Queue Events</h4>
+To queue an event to be processed without using the UI send a <b>POST</b> request to <b>http://localhost:@httpContextAccessor.HttpContext.Connection.LocalPort/runtime/test-event</b> with the 
+JSON Lambda event document as the POST request's body.
 </p>
 
 <h2>Frequently Asked Questions</h2>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Index.razor
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Index.razor
@@ -12,6 +12,10 @@
     Run .NET Lambda function code inside this tool. IDEs can attach their debuggers to this tool and step through 
     the Lambda code.
 </p>
+<p>
+    If you are developing .NET Lambda function using <b>custom runtimes</b> or C# <b>top level statements</b> that use the <b>Amazon.Lambda.RuntimeSupport</b> NuGet package the 
+    <a href="/runtime">Executable Assembly</a> page should be used to test the function.
+</p>
 
 <FunctionPickerComponent @ref="FunctionPicker" />
 
@@ -83,11 +87,9 @@
 
 @code {
 
-    const string ResponseSuccessStyle = "white-space: pre-wrap; height: min-content; font-size: 75%; color: black";
-    const string ResponseErrorStyle = "white-space: pre-wrap; height: min-content; font-size: 75%; color: red";
 
     string ResultsPanelStyle { get; set; } = "display: none;";
-    string FunctionResponseStyle { get; set; } = ResponseSuccessStyle;
+    string FunctionResponseStyle { get; set; } = Constants.ResponseSuccessStyle;
 
     FunctionPickerComponent FunctionPicker { get; set; }
 
@@ -177,12 +179,12 @@
         if (response.IsSuccess)
         {
             this.FunctionResponse = response.Response;
-            this.FunctionResponseStyle = ResponseSuccessStyle;
+            this.FunctionResponseStyle = Constants.ResponseSuccessStyle;
         }
         else
         {
             this.FunctionResponse = response.Error;
-            this.FunctionResponseStyle = ResponseErrorStyle;
+            this.FunctionResponseStyle = Constants.ResponseErrorStyle;
         }
 
 

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Runtime.razor
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Runtime.razor
@@ -1,0 +1,297 @@
+@page "/runtime"
+
+@using Amazon.Lambda.TestTool.BlazorTester.Services
+@using Amazon.Lambda.TestTool.SampleRequests;
+@using Microsoft.AspNetCore.Http;
+
+@inject IHttpContextAccessor httpContextAccessor;
+@inject LocalLambdaOptions LambdaOptions
+@inject IRuntimeApiDataStore RuntimeApiModel
+@inject IModalService Modal
+
+<h2>Test Executable Assembly</h2>
+
+<p>
+    For Lambda functions written as executable assemblies, i.e. custom runtimes functions and top level statement functions, this page can be used for testing the functions locally. 
+    Set the <b>AWS_LAMBDA_RUNTIME_API</b> environment variable to <b>localhost:@httpContextAccessor.HttpContext.Connection.LocalPort</b> while debugging executable assembly 
+    Lambda function. More information can be found in the <a href="documentation">documentation</a>.
+</p>
+
+<div class="row">
+    <div class="col-sm-6">
+        <h3>Queue Event:</h3>
+        <label class="" for="sample-requests">Example Requests:</label>
+        <select class="control" id="sample-requests" @bind="SelectedSampleRequestName">
+            <option id="@NO_SAMPLE_SELECTED_ID"> -- select a request -- </option>
+            @if (@SampleRequests.ContainsKey(SampleRequestManager.SAVED_REQUEST_GROUP))
+            {
+                <optgroup id="saved-select-request-group" label="@SampleRequestManager.SAVED_REQUEST_GROUP">
+                    @foreach (var request in SampleRequests[SampleRequestManager.SAVED_REQUEST_GROUP])
+                    {
+                        <option value="@request.Filename">@request.Name</option>
+                    }
+                </optgroup>
+            }
+            @foreach (var group in SampleRequests.Keys)
+            {
+                @if (!string.Equals(group, SampleRequestManager.SAVED_REQUEST_GROUP))
+                {
+                    <optgroup label="@group">
+                        @foreach (var request in SampleRequests[group])
+                        {
+                            <option value="@request.Filename">@request.Name</option>
+                        }
+                    </optgroup>
+                }
+            }
+        </select>
+        <label class="col-xs-3 control-label" for="function-payload">Function Input:</label>
+        <textarea class="form-control" style="margin: 5px" rows="20" @bind="FunctionInput" placeholder="JSON document as input to Lambda Function. Plain strings must be wrapped in quotes."></textarea>
+        <div class="col-sm form-group">
+            <button class="btn btn-primary btn-sm" @onclick="OnAddEventClick">Queue Event</button>
+        </div>
+    </div>
+    <div class="col-sm-6">
+        <h3>Active Event:</h3>
+        @if (RuntimeApiModel.ActiveEvent == null)
+        {
+            <h2>No active event</h2>
+        }
+        else
+        {
+                  <div>
+                      <div style="cursor: pointer" @onclick="() => OnRequeue(RuntimeApiModel.ActiveEvent.AwsRequestId)">
+                            @((MarkupString)REBOOT_ICON)
+                      </div>
+                      <p><b>Request ID:</b> @RuntimeApiModel.ActiveEvent.AwsRequestId</p>
+                      <p><b>Status:</b> <span style="@GetStatusStyle(RuntimeApiModel.ActiveEvent.EventStatus)">@RuntimeApiModel.ActiveEvent.EventStatus</span></p>
+                      <p><b>Last Updated:</b> @RuntimeApiModel.ActiveEvent.LastUpdated</p>
+                      <p><b>Event JSON:</b><span class="event-value"><span class="fake-link" @onclick="() => ShowEventJson(RuntimeApiModel.ActiveEvent)">@CreateSnippet(RuntimeApiModel.ActiveEvent.EventJson)</span></span></p>
+                      @if (RuntimeApiModel.ActiveEvent.EventStatus == IEventContainer.Status.Failure)
+                      {
+                          <p><b>Error Type:</b> @RuntimeApiModel.ActiveEvent.ErrorType</p>
+                          <p>
+                              <b>Error Response:</b>
+                              <pre class="form-control" style="@Constants.ResponseErrorStyleSizeConstraint" >@RuntimeApiModel.ActiveEvent.ErrorResponse</pre>
+                          </p>
+                      }
+                      else
+                      {
+                          <p>
+                              <b>Response:</b>
+                              <pre class="form-control" style="@Constants.ResponseSuccessStyleSizeConstraint">@Amazon.Lambda.TestTool.Utils.PrettyPrintJson(RuntimeApiModel.ActiveEvent.Response)</pre>
+                          </p>
+                      }
+                  </div>
+        }
+    </div>
+</div>
+
+
+<div class="row">
+    <div class="col-sm-6">
+        <h3>Queued Events: <button class="btn btn-secondary btn-sm" @onclick="OnClearQueued">Clear</button></h3>
+        <div class="col-xs-5 event-list">
+            @foreach (var evnt in @RuntimeApiModel.QueuedEvents)
+            {
+                <div class="event-list-item">
+                    <div class="row" style="padding: 2px">
+                        <div class="col-sm-11 row">
+                            <div class="event-label">Request ID:</div><div class="event-value"> @evnt.AwsRequestId</div>
+                            <div class="event-label">Last Updated:</div><div class="event-value">@evnt.LastUpdated</div>
+                        </div>
+                        <div class="col-sm-1 " style="cursor: pointer" @onclick="() => OnDeleteEvent(evnt.AwsRequestId)">
+                            @((MarkupString)CLOSE_ICON)
+                        </div>
+                    </div>
+                    <div class="row" style="padding: 2px">
+                        <div class="event-label">Event JSON:</div><div class="event-value"><span class="fake-link" @onclick="() => ShowEventJson(evnt)">@CreateSnippet(evnt.EventJson)</span></div>
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
+    <div class="col-sm-6">
+        <h3>Executed Events: <button class="btn btn-secondary btn-sm" @onclick="OnClearExecuted">Clear</button></h3>
+        <div class="col-xs-5 event-list">
+            @foreach (var evnt in @RuntimeApiModel.ExecutedEvents.OrderByDescending(x => x.LastUpdated))
+            {
+                <div class="event-list-item">
+                    <div class="row" style="padding: 2px">
+                        <div class="col-sm-1 " style="cursor: pointer" @onclick="() => OnRequeue(evnt.AwsRequestId)">
+                            @((MarkupString)REBOOT_ICON)
+                        </div>
+                        <div class="col-sm-10 row">
+                            <div class="event-label">Request ID:</div><div class="event-value"> @evnt.AwsRequestId</div>
+                            <div class="event-label">Status:</div><div class="event-value" style="@GetStatusStyle(evnt.EventStatus)">@evnt.EventStatus</div>
+                            <div class="event-label">Last Updated:</div><div class="event-value">@evnt.LastUpdated</div>
+                        </div>
+                        <div class="col-sm-1 " style="cursor: pointer" @onclick="() => OnDeleteEvent(evnt.AwsRequestId)">
+                            @((MarkupString)CLOSE_ICON)
+                        </div>
+                    </div>
+                    <div class="row" style="padding: 2px">
+                        <div class="event-label">Event JSON:</div><div class="event-value"><span class="fake-link" @onclick="() => ShowEventJson(evnt)">@CreateSnippet(evnt.EventJson)</span></div>
+                    </div>
+                    @if(evnt.EventStatus == IEventContainer.Status.Success)
+                    {
+                    <div class="row" style="padding: 2px">
+                        <div class="event-label">Response: </div><div class="event-value"><span class="fake-link" @onclick="() => ShowResponse(evnt)">@CreateSnippet(evnt.Response)</span></div>
+                    </div>
+                    }
+                    else if(evnt.EventStatus == IEventContainer.Status.Failure)
+                    {
+                    <div class="row" style="padding: 2px">
+                        <div class="event-label">Error Type:</div><div class="event-value">@evnt.ErrorType</div>
+                    </div>
+                    <div class="row" style="padding: 2px">
+                        <div class="event-label">Error Response: </div><div class="event-value"><span class="fake-link" @onclick="() => ShowError(evnt)">@CreateSnippet(evnt.ErrorResponse)</span></div>
+                    </div>
+                    }
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+
+
+
+@code {
+    private const string REBOOT_ICON = @"
+<svg xmlns=""http://www.w3.org/2000/svg"" width=""16"" height=""16"" fill=""currentColor"" class=""bi bi-bootstrap-reboot"" viewBox=""0 0 16 16"">
+    <path d=""M1.161 8a6.84 6.84 0 1 0 6.842-6.84.58.58 0 1 1 0-1.16 8 8 0 1 1-6.556 3.412l-.663-.577a.58.58 0 0 1 .227-.997l2.52-.69a.58.58 0 0 1 .728.633l-.332 2.592a.58.58 0 0 1-.956.364l-.643-.56A6.812 6.812 0 0 0 1.16 8z""/>
+</svg>
+";
+
+    private const string CLOSE_ICON = @"
+<svg xmlns=""http://www.w3.org/2000/svg"" width=""16"" height=""16"" fill=""currentColor"" class=""bi bi-x"" viewBox=""0 0 16 16"">
+  <path d=""M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z""/>
+</svg>
+";
+
+    private const string NO_SAMPLE_SELECTED_ID = "void-select-request";
+
+    private string FunctionInput { get; set; }
+
+    private IDictionary<string, IList<LambdaRequest>> SampleRequests { get; set; }
+
+    string _selectedSampleRequestName;
+    string SelectedSampleRequestName
+    {
+        get => this._selectedSampleRequestName;
+        set
+        {
+            this._selectedSampleRequestName = value;
+            if(!string.Equals(value, NO_SAMPLE_SELECTED_ID))
+            {
+                this.FunctionInput = SampleRequestManager.GetRequest(this._selectedSampleRequestName);
+            }
+            this.StateHasChanged();
+        }
+    }
+
+    SampleRequestManager SampleRequestManager { get; set; }
+
+    protected override void OnInitialized()
+    {
+        RuntimeApiModel.StateChange += RuntimeApiModelOnStateChange;
+        this.SampleRequestManager = new SampleRequestManager(LambdaOptions.GetPreferenceDirectory(false));
+        this.SampleRequests = SampleRequestManager.GetSampleRequests();
+    }
+
+    private void RuntimeApiModelOnStateChange(object sender, EventArgs e)
+    {
+        this.InvokeAsync(this.StateHasChanged);
+    }
+
+    void OnAddEventClick()
+    {
+        RuntimeApiModel.QueueEvent(this.FunctionInput);
+        this.FunctionInput = "";
+        this.SelectedSampleRequestName = NO_SAMPLE_SELECTED_ID;
+        this.StateHasChanged();
+    }
+
+    void OnClearQueued()
+    {
+        this.RuntimeApiModel.ClearQueued();
+        this.StateHasChanged();
+    }
+
+    void OnClearExecuted()
+    {
+        this.RuntimeApiModel.ClearExecuted();
+        this.StateHasChanged();
+    }
+
+    void OnRequeue(string awsRequestId)
+    {
+        IEventContainer evnt = null;
+        if(string.Equals(this.RuntimeApiModel.ActiveEvent?.AwsRequestId, awsRequestId))
+        {
+            evnt = this.RuntimeApiModel.ActiveEvent;
+        }
+        else
+        {
+            evnt = this.RuntimeApiModel.ExecutedEvents.FirstOrDefault(x => string.Equals(x.AwsRequestId, awsRequestId));
+        }
+
+        if (evnt == null)
+            return;
+
+        this.RuntimeApiModel.QueueEvent(evnt.EventJson);
+        this.StateHasChanged();
+    }
+
+    void OnDeleteEvent(string awsRequestId)
+    {
+        this.RuntimeApiModel.DeleteEvent(awsRequestId);
+        this.StateHasChanged();
+    }
+
+    string GetStatusStyle(IEventContainer.Status status) => status switch
+    {
+        IEventContainer.Status.Success => "color:green",
+        IEventContainer.Status.Failure => "color:red",
+        _ => "color:black"
+    };
+
+    string CreateSnippet(string fullString)
+    {
+        const int maxLength = 50;
+        string trim;
+        if (fullString?.Length < maxLength)
+        {
+            trim = fullString;
+        }
+        else
+        {
+            trim = fullString.Substring(0, maxLength);
+        }
+
+        return trim;
+    }
+
+    void ShowEventJson(IEventContainer evnt)
+    {
+        ShowExpandedText("Event JSON", evnt.EventJson);
+    }
+
+    void ShowResponse(IEventContainer evnt)
+    {
+        ShowExpandedText("Response", evnt.Response);
+    }
+
+    void ShowError(IEventContainer evnt)
+    {
+        ShowExpandedText("Error Response", evnt.ErrorResponse);
+    }
+
+    void ShowExpandedText(string title, string text)
+    {
+        var parameters = new ModalParameters();
+        parameters.Add(ExpandedTextDialog.PARAMETER_NAME_FULL_TEXT, text);
+        Modal.Show<ExpandedTextDialog>(title, parameters);
+    }
+}

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Runtime.razor
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Runtime.razor
@@ -14,7 +14,7 @@
 <p>
     For Lambda functions written as executable assemblies, i.e. custom runtimes functions and top level statement functions, this page can be used for testing the functions locally. 
     Set the <b>AWS_LAMBDA_RUNTIME_API</b> environment variable to <b>localhost:@httpContextAccessor.HttpContext.Connection.LocalPort</b> while debugging executable assembly 
-    Lambda function. More information can be found in the <a href="documentation">documentation</a>.
+    Lambda function. More information can be found in the <a href="/documentation">documentation</a>.
 </p>
 
 <div class="row">
@@ -79,7 +79,7 @@
                       {
                           <p>
                               <b>Response:</b>
-                              <pre class="form-control" style="@Constants.ResponseSuccessStyleSizeConstraint">@Amazon.Lambda.TestTool.Utils.PrettyPrintJson(RuntimeApiModel.ActiveEvent.Response)</pre>
+                              <pre class="form-control" style="@Constants.ResponseSuccessStyleSizeConstraint">@Amazon.Lambda.TestTool.Utils.TryPrettyPrintJson(RuntimeApiModel.ActiveEvent.Response)</pre>
                           </p>
                       }
                   </div>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Services/RuntimeApiDataStore.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Services/RuntimeApiDataStore.cs
@@ -97,7 +97,7 @@ namespace Amazon.Lambda.TestTool.BlazorTester.Services
                 Monitor.Enter(_lock);
                 try
                 {
-                    return new ReadOnlyCollection<EventContainer>(_queuedEvents); 
+                    return new ReadOnlyCollection<EventContainer>(_queuedEvents.ToArray()); 
                 }
                 finally
                 {
@@ -113,7 +113,7 @@ namespace Amazon.Lambda.TestTool.BlazorTester.Services
                 Monitor.Enter(_lock);
                 try
                 {
-                    return new ReadOnlyCollection<EventContainer>(_executedEvents);
+                    return new ReadOnlyCollection<EventContainer>(_executedEvents.ToArray());
                 }
                 finally
                 {

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Services/RuntimeApiDataStore.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Services/RuntimeApiDataStore.cs
@@ -1,0 +1,322 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+
+namespace Amazon.Lambda.TestTool.BlazorTester.Services
+{
+    public interface IRuntimeApiDataStore
+    {
+        EventContainer QueueEvent(string eventBody);
+        
+        IReadOnlyList<IEventContainer> QueuedEvents { get; }
+        
+        IReadOnlyList<IEventContainer> ExecutedEvents { get; }
+
+        void ClearQueued();
+
+        void ClearExecuted();
+
+        void DeleteEvent(string awsRequestId);
+
+
+        IEventContainer ActiveEvent { get; }
+
+        event EventHandler StateChange;
+
+        bool TryActivateEvent(out IEventContainer activeEvent);
+
+        void ReportSuccess(string awsRequestId, string response);
+        void ReportError(string awsRequestId, string errorType, string errorBody);
+    }
+
+    public class RuntimeApiDataStore : IRuntimeApiDataStore
+    {
+        private IList<EventContainer> _queuedEvents = new List<EventContainer>();
+        private IList<EventContainer> _executedEvents = new List<EventContainer>();
+        private int _eventCounter = 1;
+        private object _lock = new object();
+        
+        public event EventHandler StateChange;
+        
+        public EventContainer QueueEvent(string eventBody)
+        {
+            var evnt = new EventContainer(this, _eventCounter++, eventBody);
+            Monitor.Enter(_lock);
+            try
+            {
+                _queuedEvents.Add(evnt);
+                Monitor.PulseAll(_lock);
+            }
+            finally
+            {
+                Monitor.Exit(_lock);
+            }
+            
+            RaiseStateChanged();
+            return evnt;
+        }
+
+        public bool TryActivateEvent(out IEventContainer activeEvent)
+        {
+            activeEvent = null;
+            Monitor.Enter(_lock);
+            try
+            {
+                if (!_queuedEvents.Any())
+                {
+                    return false;
+                }
+
+                var evnt = _queuedEvents[0];
+                _queuedEvents.RemoveAt(0);
+                evnt.EventStatus = IEventContainer.Status.Executing;
+                if (ActiveEvent != null)
+                {
+                    _executedEvents.Add(ActiveEvent as EventContainer);
+                }
+                ActiveEvent = evnt;
+                activeEvent = ActiveEvent;
+                RaiseStateChanged();
+                Monitor.PulseAll(_lock);
+                return true;
+            }
+            finally
+            {
+                Monitor.Exit(_lock);
+            }
+        }
+        
+        public IEventContainer ActiveEvent { get; private set; }
+
+        public IReadOnlyList<IEventContainer> QueuedEvents
+        {
+            get
+            {
+                Monitor.Enter(_lock);
+                try
+                {
+                    return new ReadOnlyCollection<EventContainer>(_queuedEvents); 
+                }
+                finally
+                {
+                    Monitor.Exit(_lock);
+                }
+            }
+        }
+
+        public IReadOnlyList<IEventContainer> ExecutedEvents
+        {
+            get
+            {
+                Monitor.Enter(_lock);
+                try
+                {
+                    return new ReadOnlyCollection<EventContainer>(_executedEvents);
+                }
+                finally
+                {
+                    Monitor.Exit(_lock);
+                }
+            }
+        }
+
+        public void ReportSuccess(string awsRequestId, string response)
+        {
+            Monitor.Enter(_lock);
+            try
+            {
+                var evnt = FindEventContainer(awsRequestId);
+                if (evnt == null)
+                {
+                    return;
+                }
+                
+                evnt.ReportSuccessResponse(response);
+                RaiseStateChanged();
+                Monitor.PulseAll(_lock);
+            }
+            finally
+            {
+                Monitor.Exit(_lock);
+            }
+        }
+        
+        public void ReportError(string awsRequestId, string errorType, string errorBody)
+        {
+            Monitor.Enter(_lock);
+            try
+            {
+                var evnt = FindEventContainer(awsRequestId);
+                if (evnt == null)
+                {
+                    return;
+                }
+                
+                evnt.ReportErrorResponse(errorType, errorBody);
+                RaiseStateChanged();
+                Monitor.PulseAll(_lock);
+            }
+            finally
+            {
+                Monitor.Exit(_lock);
+            }
+        }
+
+        public void ClearQueued()
+        {
+            Monitor.Enter(_lock);
+            try
+            {
+                this._queuedEvents.Clear();
+                RaiseStateChanged();
+                Monitor.PulseAll(_lock);
+            }
+            finally
+            {
+                Monitor.Exit(_lock);
+            }
+        }
+
+        public void ClearExecuted()
+        {
+            Monitor.Enter(_lock);
+            try
+            {
+                this._executedEvents.Clear();
+                RaiseStateChanged();
+                Monitor.PulseAll(_lock);
+            }
+            finally
+            {
+                Monitor.Exit(_lock);
+            }
+        }
+
+        public void DeleteEvent(string awsRequestId)
+        {
+            Monitor.Enter(_lock);
+            try
+            {
+                var executedEvent = this._executedEvents.FirstOrDefault(x => string.Equals(x.AwsRequestId, awsRequestId));
+                if (executedEvent != null)
+                {
+                    this._executedEvents.Remove(executedEvent);
+                }
+                else
+                {
+                    executedEvent = this._queuedEvents.FirstOrDefault(x => string.Equals(x.AwsRequestId, awsRequestId));
+                    if (executedEvent != null)
+                    {
+                        this._queuedEvents.Remove(executedEvent);
+                    }
+                }
+                RaiseStateChanged();
+                Monitor.PulseAll(_lock);
+            }
+            finally
+            {
+                Monitor.Exit(_lock);
+            }
+        }
+
+        private EventContainer FindEventContainer(string awsRequestId)
+        {
+            if (string.Equals(this.ActiveEvent?.AwsRequestId, awsRequestId))
+            {
+                return this.ActiveEvent as EventContainer;
+            }
+
+            var evnt = _executedEvents.FirstOrDefault(x => string.Equals(x.AwsRequestId, awsRequestId)) as EventContainer;
+            if (evnt != null)
+            {
+                return evnt;
+            }
+
+            evnt = _queuedEvents.FirstOrDefault(x => string.Equals(x.AwsRequestId, awsRequestId)) as EventContainer;
+
+            return evnt;
+        }
+
+        internal void RaiseStateChanged()
+        {
+            var handler = StateChange;
+            handler?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    public interface IEventContainer
+    {
+        public enum Status {Queued, Executing, Success, Failure}
+        
+        string AwsRequestId { get; }
+        string EventJson { get; }
+        string ErrorResponse { get; }
+        string ErrorType { get; }
+        
+        string Response { get; }
+        Status EventStatus { get; }
+        
+        string FunctionArn { get; }
+        
+        DateTime LastUpdated { get; }
+    }
+
+    public class EventContainer : IEventContainer
+    {
+        
+        private const string defaultFunctionArn = "arn:aws:lambda:us-west-2:123412341234:function:Function";
+        public string AwsRequestId { get; }
+        public string EventJson { get; }
+        public string ErrorResponse { get; private set; }
+        
+        public string ErrorType { get; private set; }
+        
+        public string Response { get; private set; }
+        
+        public DateTime LastUpdated { get; private set; }
+
+        private IEventContainer.Status _status = IEventContainer.Status.Queued;
+        public IEventContainer.Status EventStatus
+        {
+            get => _status;
+            set
+            {
+                _status = value;
+                LastUpdated = DateTime.Now;
+            }
+        }
+
+        private readonly RuntimeApiDataStore _dataStore;
+        public EventContainer(RuntimeApiDataStore dataStore, int eventCount, string eventJson)
+        {
+            LastUpdated = DateTime.Now;
+            this._dataStore = dataStore;
+            this.AwsRequestId = eventCount.ToString("D12");
+            this.EventJson = eventJson;
+        }
+
+        public string FunctionArn
+        {
+            get => defaultFunctionArn;
+        }
+
+        public void ReportSuccessResponse(string response)
+        {
+            LastUpdated = DateTime.Now;
+            this.Response = response;
+            this.EventStatus = IEventContainer.Status.Success;
+            _dataStore.RaiseStateChanged();
+        }
+        
+        public void ReportErrorResponse(string errorType, string errorBody)
+        {
+            LastUpdated = DateTime.Now;
+            this.ErrorType = errorType;
+            this.ErrorResponse = errorBody;
+            this.EventStatus = IEventContainer.Status.Failure;
+            _dataStore.RaiseStateChanged();
+        }
+    }
+}

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Shared/NavMenu.razor
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Shared/NavMenu.razor
@@ -4,6 +4,12 @@
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
                 <span class="oi oi-media-play" aria-hidden="true"></span> Test Function
             </NavLink>
+@if(Utils.IsExecutableAssembliesSupported)
+{
+            <NavLink class="nav-link" href="runtime" Match="NavLinkMatch.All">
+                <span class="oi oi-loop-square" aria-hidden="true"></span> Executable Assembly
+            </NavLink>            
+}
             <NavLink class="nav-link" href="monitor-dlq" Match="NavLinkMatch.All">
                 <span class="oi oi-list" aria-hidden="true"></span> Dead Letter Queue
             </NavLink>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/wwwroot/css/site.css
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/wwwroot/css/site.css
@@ -36,16 +36,16 @@ app {
     flex: 1;
 }
 
-    .main .top-row {
-        background-color: #f7f7f7;
-        border-bottom: 1px solid #d6d5d5;
-        justify-content: flex-end;
-    }
+.main .top-row {
+    background-color: #f7f7f7;
+    border-bottom: 1px solid #d6d5d5;
+    justify-content: flex-end;
+}
 
-        .main .top-row > a, .main .top-row .btn-link {
-            white-space: nowrap;
-            margin-left: 1.5rem;
-        }
+.main .top-row > a, .main .top-row .btn-link {
+    white-space: nowrap;
+    margin-left: 1.5rem;
+}
 
 .main .top-row a:first-child {
     overflow: hidden;
@@ -247,4 +247,34 @@ app {
 
 .faq-answer {
     
+}
+
+.event-list-item {
+    /* Add shadows to create the "card" effect */
+    box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
+    transition: 0.3s;
+    padding: 5px 16px;
+    margin-bottom: 10px;
+    font-size: 0.875em;
+}
+
+    /* On mouse-over, add a deeper shadow */
+    .event-list-item:hover {
+        box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2);
+    }
+
+.event-label {
+    margin: 5px;
+    font-weight: bold
+}
+
+.event-value {
+    margin: 5px;
+}
+
+.event-list {
+    border-style: double;
+    padding: 2px;
+    overflow-y: scroll;
+    height: 400px;
 }

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Utils.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Utils.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.Json;
 
 namespace Amazon.Lambda.TestTool
 {
@@ -176,6 +177,35 @@ namespace Amazon.Lambda.TestTool
             }
 
             Console.WriteLine(sb.ToString());
+        }
+
+        public static string PrettyPrintJson(string json)
+        {
+            try
+            {
+                var doc = JsonDocument.Parse(json);
+                var prettyPrintJson = System.Text.Json.JsonSerializer.Serialize(doc, new JsonSerializerOptions()
+                {
+                    WriteIndented = true
+                });
+                return prettyPrintJson;
+            }
+            catch (Exception)
+            {
+                return json;
+            }
+        }
+
+        public static bool IsExecutableAssembliesSupported
+        {
+            get
+            {
+#if NET6_0_OR_GREATER
+                return true;
+#else
+                return false;
+#endif
+            }
         }
     }
 }

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Utils.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Utils.cs
@@ -179,11 +179,16 @@ namespace Amazon.Lambda.TestTool
             Console.WriteLine(sb.ToString());
         }
 
-        public static string PrettyPrintJson(string json)
+        /// <summary>
+        /// Attempt to pretty print the input string. If pretty print fails return back the input string in its original form.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        public static string TryPrettyPrintJson(string data)
         {
             try
             {
-                var doc = JsonDocument.Parse(json);
+                var doc = JsonDocument.Parse(data);
                 var prettyPrintJson = System.Text.Json.JsonSerializer.Serialize(doc, new JsonSerializerOptions()
                 {
                     WriteIndented = true
@@ -192,7 +197,7 @@ namespace Amazon.Lambda.TestTool
             }
             catch (Exception)
             {
-                return json;
+                return data;
             }
         }
 

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.BlazorTester.Tests/Amazon.Lambda.TestTool.BlazorTester.Tests.csproj
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.BlazorTester.Tests/Amazon.Lambda.TestTool.BlazorTester.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Amazon.Lambda.TestTool.BlazorTester\Amazon.Lambda.TestTool.BlazorTester.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.BlazorTester.Tests/RuntimeApiControllerTests.cs
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.BlazorTester.Tests/RuntimeApiControllerTests.cs
@@ -1,0 +1,177 @@
+﻿using Amazon.Lambda.TestTool.BlazorTester.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace Amazon.Lambda.TestTool.BlazorTester.Tests
+{
+    public class RuntimeApiControllerTests
+    {
+        [Fact]
+        public async Task ExecuteEventSuccessfully()
+        {
+            using var session = await TestSession.CreateSessionAsync(10111);
+
+            using var queueResponse = await session.Client.SendAsync(new HttpRequestMessage
+            {
+                RequestUri = new Uri("/runtime/test-event", UriKind.Relative),
+                Method = HttpMethod.Post,
+                Content = new StringContent("\"raw data\"")
+            });
+            Assert.Equal(HttpStatusCode.Accepted, queueResponse.StatusCode);
+            Assert.Single(session.Store.QueuedEvents);
+
+            using var getNextInvokeResponse = await session.Client.SendAsync(new HttpRequestMessage
+            {
+                RequestUri = new Uri("/2018-06-01/runtime/invocation/next", UriKind.Relative),
+                Method = HttpMethod.Get,
+            });
+            Assert.Equal(HttpStatusCode.OK, getNextInvokeResponse.StatusCode);
+            Assert.Empty(session.Store.QueuedEvents);
+
+            var awsRequestId = getNextInvokeResponse.Headers.GetValues("Lambda-Runtime-Aws-Request-Id").FirstOrDefault();
+            Assert.Equal(session.Store.ActiveEvent.AwsRequestId, awsRequestId);
+
+            Assert.Single(getNextInvokeResponse.Headers.GetValues("Lambda-Runtime-Trace-Id"));
+            Assert.Single(getNextInvokeResponse.Headers.GetValues("Lambda-Runtime-Invoked-Function-Arn"));
+
+            var responseBody = await getNextInvokeResponse.Content.ReadAsStringAsync();
+            Assert.Equal("\"raw data\"", responseBody);
+
+            using var postSuccessResponse = await session.Client.SendAsync(new HttpRequestMessage
+            {
+                RequestUri = new Uri($"/2018-06-01/runtime/invocation/{awsRequestId}/response", UriKind.Relative),
+                Method = HttpMethod.Post,
+                Content = new StringContent("\"Everything is good here\"")
+            });
+            Assert.Equal(HttpStatusCode.Accepted, postSuccessResponse.StatusCode);
+            Assert.Equal(IEventContainer.Status.Success, session.Store.ActiveEvent.EventStatus);
+            Assert.Equal("\"Everything is good here\"", session.Store.ActiveEvent.Response);
+        }
+
+        [Fact]
+        public async Task ExecuteEventFailure()
+        {
+            using var session = await TestSession.CreateSessionAsync(10112);
+
+            using var queueResponse = await session.Client.SendAsync(new HttpRequestMessage
+            {
+                RequestUri = new Uri("/runtime/test-event", UriKind.Relative),
+                Method = HttpMethod.Post,
+                Content = new StringContent("\"this event will fail\"")
+            });
+            Assert.Equal(HttpStatusCode.Accepted, queueResponse.StatusCode);
+            Assert.Single(session.Store.QueuedEvents);
+
+            using var getNextInvokeResponse = await session.Client.SendAsync(new HttpRequestMessage
+            {
+                RequestUri = new Uri("/2018-06-01/runtime/invocation/next", UriKind.Relative),
+                Method = HttpMethod.Get,
+            });
+            Assert.Equal(HttpStatusCode.OK, getNextInvokeResponse.StatusCode);
+            Assert.Empty(session.Store.QueuedEvents);
+
+            var awsRequestId = getNextInvokeResponse.Headers.GetValues("Lambda-Runtime-Aws-Request-Id").FirstOrDefault();
+            Assert.Equal(session.Store.ActiveEvent.AwsRequestId, awsRequestId);
+
+            Assert.Single(getNextInvokeResponse.Headers.GetValues("Lambda-Runtime-Trace-Id"));
+            Assert.Single(getNextInvokeResponse.Headers.GetValues("Lambda-Runtime-Invoked-Function-Arn"));
+
+            var responseBody = await getNextInvokeResponse.Content.ReadAsStringAsync();
+            Assert.Equal("\"this event will fail\"", responseBody);
+
+            var postFailureRequest = new HttpRequestMessage
+            {
+                RequestUri = new Uri($"/2018-06-01/runtime/invocation/{awsRequestId}/error", UriKind.Relative),
+                Method = HttpMethod.Post,
+                Content = new StringContent("\"Big long exception stacktrace\"")
+            };
+            postFailureRequest.Headers.Add("Lambda-Runtime-Function-Error-Type", "Company.MyException");
+
+            using var postFailureResponse = await session.Client.SendAsync(postFailureRequest);
+            Assert.Equal(HttpStatusCode.Accepted, postFailureResponse.StatusCode);
+            Assert.Equal(IEventContainer.Status.Failure, session.Store.ActiveEvent.EventStatus);
+            Assert.Equal("Company.MyException", session.Store.ActiveEvent.ErrorType);
+            Assert.Equal("\"Big long exception stacktrace\"", session.Store.ActiveEvent.ErrorResponse);
+        }
+
+        [Fact]
+        public async Task InitError()
+        {
+            using var session = await TestSession.CreateSessionAsync(10113);
+
+            using var queueResponse = await session.Client.SendAsync(new HttpRequestMessage
+            {
+                RequestUri = new Uri("/2015-03-31/functions/function/invocations", UriKind.Relative),
+                Method = HttpMethod.Post,
+                Content = new StringContent("\"Failed to startup\"")
+            });
+            Assert.Equal(HttpStatusCode.Accepted, queueResponse.StatusCode);
+        }
+
+        public class TestSession : IDisposable
+        {
+            private bool disposedValue;
+
+            private CancellationTokenSource Source { get; set; }
+
+            private int Port { get; set; }
+
+            private IWebHost Host { get; set; }
+
+            public HttpClient Client { get; private set; }
+
+            public IRuntimeApiDataStore Store { get; private set; }
+
+            public static async Task<TestSession> CreateSessionAsync(int port)
+            {
+                var session = new TestSession()
+                {
+                    Port = port,
+                    Source = new CancellationTokenSource()
+                };
+
+                session.Host = await Startup.StartWebTesterAsync(new LocalLambdaOptions { Port = port }, false, session.Source.Token);
+
+                session.Client = new HttpClient()
+                {
+                    BaseAddress = new Uri("http://localhost:" + session.Port)
+                };
+
+                session.Store = session.Host.Services.GetService<IRuntimeApiDataStore>();
+
+                return session;
+            }
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (!disposedValue)
+                {
+                    if (disposing)
+                    {
+                        this.Client.Dispose();
+                        this.Source.Cancel();
+                        this.Host.StopAsync().GetAwaiter().GetResult();
+                    }
+
+                    disposedValue = true;
+                }
+            }
+
+            public void Dispose()
+            {
+                Dispose(disposing: true);
+                GC.SuppressFinalize(this);
+            }
+        }
+    }
+}

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.BlazorTester.Tests/RuntimeApiDataStoreTests.cs
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.BlazorTester.Tests/RuntimeApiDataStoreTests.cs
@@ -1,0 +1,153 @@
+using Amazon.Lambda.TestTool.BlazorTester.Services;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Amazon.Lambda.TestTool.BlazorTester.Tests
+{
+    public class RuntimeApiDataStoreTests
+    {
+        [Fact]
+        public void ActivateEvents()
+        {
+            var dataStore = new RuntimeApiDataStore();
+
+            IEventContainer evnt;
+            Assert.False(dataStore.TryActivateEvent(out evnt));
+            Assert.Empty(dataStore.QueuedEvents);
+
+            dataStore.QueueEvent("{}");
+            Assert.Single(dataStore.QueuedEvents);
+            Assert.Equal(IEventContainer.Status.Queued, dataStore.QueuedEvents[0].EventStatus);
+
+            Assert.True(dataStore.TryActivateEvent(out evnt));
+            Assert.Equal("{}", evnt.EventJson);
+            Assert.Equal(evnt, dataStore.ActiveEvent);
+            Assert.Equal(IEventContainer.Status.Executing, dataStore.ActiveEvent.EventStatus);
+            Assert.Equal("{}", dataStore.ActiveEvent.EventJson);
+        }
+
+        [Fact]
+        public void EnsureRequestIdsAreDifferent()
+        {
+            var dataStore = new RuntimeApiDataStore();
+            for(int i = 0; i< 10; i++)
+            {
+                dataStore.QueueEvent("{}");
+            }
+            Assert.Equal(10, dataStore.QueuedEvents.Count);
+
+            var requestIds = new HashSet<string>();
+            for(int i = 0;i < 10;i++)
+            {
+                Assert.True(dataStore.TryActivateEvent(out var evnt));
+                Assert.DoesNotContain(evnt.AwsRequestId, requestIds);
+                requestIds.Add(evnt.AwsRequestId);
+            }
+
+            // This is 9 because the 10th event is the active event.
+            Assert.Equal(9, dataStore.ExecutedEvents.Count);
+        }
+
+        [Fact]
+        public void ReportSuccess()
+        {
+            var dataStore = new RuntimeApiDataStore();
+            dataStore.QueueEvent("{}");
+            Assert.Equal(IEventContainer.Status.Queued, dataStore.QueuedEvents[0].EventStatus);
+
+            Assert.True(dataStore.TryActivateEvent(out var evnt));
+
+            dataStore.ReportSuccess(evnt.AwsRequestId, "\"Success\"");
+
+            Assert.Equal(IEventContainer.Status.Success, dataStore.ActiveEvent.EventStatus);
+            Assert.Equal("\"Success\"", dataStore.ActiveEvent.Response);
+        }
+
+        [Fact]
+        public void ReportError()
+        {
+            var dataStore = new RuntimeApiDataStore();
+            dataStore.QueueEvent("{}");
+            Assert.Equal(IEventContainer.Status.Queued, dataStore.QueuedEvents[0].EventStatus);
+
+            Assert.True(dataStore.TryActivateEvent(out var evnt));
+
+            dataStore.ReportError(evnt.AwsRequestId, "BadError", "\"YouFail\"");
+
+            Assert.Equal(IEventContainer.Status.Failure, dataStore.ActiveEvent.EventStatus);
+            Assert.Equal("BadError", dataStore.ActiveEvent.ErrorType);
+            Assert.Equal("\"YouFail\"", dataStore.ActiveEvent.ErrorResponse);
+        }
+
+        [Fact]
+        public void ClearQueue()
+        {
+            var dataStore = new RuntimeApiDataStore();
+            for (int i = 0; i < 10; i++)
+            {
+                dataStore.QueueEvent("{}");
+            }
+            Assert.Equal(10, dataStore.QueuedEvents.Count);
+
+            dataStore.ClearQueued();
+            Assert.Empty(dataStore.QueuedEvents);
+        }
+
+        [Fact]
+        public void ClearExecuted()
+        {
+            var dataStore = new RuntimeApiDataStore();
+            for (int i = 0; i < 10; i++)
+            {
+                dataStore.QueueEvent("{}");
+            }
+            Assert.Equal(10, dataStore.QueuedEvents.Count);
+
+            for (int i = 0; i < 10; i++)
+            {
+                Assert.True(dataStore.TryActivateEvent(out _));
+            }
+
+            // This is 9 because the 10th event is the active event.
+            Assert.Equal(9, dataStore.ExecutedEvents.Count);
+            dataStore.ClearExecuted();
+            Assert.Empty(dataStore.ExecutedEvents);
+        }
+
+        [Fact]
+        public void DeleteEvent()
+        {
+            var dataStore = new RuntimeApiDataStore();
+            for (int i = 0; i < 10; i++)
+            {
+                dataStore.QueueEvent("{}");
+            }
+
+            for (int i = 0; i < 5; i++)
+            {
+                Assert.True(dataStore.TryActivateEvent(out _));
+            }
+
+            Assert.Equal(5, dataStore.QueuedEvents.Count);
+            Assert.Equal(4, dataStore.ExecutedEvents.Count);
+
+            var deletedQueueEvent = dataStore.QueuedEvents[1];
+            dataStore.DeleteEvent(deletedQueueEvent.AwsRequestId);
+
+            Assert.Equal(4, dataStore.QueuedEvents.Count);
+            Assert.Equal(4, dataStore.ExecutedEvents.Count);
+            Assert.Null(dataStore.QueuedEvents.FirstOrDefault(x => string.Equals(x.AwsRequestId, deletedQueueEvent.AwsRequestId)));
+
+            var deletedExecutedEvent = dataStore.ExecutedEvents[1];
+            dataStore.DeleteEvent(deletedExecutedEvent.AwsRequestId);
+            Assert.Equal(4, dataStore.QueuedEvents.Count);
+            Assert.Equal(3, dataStore.ExecutedEvents.Count);
+            Assert.Null(dataStore.ExecutedEvents.FirstOrDefault(x => string.Equals(x.AwsRequestId, deletedExecutedEvent.AwsRequestId)));
+
+            dataStore.DeleteEvent("does-not-exist");
+            Assert.Equal(4, dataStore.QueuedEvents.Count);
+            Assert.Equal(3, dataStore.ExecutedEvents.Count);
+        }
+    }
+}


### PR DESCRIPTION
*Description of changes:*

## What is an executable assembly?
.NET Lambda functions deployed using Custom Runtimes or in .NET 6 using Top Level statements are deployed as executable assemblies. That means the Lambda function handler string is not used by the Lambda runtime client to reflect on the method to call for each event. Instead the provided assembly is executed and during the startup of the assembly it initializes `Amazon.Lambda.RuntimeSupport` as the Lambda runtime client and indicates what method to call for each method. In this programming model the .NET Lambda Test Tool can not locally debug .NET Lambda functions in the test page.

## What is being changed?
To support .NET Lambda functions as executable assemblies the Test Tool will mock the Lambda Runtime API that the Lambda runtime client running in the executable assembly will connect to. Developers can locally launch their executable assemblies to point at the test tool. In the test tool itself users can queue events that will be sent the Lambda function via the Lambda Runtime API.

## Code changes summary:
There are 3 main code file changes
* **Controllers\RuntimeApiController** - Emulates the Lambda Runtime API as defined here https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html
* **Pages\Runtime.razor** - UI for queuing events that will dispatched through Controllers\RuntimeApiController and can view the status of events.
* **Services\RuntimeApiDataStore.cs** - Used as the datastore for events sharing information between the UI and the controller.

There was also a some rework for how the tool is started up to make it easier for unit testing.

## Walkthrough:

After launching the test tool navigate to the **Executable Assembly** page. On this page you can queue events to be processed.

![image](https://user-images.githubusercontent.com/1653751/151930101-b6172681-fdbe-4378-9d41-baf0a8ced9ec.png)

Here is an example of a .NET 6 Lambda function using top level statements. The `LambdaBootstrapBuilder` is used to create the Lambda runtime client which will reach out to the Lambda runtime API for events to process.

```csharp
using Amazon.Lambda.Core;
using Amazon.Lambda.RuntimeSupport;
using Amazon.Lambda.Serialization.SystemTextJson;

var handler = (string input, ILambdaContext context) =>
{
    return new Casing(input?.ToLower(), input?.ToUpper());
};

await LambdaBootstrapBuilder.Create<string, Casing>(handler, new DefaultLambdaJsonSerializer())
    .Build()
    .RunAsync();

public record Casing(string Lower, string Upper);
```

To have the Lambda function connect to the test tool's implementation of the Lambda Runtime API set the **AWS_LAMBDA_RUNTIME_API** environment variable to **localhost:<port-of-testtool>**. In Visual Studio this is done by editing the launchSettings.json file. Here is a full launchSettings.json example.
```
{
  "profiles": {
    "Runtime API": {
      "commandName": "Project",
      "environmentVariables": {
        "AWS_LAMBDA_RUNTIME_API": "localhost:5050"
      }
    }
  }
}
````

With the launchSettings.json file configured push **F5** in Visual Studio to debug the Lambda function and the events that we have queued up will start to be processed.

![image](https://user-images.githubusercontent.com/1653751/151931620-b35c2edd-eb12-42e7-b98c-9fafd6b42c40.png)

Here you can see one event was successfully processed and one event is was failed to processed. The links can be clicked to view the full text of the fields.

Note the Lambda function will still be running polling for events till it is forcibly shutdown. More events can be queued in the test tool and existing events can be requeued.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
