### PR TITLE
Fix source generator to use default JsonSerializerOptions

### DIFF
--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/AbstractLambdaJsonSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/AbstractLambdaJsonSerializer.cs
@@ -1,8 +1,10 @@
-﻿using System;
+﻿using Amazon.Lambda.Serialization.SystemTextJson.Converters;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Amazon.Lambda.Serialization.SystemTextJson
 {
@@ -118,6 +120,33 @@ namespace Amazon.Lambda.Serialization.SystemTextJson
             {
                 throw new JsonSerializerException($"Error converting the Lambda event JSON payload to type {typeof(T).FullName}: {e.Message}", e);
             }
+        }
+
+        /// <summary>
+        /// Create the default instance of JsonSerializerOptions used in serializer
+        /// </summary>
+        /// <returns></returns>
+        protected virtual JsonSerializerOptions CreateDefaultJsonSerializationOptions()
+        {
+            var serializer = new JsonSerializerOptions()
+            {
+#if NET6_0_OR_GREATER
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+#else
+                IgnoreNullValues = true,
+#endif
+                PropertyNameCaseInsensitive = true,
+                PropertyNamingPolicy = new AwsNamingPolicy(),
+                Converters =
+                {
+                    new DateTimeConverter(),
+                    new MemoryStreamConverter(),
+                    new ConstantClassConverter(),
+                    new ByteArrayConverter()
+                }
+            };
+
+            return serializer;
         }
 
         /// <summary>

--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/DefaultLambdaJsonSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/DefaultLambdaJsonSerializer.cs
@@ -53,19 +53,7 @@ namespace Amazon.Lambda.Serialization.SystemTextJson
         public DefaultLambdaJsonSerializer(Action<JsonSerializerOptions> customizer, Action<JsonWriterOptions> jsonWriterCustomizer)
             : base(jsonWriterCustomizer)
         {
-            SerializerOptions = new JsonSerializerOptions()
-            {
-                IgnoreNullValues = true,
-                PropertyNameCaseInsensitive = true,
-                PropertyNamingPolicy = new AwsNamingPolicy(),
-                Converters =
-                {
-                    new DateTimeConverter(),
-                    new MemoryStreamConverter(),
-                    new ConstantClassConverter(),
-                    new ByteArrayConverter()
-                }
-            };
+            SerializerOptions = CreateDefaultJsonSerializationOptions();
 
             customizer?.Invoke(this.SerializerOptions);
             jsonWriterCustomizer?.Invoke(this.WriterOptions);

--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/README.md
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/README.md
@@ -22,3 +22,65 @@ public Response CustomSerializerMethod(Request input)
     ...
 }
 ```
+
+## Using C# source generator for serialization
+
+C# 9 provides source generators, which allow code generation during compilation. This can reduce 
+the use of reflection APIs and improve application startup time. .NET 6 updated the native 
+JSON library [System.Text.Json to use source generators](https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-source-generation?pivots=dotnet-6-0), 
+allowing JSON parsing without requiring reflection APIs.
+
+To use the source generator for JSON serializing in Lambda, you must define a new empty class 
+in your project that derives from `System.Text.Json.Serialization.JsonSerializerContext`. This 
+class must be a partial class because the source generator adds code to this class to handle 
+serialization. On the empty partial class, add the `JsonSerializable` attribute for each .NET 
+type the source generator must generate the serialization code for.
+
+Here is an example called HttpApiJsonSerializerContext that registers the Amazon API Gateway 
+HTTP API event and response types to have the serialization code generated:
+
+```csharp
+[JsonSerializable(typeof(APIGatewayHttpApiV2ProxyRequest))]
+[JsonSerializable(typeof(APIGatewayHttpApiV2ProxyResponse))]
+public partial class HttpApiJsonSerializerContext : JsonSerializerContext
+{
+}
+```
+
+To register the source generator for serialization use the `LambdaSerializer` attribute 
+passing in the `SourceGeneratorLambdaJsonSerializer` type along with the custom context 
+type (i.e. `HttpApiJsonSerializerContext`) as the generic parameter.
+
+```csharp
+[assembly: LambdaSerializer(
+        typeof(SourceGeneratorLambdaJsonSerializer
+                    <APIGatewayExampleImage.HttpApiJsonSerializerContext>))]
+```
+
+## Customizing serialization options
+
+Both `DefaultLambdaJsonSerializer` and `SourceGeneratorLambdaJsonSerializer` construct an 
+instance of `JsonSerializerOptions` that is used to customize the serialization and deserialization 
+of the Lambda JSON events. For example adding special converters and naming policies.
+
+To further customize the `JsonSerializerOptions` create a new type extending from extend 
+either `DefaultLambdaJsonSerializer` or `SourceGeneratorLambdaJsonSerializer` and pass 
+in an `Action` customizer to the base constructor. Then register the new type as the 
+serializer using the `LambdaSerializer` attribute. Below is an example of a custom serializer.
+
+```csharp
+public class CustomLambdaSerializer : DefaultLambdaJsonSerializer
+{
+    public CustomLambdaSerializer()
+        : base(CreateCustomizer())
+    { }
+
+    private static Action<JsonSerializerOptions> CreateCustomizer()
+    {
+        return (JsonSerializerOptions options) =>
+        {
+            // Customize options
+        };
+    }
+}
+```

--- a/Libraries/test/EventsTests.NET6/SourceGeneratorSerializerTests.cs
+++ b/Libraries/test/EventsTests.NET6/SourceGeneratorSerializerTests.cs
@@ -14,7 +14,6 @@ using Amazon.Lambda.CloudWatchEvents.BatchEvents;
 
 namespace EventsTests.NET6
 {
-    [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
     [JsonSerializable(typeof(APIGatewayHttpApiV2ProxyRequest))]
     [JsonSerializable(typeof(APIGatewayHttpApiV2ProxyResponse))]
     internal partial class HttpApiJsonSerializationContext : JsonSerializerContext
@@ -22,14 +21,12 @@ namespace EventsTests.NET6
 
     }
 
-    [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
     [JsonSerializable(typeof(S3ObjectLambdaEvent))]
     internal partial class S3ObjectLambdaSerializationContext : JsonSerializerContext
     {
 
     }
 
-    [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
     [JsonSerializable(typeof(BatchJobStateChangeEvent))]
     internal partial class BatchJobStateChangeEventSerializationContext : JsonSerializerContext
     {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1106

*Description of changes:*
This issue fixes an issue with the new Lambda source generator based serializer to not have the same JSON serialization options used for the other Lambda serializer in the package. 

The original thought was the json serialization options were not needed because the source generator serializer could be customized using the `JsonSourceGenerationOptions` attribute. The problem with this approach is it means the default options won't work for most users due to casing differences and there isn't a way to add converters to `JsonSourceGenerationOptions` as well.

I also updated the **README.md** to have documentation on the source generator serializer as well how to customize the JSON serializer settings.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
