### PR TITLE
Fixed issue with log multiline log message being broken for multiple CloudWatch Log records

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/Constants.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/Constants.cs
@@ -12,6 +12,7 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
         internal const string ENVIRONMENT_VARIABLE_AWS_LAMBDA_DOTNET_PREJIT = "AWS_LAMBDA_DOTNET_PREJIT";
         internal const string ENVIRONMENT_VARIABLE_AWS_LAMBDA_INITIALIZATION_TYPE = "AWS_LAMBDA_INITIALIZATION_TYPE";
         internal const string ENVIRONMENT_VARIABLE_LANG = "LANG";
+        internal const string ENVIRONMENT_VARIABLE_TELEMETRY_LOG_FD = "_LAMBDA_TELEMETRY_LOG_FD";
         internal const string AWS_LAMBDA_INITIALIZATION_TYPE_PC = "provisioned-concurrency";
         internal const string AWS_LAMBDA_INITIALIZATION_TYPE_ON_DEMAND = "on-demand";
 

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/FileDescriptorLogStream.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/FileDescriptorLogStream.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.IO;
+using System.Buffers;
+using Microsoft.Win32.SafeHandles;
+using System.Collections.Concurrent;
+
+namespace Amazon.Lambda.RuntimeSupport.Helpers
+{
+    /// <summary>
+    /// This class wraps the utility of writing to the Lambda telemetry file descriptor for logging into a standard .NET Stream.
+    /// The message
+    /// </summary>
+    public static class FileDescriptorLogFactory
+    {
+        private readonly static ConcurrentDictionary<string, StreamWriter> _writers = new ConcurrentDictionary<string, StreamWriter>();
+
+        /// <summary>
+        /// Get the StreamWriter for the particular file descriptor ID. If the same ID is passed the same StreamWriter instance is returned.
+        /// </summary>
+        /// <param name="fileDescriptorId"></param>
+        /// <returns></returns>
+        public static StreamWriter GetWriter(string fileDescriptorId)
+        {
+            // AutoFlush must be turned out otherwise the StreamWriter might not send the data to the stream before the Lambda function completes.
+            var writer = _writers.GetOrAdd(fileDescriptorId, (x) => new StreamWriter(new FileDescriptorLogStream(fileDescriptorId)) { AutoFlush = true });
+            return writer;
+        }
+
+        /// <summary>
+        /// Write log message to the file descriptor which will make sure the message is recorded as a single CloudWatch Log record.
+        /// The format of the message must be:
+        /// +----------------------+------------------------+-----------------------+
+        /// | Frame Type - 4 bytes | Length (len) - 4 bytes | Message - 'len' bytes |
+        /// +----------------------+------------------------+-----------------------+
+        /// The first 4 bytes are the frame type. For logs this is always 0xa55a0001.
+        /// The second 4 bytes are the length of the message.
+        /// The remaining bytes are the message itself. Byte order is big-endian.
+        /// </summary>
+        private class FileDescriptorLogStream : Stream
+        {
+            private const uint FRAME_TYPE = 0xa55a0001;
+            private readonly Stream _fileDescriptorStream;
+            private readonly byte[] _frameTypeBytes;
+
+            public FileDescriptorLogStream(string fileDescriptorId)
+            {
+                SafeFileHandle handle = new SafeFileHandle(new IntPtr(int.Parse(fileDescriptorId)), false);
+                _fileDescriptorStream = new FileStream(handle, FileAccess.Write);
+
+                _frameTypeBytes = BitConverter.GetBytes(FRAME_TYPE);
+                if (BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(_frameTypeBytes);
+                }
+            }
+
+            public override void Flush()
+            {
+                _fileDescriptorStream.Flush();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                var messageLengthBytes = BitConverter.GetBytes(count - offset);
+                if (BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(messageLengthBytes);
+                }
+
+                var typeAndLength = ArrayPool<byte>.Shared.Rent(8);
+                try
+                {
+                    Buffer.BlockCopy(_frameTypeBytes, 0, typeAndLength, 0, 4);
+                    Buffer.BlockCopy(messageLengthBytes, 0, typeAndLength, 4, 4);
+
+                    _fileDescriptorStream.Write(typeAndLength, 0, 8);
+                    _fileDescriptorStream.Write(buffer, offset, count);
+                    _fileDescriptorStream.Flush();
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(typeAndLength);
+                }
+            }
+
+            #region Not implemented read and seek operations
+            public override bool CanRead => false;
+
+            public override bool CanSeek => false;
+
+            public override bool CanWrite => true;
+
+            public override long Length => throw new NotSupportedException();
+
+            public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException();
+            }
+            #endregion
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/Amazon.Lambda.RuntimeSupport.IntegrationTests.csproj
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/Amazon.Lambda.RuntimeSupport.IntegrationTests.csproj
@@ -6,10 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="get-loggertest-request.json" />
     <None Remove="get-weatherforecast-request.json" />
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="get-loggertest-request.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="get-weatherforecast-request.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/get-loggertest-request.json
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/get-loggertest-request.json
@@ -1,0 +1,41 @@
+﻿{
+  "version": "2.0",
+  "routeKey": "$default",
+  "rawPath": "/loggertest",
+  "rawQueryString": "",
+  "cookies": [],
+  "headers": {
+  },
+  "queryStringParameters": {
+    "parameter1": "value1,value2",
+    "parameter2": "value"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "apiId": "api-id",
+    "authentication": {
+    },
+    "authorizer": {
+    },
+    "domainName": "id.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "domain-id",
+    "http": {
+      "method": "GET",
+      "path": "/loggertest",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "IP",
+      "userAgent": "agent"
+    },
+    "requestId": "request-id",
+    "routeId": "route-id",
+    "routeKey": "$default-route",
+    "stage": "$default-stage",
+    "time": "12/Mar/2020:19:03:58 +0000",
+    "timeEpoch": 1583348638390
+  },
+  "body": null,
+  "pathParameters": {},
+  "isBase64Encoded": true,
+  "stageVariables": {
+  }
+}

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/CustomRuntimeAspNetCoreMinimalApiTest/Controllers/LoggerTestController.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/CustomRuntimeAspNetCoreMinimalApiTest/Controllers/LoggerTestController.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Amazon.Lambda.Core;
+
+namespace CustomRuntimeAspNetCoreMinimalApiTest.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class LoggerTestController : ControllerBase
+    {
+        [HttpGet()]
+        public long Get()
+        {
+            var lambdaContext = this.HttpContext.Items["LambdaContext"] as ILambdaContext;
+
+            const int maxLogs = 10000;
+            long actualLogsWritten = 0;
+            Action stdOutTest = () =>
+            {
+                long index = 0;
+                while (index < maxLogs)
+                {
+                    Console.WriteLine($"StdOut: {index++}");
+                    Interlocked.Increment(ref actualLogsWritten);
+                    Thread.Yield();
+                }
+            };
+
+            Action stdErrTest = () =>
+            {
+                long index = 0;
+                while (index < maxLogs)
+                {
+                    Console.Error.WriteLine($"StdErr: {index++}");
+                    Interlocked.Increment(ref actualLogsWritten);
+                    Thread.Yield();
+                }
+            };
+
+            Action contextLoggerTest = () =>
+            {
+                long index = 0;
+                while (index < maxLogs)
+                {
+                    lambdaContext!.Logger.LogWarning($"ContextLogger: {index++}");
+                    Interlocked.Increment(ref actualLogsWritten);
+                    Thread.Yield();
+                }
+            };
+
+
+            var tasks = new List<Task>();
+            for (int i = 0; i < 3; i++)
+            {
+                tasks.Add(Task.Run(stdOutTest));
+                tasks.Add(Task.Run(stdErrTest));
+                tasks.Add(Task.Run(contextLoggerTest));
+            }
+
+            Task.WaitAll(tasks.ToArray());
+
+            return actualLogsWritten;
+        }
+    }
+}


### PR DESCRIPTION
*Description of changes:*
If log messages contain newlines each line gets broken up over separate CloudWatch Logs. This is particular bad for stack traces. This is due to the runtime using STDOUT and STDERR for logging and the Lambda service doesn't know the start and stop of messages other then using newlines.

To fix this problem the .NET runtime will write log messages to the Lambda telemetry file descriptor if it is available. Otherwise fallback to STDOUT and STDERR. This is similar to the [Java Lambda runtime](https://github.com/aws/aws-lambda-java-libs/blob/master/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/logging/FramedTelemetryLogSink.java#L11).

Besides confirming all of the existing log tests a new stress test was added to confirm no threading issues and there was no affect to performance.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
