### PR TITLE
Fixed issue with ASP.NET Core Minimal API MapPost with complex types 

### DIFF
--- a/Libraries/Libraries.sln
+++ b/Libraries/Libraries.sln
@@ -4,9 +4,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 17.0.31717.71
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{AAB54E74-20B1-42ED-BC3D-CE9F7BC7FD12}"
-ProjectSection(SolutionItems) = preProject
-	src\Amazon.Lambda.Annotations.nuspec = src\Amazon.Lambda.Annotations.nuspec
-EndProjectSection
+	ProjectSection(SolutionItems) = preProject
+		src\Amazon.Lambda.Annotations.nuspec = src\Amazon.Lambda.Annotations.nuspec
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A101C2F7-C63F-4FDE-94BB-DFA637EBEA44}"
 	ProjectSection(SolutionItems) = preProject
@@ -106,13 +106,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HandlerTestNoSerializer", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestServerlessApp", "test\TestServerlessApp\TestServerlessApp.csproj", "{3D322CAB-0DDD-4C84-B3ED-0862F244AF5C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.Lambda.Annotations.SourceGenerators.Tests", "test\Amazon.Lambda.Annotations.SourceGenerators.Tests\Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj", "{D76F2C74-3D7F-4DB3-BA1A-F2EA14749253}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.Lambda.Annotations.SourceGenerators.Tests", "test\Amazon.Lambda.Annotations.SourceGenerators.Tests\Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj", "{D76F2C74-3D7F-4DB3-BA1A-F2EA14749253}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.Lambda.Annotations", "src\Amazon.Lambda.Annotations\Amazon.Lambda.Annotations.csproj", "{ADA9AF37-A8C1-47E6-BBBD-5C7E49C26C0E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.Lambda.Annotations", "src\Amazon.Lambda.Annotations\Amazon.Lambda.Annotations.csproj", "{ADA9AF37-A8C1-47E6-BBBD-5C7E49C26C0E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.Lambda.Annotations.SourceGenerator", "src\Amazon.Lambda.Annotations.SourceGenerator\Amazon.Lambda.Annotations.SourceGenerator.csproj", "{3C617909-D61F-4AA8-B11C-4C9ECC865D75}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.Lambda.Annotations.SourceGenerator", "src\Amazon.Lambda.Annotations.SourceGenerator\Amazon.Lambda.Annotations.SourceGenerator.csproj", "{3C617909-D61F-4AA8-B11C-4C9ECC865D75}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestServerlessApp.IntegrationTests", "test\TestServerlessApp.IntegrationTests\TestServerlessApp.IntegrationTests.csproj", "{2D956162-04BE-402E-9487-AE785AA14DE4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestServerlessApp.IntegrationTests", "test\TestServerlessApp.IntegrationTests\TestServerlessApp.IntegrationTests.csproj", "{2D956162-04BE-402E-9487-AE785AA14DE4}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.Lambda.AspNetCoreServer.Hosting", "src\Amazon.Lambda.AspNetCoreServer.Hosting\Amazon.Lambda.AspNetCoreServer.Hosting.csproj", "{02908C6F-FBDF-4949-B039-0F4632265B90}"
 EndProject
@@ -121,6 +121,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventsTests.NET6", "test\EventsTests.NET6\EventsTests.NET6.csproj", "{C1BB30D2-3237-4CFC-BA93-627471148EC2}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.Lambda.KafkaEvents", "src\Amazon.Lambda.KafkaEvents\Amazon.Lambda.KafkaEvents.csproj", "{982A26C7-A5D1-4783-A7F8-F2B28AA2459E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestMinimalAPIApp", "test\TestMinimalAPIApp\TestMinimalAPIApp.csproj", "{8AB1CBD7-2D08-492F-9C09-3E754364046C}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -329,6 +331,10 @@ Global
 		{982A26C7-A5D1-4783-A7F8-F2B28AA2459E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{982A26C7-A5D1-4783-A7F8-F2B28AA2459E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{982A26C7-A5D1-4783-A7F8-F2B28AA2459E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8AB1CBD7-2D08-492F-9C09-3E754364046C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8AB1CBD7-2D08-492F-9C09-3E754364046C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8AB1CBD7-2D08-492F-9C09-3E754364046C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8AB1CBD7-2D08-492F-9C09-3E754364046C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -387,6 +393,7 @@ Global
 		{2FFBE745-B7D5-4E44-B76D-88A0C2402FEB} = {B5BD0336-7D08-492C-8489-42C987E29B39}
 		{C1BB30D2-3237-4CFC-BA93-627471148EC2} = {1DE4EE60-45BA-4EF7-BE00-B9EB861E4C69}
 		{982A26C7-A5D1-4783-A7F8-F2B28AA2459E} = {AAB54E74-20B1-42ED-BC3D-CE9F7BC7FD12}
+		{8AB1CBD7-2D08-492F-9C09-3E754364046C} = {1DE4EE60-45BA-4EF7-BE00-B9EB861E4C69}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {503678A4-B8D1-4486-8915-405A3E9CF0EB}

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/InvokeFeatures.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/InvokeFeatures.cs
@@ -28,6 +28,10 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
                              ITlsConnectionFeature
 
                              ,IHttpResponseBodyFeature
+
+#if NET6_0_OR_GREATER
+                            ,IHttpRequestBodyDetectionFeature
+#endif
     /*
     ,
                          IHttpUpgradeFeature,
@@ -46,6 +50,10 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
             this[typeof(IServiceProvidersFeature)] = this;
             this[typeof(ITlsConnectionFeature)] = this;
             this[typeof(IHttpResponseBodyFeature)] = this;
+
+#if NET6_0_OR_GREATER
+            this[typeof(IHttpRequestBodyDetectionFeature)] = this;
+#endif
         }
 
         #region IFeatureCollection
@@ -345,5 +353,16 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
         public X509Certificate2 ClientCertificate { get; set; }
 
         #endregion
+
+#if NET6_0_OR_GREATER
+        bool IHttpRequestBodyDetectionFeature.CanHaveBody
+        {
+            get
+            {
+                var requestFeature = (IHttpRequestFeature)this;
+                return requestFeature.Body != null;
+            }
+        }
+#endif
     }
 }

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestMinimalAPI.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestMinimalAPI.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Serialization.SystemTextJson;
+using Amazon.Lambda.APIGatewayEvents;
+using Xunit;
+
+namespace Amazon.Lambda.AspNetCoreServer.Test
+{
+    public class TestMinimalAPI : IClassFixture<TestMinimalAPI.TestMinimalAPIAppFixture>
+    {
+        TestMinimalAPIAppFixture _fixture;
+
+        public TestMinimalAPI(TestMinimalAPI.TestMinimalAPIAppFixture fixture)
+        {
+            this._fixture = fixture;
+        }
+
+        [Fact]
+        public void TestMapPostComplexType()
+        {
+            var response = _fixture.ExecuteRequest<APIGatewayProxyResponse>("minimal-api-post.json");
+            Assert.Equal((int)HttpStatusCode.OK, response.StatusCode);
+            Assert.Contains("works:string", response.Body);
+        }
+
+        public class TestMinimalAPIAppFixture : IDisposable
+        {
+            object lock_process = new object();
+            public TestMinimalAPIAppFixture()
+            {
+            }
+
+            public void Dispose()
+            {
+            }
+
+
+            public T ExecuteRequest<T>(string eventFilePath)
+            {
+                var requestFilePath = Path.Combine(Path.GetDirectoryName(this.GetType().GetTypeInfo().Assembly.Location), eventFilePath);
+                var responseFilePath = Path.GetTempFileName();
+
+                var comamndArgument = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? $"/c" : $"-c";
+                ProcessStartInfo processStartInfo = new ProcessStartInfo();
+                processStartInfo.FileName = GetSystemShell();
+                processStartInfo.Arguments = $"{comamndArgument} dotnet run \"{requestFilePath}\" \"{responseFilePath}\"";
+                processStartInfo.WorkingDirectory = GetTestAppDirectory();
+
+
+                lock (lock_process)
+                {
+                    using var process = Process.Start(processStartInfo);
+                    process.WaitForExit(15000);
+
+                    if(!File.Exists(responseFilePath))
+                    {
+                        throw new Exception("No response file found");
+                    }
+
+                    using var responseFileStream = File.OpenRead(responseFilePath);
+
+                    var serializer = new DefaultLambdaJsonSerializer();
+                    var response = serializer.Deserialize<T>(responseFileStream);
+
+                    return response;
+                }
+            }
+
+            private string GetTestAppDirectory()
+            {
+                var path = this.GetType().GetTypeInfo().Assembly.Location;
+                while(!string.Equals(new DirectoryInfo(path).Name, "test"))
+                {
+                    path = Directory.GetParent(path).FullName;
+                }
+
+                return Path.GetFullPath(Path.Combine(path, "TestMinimalAPIApp"));
+            }
+
+            private string GetSystemShell()
+            {
+                if (TryGetEnvironmentVariable("COMSPEC", out var comspec))
+                {
+                    return comspec!;
+                }
+
+                if (TryGetEnvironmentVariable("SHELL", out var shell))
+                {
+                    return shell!;
+                }
+
+                // fallback to defaults
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "cmd.exe" : "/bin/sh";
+            }
+
+            private bool TryGetEnvironmentVariable(string variable, out string? value)
+            {
+                value = Environment.GetEnvironmentVariable(variable);
+                return !string.IsNullOrEmpty(value);
+            }
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/minimal-api-post.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/minimal-api-post.json
@@ -1,0 +1,119 @@
+{
+  "resource": "/{proxy+}",
+  "path": "/test-post-complex",
+  "httpMethod": "POST",
+  "headers": {
+    "Accept": "*/*",
+    "Accept-Encoding": "gzip, deflate, br",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Content-Type": "application/json",
+    "Host": "ttrvuhs0tf.execute-api.us-west-2.amazonaws.com",
+    "Postman-Token": "cd27ded3-67a6-4d10-8deb-c3767b0f4e12",
+    "User-Agent": "PostmanRuntime/7.28.4",
+    "Via": "1.1 34f8ef0e4c880df0650a814412a26ea6.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "_5JSGn-BbiG9tyOsheuRSYUdQ5RZht0hu_-CcM7or8fBFv8J_rc_Ug==",
+    "X-Amzn-Trace-Id": "Root=1-622701c5-7656138c73e95d8d237e44d7",
+    "X-Forwarded-For": "50.35.66.233, 64.252.140.140",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "multiValueHeaders": {
+    "Accept": [
+      "*/*"
+    ],
+    "Accept-Encoding": [
+      "gzip, deflate, br"
+    ],
+    "CloudFront-Forwarded-Proto": [
+      "https"
+    ],
+    "CloudFront-Is-Desktop-Viewer": [
+      "true"
+    ],
+    "CloudFront-Is-Mobile-Viewer": [
+      "false"
+    ],
+    "CloudFront-Is-SmartTV-Viewer": [
+      "false"
+    ],
+    "CloudFront-Is-Tablet-Viewer": [
+      "false"
+    ],
+    "CloudFront-Viewer-Country": [
+      "US"
+    ],
+    "Content-Type": [
+      "application/json"
+    ],
+    "Host": [
+      "ttrvuhs0tf.execute-api.us-west-2.amazonaws.com"
+    ],
+    "Postman-Token": [
+      "cd27ded3-67a6-4d10-8deb-c3767b0f4e12"
+    ],
+    "User-Agent": [
+      "PostmanRuntime/7.28.4"
+    ],
+    "Via": [
+      "1.1 34f8ef0e4c880df0650a814412a26ea6.cloudfront.net (CloudFront)"
+    ],
+    "X-Amz-Cf-Id": [
+      "_5JSGn-BbiG9tyOsheuRSYUdQ5RZht0hu_-CcM7or8fBFv8J_rc_Ug=="
+    ],
+    "X-Amzn-Trace-Id": [
+      "Root=1-622701c5-7656138c73e95d8d237e44d7"
+    ],
+    "X-Forwarded-For": [
+      "50.35.66.233, 64.252.140.140"
+    ],
+    "X-Forwarded-Port": [
+      "443"
+    ],
+    "X-Forwarded-Proto": [
+      "https"
+    ]
+  },
+  "queryStringParameters": null,
+  "multiValueQueryStringParameters": null,
+  "pathParameters": {
+    "proxy": "test-post-complex"
+  },
+  "stageVariables": null,
+  "requestContext": {
+    "resourceId": "ri47io",
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "POST",
+    "extendedRequestId": "Op027H0XvHcFsKA=",
+    "requestTime": "08/Mar/2022:07:12:05 +0000",
+    "path": "/Prod/test-post-complex",
+    "accountId": "626492997873",
+    "protocol": "HTTP/1.1",
+    "stage": "Prod",
+    "domainPrefix": "ttrvuhs0tf",
+    "requestTimeEpoch": 1646723525700,
+    "requestId": "93432dd3-85b0-45c7-88ce-742b5d2b0550",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "sourceIp": "50.35.66.233",
+      "principalOrgId": null,
+      "accessKey": null,
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "PostmanRuntime/7.28.4",
+      "user": null
+    },
+    "domainName": "ttrvuhs0tf.execute-api.us-west-2.amazonaws.com",
+    "apiId": "ttrvuhs0tf"
+  },
+  "body": "{\r\n  \"testString\": \"string\"\r\n}",
+  "isBase64Encoded": false
+}

--- a/Libraries/test/TestMinimalAPIApp/Program.cs
+++ b/Libraries/test/TestMinimalAPIApp/Program.cs
@@ -1,0 +1,60 @@
+using Amazon.Lambda.AspNetCoreServer.Hosting.Internal;
+using Amazon.Lambda.AspNetCoreServer.Internal;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.TestUtilities;
+using Amazon.Lambda.Serialization.SystemTextJson;
+using Microsoft.AspNetCore.Hosting.Server;
+
+if (args.Length != 2)
+{
+    throw new Exception("Incorrect command line arguments: <request-file-path> <response-file-path>");
+}
+
+// Grab the request we want to test with
+var requestFilePath = args[0];
+if(!File.Exists(requestFilePath))
+{
+    throw new Exception($"Unable to find request path {requestFilePath}");
+}
+var requestJsonContent = File.ReadAllText(requestFilePath);
+
+var lambdaSerializer = new DefaultLambdaJsonSerializer();
+var apiGatewayRequest = lambdaSerializer.Deserialize<APIGatewayProxyRequest>(new MemoryStream(System.Text.Encoding.UTF8.GetBytes(requestJsonContent)));
+
+
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Inject our own Lambda server replacing Kestrel.
+builder.Services.AddSingleton<IServer, LambdaServer>();
+
+var app = builder.Build();
+
+app.UseHttpsRedirection();
+
+app.MapGet("/", () => "Welcome to running ASP.NET Core Minimal API on AWS Lambda");
+
+app.MapPost("/test-post-complex", (Jane jane) =>
+{
+    return Results.Ok($"works:{jane.TestString}");
+});
+
+var source = new CancellationTokenSource();
+_ = app.RunAsync(source.Token);
+await Task.Delay(1000);
+
+// Now that ASP.NET Core has started send the request into ASP.NET Core via Lambda function which will grab the LambdaServer register for IServer and forward the request in.
+var lambdaFunction = new APIGatewayRestApiLambdaRuntimeSupportServer.APIGatewayRestApiMinimalApi(app.Services);
+var response = await lambdaFunction.FunctionHandlerAsync(apiGatewayRequest, new TestLambdaContext());
+
+var responseFilePath = args[1];
+using (var outputStream = File.OpenWrite(responseFilePath))
+{
+    lambdaSerializer.Serialize(response, outputStream);
+}
+
+source.Cancel();
+
+
+public record Jane(string TestString);
+

--- a/Libraries/test/TestMinimalAPIApp/TestMinimalAPIApp.csproj
+++ b/Libraries/test/TestMinimalAPIApp/TestMinimalAPIApp.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Amazon.Lambda.AspNetCoreServer.Hosting\Amazon.Lambda.AspNetCoreServer.Hosting.csproj" />
+    <ProjectReference Include="..\..\src\Amazon.Lambda.AspNetCoreServer\Amazon.Lambda.AspNetCoreServer.csproj" />
+    <ProjectReference Include="..\..\src\Amazon.Lambda.TestUtilities\Amazon.Lambda.TestUtilities.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/TestMinimalAPIApp/appsettings.json
+++ b/Libraries/test/TestMinimalAPIApp/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-toolkit-visual-studio/issues/223

*Description of changes:*
This PR fixes an issue when using ASP.NET Core Minimal API and doing a post with a complex types. .NET 6 added a new feature collection called `IHttpRequestBodyDetectionFeature` to detect whether a response has a body. This was added to allow ASP.NET Core be able to tell the difference between not having a body versus explicitly passing an empty body.

The fix was all in the `InvokeFeatures` class. The rest of the PR is adding a test framework for writing unit tests for Lambda ASP.NET Core Minimal API projects.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
