### PR TITLE
Fix computed function handler string for Amazon.Lambda.Annotations.

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/LambdaFunctionModel.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/LambdaFunctionModel.cs
@@ -32,7 +32,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
         public string Serializer { get; set; }
 
         /// <inheritdoc />
-        public string Handler => $"{LambdaMethod.ContainingNamespace}::{GeneratedMethod.ContainingType.FullName}::{LambdaMethod.Name}";
+        public string Handler => $"{LambdaMethod.ContainingAssembly}::{GeneratedMethod.ContainingType.FullName}::{LambdaMethod.Name}";
 
         /// <inheritdoc />
         public string Name => LambdaMethod.LambdaFunctionAttribute.Data.Name ??

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/LambdaMethodModel.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/LambdaMethodModel.cs
@@ -50,6 +50,11 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
         public string ContainingNamespace { get; set; }
 
         /// <summary>
+        /// Gets or sets the name of the assemblying containing the Lambda function.
+        /// </summary>
+        public string ContainingAssembly { get; set; }
+
+        /// <summary>
         /// Gets or sets type of Lambda event
         /// </summary>
         public List<EventType> Events { get; set; }

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/LambdaMethodModelBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/LambdaMethodModelBuilder.cs
@@ -21,6 +21,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
                 ReturnsVoidOrTask = lambdaMethodSymbol.ReturnsVoid || lambdaMethodSymbol.ReturnType.Equals(context.Compilation.GetTypeByMetadataName("System.Threading.Tasks.Task"), SymbolEqualityComparer.Default),
                 Parameters = ParameterModelBuilder.Build(lambdaMethodSymbol, context),
                 Name = lambdaMethodSymbol.Name,
+                ContainingAssembly = lambdaMethodSymbol.ContainingAssembly.Name,
                 ContainingNamespace = lambdaMethodSymbol.ContainingNamespace.ToDisplayString(),
                 Events = EventTypeBuilder.Build(lambdaMethodSymbol, context),
                 ContainingType = TypeModelBuilder.Build(lambdaMethodSymbol.ContainingType, context),

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
@@ -51,6 +51,10 @@
       <Content Include="Snapshots\**" />
     </ItemGroup>
 
+    <ItemGroup>
+      <None Remove="Snapshots\ServerlessTemplates\subnamespace.template" />
+    </ItemGroup>
+
   <ItemGroup>
     <Content Update="Snapshots\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Functions_ToUpper_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Functions_ToUpper_Generated.g.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text;
+using Amazon.Lambda.Core;
+
+namespace TestServerlessApp.Sub1
+{
+    public class Functions_ToUpper_Generated
+    {
+        private readonly Functions functions;
+
+        public Functions_ToUpper_Generated()
+        {
+            SetExecutionEnvironment();
+            functions = new Functions();
+        }
+
+        public string ToUpper(string text)
+        {
+            return functions.ToUpper(text);
+        }
+
+        private static void SetExecutionEnvironment()
+        {
+            const string envName = "AWS_EXECUTION_ENV";
+
+            var envValue = new StringBuilder();
+
+            // If there is an existing execution environment variable add the annotations package as a suffix.
+            if(!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(envName)))
+            {
+                envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
+            }
+
+            envValue.Append("amazon-lambda-annotations_0.5.1.0");
+
+            Environment.SetEnvironmentVariable(envName, envValue.ToString());
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/complexCalculator.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/complexCalculator.template
@@ -20,7 +20,7 @@
         "ImageUri": ".",
         "ImageConfig": {
           "Command": [
-            "TestServerlessApp::TestServerlessApp.ComplexCalculator_Add_Generated::Add"
+            "TestProject::TestServerlessApp.ComplexCalculator_Add_Generated::Add"
           ]
         },
         "Events": {
@@ -53,7 +53,7 @@
         "ImageUri": ".",
         "ImageConfig": {
           "Command": [
-            "TestServerlessApp::TestServerlessApp.ComplexCalculator_Subtract_Generated::Subtract"
+            "TestProject::TestServerlessApp.ComplexCalculator_Subtract_Generated::Subtract"
           ]
         },
         "Events": {

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/greeter.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/greeter.template
@@ -20,7 +20,7 @@
         "ImageUri": ".",
         "ImageConfig": {
           "Command": [
-            "TestServerlessApp::TestServerlessApp.Greeter_SayHello_Generated::SayHello"
+            "TestProject::TestServerlessApp.Greeter_SayHello_Generated::SayHello"
           ]
         },
         "Events": {
@@ -53,7 +53,7 @@
         "ImageUri": ".",
         "ImageConfig": {
           "Command": [
-            "TestServerlessApp::TestServerlessApp.Greeter_SayHelloAsync_Generated::SayHelloAsync"
+            "TestProject::TestServerlessApp.Greeter_SayHelloAsync_Generated::SayHelloAsync"
           ]
         },
         "Events": {

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/simpleCalculator.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/simpleCalculator.template
@@ -20,7 +20,7 @@
         "ImageUri": ".",
         "ImageConfig": {
           "Command": [
-            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Add_Generated::Add"
+            "TestProject::TestServerlessApp.SimpleCalculator_Add_Generated::Add"
           ]
         },
         "Events": {
@@ -52,7 +52,7 @@
         "ImageUri": ".",
         "ImageConfig": {
           "Command": [
-            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Subtract_Generated::Subtract"
+            "TestProject::TestServerlessApp.SimpleCalculator_Subtract_Generated::Subtract"
           ]
         },
         "Events": {
@@ -84,7 +84,7 @@
         "ImageUri": ".",
         "ImageConfig": {
           "Command": [
-            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Multiply_Generated::Multiply"
+            "TestProject::TestServerlessApp.SimpleCalculator_Multiply_Generated::Multiply"
           ]
         },
         "Events": {
@@ -116,7 +116,7 @@
         "ImageUri": ".",
         "ImageConfig": {
           "Command": [
-            "TestServerlessApp::TestServerlessApp.SimpleCalculator_DivideAsync_Generated::DivideAsync"
+            "TestProject::TestServerlessApp.SimpleCalculator_DivideAsync_Generated::DivideAsync"
           ]
         },
         "Events": {
@@ -145,7 +145,7 @@
         "ImageUri": ".",
         "ImageConfig": {
           "Command": [
-            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Pi_Generated::Pi"
+            "TestProject::TestServerlessApp.SimpleCalculator_Pi_Generated::Pi"
           ]
         }
       }
@@ -165,7 +165,7 @@
         "ImageUri": ".",
         "ImageConfig": {
           "Command": [
-            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Random_Generated::Random"
+            "TestProject::TestServerlessApp.SimpleCalculator_Random_Generated::Random"
           ]
         }
       }
@@ -185,7 +185,7 @@
         "ImageUri": ".",
         "ImageConfig": {
           "Command": [
-            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Randoms_Generated::Randoms"
+            "TestProject::TestServerlessApp.SimpleCalculator_Randoms_Generated::Randoms"
           ]
         }
       }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/subnamespace.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/subnamespace.template
@@ -1,0 +1,26 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Transform": "AWS::Serverless-2016-10-31",
+  "Resources": {
+    "ToUpper": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations"
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestProject::TestServerlessApp.Sub1.Functions_ToUpper_Generated::ToUpper"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
@@ -180,5 +180,41 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
             var actualTemplateContent = File.ReadAllText(Path.Combine("TestServerlessApp", "serverless.template"));
             Assert.Equal(expectedTemplateContent, actualTemplateContent);
         }
+
+        [Fact]
+        public async Task VerifyFunctionInSubNamespace()
+        {
+            var expectedTemplateContent = File.ReadAllText(Path.Combine("Snapshots", "ServerlessTemplates", "subnamespace.template")).ToEnvironmentLineEndings();
+            var expectedSubNamespaceGenerated = File.ReadAllText(Path.Combine("Snapshots", "Functions_ToUpper_Generated.g.cs")).ToEnvironmentLineEndings();
+
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        (Path.Combine("TestServerlessApp", "Sub1", "Functions.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "Sub1", "Functions.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"))),
+                    },
+                    GeneratedSources =
+                    {
+                        (
+                            typeof(SourceGenerator.Generator),
+                            "Functions_ToUpper_Generated.g.cs",
+                            SourceText.From(expectedSubNamespaceGenerated, Encoding.UTF8, SourceHashAlgorithm.Sha256)
+                        )
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("Functions_ToUpper_Generated.g.cs", expectedSubNamespaceGenerated),
+                        new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments($"TestServerlessApp{Path.DirectorySeparatorChar}serverless.template", expectedTemplateContent)
+                    }
+                }
+            }.RunAsync();
+
+            var actualTemplateContent = File.ReadAllText(Path.Combine("TestServerlessApp", "serverless.template"));
+            Assert.Equal(expectedTemplateContent, actualTemplateContent);
+        }
     }
 }

--- a/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixture.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixture.cs
@@ -55,7 +55,7 @@ namespace TestServerlessApp.IntegrationTests
 
             Assert.Equal(StackStatus.CREATE_COMPLETE, await _cloudFormationHelper.GetStackStatusAsync(_stackName));
             Assert.True(await _s3Helper.BucketExistsAsync(_bucketName));
-            Assert.Equal(11, LambdaFunctions.Count);
+            Assert.Equal(12, LambdaFunctions.Count);
             Assert.False(string.IsNullOrEmpty(RestApiUrlPrefix));
             Assert.False(string.IsNullOrEmpty(RestApiUrlPrefix));
 

--- a/Libraries/test/TestServerlessApp/Sub1/Functions.cs
+++ b/Libraries/test/TestServerlessApp/Sub1/Functions.cs
@@ -1,0 +1,14 @@
+﻿using Amazon.Lambda.Annotations;
+using Amazon.Lambda.Core;
+
+namespace TestServerlessApp.Sub1
+{
+    public class Functions
+    {
+        [LambdaFunction(Name = "ToUpper", PackageType = LambdaPackageType.Image)]
+        public string ToUpper(string text)
+        {
+            return text.ToUpper();
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp/serverless.template
+++ b/Libraries/test/TestServerlessApp/serverless.template
@@ -347,6 +347,26 @@
           ]
         }
       }
+    },
+    "ToUpper": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations"
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.Sub1.Functions_ToUpper_Generated::ToUpper"
+          ]
+        }
+      }
     }
   },
   "Outputs": {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1155

*Description of changes:*
This PR is for the Amazon.Lambda.Annotations source generator.

When computing the function handler string for the CloudFormation template the code was using the namespace for the first token instead of the assembly name.

Fixing this behavior caused other source generator tests to be updated to use the testing framework's default assembly name `TestProject` instead of the previous value `TestServerlessApp`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
