### PR TITLE
Error message for missing Amazon.Lambda.APIGatewayEvents package

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/AnalyzerReleases.Unshipped.md
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/AnalyzerReleases.Unshipped.md
@@ -1,2 +1,8 @@
 ; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+AWSLambda0104 | AWSLambdaCSharpGenerator | Error | Missing reference to a required dependency

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/DiagnosticDescriptors.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/DiagnosticDescriptors.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Reflection.Metadata;
-using System.Runtime.InteropServices.ComTypes;
 using Microsoft.CodeAnalysis;
 
 namespace Amazon.Lambda.Annotations.SourceGenerator.Diagnostics
@@ -10,7 +8,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Diagnostics
         /// Generic errors
         public static readonly DiagnosticDescriptor UnhandledException = new DiagnosticDescriptor(id: "AWSLambda0001",
             title: "Unhandled exception",
-            messageFormat: $"This is a bug. Please run the build with detailed verbosity (dotnet build --verbosity detailed) and file a bug at https://github.com/aws/aws-lambda-dotnet with the build output and stack trace {{0}}.",
+            messageFormat: "This is a bug. Please run the build with detailed verbosity (dotnet build --verbosity detailed) and file a bug at https://github.com/aws/aws-lambda-dotnet with the build output and stack trace {0}.",
             category: "AWSLambda",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true,
@@ -38,5 +36,13 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Diagnostics
             category: "AWSLambdaCSharpGenerator",
             DiagnosticSeverity.Info,
             isEnabledByDefault: true);
+        
+        public static readonly DiagnosticDescriptor MissingDependencies = new DiagnosticDescriptor(id: "AWSLambda0104",
+            title: "Missing reference to a required dependency",
+            messageFormat: "Your project has a missing required package dependency. Please add a reference to the following package: {0}",
+            category: "AWSLambdaCSharpGenerator",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
     }
 }

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Generator.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Generator.cs
@@ -80,7 +80,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
                         || lambdaMethodModel.HasAttribute(context, TypeFullNames.HttpApiAttribute))
                     {
                         // Check for arbitrary type from "Amazon.Lambda.APIGatewayEvents"
-                        if (context.Compilation.ReferencedAssemblyNames.FirstOrDefault(x => x.Name == "Amazon.Lambda.APIGatewayEvents"))
+                        if (context.Compilation.ReferencedAssemblyNames.FirstOrDefault(x => x.Name == "Amazon.Lambda.APIGatewayEvents") == null)
                         {
                             diagnosticReporter.Report(Diagnostic.Create(DiagnosticDescriptors.MissingDependencies,
                                 lambdaMethod.GetLocation(),

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Generator.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Generator.cs
@@ -80,7 +80,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
                         || lambdaMethodModel.HasAttribute(context, TypeFullNames.HttpApiAttribute))
                     {
                         // Check for arbitrary type from "Amazon.Lambda.APIGatewayEvents"
-                        if (context.Compilation.GetTypeByMetadataName(TypeFullNames.APIGatewayProxyRequest) == null)
+                        if (context.Compilation.ReferencedAssemblyNames.FirstOrDefault(x => x.Name == "Amazon.Lambda.APIGatewayEvents"))
                         {
                             diagnosticReporter.Report(Diagnostic.Create(DiagnosticDescriptors.MissingDependencies,
                                 lambdaMethod.GetLocation(),


### PR DESCRIPTION
*Issue #1052:*

Resolves #1052 by producing a helpful actionable message in the case where a reference to `Amazon.Lambda.APIGatewayEvents` is required but missing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.