### PR TITLE
Add API Gateway V2 HTTP API sample request

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Resources/SampleRequests/http-api-v2-request.json
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Resources/SampleRequests/http-api-v2-request.json
@@ -1,0 +1,62 @@
+{
+  "version": "2.0",
+  "routeKey": "$default",
+  "rawPath": "/path/to/resource",
+  "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
+  "cookies": [ "cookie1", "cookie2" ],
+  "headers": {
+    "Header1": "value1",
+    "Header2": "value2"
+  },
+  "queryStringParameters": {
+    "parameter1": "value1,value2",
+    "parameter2": "value"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "apiId": "api-id",
+    "authentication": {
+      "clientCert": {
+        "clientCertPem": "CERT_CONTENT",
+        "subjectDN": "www.example.com",
+        "issuerDN": "Example issuer",
+        "serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
+        "validity": {
+          "notBefore": "May 28 12:30:02 2019 GMT",
+          "notAfter": "Aug  5 09:36:04 2021 GMT"
+        }
+      }
+    },
+    "authorizer": {
+      "jwt": {
+        "claims": {
+          "claim1": "value1",
+          "claim2": "value2"
+        },
+        "scopes": [ "scope1", "scope2" ]
+      }
+    },
+    "domainName": "id.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "domain-id",
+    "http": {
+      "method": "POST",
+      "path": "/path/to/resource",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "IP",
+      "userAgent": "agent"
+    },
+    "requestId": "request-id",
+    "routeId": "route-id",
+    "routeKey": "$default-route",
+    "stage": "$default-stage",
+    "time": "12/Mar/2020:19:03:58 +0000",
+    "timeEpoch": 1583348638390
+  },
+  "body": "Hello from Lambda",
+  "pathParameters": { "parameter1": "value1" },
+  "isBase64Encoded": false,
+  "stageVariables": {
+    "stageVariable1": "value1",
+    "stageVariable2": "value2"
+  }
+}

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Resources/SampleRequests/manifest.xml
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Resources/SampleRequests/manifest.xml
@@ -44,6 +44,10 @@
     <filename>aws-proxy.json</filename>
   </request>
   <request category="AWS">
+    <name>API Gateway V2 HTTP API</name>
+    <filename>http-api-v2-request.json</filename>
+  </request>
+  <request category="AWS">
     <name>AWS Batch Get Job Request</name>
     <filename>batch-get-job.json</filename>
   </request>


### PR DESCRIPTION
Add a sample request for API Gateway v2 HTTP API requests to the Lambda Test Tool.

I've been experimenting with the `Amazon.Lambda.AspNetCoreServer.Hosting` package with ASP.NET Core 6 Minimal APIs today, and accidentally using the API Gateway template in the tool (because I thought it was the right one) instead of a HTTP v2 request lead me to a bit of wasted time and then searching around to find an example.

The sample here is a slightly adjusted version of [http-api-v2-request.json](https://github.com/aws/aws-lambda-dotnet/blob/master/Libraries/test/EventsTests.Shared/http-api-v2-request.json), but the content is relatively arbitrary and could be changed further. As long as it has the basic properties needed to do a basic HTTP request it should be useful.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
