### PR TITLE
Update README.md

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/README.md
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/README.md
@@ -67,7 +67,7 @@ namespace TestWebApp
 }
 ```
 
-The function handler for the Lambda function will be **TestWebApp::TestWebApp.LambdaFunction::FunctionHandlerAsync**.
+The function handler for the Lambda function will be **TestWebApp::TestWebApp.LambdaEntryPoint::FunctionHandlerAsync**.
 
 ## Bootstrapping application (IWebHostBuilder vs IHostBuilder)
 


### PR DESCRIPTION
Corrected Lambda Entrypoint. Should be the same as the class name.

*Issue #, if available:*

*Description of changes:*
I believe the documentation was incorrect. The Lambda Handler mentioned in the readme should match the class name which is currently does not


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
