### PR TITLE
Version bump Amazon.Lambda.DynamoDBEvents to update AWSSDK.DynamoDBv2 to version 3.7.3.24.

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2017/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,7 +7,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.13" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.24" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.13" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.24" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -7,8 +7,8 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.13" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.24" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.13" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.24" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -5,8 +5,8 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.13" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.24" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,7 +7,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.13" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.24" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
-    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.13" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.24" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -7,8 +7,8 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.13" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.24" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
-    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.13" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.24" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -5,8 +5,8 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.13" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.24" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/WebSocketAPIServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/WebSocketAPIServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -11,6 +11,6 @@
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />
     <PackageReference Include="AWSSDK.ApiGatewayManagementApi" Version="3.7.0.139" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.13" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.24" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
-    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.13" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.24" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -7,8 +7,8 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.13" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.24" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
-    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.13" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.24" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -7,8 +7,8 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.13" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.24" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -15,6 +15,6 @@
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />
     <PackageReference Include="AWSSDK.ApiGatewayManagementApi" Version="3.7.0.139" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.13" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.24" />
   </ItemGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents/Amazon.Lambda.DynamoDBEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents/Amazon.Lambda.DynamoDBEvents.csproj
@@ -6,14 +6,14 @@
     <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <Description>Amazon Lambda .NET Core support - DynamoDBEvents package.</Description>
     <AssemblyTitle>Amazon.Lambda.DynamoDBEvents</AssemblyTitle>
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionPrefix>2.1.1</VersionPrefix>
     <AssemblyName>Amazon.Lambda.DynamoDBEvents</AssemblyName>
     <PackageId>Amazon.Lambda.DynamoDBEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.24" />
   </ItemGroup>
 
 </Project>

--- a/Libraries/test/EventsTests.NET6/EventsTests.NET6.csproj
+++ b/Libraries/test/EventsTests.NET6/EventsTests.NET6.csproj
@@ -60,7 +60,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="AWSSDK.Core" Version="3.7.0" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.10.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Libraries/test/EventsTests.NETCore31/EventsTests.NETCore31.csproj
+++ b/Libraries/test/EventsTests.NETCore31/EventsTests.NETCore31.csproj
@@ -63,7 +63,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="AWSSDK.Core" Version="3.7.0" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.10.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-sdk-net/issues/1980

*Description of changes:*
Version bump `Amazon.Lambda.DynamoDBEvents` to update `AWSSDK.DynamoDBv2` to version `3.7.3.24`.

*NOTE:* Also needed to update `AWSSDK.Core` reference to latest version in `EventsTests.NET6.csproj` and `EventsTests.NETCore31.csproj`, since `AWSSDK.DynamoDBv2 3.7.3.24` adds constraint `AWSSDK.Core (>= 3.7.10.8 && < 4.0.0)`.

___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
