### PR TITLE
Corrected property name ConnectionAt to ConnectedAt in APIGatewayProxyRequest.ProxyRequestContext class.

### DIFF
--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayProxyRequest.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayProxyRequest.cs
@@ -185,7 +185,7 @@
             /// This field is only set for WebSocket API requests.
             /// </para>
             /// </summary>
-            public long ConnectionAt { get; set; }
+            public long ConnectedAt { get; set; }
 
             /// <summary>
             /// A domain name for the WebSocket API. This can be used to make a callback to the client (instead of a hard-coded value).

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/Amazon.Lambda.APIGatewayEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/Amazon.Lambda.APIGatewayEvents.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>    
     <Description>Amazon Lambda .NET Core support - API Gateway package.</Description>
     <AssemblyTitle>Amazon.Lambda.APIGatewayEvents</AssemblyTitle>
-    <VersionPrefix>2.4.0</VersionPrefix>
+    <VersionPrefix>2.4.1</VersionPrefix>
     <AssemblyName>Amazon.Lambda.APIGatewayEvents</AssemblyName>
     <PackageId>Amazon.Lambda.APIGatewayEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -968,6 +968,76 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
+#if NETCOREAPP3_1_OR_GREATER
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+#endif
+        public void WebSocketApiConnectTest(Type serializerType)
+        {
+            var serializer = Activator.CreateInstance(serializerType) as ILambdaSerializer;
+            using (var fileStream = LoadJsonTestFile("websocket-api-connect-request.json"))
+            {
+                var proxyEvent = serializer.Deserialize<APIGatewayProxyRequest>(fileStream);
+
+                Assert.Null(proxyEvent.Resource);
+                Assert.Null(proxyEvent.Path);
+                Assert.Null(proxyEvent.HttpMethod);
+                Assert.Null(proxyEvent.Body);
+
+                var headers = proxyEvent.Headers;
+                Assert.Equal(headers["HeaderAuth1"], "headerValue1");
+                Assert.Equal(headers["Host"], "lg10ltpf4f.execute-api.us-east-2.amazonaws.com");
+                Assert.Equal(headers["Sec-WebSocket-Extensions"], "permessage-deflate; client_max_window_bits");
+                Assert.Equal(headers["Sec-WebSocket-Key"], "BvlrrFKoKAPDYOlwBcGKWw==");
+                Assert.Equal(headers["Sec-WebSocket-Version"], "13");
+                Assert.Equal(headers["X-Amzn-Trace-Id"], "Root=1-625d9ad1-37a5d33a61dd9be33ae3a247");
+                Assert.Equal(headers["X-Forwarded-For"], "52.95.4.0");
+                Assert.Equal(headers["X-Forwarded-Port"], "443");
+                Assert.Equal(headers["X-Forwarded-Proto"], "https");
+
+                var multiValueHeaders = proxyEvent.MultiValueHeaders;
+                Assert.Equal(multiValueHeaders["HeaderAuth1"].Count, 1);
+                Assert.Equal(multiValueHeaders["HeaderAuth1"][0], "headerValue1");
+                Assert.Equal(multiValueHeaders["Host"].Count, 1);
+                Assert.Equal(multiValueHeaders["Host"][0], "lg10ltpf4f.execute-api.us-east-2.amazonaws.com");
+                Assert.Equal(multiValueHeaders["Sec-WebSocket-Extensions"].Count, 1);
+                Assert.Equal(multiValueHeaders["Sec-WebSocket-Extensions"][0], "permessage-deflate; client_max_window_bits");
+                Assert.Equal(multiValueHeaders["Sec-WebSocket-Key"].Count, 1);
+                Assert.Equal(multiValueHeaders["Sec-WebSocket-Key"][0], "BvlrrFKoKAPDYOlwBcGKWw==");
+                Assert.Equal(multiValueHeaders["Sec-WebSocket-Version"].Count, 1);
+                Assert.Equal(multiValueHeaders["Sec-WebSocket-Version"][0], "13");
+                Assert.Equal(multiValueHeaders["X-Amzn-Trace-Id"].Count, 1);
+                Assert.Equal(multiValueHeaders["X-Amzn-Trace-Id"][0], "Root=1-625d9ad1-37a5d33a61dd9be33ae3a247");
+                Assert.Equal(multiValueHeaders["X-Forwarded-For"].Count, 1);
+                Assert.Equal(multiValueHeaders["X-Forwarded-For"][0], "52.95.4.0");
+                Assert.Equal(multiValueHeaders["X-Forwarded-Port"].Count, 1);
+                Assert.Equal(multiValueHeaders["X-Forwarded-Port"][0], "443");
+                Assert.Equal(multiValueHeaders["X-Forwarded-Proto"].Count, 1);
+                Assert.Equal(multiValueHeaders["X-Forwarded-Proto"][0], "https");
+
+                var requestContext = proxyEvent.RequestContext;
+                Assert.Equal(requestContext.RouteKey, "$connect");
+                Assert.Equal(requestContext.EventType, "CONNECT");
+                Assert.Equal(requestContext.ExtendedRequestId, "QyUg1HJgCYcFvbw=");
+                Assert.Equal(requestContext.RequestTime, "18/Apr/2022:17:07:29 +0000");
+                Assert.Equal(requestContext.MessageDirection, "IN");
+                Assert.Equal(requestContext.Stage, "production");
+                Assert.Equal(requestContext.ConnectedAt, 1650301649973);
+                Assert.Equal(requestContext.RequestTimeEpoch, 1650301649973);
+                Assert.Equal(requestContext.RequestId, "QyUg1HJgCYcFvbw=");
+                Assert.Equal(requestContext.DomainName, "lg10ltpf4f.execute-api.us-east-2.amazonaws.com");
+                Assert.Equal(requestContext.ConnectionId, "QyUg1czHCYcCHXw=");
+                Assert.Equal(requestContext.ApiId, "lg10ltpf4f");
+
+                Assert.False(proxyEvent.IsBase64Encoded);
+
+                var identity = requestContext.Identity;
+                Assert.Equal(identity.SourceIp, "52.95.4.0");
+            }
+        }
+
+        [Theory]
+        [InlineData(typeof(JsonSerializer))]
 #if NETCOREAPP3_1_OR_GREATER        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]

--- a/Libraries/test/EventsTests.Shared/EventsTests.Shared.projitems
+++ b/Libraries/test/EventsTests.Shared/EventsTests.Shared.projitems
@@ -19,6 +19,7 @@
     <Content Include="$(MSBuildThisFileDirectory)dynamodb-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)ecs-container-state-change-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)ecs-task-state-change-event.json" />
+    <Content Include="$(MSBuildThisFileDirectory)websocket-api-connect-request.json" />
     <Content Include="$(MSBuildThisFileDirectory)http-api-v2-request.json" />
     <Content Include="$(MSBuildThisFileDirectory)amazonmq-activemq.json" />
     <Content Include="$(MSBuildThisFileDirectory)kinesis-analytics-firehoseinputpreprocessing-event.json" />

--- a/Libraries/test/EventsTests.Shared/websocket-api-connect-request.json
+++ b/Libraries/test/EventsTests.Shared/websocket-api-connect-request.json
@@ -1,0 +1,60 @@
+﻿{
+  "headers": {
+    "HeaderAuth1": "headerValue1",
+    "Host": "lg10ltpf4f.execute-api.us-east-2.amazonaws.com",
+    "Sec-WebSocket-Extensions": "permessage-deflate; client_max_window_bits",
+    "Sec-WebSocket-Key": "BvlrrFKoKAPDYOlwBcGKWw==",
+    "Sec-WebSocket-Version": "13",
+    "X-Amzn-Trace-Id": "Root=1-625d9ad1-37a5d33a61dd9be33ae3a247",
+    "X-Forwarded-For": "52.95.4.0",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "multiValueHeaders": {
+    "HeaderAuth1": [
+      "headerValue1"
+    ],
+    "Host": [
+      "lg10ltpf4f.execute-api.us-east-2.amazonaws.com"
+    ],
+    "Sec-WebSocket-Extensions": [
+      "permessage-deflate; client_max_window_bits"
+    ],
+    "Sec-WebSocket-Key": [
+      "BvlrrFKoKAPDYOlwBcGKWw=="
+    ],
+    "Sec-WebSocket-Version": [
+      "13"
+    ],
+    "X-Amzn-Trace-Id": [
+      "Root=1-625d9ad1-37a5d33a61dd9be33ae3a247"
+    ],
+    "X-Forwarded-For": [
+      "52.95.4.0"
+    ],
+    "X-Forwarded-Port": [
+      "443"
+    ],
+    "X-Forwarded-Proto": [
+      "https"
+    ]
+  },
+  "requestContext": {
+    "routeKey": "$connect",
+    "eventType": "CONNECT",
+    "extendedRequestId": "QyUg1HJgCYcFvbw=",
+    "requestTime": "18/Apr/2022:17:07:29 +0000",
+    "messageDirection": "IN",
+    "stage": "production",
+    "connectedAt": 1650301649973,
+    "requestTimeEpoch": 1650301649973,
+    "identity": {
+      "sourceIp": "52.95.4.0"
+    },
+    "requestId": "QyUg1HJgCYcFvbw=",
+    "domainName": "lg10ltpf4f.execute-api.us-east-2.amazonaws.com",
+    "connectionId": "QyUg1czHCYcCHXw=",
+    "apiId": "lg10ltpf4f"
+  },
+  "isBase64Encoded": false
+}


### PR DESCRIPTION
*Issue #, if available:* #1140

*Description of changes:*
Corrected property name ConnectionAt to ConnectedAt in APIGatewayProxyRequest.ProxyRequestContext class.

*NOTE:* There is no test case for this request, and also there is no sample request event available in Lambda documentation for WebProxy integration. This is a breaking change, hence change log needs to be updated accordingly post-release.
___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
