### PR TITLE
Use TryGetValue() on dictionaries

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction.cs
@@ -177,9 +177,9 @@ namespace Amazon.Lambda.AspNetCoreServer
                     connectionFeatures.RemoteIpAddress = remoteIpAddress;
                 }
 
-                if (apiGatewayRequest?.Headers?.ContainsKey("X-Forwarded-Port") == true)
+                if (apiGatewayRequest?.Headers?.TryGetValue("X-Forwarded-Port", out var port) == true)
                 {
-                    connectionFeatures.RemotePort = int.Parse(apiGatewayRequest.Headers["X-Forwarded-Port"]);
+                    connectionFeatures.RemotePort = int.Parse(port, CultureInfo.InvariantCulture);
                 }
 
                 // Call consumers customize method in case they want to change how API Gateway's request

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -154,10 +154,10 @@ namespace Amazon.Lambda.AspNetCoreServer
                 requestFeatures.Method = apiGatewayRequest.HttpMethod;
 
                 string path = null;
-                if (apiGatewayRequest.PathParameters != null && apiGatewayRequest.PathParameters.ContainsKey("proxy") &&
+                if (apiGatewayRequest.PathParameters != null && apiGatewayRequest.PathParameters.TryGetValue("proxy", out var proxy) &&
                     !string.IsNullOrEmpty(apiGatewayRequest.Resource))
                 {
-                    var proxyPath = apiGatewayRequest.PathParameters["proxy"];
+                    var proxyPath = proxy;
                     path = apiGatewayRequest.Resource.Replace("{proxy+}", proxyPath);
                 }
 
@@ -242,9 +242,9 @@ namespace Amazon.Lambda.AspNetCoreServer
                     connectionFeatures.RemoteIpAddress = remoteIpAddress;
                 }
 
-                if (apiGatewayRequest?.Headers?.ContainsKey("X-Forwarded-Port") == true)
+                if (apiGatewayRequest?.Headers?.TryGetValue("X-Forwarded-Port", out var forwardedPort) == true)
                 {
-                    connectionFeatures.RemotePort = int.Parse(apiGatewayRequest.Headers["X-Forwarded-Port"]);
+                    connectionFeatures.RemotePort = int.Parse(forwardedPort, CultureInfo.InvariantCulture);
                 }
 
                 // Call consumers customize method in case they want to change how API Gateway's request

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
@@ -371,9 +371,9 @@ namespace Amazon.Lambda.AspNetCoreServer
             // ASP.NET Core will typically return content type with encoding like this "application/json; charset=utf-8"
             // To find the content type in the dictionary we need to strip the encoding off.
             var contentTypeWithoutEncoding = contentType.Split(';')[0].Trim();
-            if (_responseContentEncodingForContentType.ContainsKey(contentTypeWithoutEncoding))
+            if (_responseContentEncodingForContentType.TryGetValue(contentTypeWithoutEncoding, out var encoding))
             {
-                return _responseContentEncodingForContentType[contentTypeWithoutEncoding];
+                return encoding;
             }
 
             return DefaultResponseContentEncoding;
@@ -391,9 +391,9 @@ namespace Amazon.Lambda.AspNetCoreServer
                 return DefaultResponseContentEncoding;
             }
 
-            if (_responseContentEncodingForContentEncoding.ContainsKey(contentEncoding))
+            if (_responseContentEncodingForContentEncoding.TryGetValue(contentEncoding, out var encoding))
             {
-                return _responseContentEncodingForContentEncoding[contentEncoding];
+                return encoding;
             }
 
             return DefaultResponseContentEncoding;

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
@@ -130,7 +130,7 @@ namespace Amazon.Lambda.AspNetCoreServer
                 var remotePort = GetSingleHeaderValue(lambdaRequest, "x-forwarded-port");
                 if (!string.IsNullOrEmpty(remotePort))
                 {
-                    connectionFeatures.RemotePort = int.Parse(remotePort);
+                    connectionFeatures.RemotePort = int.Parse(remotePort, CultureInfo.InvariantCulture);
                 }
 
                 // Call consumers customize method in case they want to change how API Gateway's request


### PR DESCRIPTION
*Description of changes:*

* Use `TryGetValue()` with dictionaries, rather than `ContainsKey()` and the indexer (`[]`).
* Also add `CultureInfo.InvariantCulture` on calls to `int.Parse()`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
