### PR TITLE
Fix error message when .NET SDK found that is below .NET 6 requirement

### DIFF
--- a/PowerShell/Module/Private/_DeploymentFunctions.ps1
+++ b/PowerShell/Module/Private/_DeploymentFunctions.ps1
@@ -619,7 +619,7 @@ function _validateDotnetInstall
 
     if (!($foundMin))
     {
-        throw 'The installed .NET Core SDK does not meet the minimum requirement to build the PowerShell Lambda package bundle. Download the .NET Core 3.1 SDK from https://www.microsoft.com/net/download'
+        throw 'The installed .NET SDK does not meet the minimum requirement to build the PowerShell Lambda package bundle. Download the .NET 6 SDK from https://www.microsoft.com/net/download'
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*
Incorrectly displays .NET Core 3.1 SDK as minimum supported version when it is actually .NET 6 SDK

*Description of changes:*
Change error message to reflect .NET 6 SDK is minimum supported version instead of .NET Core 3.1 SDK

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
