### PR TITLE
Fix issue with large function input in Mock Lambda test tool

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Startup.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Startup.cs
@@ -80,7 +80,8 @@ namespace Amazon.Lambda.TestTool.BlazorTester
             services.AddSingleton<IRuntimeApiDataStore, RuntimeApiDataStore>();
             services.AddControllers();
             services.AddRazorPages();
-            services.AddServerSideBlazor();
+            services.AddServerSideBlazor()
+                    .AddHubOptions(options => options.MaximumReceiveMessageSize = null);
             services.AddHttpContextAccessor();
 
             services.AddBlazoredModal();
@@ -107,7 +108,11 @@ namespace Amazon.Lambda.TestTool.BlazorTester
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();
-                endpoints.MapBlazorHub();
+                endpoints.MapBlazorHub(o =>
+                {
+                    o.ApplicationMaxBufferSize = 6 * (1024 * 1024);
+                    o.TransportMaxBufferSize = 6 * (1024 * 1024);
+                });
                 endpoints.MapFallbackToPage("/_Host");
             });
         }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1110

*Description of changes:*
If the function input is too large the value does not get bound to the Razor `FunctionInput` property. The issue is SignalR by default uses 32K buffer size for transferring to the server side. Following the links from below I increased the buffer size and confirmed it now works.

https://github.com/dotnet/aspnetcore/issues/5623#issuecomment-660844819

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
