### PR TITLE
Added support for Amazon Lex V2 event.

### DIFF
--- a/Libraries/Libraries.sln
+++ b/Libraries/Libraries.sln
@@ -126,6 +126,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestMinimalAPIApp", "test\T
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.Lambda.MQEvents", "src\Amazon.Lambda.MQEvents\Amazon.Lambda.MQEvents.csproj", "{BF85932E-2DFF-41CD-8090-A672468B8FBB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.Lambda.LexV2Events", "src\Amazon.Lambda.LexV2Events\Amazon.Lambda.LexV2Events.csproj", "{3C6AABF5-0372-41E0-874F-DF18ECCC7FB6}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		test\EventsTests.Shared\EventsTests.Shared.projitems*{44e9d925-b61d-4234-97b7-61424c963ba6}*SharedItemsImports = 5
@@ -341,6 +343,10 @@ Global
 		{BF85932E-2DFF-41CD-8090-A672468B8FBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BF85932E-2DFF-41CD-8090-A672468B8FBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BF85932E-2DFF-41CD-8090-A672468B8FBB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C6AABF5-0372-41E0-874F-DF18ECCC7FB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C6AABF5-0372-41E0-874F-DF18ECCC7FB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C6AABF5-0372-41E0-874F-DF18ECCC7FB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C6AABF5-0372-41E0-874F-DF18ECCC7FB6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -401,6 +407,7 @@ Global
 		{982A26C7-A5D1-4783-A7F8-F2B28AA2459E} = {AAB54E74-20B1-42ED-BC3D-CE9F7BC7FD12}
 		{8AB1CBD7-2D08-492F-9C09-3E754364046C} = {1DE4EE60-45BA-4EF7-BE00-B9EB861E4C69}
 		{BF85932E-2DFF-41CD-8090-A672468B8FBB} = {AAB54E74-20B1-42ED-BC3D-CE9F7BC7FD12}
+		{3C6AABF5-0372-41E0-874F-DF18ECCC7FB6} = {AAB54E74-20B1-42ED-BC3D-CE9F7BC7FD12}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {503678A4-B8D1-4486-8915-405A3E9CF0EB}

--- a/Libraries/src/Amazon.Lambda.LexV2Events/Amazon.Lambda.LexV2Events.csproj
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/Amazon.Lambda.LexV2Events.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\..\buildtools\common.props" />
+
+  <PropertyGroup>
+    <Description>Amazon Lambda .NET Core support - Amazon Lex V2 package.</Description>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <AssemblyTitle>Amazon.Lambda.LexV2Events</AssemblyTitle>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <AssemblyName>Amazon.Lambda.LexV2Events</AssemblyName>
+    <PackageId>Amazon.Lambda.LexV2Events</PackageId>
+    <PackageTags>AWS;Amazon;Lambda;Lex;LexV2</PackageTags>
+  </PropertyGroup>
+
+</Project>

--- a/Libraries/src/Amazon.Lambda.LexV2Events/Amazon.Lambda.LexV2Events.csproj
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/Amazon.Lambda.LexV2Events.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>Amazon Lambda .NET Core support - Amazon Lex V2 package.</Description>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.LexV2Events</AssemblyTitle>
     <VersionPrefix>1.0.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.LexV2Events</AssemblyName>

--- a/Libraries/src/Amazon.Lambda.LexV2Events/KendraResponse.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/KendraResponse.cs
@@ -1,0 +1,369 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Amazon.Lambda.LexV2Events
+{
+    /// <summary>
+    /// A class that represents Kendra Response
+    /// https://docs.aws.amazon.com/kendra/latest/dg/API_Query.html#API_Query_ResponseSyntax 
+    /// </summary>
+    public class KendraResponse
+    {
+        /// <summary>
+        /// Contains the facet results. A <code>FacetResult</code> contains the counts for each
+        /// attribute key that was specified in the <code>Facets</code> input parameter.
+        /// </summary>
+        public IList<FacetResult> FacetResults { get; set; }
+
+        /// <summary>
+        /// The unique identifier for the search. You use <code>QueryId</code> to identify the
+        /// search when using the feedback API.
+        /// </summary>
+        public string QueryId { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property ResultItems. 
+        /// <para>
+        /// The results of the search.
+        /// </para>
+        /// </summary>
+        public IList<QueryResultItem> ResultItems { get; set; }
+
+        /// <summary>
+        /// A list of information related to suggested spell corrections for a query.
+        /// </summary>
+        public IList<SpellCorrectedQuery> SpellCorrectedQueries { get; set; }
+
+        /// <summary>
+        /// The total number of items found by the search; however, you can only retrieve up to
+        /// 100 items. For example, if the search found 192 items, you can only retrieve the first
+        /// 100 of the items.
+        /// </summary>
+        public int TotalNumberOfResults { get; set; }
+
+        /// <summary>
+        /// A list of warning codes and their messages on problems with your query.
+        /// 
+        /// <para>
+        /// Amazon Kendra currently only supports one type of warning, which is a warning on invalid
+        /// syntax used in the query. For examples of invalid query syntax, see <a href="https://docs.aws.amazon.com/kendra/latest/dg/searching-example.html#searching-index-query-syntax">Searching
+        /// with advanced query syntax</a>.
+        /// </para>
+        /// </summary>
+        public IList<Warning> Warnings { get; set; }
+
+        /// <summary>
+        /// The facet values for the documents in the response.
+        /// </summary>
+        public class FacetResult
+        {
+            /// <summary>
+            /// The key for the facet values. This is the same as the <code>DocumentAttributeKey</code> provided in the query.
+            /// </summary>
+            public string DocumentAttributeKey { get; set; }
+
+            /// <summary>
+            /// An array of key/value pairs, where the key is the value of the attribute and the count is the number of documents that share the key value.
+            /// </summary>
+            public IList<DocumentAttributeValueCountPair> DocumentAttributeValueCountPairs { get; set; }
+
+            /// <summary>
+            /// The data type of the facet value. This is the same as the type defined for the index field when it was created.
+            /// </summary>
+            public string DocumentAttributeValueType { get; set; }
+        }
+
+        /// <summary>
+        /// Provides the count of documents that match a particular attribute when doing a faceted
+        /// search.
+        /// </summary>
+        public class DocumentAttributeValueCountPair
+        {
+            /// <summary>
+            /// The number of documents in the response that have the attribute value for the key.
+            /// </summary>
+            public int? Count { get; set; }
+
+            /// <summary>
+            /// The value of the attribute. For example, "HR."
+            /// </summary>
+            public DocumentAttributeValue DocumentAttributeValue { get; set; }
+        }
+
+        /// <summary>
+        /// The value of a custom document attribute. You can only provide one value for a custom
+        /// attribute.
+        /// </summary>
+        public class DocumentAttributeValue
+        {
+            /// <summary>
+            /// A date expressed as an ISO 8601 string.
+            ///  
+            /// <para>
+            /// It is important for the time zone to be included in the ISO 8601 date-time format.
+            /// For example, 2012-03-25T12:30:10+01:00 is the ISO 8601 date-time format for March
+            /// 25th 2012 at 12:30PM (plus 10 seconds) in Central European Time.
+            /// </para>
+            /// </summary>
+            public DateTime? DateValue { get; set; }
+
+            /// <summary>
+            /// A long integer value.
+            /// </summary>
+            public long? LongValue { get; set; }
+
+            /// <summary>
+            /// A list of strings. 
+            /// </summary>
+            public IList<string> StringListValue { get; set; }
+
+            /// <summary>
+            /// A string, such as "department".
+            /// </summary>
+            public string StringValue { get; set; }
+        }
+
+        /// <summary>
+        /// A query with suggested spell corrections.
+        /// </summary>
+        public class SpellCorrectedQuery
+        {
+            /// <summary>
+            /// The corrected misspelled word or words in a query.
+            /// </summary>
+            public IList<Correction> Corrections { get; set; }
+
+            /// <summary>
+            /// The query with the suggested spell corrections.
+            /// </summary>
+            public string SuggestedQueryText { get; set; }
+        }
+
+        /// <summary>
+        /// A corrected misspelled word in a query.
+        /// </summary>
+        public class Correction
+        {
+            /// <summary>
+            /// The zero-based location in the response string or text where the corrected word starts.
+            /// </summary>
+            public int? BeginOffset { get; set; }
+
+            /// <summary>
+            /// The string or text of a corrected misspelled word in a query.
+            /// </summary>
+            public string CorrectedTerm { get; set; }
+
+            /// <summary>
+            /// The zero-based location in the response string or text where the corrected word ends.
+            /// </summary>
+            public int? EndOffset { get; set; }
+
+            /// <summary>
+            /// The string or text of a misspelled word in a query.
+            /// </summary>
+            public string Term { get; set; }
+        }
+
+        /// <summary>
+        /// The warning code and message that explains a problem with a query.
+        /// </summary>
+        public class Warning
+        {
+            /// <summary>
+            /// The code used to show the type of warning for the query.
+            /// </summary>
+            public string Code { get; set; }
+
+            /// <summary>
+            /// The message that explains the problem with the query.
+            /// </summary>
+            public string Message { get; set; }
+        }
+
+        /// <summary>
+        /// A single query result.
+        /// 
+        ///  
+        /// <para>
+        /// A query result contains information about a document returned by the query. This includes
+        /// the original location of the document, a list of attributes assigned to the document,
+        /// and relevant text from the document that satisfies the query.
+        /// </para>
+        /// </summary>
+        public class QueryResultItem
+        {
+            /// <summary>
+            /// Gets and sets the property AdditionalAttributes. 
+            /// <para>
+            /// One or more additional attributes associated with the query result.
+            /// </para>
+            /// </summary>
+            public IList<AdditionalResultAttribute> AdditionalAttributes { get; set; }
+
+            /// <summary>
+            /// An array of document attributes for the document that the query result maps to. For
+            /// example, the document author (Author) or the source URI (SourceUri) of the document.
+            /// </summary>
+            public IList<DocumentAttribute> DocumentAttributes { get; set; }
+
+            /// <summary>
+            /// An extract of the text in the document. Contains information about highlighting the
+            /// relevant terms in the excerpt.
+            /// </summary>
+            public TextWithHighlights DocumentExcerpt { get; set; }
+
+            /// <summary>
+            /// The unique identifier for the document.
+            /// </summary>
+            public string DocumentId { get; set; }
+
+            /// <summary>
+            /// The title of the document. Contains the text of the title and information for highlighting
+            /// the relevant terms in the title.
+            /// </summary>
+            public TextWithHighlights DocumentTitle { get; set; }
+
+            /// <summary>
+            /// The URI of the original location of the document.
+            /// </summary>
+            public string DocumentURI { get; set; }
+
+            /// <summary>
+            /// A token that identifies a particular result from a particular query. Use this token
+            /// to provide click-through feedback for the result. For more information, see <a href="https://docs.aws.amazon.com/kendra/latest/dg/submitting-feedback.html">
+            /// Submitting feedback </a>.
+            /// </summary>
+            public string FeedbackToken { get; set; }
+
+            /// <summary>
+            /// The unique identifier for the query result.
+            /// </summary>
+            public string Id { get; set; }
+
+            /// <summary>
+            /// Indicates the confidence that Amazon Kendra has that a result matches the query that
+            /// you provided. Each result is placed into a bin that indicates the confidence, <code>VERY_HIGH</code>,
+            /// <code>HIGH</code>, <code>MEDIUM</code> and <code>LOW</code>. You can use the score
+            /// to determine if a response meets the confidence needed for your application.
+            ///
+            /// <para>
+            /// The field is only set to <code>LOW</code> when the <code>Type</code> field is set
+            /// to <code>DOCUMENT</code> and Amazon Kendra is not confident that the result matches
+            /// the query.
+            /// </para>
+            /// </summary>
+            public ScoreAttributes ScoreAttributes { get; set; }
+
+            /// <summary>
+            /// The type of document. 
+            /// </summary>
+            public string Type { get; set; }
+        }
+
+        /// <summary>
+        /// An attribute returned from an index query.
+        /// </summary>
+        public class AdditionalResultAttribute
+        {
+            /// <summary>
+            /// The key that identifies the attribute.
+            /// </summary>
+            public string Key { get; set; }
+
+            /// <summary>
+            /// An object that contains the attribute value.
+            /// </summary>
+            public AdditionalResultAttributeValue Value { get; set; }
+
+            /// <summary>
+            /// The data type of the <code>Value</code> property.
+            /// </summary>
+            public string ValueType { get; set; }
+        }
+
+        /// <summary>
+        /// An attribute returned with a document from a search.
+        /// </summary>
+        public class AdditionalResultAttributeValue
+        {
+            /// <summary>
+            /// The text associated with the attribute and information about the highlight to apply
+            /// to the text.
+            /// </summary>
+            public TextWithHighlights TextWithHighlightsValue { get; set; }
+        }
+
+        /// <summary>
+        /// A custom attribute value assigned to a document.
+        /// </summary>
+        public class DocumentAttribute
+        {
+            /// <summary>
+            /// The identifier for the attribute.
+            /// </summary>
+            public string Key { get; set; }
+
+            /// <summary>
+            /// The value of the attribute.
+            /// </summary>
+            public DocumentAttributeValue Value { get; set; }
+        }
+
+        /// <summary>
+        /// Provides text and information about where to highlight the text.
+        /// </summary>
+        public class TextWithHighlights
+        {
+            /// <summary>
+            /// The beginning and end of the text that should be highlighted.
+            /// </summary>
+            public IList<Highlight> Highlights { get; set; }
+
+            /// <summary>
+            /// The text to display to the user.
+            /// </summary>
+            public string Text { get; set; }
+        }
+
+        /// <summary>
+        /// Provides information that you can use to highlight a search result so that your users
+        /// can quickly identify terms in the response.
+        /// </summary>
+        public class Highlight
+        {
+            /// <summary>
+            /// The zero-based location in the response string where the highlight starts.
+            /// </summary>
+            public int BeginOffset { get; set; }
+
+            /// <summary>
+            /// The zero-based location in the response string where the highlight ends.
+            /// </summary>
+            public int EndOffset { get; set; }
+
+            /// <summary>
+            /// Indicates whether the response is the best response. True if this is the best response;
+            /// otherwise, false.
+            /// </summary>
+            public bool TopAnswer { get; set; }
+
+            /// <summary>
+            /// The highlight type. 
+            /// </summary>
+            public string Type { get; set; }
+        }
+
+        /// <summary>
+        /// Provides a relative ranking that indicates how confident Amazon Kendra is that the
+        /// response matches the query.
+        /// </summary>
+        public class ScoreAttributes
+        {
+            /// <summary>
+            /// A relative ranking for how well the response matches the query.
+            /// </summary>
+            public string ScoreConfidence { get; set; }
+        }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.LexV2Events/LexV2ActiveContext.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/LexV2ActiveContext.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Amazon.Lambda.LexV2Events
+{
+    /// <summary>
+    /// Contains information about the contexts that a user is using in a session.
+    /// https://docs.aws.amazon.com/lexv2/latest/dg/API_runtime_ActiveContext.html
+    /// </summary>
+    [DataContract]
+    public class LexV2ActiveContext
+    {
+        /// <summary>
+        /// A list of contexts active for the request. A context can be activated when a previous intent is fulfilled, or by including the context in the request.
+        /// </summary>
+        [DataMember(Name = "contextAttributes", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("contextAttributes")]
+        #endif
+        public IDictionary<string, string> ContextAttributes { get; set; }
+
+        /// <summary>
+        /// The name of the context.
+        /// </summary>
+        [DataMember(Name = "name", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("name")]
+        #endif
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The number of turns that the context is active. You can specify up to 20 turns. Each request and response from the bot is a turn.
+
+        /// </summary>
+        [DataMember(Name = "timeToLive", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("timeToLive")]
+        #endif
+        public ActiveContextTimeToLive TimeToLive { get; set; }
+
+        /// <summary>
+        /// The time that a context is active. You can specify the time to live in seconds or in conversation turns.
+        /// https://docs.aws.amazon.com/lexv2/latest/dg/API_runtime_ActiveContextTimeToLive.html
+        /// </summary>
+        [DataContract]
+        public class ActiveContextTimeToLive
+        {
+            /// <summary>
+            /// The number of seconds that the context is active. You can specify between 5 and 86400 seconds (24 hours).
+            /// </summary>
+            [DataMember(Name = "timeToLiveInSeconds", EmitDefaultValue = false)]
+#if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("timeToLiveInSeconds")]
+#endif
+            public int TimeToLiveInSeconds { get; set; }
+
+            /// <summary>
+            /// The number of turns that the context is active. You can specify up to 20 turns. Each request and response from the bot is a turn.
+
+            /// </summary>
+            [DataMember(Name = "turnsToLive", EmitDefaultValue = false)]
+#if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("turnsToLive")]
+#endif
+            public int TurnsToLive { get; set; }
+        }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.LexV2Events/LexV2ActiveContext.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/LexV2ActiveContext.cs
@@ -14,28 +14,21 @@ namespace Amazon.Lambda.LexV2Events
         /// A list of contexts active for the request. A context can be activated when a previous intent is fulfilled, or by including the context in the request.
         /// </summary>
         [DataMember(Name = "contextAttributes", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("contextAttributes")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("contextAttributes")]
         public IDictionary<string, string> ContextAttributes { get; set; }
 
         /// <summary>
         /// The name of the context.
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("name")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("name")]
         public string Name { get; set; }
 
         /// <summary>
         /// The number of turns that the context is active. You can specify up to 20 turns. Each request and response from the bot is a turn.
-
         /// </summary>
         [DataMember(Name = "timeToLive", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("timeToLive")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("timeToLive")]
         public ActiveContextTimeToLive TimeToLive { get; set; }
 
         /// <summary>
@@ -49,19 +42,14 @@ namespace Amazon.Lambda.LexV2Events
             /// The number of seconds that the context is active. You can specify between 5 and 86400 seconds (24 hours).
             /// </summary>
             [DataMember(Name = "timeToLiveInSeconds", EmitDefaultValue = false)]
-#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("timeToLiveInSeconds")]
-#endif
             public int TimeToLiveInSeconds { get; set; }
 
             /// <summary>
             /// The number of turns that the context is active. You can specify up to 20 turns. Each request and response from the bot is a turn.
-
             /// </summary>
             [DataMember(Name = "turnsToLive", EmitDefaultValue = false)]
-#if NETCOREAPP3_1
             [System.Text.Json.Serialization.JsonPropertyName("turnsToLive")]
-#endif
             public int TurnsToLive { get; set; }
         }
     }

--- a/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Bot.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Bot.cs
@@ -1,0 +1,33 @@
+﻿namespace Amazon.Lambda.LexV2Events
+{
+    /// <summary>
+    /// The class identifies the Lex V2 bot that is invoking the Lambda function.
+    /// </summary>
+    public class LexV2Bot
+    {
+        /// <summary>
+        /// The unique identifier assigned to the bot.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The name of the bot.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The unique identifier assigned to the bot alias.
+        /// </summary>
+        public string AliasId { get; set; }
+
+        /// <summary>
+        /// The language and locale of the bot locale.
+        /// </summary>
+        public string LocaleId { get; set; }
+
+        /// <summary>
+        /// The numeric version of the bot.
+        /// </summary>
+        public string Version { get; set; }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.LexV2Events/LexV2DialogAction.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/LexV2DialogAction.cs
@@ -1,0 +1,39 @@
+﻿using System.Runtime.Serialization;
+
+namespace Amazon.Lambda.LexV2Events
+{
+    /// <summary>
+    /// The class that represents the next action that Amazon Lex V2 should take.
+    /// https://docs.aws.amazon.com/lexv2/latest/dg/API_runtime_DialogAction.html
+    /// </summary>
+    [DataContract]
+    public class LexV2DialogAction
+    {
+        /// <summary>
+        /// Configures the slot to use spell-by-letter or spell-by-word style. When you use a style on a slot, users can spell out their input to make it clear to your bot.
+        /// </summary>
+        [DataMember(Name = "slotElicitationStyle", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("slotElicitationStyle")]
+        #endif
+        public string SlotElicitationStyle { get; set; }
+
+        /// <summary>
+        /// The name of the slot that should be elicited from the user.
+        /// </summary>
+        [DataMember(Name = "slotToElicit", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("slotToElicit")]
+        #endif
+        public string SlotToElicit { get; set; }
+
+        /// <summary>
+        /// The next action that the bot should take in its interaction with the user. Could be one of <c>Close</c>, <c>ConfirmIntent</c>, <c>Delegate</c>, <c>ElicitIntent</c> or <c>ElicitSlot</c>.
+        /// </summary>
+        [DataMember(Name = "type", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("type")]
+        #endif
+        public string Type { get; set; }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.LexV2Events/LexV2DialogAction.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/LexV2DialogAction.cs
@@ -13,27 +13,21 @@ namespace Amazon.Lambda.LexV2Events
         /// Configures the slot to use spell-by-letter or spell-by-word style. When you use a style on a slot, users can spell out their input to make it clear to your bot.
         /// </summary>
         [DataMember(Name = "slotElicitationStyle", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("slotElicitationStyle")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("slotElicitationStyle")]
         public string SlotElicitationStyle { get; set; }
 
         /// <summary>
         /// The name of the slot that should be elicited from the user.
         /// </summary>
         [DataMember(Name = "slotToElicit", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("slotToElicit")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("slotToElicit")]
         public string SlotToElicit { get; set; }
 
         /// <summary>
         /// The next action that the bot should take in its interaction with the user. Could be one of <c>Close</c>, <c>ConfirmIntent</c>, <c>Delegate</c>, <c>ElicitIntent</c> or <c>ElicitSlot</c>.
         /// </summary>
         [DataMember(Name = "type", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("type")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("type")]
         public string Type { get; set; }
     }
 }

--- a/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Event.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Event.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Amazon.Lambda.LexV2Events
+{
+    /// <summary>
+    /// This class represents the input event from Amazon Lex V2. It used as the input parameter
+    /// for Lambda functions.
+    /// https://docs.aws.amazon.com/lexv2/latest/dg/lambda.html#lambda-input-format
+    /// </summary>
+    public class LexV2Event
+    {
+        /// <summary>
+        /// Message Version
+        /// </summary>
+        public string MessageVersion { get; set; }
+
+        /// <summary>
+        /// Indicates the action that called the Lambda function. When the source is DialogCodeHook, the Lambda function was called after input from the user. 
+        /// When the source is FulfillmentCodeHook the Lambda function was called after all required slots have been filled and the intent is ready for fulfillment.
+        /// </summary>
+        public string InvocationSource { get; set; }
+
+        /// <summary>
+        /// Input Mode. Could be one of <c>DTMF</c>, <c>Speech</c> or <c>Text</c>.
+        /// </summary>
+        public string InputMode { get; set; }
+
+        /// <summary>
+        /// Indicates the type of response. Could be one of <c>CustomPayload</c>, <c>ImageResponseCard</c>, <c>PlainText</c> or <c>SSML</c>.
+        /// </summary>
+        public string ResponseContentType { get; set; }
+
+        /// <summary>
+        /// The identifier of the session in use.
+        /// </summary>
+        public string SessionId { get; set; }
+
+        /// <summary>
+        /// The text that was used to process the input from the user. 
+        /// For text or DTMF input, this is the text that the user typed. 
+        /// For speech input, this is the text that was recognized from the speech.
+        /// </summary>
+        public string InputTranscript { get; set; }
+
+        /// <summary>
+        /// The LexV2 bot invoking the Lambda function.
+        /// </summary>
+        public LexV2Bot Bot { get; set; }
+
+        /// <summary>
+        /// One or more intents that Amazon Lex V2 considers possible matches to the user's utterance.
+        /// </summary>
+        public IList<LexV2Interpretation> Interpretations { get; set; }
+
+        /// <summary>
+        /// The next state of the dialog between the user and the bot if the Lambda function doesn't change the flow. 
+        /// Only present when the <c>invocationSource</c> field is <c>DialogCodeHook</c> and when the predicted dialog action is <c>ElicitSlot</c>.
+        /// </summary>
+        public LexV2ProposedNextState ProposedNextState { get; set; }
+
+        /// <summary>
+        /// Request-specific attributes that the client sends in the request. Use request attributes to pass information 
+        /// that doesn't need to persist for the entire session.
+        /// </summary>
+        public IDictionary<string, string> RequestAttributes { get; set; }
+
+        /// <summary>
+        /// The current state of the conversation between the user and your Amazon Lex V2 bot.
+        /// </summary>
+        public LexV2SessionState SessionState { get; set; }
+
+        /// <summary>
+        /// One or more transcriptions that Amazon Lex V2 considers possible matches to the user's audio utterance.
+        /// </summary>
+        public IList<LexV2Transcription> Transcriptions { get; set; }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Intent.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Intent.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Amazon.Lambda.LexV2Events
+{
+    /// <summary>
+    /// The class that represents the current intent that Amazon Lex V2 is attempting to fulfill.
+    /// https://docs.aws.amazon.com/lexv2/latest/dg/API_runtime_Intent.html
+    /// </summary>
+    [DataContract]
+    public class LexV2Intent
+    {
+        /// <summary>
+        /// Contains information about whether fulfillment of the intent has been confirmed. Could be one of <c>Confirmed</c>, <c>Denied</c> or <c>None</c>.
+        /// </summary>
+        [DataMember(Name = "confirmationState", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("confirmationState")]
+        #endif
+        public string ConfirmationState { get; set; }
+
+        /// <summary>
+        /// The name of the intent.
+        /// </summary>
+        [DataMember(Name = "name", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("name")]
+        #endif
+        public string Name { get; set; }
+
+        /// <summary>
+        /// A map of all of the slots for the intent. The name of the slot maps to the value of the slot. If a slot has not been filled, the value is null.
+        /// </summary> 
+        [DataMember(Name = "slots", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+              [System.Text.Json.Serialization.JsonPropertyName("slots")]
+        #endif
+        public IDictionary<string, LexV2Slot> Slots { get; set; }
+
+        /// <summary>
+        /// Contains fulfillment information for the intent. Could be one of <c>Failed</c>, <c>Fulfilled</c>, <c>FulfillmentInProgress</c>, <c>InProgress</c>, <c>ReadyForFulfillment</c> or <c>Waiting</c>.
+        /// </summary>
+        [DataMember(Name = "state", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+              [System.Text.Json.Serialization.JsonPropertyName("state")]
+        #endif
+        public string State { get; set; }
+
+        /// <summary>
+        /// Only present when intent is KendraSearchIntent.
+        /// </summary>
+        [DataMember(Name = "kendraResponse", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+              [System.Text.Json.Serialization.JsonPropertyName("kendraResponse")]
+        #endif
+        public KendraResponse KendraResponse { get; set; }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Intent.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Intent.cs
@@ -14,45 +14,35 @@ namespace Amazon.Lambda.LexV2Events
         /// Contains information about whether fulfillment of the intent has been confirmed. Could be one of <c>Confirmed</c>, <c>Denied</c> or <c>None</c>.
         /// </summary>
         [DataMember(Name = "confirmationState", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("confirmationState")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("confirmationState")]
         public string ConfirmationState { get; set; }
 
         /// <summary>
         /// The name of the intent.
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("name")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("name")]
         public string Name { get; set; }
 
         /// <summary>
         /// A map of all of the slots for the intent. The name of the slot maps to the value of the slot. If a slot has not been filled, the value is null.
         /// </summary> 
         [DataMember(Name = "slots", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-              [System.Text.Json.Serialization.JsonPropertyName("slots")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("slots")]
         public IDictionary<string, LexV2Slot> Slots { get; set; }
 
         /// <summary>
         /// Contains fulfillment information for the intent. Could be one of <c>Failed</c>, <c>Fulfilled</c>, <c>FulfillmentInProgress</c>, <c>InProgress</c>, <c>ReadyForFulfillment</c> or <c>Waiting</c>.
         /// </summary>
         [DataMember(Name = "state", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-              [System.Text.Json.Serialization.JsonPropertyName("state")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("state")]
         public string State { get; set; }
 
         /// <summary>
         /// Only present when intent is KendraSearchIntent.
         /// </summary>
         [DataMember(Name = "kendraResponse", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-              [System.Text.Json.Serialization.JsonPropertyName("kendraResponse")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("kendraResponse")]
         public KendraResponse KendraResponse { get; set; }
     }
 }

--- a/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Interpretation.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Interpretation.cs
@@ -1,0 +1,84 @@
+﻿namespace Amazon.Lambda.LexV2Events
+{
+    /// <summary>
+    /// An intent that Amazon Lex V2 determined might satisfy the user's utterance. The intents are ordered by the confidence score.
+    /// https://docs.aws.amazon.com/lexv2/latest/dg/API_runtime_Interpretation.html
+    /// </summary>
+    public class LexV2Interpretation
+    {
+        /// <summary>
+        /// Intents that might satisfy the user's utterance.
+        /// </summary>
+        public LexV2Intent Intent { get; set; }
+
+        /// <summary>
+        /// Determines the threshold where Amazon Lex V2 will insert the <c>AMAZON.FallbackIntent</c>, <c>AMAZON.KendraSearchIntent</c>, or both when returning 
+        /// alternative intents in a response. <c>AMAZON.FallbackIntent</c> and <c>AMAZON.KendraSearchIntent</c> are only inserted if they are configured for the bot.
+        /// </summary>
+        public LexV2ConfidenceScore NluConfidence { get; set; }
+
+        /// <summary>
+        /// The sentiment expressed in an utterance.
+        /// </summary>
+        /// 
+        public LexV2SentimentResponse SentimentResponse { get; set; }
+    }
+
+    /// <summary>
+    /// The class that represents a score that indicates the confidence that Amazon Lex V2 has that an intent is the one that satisfies the user's intent.
+    /// https://docs.aws.amazon.com/lexv2/latest/dg/API_runtime_ConfidenceScore.html
+    /// </summary>
+    public class LexV2ConfidenceScore
+    {
+        /// <summary>
+        /// A score that indicates how confident Amazon Lex V2 is that an intent satisfies the user's intent. 
+        /// Ranges between 0.00 and 1.00. Higher scores indicate higher confidence.
+        /// </summary>
+        public double? Score { get; set; }
+    }
+
+    /// <summary>
+    /// Provides information about the sentiment expressed in a user's response in a conversation. Sentiments are determined using Amazon Comprehend. 
+    /// Sentiments are only returned if they are enabled for the bot.
+    /// https://docs.aws.amazon.com/lexv2/latest/dg/API_runtime_SentimentResponse.html
+    /// </summary>
+    public class LexV2SentimentResponse
+    {
+        /// <summary>
+        /// The overall sentiment expressed in the user's response. This is the sentiment most likely expressed by the user based on the analysis by Amazon Comprehend.
+        /// </summary>
+        public string Sentiment { get; set; }
+
+        /// <summary>
+        /// The individual sentiment responses for the utterance.
+        /// </summary>
+        public LexV2SentimentScore SentimentScore { get; set; }
+    }
+
+    /// <summary>
+    /// The class that represents the individual sentiment responses for the utterance.
+    /// https://docs.aws.amazon.com/lexv2/latest/dg/API_runtime_SentimentScore.html
+    /// </summary>
+    public class LexV2SentimentScore
+    {
+        /// <summary>
+        /// The level of confidence that Amazon Comprehend has in the accuracy of its detection of the <c>MIXED</c> sentiment.
+        /// </summary>
+        public double? Mixed { get; set; }
+
+        /// <summary>
+        /// The level of confidence that Amazon Comprehend has in the accuracy of its detection of the <c>NEGATIVE</c> sentiment.
+        /// </summary>
+        public double? Negative { get; set; }
+
+        /// <summary>
+        /// The level of confidence that Amazon Comprehend has in the accuracy of its detection of the <c>NEUTRAL</c> sentiment.
+        /// </summary>
+        public double? Neutral { get; set; }
+
+        /// <summary>
+        /// The level of confidence that Amazon Comprehend has in the accuracy of its detection of the <c>POSITIVE</c> sentiment.
+        /// </summary>
+        public double? Positive { get; set; }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Message.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Message.cs
@@ -1,0 +1,110 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Amazon.Lambda.LexV2Events
+{
+    /// <summary>
+    /// The class that represents the container for text that is returned to the customer.
+    /// https://docs.aws.amazon.com/lexv2/latest/dg/API_runtime_Message.html
+    /// </summary>
+    [DataContract]
+    public class LexV2Message
+    {
+        /// <summary>
+        /// The text of the message.
+        /// </summary>
+        [DataMember(Name = "content", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("content")]
+        #endif
+        public string Content { get; set; }
+
+        /// <summary>
+        /// Indicates the type of response. Could be one of <c>CustomPayload</c>, <c>ImageResponseCard</c>, <c>PlainText</c> or <c>SSML</c>.
+        /// </summary>
+        [DataMember(Name = "contentType", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("contentType")]
+        #endif
+        public string ContentType { get; set; }
+
+        /// <summary>
+        /// A card that is shown to the user by a messaging platform. You define the contents of the card, the card is displayed by the platform.
+        /// </summary>
+        [DataMember(Name = "imageResponseCard", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("imageResponseCard")]
+        #endif
+        public LexV2ImageResponseCard ImageResponseCard { get; set; }
+    }
+
+    /// <summary>
+    /// The class that represents a card that is shown to the user by a messaging platform.
+    /// https://docs.aws.amazon.com/lexv2/latest/dg/API_runtime_ImageResponseCard.html
+    /// </summary>
+    [DataContract]
+    public class LexV2ImageResponseCard
+    {
+        /// <summary>
+        /// A list of buttons that should be displayed on the response card. The arrangement of the buttons is determined by the platform that displays the button.
+        /// </summary>
+        [DataMember(Name = "buttons", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("buttons")]
+        #endif
+        public IList<LexV2Button> Buttons { get; set; }
+
+        /// <summary>
+        /// TheThe URL of an image to display on the response card. The image URL must be publicly available so that the platform displaying the response card has access to the image.
+        /// </summary>
+        [DataMember(Name = "imageUrl", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("imageUrl")]
+        #endif
+        public string ImageUrl { get; set; }
+
+        /// <summary>
+        /// The subtitle to display on the response card. The format of the subtitle is determined by the platform displaying the response card.
+        /// </summary>
+        [DataMember(Name = "subtitle", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("subtitle")]
+        #endif
+        public string Subtitle { get; set; }
+
+        /// <summary>
+        /// The title to display on the response card. The format of the title is determined by the platform displaying the response card.
+        /// </summary>
+        [DataMember(Name = "title", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("title")]
+        #endif
+        public string Title { get; set; }
+    }
+
+    /// <summary>
+    /// The class that represents a button that appears on a response card show to the user.
+    /// https://docs.aws.amazon.com/lexv2/latest/dg/API_runtime_Button.html
+    /// </summary>
+    [DataContract]
+    public class LexV2Button
+    {
+        /// <summary>
+        /// The text that is displayed on the button.
+        /// </summary>
+        [DataMember(Name = "text", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("text")]
+        #endif
+        public string Text { get; set; }
+
+        /// <summary>
+        /// The value returned to Amazon Lex V2 when a user chooses the button.
+        /// </summary>
+        [DataMember(Name = "value", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("value")]
+        #endif
+        public string Value { get; set; }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Message.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Message.cs
@@ -14,27 +14,21 @@ namespace Amazon.Lambda.LexV2Events
         /// The text of the message.
         /// </summary>
         [DataMember(Name = "content", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("content")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("content")]
         public string Content { get; set; }
 
         /// <summary>
         /// Indicates the type of response. Could be one of <c>CustomPayload</c>, <c>ImageResponseCard</c>, <c>PlainText</c> or <c>SSML</c>.
         /// </summary>
         [DataMember(Name = "contentType", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("contentType")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("contentType")]
         public string ContentType { get; set; }
 
         /// <summary>
         /// A card that is shown to the user by a messaging platform. You define the contents of the card, the card is displayed by the platform.
         /// </summary>
         [DataMember(Name = "imageResponseCard", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("imageResponseCard")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("imageResponseCard")]
         public LexV2ImageResponseCard ImageResponseCard { get; set; }
     }
 
@@ -49,36 +43,28 @@ namespace Amazon.Lambda.LexV2Events
         /// A list of buttons that should be displayed on the response card. The arrangement of the buttons is determined by the platform that displays the button.
         /// </summary>
         [DataMember(Name = "buttons", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("buttons")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("buttons")]
         public IList<LexV2Button> Buttons { get; set; }
 
         /// <summary>
         /// TheThe URL of an image to display on the response card. The image URL must be publicly available so that the platform displaying the response card has access to the image.
         /// </summary>
         [DataMember(Name = "imageUrl", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("imageUrl")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("imageUrl")]
         public string ImageUrl { get; set; }
 
         /// <summary>
         /// The subtitle to display on the response card. The format of the subtitle is determined by the platform displaying the response card.
         /// </summary>
         [DataMember(Name = "subtitle", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("subtitle")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("subtitle")]
         public string Subtitle { get; set; }
 
         /// <summary>
         /// The title to display on the response card. The format of the title is determined by the platform displaying the response card.
         /// </summary>
         [DataMember(Name = "title", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("title")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("title")]
         public string Title { get; set; }
     }
 
@@ -93,18 +79,14 @@ namespace Amazon.Lambda.LexV2Events
         /// The text that is displayed on the button.
         /// </summary>
         [DataMember(Name = "text", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("text")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("text")]
         public string Text { get; set; }
 
         /// <summary>
         /// The value returned to Amazon Lex V2 when a user chooses the button.
         /// </summary>
         [DataMember(Name = "value", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("value")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("value")]
         public string Value { get; set; }
     }
 }

--- a/Libraries/src/Amazon.Lambda.LexV2Events/LexV2ProposedNextState.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/LexV2ProposedNextState.cs
@@ -1,0 +1,19 @@
+﻿namespace Amazon.Lambda.LexV2Events
+{
+    /// <summary>
+    /// Contains information about the next action that the bot will take if the Lambda function sets the dialogAction to Delegate.
+    /// https://docs.aws.amazon.com/lexv2/latest/dg/lambda.html#request-proposednextstate
+    /// </summary>
+    public class LexV2ProposedNextState
+    {
+        /// <summary>
+        /// Dialog action that Amazon Lex V2 will perform next.
+        /// </summary>
+        public LexV2DialogAction DialogAction { get; set; }
+
+        /// <summary>
+        /// Intent that the bot has determined that the user is trying to fulfill.
+        /// </summary>
+        public LexV2Intent Intent { get; set; }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Response.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Response.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Amazon.Lambda.LexV2Events
+{
+    /// <summary>
+    /// This class represents response from the Lambda function.
+    /// https://docs.aws.amazon.com/lexv2/latest/dg/lambda.html#lambda-response-format
+    /// </summary>
+    [DataContract]
+    public class LexV2Response
+    {
+        /// <summary>
+        /// The current state of the conversation with the user. The actual contents of the structure depends on the type of dialog action.
+        /// </summary>
+        [DataMember(Name = "sessionState", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("sessionState")]
+        #endif
+        public LexV2SessionState SessionState { get; set; }
+
+        /// <summary>
+        /// One or more messages that Amazon Lex V2 shows to the customer to perform the next turn of the conversation. Required if <c>dialogAction.type</c> is <c>ElicitIntent</c>. 
+        /// If you don't supply messages, Amazon Lex V2 uses the appropriate message defined when the bot was created.
+        /// </summary>
+        [DataMember(Name = "messages", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("messages")]
+        #endif
+        public IList<LexV2Message> Messages { get; set; }
+
+        /// <summary>
+        /// Request-specific attributes that the client sends in the request.
+        /// </summary>
+        [DataMember(Name = "requestAttributes", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("requestAttributes")]
+        #endif
+        public IDictionary<string, string> RequestAttributes { get; set; }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Response.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Response.cs
@@ -15,9 +15,7 @@ namespace Amazon.Lambda.LexV2Events
         /// The current state of the conversation with the user. The actual contents of the structure depends on the type of dialog action.
         /// </summary>
         [DataMember(Name = "sessionState", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("sessionState")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("sessionState")]
         public LexV2SessionState SessionState { get; set; }
 
         /// <summary>
@@ -25,18 +23,14 @@ namespace Amazon.Lambda.LexV2Events
         /// If you don't supply messages, Amazon Lex V2 uses the appropriate message defined when the bot was created.
         /// </summary>
         [DataMember(Name = "messages", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("messages")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("messages")]
         public IList<LexV2Message> Messages { get; set; }
 
         /// <summary>
         /// Request-specific attributes that the client sends in the request.
         /// </summary>
         [DataMember(Name = "requestAttributes", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("requestAttributes")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("requestAttributes")]
         public IDictionary<string, string> RequestAttributes { get; set; }
     }
 }

--- a/Libraries/src/Amazon.Lambda.LexV2Events/LexV2SessionState.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/LexV2SessionState.cs
@@ -1,0 +1,119 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Amazon.Lambda.LexV2Events
+{
+    /// <summary>
+    /// The class that represents the state of the user's session with Amazon Lex V2.
+    /// https://docs.aws.amazon.com/lexv2/latest/dg/API_runtime_SessionState.html
+    /// </summary>
+    [DataContract]
+    public class LexV2SessionState
+    {
+        /// <summary>
+        /// One or more contexts that indicate to Amazon Lex V2 the context of a request. When a context is active, Amazon Lex V2 considers 
+        /// intents with the matching context as a trigger as the next intent in a session.
+        /// </summary>
+        [DataMember(Name = "activeContexts", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("activeContexts")]
+        #endif
+        public IList<LexV2ActiveContext> ActiveContexts { get; set; }
+
+        /// <summary>
+        /// The next step that Amazon Lex V2 should take in the conversation with a user.
+        /// </summary>
+        [DataMember(Name = "dialogAction", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("dialogAction")]
+        #endif
+        public LexV2DialogAction DialogAction { get; set; }
+
+        /// <summary>
+        /// The active intent that Amazon Lex V2 is processing.
+        /// </summary>
+        [DataMember(Name = "intent", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("intent")]
+        #endif
+        public LexV2Intent Intent { get; set; }
+
+        /// <summary>
+        /// A unique identifier for a specific request.
+        /// </summary>
+        [DataMember(Name = "originatingRequestId", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("originatingRequestId")]
+        #endif
+        public string OriginatingRequestId { get; set; }
+
+        /// <summary>
+        /// Hints for phrases that a customer is likely to use for a slot. Amazon Lex V2 uses the hints to help determine the correct value of a slot.
+        /// </summary>
+        [DataMember(Name = "runtimeHints", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("runtimeHints")]
+        #endif
+        public LexV2RuntimeHints RuntimeHints { get; set; }
+
+        /// <summary>
+        /// Map of key/value pairs representing session-specific context information. It contains application information passed between Amazon Lex V2 and a client application.
+        /// </summary>
+        [DataMember(Name = "sessionAttributes", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("sessionAttributes")]
+        #endif
+        public Dictionary<string, string> SessionAttributes { get; set; }
+    }
+
+    /// <summary>
+    /// The class that represents hints to the phrases which can be provided to Amazon Lex V2 that a customer is likely to use for a slot.
+    /// https://docs.aws.amazon.com/lexv2/latest/dg/API_runtime_RuntimeHints.html
+    /// </summary>
+    [DataContract]
+    public class LexV2RuntimeHints
+    {
+        /// <summary>
+        /// A list of the slots in the intent that should have runtime hints added, and the phrases that should be added for each slot.
+        /// </summary>
+        [DataMember(Name = "slotHints", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("slotHints")]
+        #endif
+        public IDictionary<string, Dictionary<string, RuntimeHintDetails>> SlotHints { get; set; }
+    }
+
+    /// <summary>
+    /// Provides an array of phrases that should be given preference when resolving values for a slot.
+    /// https://docs.aws.amazon.com/lexv2/latest/dg/API_runtime_RuntimeHintDetails.html
+    /// </summary>
+    [DataContract]
+    public class RuntimeHintDetails
+    {
+        /// <summary>
+        /// One or more strings that Amazon Lex V2 should look for in the input to the bot. Each phrase is given preference when deciding on slot values.
+        /// </summary>
+        [DataMember(Name = "runtimeHintValues", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("runtimeHintValues")]
+        #endif
+        public IList<RuntimeHintValue> RuntimeHintValues { get; set; }
+    }
+
+    /// <summary>
+    /// Provides the phrase that Amazon Lex V2 should look for in the user's input to the bot.
+    /// https://docs.aws.amazon.com/lexv2/latest/dg/API_runtime_RuntimeHintValue.html
+    /// </summary>
+    [DataContract]
+    public class RuntimeHintValue
+    {
+        /// <summary>
+        /// The phrase that Amazon Lex V2 should look for in the user's input to the bot.
+        /// </summary>
+        [DataMember(Name = "phrase", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("phrase")]
+        #endif
+        public string Phrase { get; set; }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.LexV2Events/LexV2SessionState.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/LexV2SessionState.cs
@@ -15,54 +15,42 @@ namespace Amazon.Lambda.LexV2Events
         /// intents with the matching context as a trigger as the next intent in a session.
         /// </summary>
         [DataMember(Name = "activeContexts", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("activeContexts")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("activeContexts")]
         public IList<LexV2ActiveContext> ActiveContexts { get; set; }
 
         /// <summary>
         /// The next step that Amazon Lex V2 should take in the conversation with a user.
         /// </summary>
         [DataMember(Name = "dialogAction", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("dialogAction")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("dialogAction")]
         public LexV2DialogAction DialogAction { get; set; }
 
         /// <summary>
         /// The active intent that Amazon Lex V2 is processing.
         /// </summary>
         [DataMember(Name = "intent", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("intent")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("intent")]
         public LexV2Intent Intent { get; set; }
 
         /// <summary>
         /// A unique identifier for a specific request.
         /// </summary>
         [DataMember(Name = "originatingRequestId", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("originatingRequestId")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("originatingRequestId")]
         public string OriginatingRequestId { get; set; }
 
         /// <summary>
         /// Hints for phrases that a customer is likely to use for a slot. Amazon Lex V2 uses the hints to help determine the correct value of a slot.
         /// </summary>
         [DataMember(Name = "runtimeHints", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("runtimeHints")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("runtimeHints")]
         public LexV2RuntimeHints RuntimeHints { get; set; }
 
         /// <summary>
         /// Map of key/value pairs representing session-specific context information. It contains application information passed between Amazon Lex V2 and a client application.
         /// </summary>
         [DataMember(Name = "sessionAttributes", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("sessionAttributes")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("sessionAttributes")]
         public Dictionary<string, string> SessionAttributes { get; set; }
     }
 
@@ -77,9 +65,7 @@ namespace Amazon.Lambda.LexV2Events
         /// A list of the slots in the intent that should have runtime hints added, and the phrases that should be added for each slot.
         /// </summary>
         [DataMember(Name = "slotHints", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("slotHints")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("slotHints")]
         public IDictionary<string, Dictionary<string, RuntimeHintDetails>> SlotHints { get; set; }
     }
 
@@ -94,9 +80,7 @@ namespace Amazon.Lambda.LexV2Events
         /// One or more strings that Amazon Lex V2 should look for in the input to the bot. Each phrase is given preference when deciding on slot values.
         /// </summary>
         [DataMember(Name = "runtimeHintValues", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("runtimeHintValues")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("runtimeHintValues")]
         public IList<RuntimeHintValue> RuntimeHintValues { get; set; }
     }
 
@@ -111,9 +95,7 @@ namespace Amazon.Lambda.LexV2Events
         /// The phrase that Amazon Lex V2 should look for in the user's input to the bot.
         /// </summary>
         [DataMember(Name = "phrase", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("phrase")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("phrase")]
         public string Phrase { get; set; }
     }
 }

--- a/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Slot.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Slot.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Amazon.Lambda.LexV2Events
+{
+    /// <summary>
+    /// The class that represents a value that Amazon Lex V2 uses to fulfill an intent.
+    /// https://docs.aws.amazon.com/lexv2/latest/dg/API_runtime_Slot.html
+    /// </summary>
+    [DataContract]
+    public class LexV2Slot
+    {
+        /// <summary>
+        /// When the shape value is List, it indicates that the values field contains a list of slot values. 
+        /// When the value is Scalar, it indicates that the value field contains a single value.
+        /// </summary>
+        [DataMember(Name = "shape", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("shape")]
+        #endif
+        public string Shape { get; set; }
+
+        /// <summary>
+        /// The current value of the slot.
+        /// </summary>
+        [DataMember(Name = "value", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("value")]
+        #endif
+        public LexV2SlotValue Value { get; set; }
+
+        /// <summary>
+        /// The resolutions array contains a list of additional values recognized for the slot.
+        /// </summary> 
+        [DataMember(Name = "values", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("values")]
+        #endif
+        public IList<LexV2Slot> Values { get; set; }
+    }
+
+    /// <summary>
+    /// The class that represents the value of a slot.
+    /// https://docs.aws.amazon.com/lexv2/latest/dg/API_runtime_Value.html
+    /// </summary>
+    [DataContract]
+    public class LexV2SlotValue
+    {
+        /// <summary>
+        /// The value that Amazon Lex V2 determines for the slot. The actual value depends on the setting of the value selection strategy for the bot.
+        /// </summary>
+        [DataMember(Name = "interpretedValue", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("interpretedValue")]
+        #endif
+        public string InterpretedValue { get; set; }
+
+        /// <summary>
+        /// The text of the utterance from the user that was entered for the slot.
+        /// </summary>
+        [DataMember(Name = "originalValue", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("originalValue")]
+        #endif
+        public string OriginalValue { get; set; }
+
+        /// <summary>
+        /// A list of additional values that have been recognized for the slot.
+        /// </summary>
+        [DataMember(Name = "resolvedValues", EmitDefaultValue = false)]
+        #if NETCOREAPP3_1
+            [System.Text.Json.Serialization.JsonPropertyName("resolvedValues")]
+        #endif
+        public IList<string> ResolvedValues { get; set; }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Slot.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Slot.cs
@@ -15,27 +15,21 @@ namespace Amazon.Lambda.LexV2Events
         /// When the value is Scalar, it indicates that the value field contains a single value.
         /// </summary>
         [DataMember(Name = "shape", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("shape")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("shape")]
         public string Shape { get; set; }
 
         /// <summary>
         /// The current value of the slot.
         /// </summary>
         [DataMember(Name = "value", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("value")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("value")]
         public LexV2SlotValue Value { get; set; }
 
         /// <summary>
         /// The resolutions array contains a list of additional values recognized for the slot.
         /// </summary> 
         [DataMember(Name = "values", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("values")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("values")]
         public IList<LexV2Slot> Values { get; set; }
     }
 
@@ -50,27 +44,21 @@ namespace Amazon.Lambda.LexV2Events
         /// The value that Amazon Lex V2 determines for the slot. The actual value depends on the setting of the value selection strategy for the bot.
         /// </summary>
         [DataMember(Name = "interpretedValue", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("interpretedValue")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("interpretedValue")]
         public string InterpretedValue { get; set; }
 
         /// <summary>
         /// The text of the utterance from the user that was entered for the slot.
         /// </summary>
         [DataMember(Name = "originalValue", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("originalValue")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("originalValue")]
         public string OriginalValue { get; set; }
 
         /// <summary>
         /// A list of additional values that have been recognized for the slot.
         /// </summary>
         [DataMember(Name = "resolvedValues", EmitDefaultValue = false)]
-        #if NETCOREAPP3_1
-            [System.Text.Json.Serialization.JsonPropertyName("resolvedValues")]
-        #endif
+        [System.Text.Json.Serialization.JsonPropertyName("resolvedValues")]
         public IList<string> ResolvedValues { get; set; }
     }
 }

--- a/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Transcription.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Transcription.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+
+namespace Amazon.Lambda.LexV2Events
+{
+    /// <summary>
+    /// The class that represents the Amazon Lex V2 Transcription that possibly matches to the user's audio utterance.
+    /// https://docs.aws.amazon.com/lexv2/latest/dg/using-transcript-confidence-scores.html
+    /// </summary>
+    public class LexV2Transcription
+    {
+        /// <summary>
+        /// Transcription Name.
+        /// </summary>
+        public string Transcription { get; set; }
+
+        /// <summary>
+        /// Transcription Confidence score to help determine if the transcription is the correct one. 
+        /// Ranges between 0.00 and 1.00. Higher scores indicate higher confidence..
+        /// </summary>
+        public double? TranscriptionConfidence { get; set; }
+
+        /// <summary>
+        /// Resolved Context.
+        /// </summary>
+        public LexV2TranscriptionResolvedContext ResolvedContext { get; set; }
+
+        /// <summary>
+        /// A map of all of the resolved slots for the transcription.
+        /// </summary> 
+        public IDictionary<string, LexV2Slot> ResolvedSlots { get; set; }
+
+        /// <summary>
+        /// The class that represents a Transcription Resolved Intent.
+        /// </summary>
+        public class LexV2TranscriptionResolvedContext
+        {
+            /// <summary>
+            /// The name of the intent.
+            /// </summary>
+            public string Intent { get; set; }
+        }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.LexV2Events/README.md
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/README.md
@@ -1,0 +1,40 @@
+# Amazon.Lambda.LexV2Events
+
+This package contains classes that can be used as input and response types for Lambda functions that process Amazon Lex V2 events.
+
+# Sample Function
+
+The following is a sample class and Lambda function that receives Amazon Lex V2 event as an input and returns back a response.
+
+```csharp
+public class Function
+{
+    public LexV2Response Handler(LexV2Event lexV2Event)
+    {
+        // Process the event.
+
+        var tempSessionState = lexV2Event.SessionState;
+        tempSessionState.DialogAction = new LexV2DialogAction() { Type = "Close" };
+
+        var response = new LexV2Response
+        {
+            SessionState = tempSessionState,
+            RequestAttributes = lexV2Event.RequestAttributes,
+            Messages = new List<LexV2Message>() { 
+                new LexV2Message() {
+                    ContentType = "ImageResponseCard",
+                    ImageResponseCard = new LexV2ImageResponseCard() {
+                        Buttons = new List<LexV2Button>() {
+                            new LexV2Button(){ Text = "Take Action", Value = "takeaction" }
+                        },
+                        Title = "Take Action",
+                        Subtitle = "Click button to take action"
+                    }
+                }
+            }
+        };
+
+        return response;
+    }
+}
+```

--- a/Libraries/test/EventsTests.NET6/EventsTests.NET6.csproj
+++ b/Libraries/test/EventsTests.NET6/EventsTests.NET6.csproj
@@ -37,6 +37,7 @@
     <ProjectReference Include="..\..\src\Amazon.Lambda.KinesisAnalyticsEvents\Amazon.Lambda.KinesisAnalyticsEvents.csproj" />
     <ProjectReference Include="..\..\src\Amazon.Lambda.KinesisFirehoseEvents\Amazon.Lambda.KinesisFirehoseEvents.csproj" />
     <ProjectReference Include="..\..\src\Amazon.Lambda.LexEvents\Amazon.Lambda.LexEvents.csproj" />
+    <ProjectReference Include="..\..\src\Amazon.Lambda.LexV2Events\Amazon.Lambda.LexV2Events.csproj" />
     <ProjectReference Include="..\..\src\Amazon.Lambda.Serialization.Json\Amazon.Lambda.Serialization.Json.csproj" />
     <ProjectReference Include="..\..\src\Amazon.Lambda.CognitoEvents\Amazon.Lambda.CognitoEvents.csproj" />
     <ProjectReference Include="..\..\src\Amazon.Lambda.ConfigEvents\Amazon.Lambda.ConfigEvents.csproj" />

--- a/Libraries/test/EventsTests.NETCore31/EventsTests.NETCore31.csproj
+++ b/Libraries/test/EventsTests.NETCore31/EventsTests.NETCore31.csproj
@@ -43,6 +43,7 @@
     <ProjectReference Include="..\..\src\Amazon.Lambda.KinesisAnalyticsEvents\Amazon.Lambda.KinesisAnalyticsEvents.csproj" />
     <ProjectReference Include="..\..\src\Amazon.Lambda.KinesisFirehoseEvents\Amazon.Lambda.KinesisFirehoseEvents.csproj" />
     <ProjectReference Include="..\..\src\Amazon.Lambda.LexEvents\Amazon.Lambda.LexEvents.csproj" />
+    <ProjectReference Include="..\..\src\Amazon.Lambda.LexV2Events\Amazon.Lambda.LexV2Events.csproj" />
     <ProjectReference Include="..\..\src\Amazon.Lambda.Serialization.Json\Amazon.Lambda.Serialization.Json.csproj" />
     <ProjectReference Include="..\..\src\Amazon.Lambda.CognitoEvents\Amazon.Lambda.CognitoEvents.csproj" />
     <ProjectReference Include="..\..\src\Amazon.Lambda.ConfigEvents\Amazon.Lambda.ConfigEvents.csproj" />

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -1331,10 +1331,8 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
-#endif
         public void LexV2Event(Type serializerType)
         {
             var serializer = Activator.CreateInstance(serializerType) as ILambdaSerializer;
@@ -1451,10 +1449,8 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
-#endif
         public void LexV2Response(Type serializerType)
         {
             var serializer = Activator.CreateInstance(serializerType) as ILambdaSerializer;

--- a/Libraries/test/EventsTests.Shared/EventsTests.Shared.projitems
+++ b/Libraries/test/EventsTests.Shared/EventsTests.Shared.projitems
@@ -33,7 +33,9 @@
     <Content Include="$(MSBuildThisFileDirectory)kinesis-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)kinesis-firehose-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)kinesis-firehose-response.json" />
+    <Content Include="$(MSBuildThisFileDirectory)lexv2-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)lex-event.json" />
+    <Content Include="$(MSBuildThisFileDirectory)lexv2-response.json" />
     <Content Include="$(MSBuildThisFileDirectory)lex-response.json" />
     <Content Include="$(MSBuildThisFileDirectory)logs-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)proxy-event.json" />

--- a/Libraries/test/EventsTests.Shared/lexv2-event.json
+++ b/Libraries/test/EventsTests.Shared/lexv2-event.json
@@ -1,0 +1,184 @@
+﻿{
+  "messageVersion": "1.0",
+  "invocationSource": "DialogCodeHook",
+  "inputMode": "DTMF",
+  "responseContentType": "ImageResponseCard",
+  "sessionId": "test_session",
+  "inputTranscript": "test_input_transcript",
+  "bot": {
+    "id": "UFIDGBA6DE",
+    "name": "testbot",
+    "aliasId": "TSTALIASID",
+    "localeId": "en_US",
+    "version": "1.0"
+  },
+  "interpretations": [
+    {
+      "intent": {
+        "name": "TestAction",
+        "slots": {
+          "ActionType": {
+            "shape": "List",
+            "value": {
+              "originalValue": "Action Value",
+              "interpretedValue": "Action Value",
+              "resolvedValues": [
+                "action value"
+              ]
+            },
+            "values": [
+              {
+                "shape": "Scalar",
+                "value": {
+                  "originalValue": "Action Value",
+                  "interpretedValue": "Action Value",
+                  "resolvedValues": [
+                    "action value"
+                  ]
+                }
+              }
+            ]
+          },
+          "ActionDate": null,
+          "ActionTime": null
+        },
+        "state": "InProgress",
+        "confirmationState": "None"
+      },
+      "nluConfidence": {
+        "score": 1.0
+      },
+      "sentimentResponse": {
+        "sentiment": "testsentiment",
+        "sentimentScore": {
+          "mixed": 0.1,
+          "negative": 0.1,
+          "neutral": 0.5,
+          "positive": 0.9
+        }
+      }
+    },
+    {
+      "intent": {
+        "name": "FallbackIntent",
+        "slots": {}
+      }
+    }
+  ],
+  "proposedNextState": {
+    "dialogAction": {
+      "slotToElicit": "ActionDate",
+      "type": "ConfirmIntent"
+    },
+    "intent": {
+      "name": "NextIntent",
+      "confirmationState": "None",
+      "slots": {},
+      "state": "Waiting"
+    }
+  },
+  "requestAttributes": {
+    "key1": "value1",
+    "key2": "value2"
+  },
+  "sessionState": {
+    "activeContexts": [
+      {
+        "contextAttributes": {
+          "contextattribute1": "contextattributevalue1",
+          "contextattribute2": "contextattributevalue2"
+        },
+        "name": "testcontext",
+        "timeToLive": {
+          "timeToLiveInSeconds": 12,
+          "turnsToLive": 20
+        }
+      }
+    ],
+    "dialogAction": {
+      "type": "ElicitSlot",
+      "slotToElicit": "Date"
+    },
+    "intent": {
+      "name": "TestAction",
+      "slots": {
+        "ActionType": {
+          "shape": "List",
+          "value": {
+            "originalValue": "Action Value",
+            "interpretedValue": "Action Value",
+            "resolvedValues": [
+              "action value"
+            ]
+          },
+          "values": [
+            {
+              "shape": "Scalar",
+              "value": {
+                "originalValue": "Action Value",
+                "interpretedValue": "Action Value",
+                "resolvedValues": [
+                  "action value"
+                ]
+              }
+            }
+          ]
+        },
+        "ActionDate": null,
+        "ActionTime": null
+      },
+      "state": "InProgress",
+      "confirmationState": "None"
+    },
+    "originatingRequestId": "85f22c97-b5d3-4a74-9e3d-95446768ecaa",
+    "runtimeHints": {
+      "slotHints": {
+        "hint1": {
+          "detail1": {
+            "runtimeHintValues": [
+              { "phrase": "hintvalue1_1" },
+              { "phrase": "hintvalue1_2" }
+            ]
+          }
+        }
+      }
+    },
+    "sessionAttributes": {
+      "sessionattribute1": "sessionvalue1",
+      "sessionattribute2": "sessionvalue2"
+    }
+  },
+  "transcriptions": [
+    {
+      "transcription": "testtranscription",
+      "transcriptionConfidence": 0.8,
+      "resolvedContext": {
+        "intent": "TestAction"
+      },
+      "resolvedSlots": {
+        "ActionType": {
+          "shape": "List",
+          "value": {
+            "originalValue": "Action Value",
+            "interpretedValue": "Action Value",
+            "resolvedValues": [
+              "action value"
+            ]
+          },
+          "values": [
+            {
+              "shape": "Scalar",
+              "value": {
+                "originalValue": "Action Value",
+                "interpretedValue": "Action Value",
+                "resolvedValues": [
+                  "action value"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/Libraries/test/EventsTests.Shared/lexv2-response.json
+++ b/Libraries/test/EventsTests.Shared/lexv2-response.json
@@ -1,0 +1,90 @@
+﻿{
+  "messages": [
+    {
+      "content": "Test Content",
+      "contentType": "ImageResponseCard",
+      "imageResponseCard": {
+        "buttons": [
+          {
+            "text": "Take Action",
+            "value": "takeaction"
+          }
+        ],
+        "imageUrl": "http://somedomain.com/testimage.png",
+        "subtitle": "Click button to take action",
+        "title": "Take Action"
+      }
+    }
+  ],
+  "sessionState": {
+    "activeContexts": [
+      {
+        "contextAttributes": {
+          "contextattribute1": "contextattributevalue1",
+          "contextattribute2": "contextattributevalue2"
+        },
+        "name": "testcontext",
+        "timeToLive": {
+          "timeToLiveInSeconds": 12,
+          "turnsToLive": 20
+        }
+      }
+    ],
+    "dialogAction": {
+      "type": "ElicitSlot",
+      "slotToElicit": "Date"
+    },
+    "intent": {
+      "name": "TestAction",
+      "slots": {
+        "ActionType": {
+          "shape": "List",
+          "value": {
+            "originalValue": "Action Value",
+            "interpretedValue": "Action Value",
+            "resolvedValues": [
+              "action value"
+            ]
+          },
+          "values": [
+            {
+              "shape": "Scalar",
+              "value": {
+                "originalValue": "Action Value",
+                "interpretedValue": "Action Value",
+                "resolvedValues": [
+                  "action value"
+                ]
+              }
+            }
+          ]
+        },
+        "ActionDate": null,
+        "ActionTime": null
+      },
+      "state": "InProgress",
+      "confirmationState": "None"
+    },
+    "originatingRequestId": "85f22c97-b5d3-4a74-9e3d-95446768ecaa",
+    "runtimeHints": {
+      "slotHints": {
+        "hint1": {
+          "detail1": {
+            "runtimeHintValues": [
+              { "phrase": "hintvalue1_1" },
+              { "phrase": "hintvalue1_2" }
+            ]
+          }
+        }
+      }
+    },
+    "sessionAttributes": {
+      "sessionattribute1": "sessionvalue1",
+      "sessionattribute2": "sessionvalue2"
+    }
+  },
+  "requestAttributes": {
+    "key1": "value1",
+    "key2": "value2"
+  }
+}


### PR DESCRIPTION
*Issue #, if available:* #1077 

*Description of changes:*
Added support for Amazon Lex V2 event.

*Testing:*
Tested end-to-end by creating a new Bot using the existing example MakeAppointment. Followed instructions at [Using an AWS Lambda function](https://docs.aws.amazon.com/lexv2/latest/dg/lambda.html) and https://catalog.us-east-1.prod.workshops.aws/workshops/94f60d43-15b7-45f4-bbbc-17889ae64ea0/en-US/banker-bot/create-first-lambda to integrate with Lambda. This has helped us uncover LexV2 documentation issue which has incorrect example for sample input event format for `transcriptionConfidence` score.

*UPDATE:* TranscriptionConfidence is of type `double` in LexV2Transcription class as confirmed by Lex team.
___

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
