### PR TITLE
Corrected the return type of Partition property in KafkaEventRecord in Amazon.Lambda.KafkaEvents package.

### DIFF
--- a/Libraries/src/Amazon.Lambda.KafkaEvents/Amazon.Lambda.KafkaEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.KafkaEvents/Amazon.Lambda.KafkaEvents.csproj
@@ -6,10 +6,10 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>Amazon Lambda .NET Core support - KafkaEvents package.</Description>
     <AssemblyTitle>Amazon.Lambda.KafkaEvents</AssemblyTitle>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <AssemblyName>Amazon.Lambda.KafkaEvents</AssemblyName>
     <PackageId>Amazon.Lambda.KafkaEvents</PackageId>
-    <PackageTags>AWS;Amazon;Lambda</PackageTags>
+    <PackageTags>AWS;Amazon;Lambda;Kafka</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/Libraries/src/Amazon.Lambda.KafkaEvents/KafkaEvent.cs
+++ b/Libraries/src/Amazon.Lambda.KafkaEvents/KafkaEvent.cs
@@ -43,7 +43,7 @@
             /// <summary>
             /// The partition associated with the event record.
             /// </summary>
-            public string Partition { get; set; }
+            public int Partition { get; set; }
 
             /// <summary>
             /// The partition offset associated with the event record.

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -1900,7 +1900,7 @@ namespace Amazon.Lambda.Tests
                 Assert.Equal(record.Value.Count, 1);
                 var eventRecord = record.Value.FirstOrDefault();
                 Assert.Equal(eventRecord.Topic, "mytopic");
-                Assert.Equal(eventRecord.Partition, "0");
+                Assert.Equal(eventRecord.Partition, 12);
                 Assert.Equal(eventRecord.Offset, 15);
                 Assert.Equal(eventRecord.Timestamp, 1545084650987);
                 Assert.Equal(eventRecord.TimestampType, "CREATE_TIME");

--- a/Libraries/test/EventsTests.Shared/kafka-event.json
+++ b/Libraries/test/EventsTests.Shared/kafka-event.json
@@ -6,7 +6,7 @@
     "mytopic-0": [
       {
         "topic": "mytopic",
-        "partition": "0",
+        "partition": 12,
         "offset": 15,
         "timestamp": 1545084650987,
         "timestampType": "CREATE_TIME",

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj
@@ -6,7 +6,7 @@
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET Core AWS Lambda functions locally.</Description>
     <LangVersion>Latest</LangVersion>
-    <VersionPrefix>0.12.1</VersionPrefix>
+    <VersionPrefix>0.12.2</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester31-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester31-pack.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET Core 3.1 AWS Lambda functions locally.</Description>
-    <VersionPrefix>0.12.1</VersionPrefix>
+    <VersionPrefix>0.12.2</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester50-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester50-pack.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET 5.0 AWS Lambda functions locally.</Description>
-    <VersionPrefix>0.12.1</VersionPrefix>
+    <VersionPrefix>0.12.2</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester60-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester60-pack.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET 6.0 AWS Lambda functions locally.</Description>
-    <VersionPrefix>0.12.1</VersionPrefix>
+    <VersionPrefix>0.12.2</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Resources/SampleRequests/kafka-event.json
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Resources/SampleRequests/kafka-event.json
@@ -6,7 +6,7 @@
     "mytopic-0": [
       {
         "topic": "mytopic",
-        "partition": "0",
+        "partition": 12,
         "offset": 15,
         "timestamp": 1545084650987,
         "timestampType": "CREATE_TIME",


### PR DESCRIPTION
*Issue #, if available:* #1070 

*Description of changes:*
Corrected the return type of `Partition` property in `KafkaEventRecord` in `Amazon.Lambda.KafkaEvents` package. This also updates the sample request in Lambda Test tool.

___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
