### PR TITLE
ci: allow triggering Source Generator CI on workflow_dispatch

### DIFF
--- a/.github/workflows/source-generator-ci.yml
+++ b/.github/workflows/source-generator-ci.yml
@@ -1,6 +1,7 @@
 name: Source Generator CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - feature/annotations


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently there is not a good way to check customer PRs (eg. #1101) because AWS creds are only available in the main repo and forked repos can't access them (which is intended).

This change will allow developers manually run the check on a PR by pulling into the main repo and trigger it manually.

Read more about manual workflow [here](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
