### PR TITLE
Adding example routes and fixing typo

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI.MinimalAPI/template/src/BlueprintBaseName.1/Controllers/CalculatorController.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI.MinimalAPI/template/src/BlueprintBaseName.1/Controllers/CalculatorController.cs
@@ -13,6 +13,7 @@ public class CalculatorController : ControllerBase
         _logger = logger;
     }
 
+    // GET calculator/add/4/2/
     [HttpGet("add/{x}/{y}")]
     public int Add(int x, int y)
     {
@@ -20,13 +21,15 @@ public class CalculatorController : ControllerBase
         return x + y;
     }
 
-    [HttpGet("substract/{x}/{y}")]
-    public int Substract(int x, int y)
+    // GET calculator/substract/4/2/
+    [HttpGet("subtract/{x}/{y}")]
+    public int Subtract(int x, int y)
     {
-        _logger.LogInformation($"{x} substract {y} is {x - y}");
+        _logger.LogInformation($"{x} subtract {y} is {x - y}");
         return x - y;
     }
 
+    // GET calculator/multiply/4/2/
     [HttpGet("multiply/{x}/{y}")]
     public int Multiply(int x, int y)
     {
@@ -34,6 +37,7 @@ public class CalculatorController : ControllerBase
         return x * y;
     }
 
+    // GET calculator/divide/4/2/
     [HttpGet("divide/{x}/{y}")]
     public int Divide(int x, int y)
     {


### PR DESCRIPTION
Adding examples to be consistent with other examples like here: https://github.com/aws/aws-lambda-dotnet/blob/a73e32362e79760d180171053e348fce63a7505d/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/Controllers/ValuesController.cs#L15


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
