### PR TITLE
Fix bootstrap.sh passing empty runtimeconfig.json when there are no matching files

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/bootstrap.sh
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/bootstrap.sh
@@ -63,22 +63,28 @@ else
 
   DEPS_FILE="${LAMBDA_TASK_ROOT}/${ASSEMBLY_NAME}.deps.json"
   if ! [ -f "${DEPS_FILE}" ]; then
-    DEPS_FILES=("${LAMBDA_TASK_ROOT}"/*.deps.json)
-    if [ "${#DEPS_FILES[@]}" -ne 1 ]; then
+    DEPS_FILES=( "${LAMBDA_TASK_ROOT}"/*.deps.json )
+
+    # Check if there were any matches to the *.deps.json glob, and that the glob was resolved
+    # This makes the matching independent from the global `nullopt` shopt's value (https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html)
+    if [ "${#DEPS_FILES[@]}" -ne 1 ] || echo "${DEPS_FILES[0]}" | grep -q -F '*'; then
       echo "Error: .NET binaries for Lambda function are not correctly installed in the ${LAMBDA_TASK_ROOT} directory of the image when the image was built. The ${LAMBDA_TASK_ROOT} directory is missing the required .deps.json file." 1>&2
       exit 105
     fi
-    DEPS_FILE="${DEPS_FILES[1]}"
+    DEPS_FILE="${DEPS_FILES[0]}"
   fi
-  
+
   RUNTIMECONFIG_FILE="${LAMBDA_TASK_ROOT}/${ASSEMBLY_NAME}.runtimeconfig.json"
   if ! [ -f "${RUNTIMECONFIG_FILE}" ]; then
-    RUNTIMECONFIG_FILES=("${LAMBDA_TASK_ROOT}"/*.runtimeconfig.json)
-    if [ "${#RUNTIMECONFIG_FILES[@]}" -ne 1 ]; then
+    RUNTIMECONFIG_FILES=( "${LAMBDA_TASK_ROOT}"/*.runtimeconfig.json )
+
+    # Check if there were any matches to the *.runtimeconfig.json glob, and that the glob was resolved
+    # This makes the matching independent from the global `nullopt` shopt's value (https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html)
+    if [ "${#RUNTIMECONFIG_FILES[@]}" -ne 1 ] || echo "${RUNTIMECONFIG_FILES[0]}" | grep -q -F '*'; then
       echo "Error: .NET binaries for Lambda function are not correctly installed in the ${LAMBDA_TASK_ROOT} directory of the image when the image was built. The ${LAMBDA_TASK_ROOT} directory is missing the required .runtimeconfig.json file." 1>&2
       exit 106
     fi
-    RUNTIMECONFIG_FILE="${RUNTIMECONFIG_FILES[1]}"
+    RUNTIMECONFIG_FILE="${RUNTIMECONFIG_FILES[0]}"
   fi
 
   DOTNET_ARGS+=("--depsfile" "${DEPS_FILE}"


### PR DESCRIPTION
### What is the issue?

From a `dotnet:5.0` or `dotnet:6` Lambda base image, building a function image having no `*.runtimeconfig.json` file under `${LAMBDA_TASK_ROOT}` resulted in the `bootstrap.sh` falsely letting this through by not expanding the `*` glob and treating ` "${LAMBDA_TASK_ROOT}"/*.runtimeconfig.json` as a literal string in a one-element array.

This resulted in `--depsfile '' --runtimeconfig ''` being passed to the runtime interface client, failing further down with:
```
Amazon.Lambda.RuntimeSupport.ExceptionHandling.LambdaValidationException:   Could not find the specified handler assembly with the file name   'MyAssembly, Culture=neutral, PublicKeyToken=null'. The assembly should be located in the root of your uploaded .zip file.
```

### How are we fixing it?

We're now checking to ensure that the glob was expanded if the array of file matches contains 1 element.


### Testing

#### Before:


```
$ ./bootstrap.sh MyAssembly::Class::Handler
...
+ exec /var/lang/bin/dotnet exec --depsfile '' --runtimeconfig '' /var/runtime/Amazon.Lambda.RuntimeSupport.dll 
```

#### After:

1) No `*.deps.json`, no `*.runtimeconfig.json`

```
$ ./bootstrap.sh MyAssembly::Class::Handler
...
Error: .NET binaries for Lambda function are not correctly installed in the /var/task directory of the image when the image was built. The /var/task directory is missing the required .deps.json file.
```


2) With `blue.deps.json`, no `*.runtimeconfig.json`

```
$ ./bootstrap.sh MyAssembly::Class::Handler
...
Error: .NET binaries for Lambda function are not correctly installed in the /var/task directory of the image when the image was built. The /var/task directory is missing the required .runtimeconfig.json file.
```


3) With `blue.deps.json`, with `blue.runtimeconfig.json`

```
$ ./bootstrap.sh MyAssembly::Class::Handler
...
+ exec /var/lang/bin/dotnet exec --depsfile /var/task/blue.deps.json --runtimeconfig /var/task/blue.runtimeconfig.json /var/runtime/Amazon.Lambda.RuntimeSupport.dll MyAssembly::Class::Handler
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
