### PR TITLE
Fixes serializer exception when using source generators in JSON serializers

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaExecutor.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaExecutor.cs
@@ -151,7 +151,7 @@ namespace Amazon.Lambda.TestTool.Runtime
                         else
                         {
                             lambdaReturnStream = new MemoryStream();
-                            request.Function.Serializer.Serialize(taskResult, lambdaReturnStream);
+                            InvokeSerializer(request, taskResult, taskResult.GetType(), lambdaReturnStream);
                         }
                     }
                 }
@@ -159,7 +159,7 @@ namespace Amazon.Lambda.TestTool.Runtime
             else
             {
                 lambdaReturnStream = new MemoryStream();
-                request.Function.Serializer.Serialize(lambdaReturnObject, lambdaReturnStream);
+                InvokeSerializer(request, lambdaReturnObject, request.Function.LambdaMethod.ReturnType, lambdaReturnStream);
             }
 
             if (lambdaReturnStream == null)
@@ -171,6 +171,12 @@ namespace Amazon.Lambda.TestTool.Runtime
                 return reader.ReadToEnd();
             }
 
+            static void InvokeSerializer(ExecutionRequest request, object lambdaReturnObject, Type returnType, Stream lambdaReturnStream)
+            {
+                var genericSerialize = typeof(ILambdaSerializer).GetMethod("Serialize");
+                var specializationSerialize = genericSerialize.MakeGenericMethod(returnType);
+                specializationSerialize.Invoke(request.Function.Serializer, new[] { lambdaReturnObject, lambdaReturnStream });
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
in Amazon.Lambda.TestTool-6.0

*Fixes Issue #1124*

*Description of changes:*
Removes two direct invocations of the serializer with `System.Object` as the type parameter (for both async and non-async result type cases). Invocations are replaced by calling the correct specialization of the generic serializer via reflection, passing the runtime type of the result object as the first type parameter of the serializer method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
