### PR TITLE
Support image/x-icon as base64 for Amazon.Lambda.AspNetCoreServer

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
@@ -72,6 +72,7 @@ namespace Amazon.Lambda.AspNetCoreServer
             ["image/gif"] = ResponseContentEncoding.Base64,
             ["image/jpeg"] = ResponseContentEncoding.Base64,
             ["image/jpg"] = ResponseContentEncoding.Base64,
+            ["image/x-icon"] = ResponseContentEncoding.Base64,
             ["application/zip"] = ResponseContentEncoding.Base64,
             ["application/pdf"] = ResponseContentEncoding.Base64,
         };


### PR DESCRIPTION
*Issue #, if available:*

Support `image/x-icon` for favicons as base64 binary content out-of-the-box.

Otherwise trying to serve an ASP.NET Core website out of API Gateway garbles the image when rendered by a browser when loading a webpage.

![image](https://user-images.githubusercontent.com/1439341/156920522-f8af3612-d5ae-485a-88cb-69a86736dc06.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
