### PR TITLE
ci: update base image prefixes for .NET 6 runtimes from `base-image` to `contributed-base-image`

### DIFF
--- a/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/Configuration.cs
+++ b/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/Configuration.cs
@@ -27,8 +27,8 @@ namespace Infrastructure
         public const string ProjectName = "aws-lambda-container-images";
         public readonly string[] DockerARM64Images = new string[] { "net6" };
         public readonly Dictionary<string, string> DockerBuildImages = new Dictionary<string, string> { {"net5", "5.0-buster-slim"}, {"net6", "6.0-bullseye-slim"} };
-        public readonly Dictionary<string, string> BaseImageAMD64Tags = new Dictionary<string, string> { { "net5", "base-image-x86_64" }, { "net6", "base-image-x86_64" } };
-        public readonly Dictionary<string, string> BaseImageARM64Tags = new Dictionary<string, string> { { "net5", "base-image-arm64" }, { "net6", "base-image-arm64" } };
+        public readonly Dictionary<string, string> BaseImageAMD64Tags = new Dictionary<string, string> { { "net5", "base-image-x86_64" }, { "net6", "contributed-base-image-x86_64" } };
+        public readonly Dictionary<string, string> BaseImageARM64Tags = new Dictionary<string, string> { { "net5", "base-image-arm64" }, { "net6", "contributed-base-image-arm64" } };
         public readonly string[] Frameworks = Environment.GetEnvironmentVariable("AWS_LAMBDA_DOTNET_FRAMEWORK_VERSION")?.Split(";");
         public readonly string[] Channels = Environment.GetEnvironmentVariable("AWS_LAMBDA_DOTNET_FRAMEWORK_CHANNEL")?.Split(";");
     }

--- a/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/PipelineStack.cs
+++ b/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/PipelineStack.cs
@@ -30,7 +30,7 @@ namespace Infrastructure
     {
         private const string PowershellArm64 = "7.1.3 powershell-7.1.3-linux-arm64.tar.gz";
         private const string PowershellAmd64 = "7.1.3 powershell-7.1.3-linux-x64.tar.gz";
-        private const string BaseImageMultiArch = "base-image-multi-arch";
+        private const string BaseImageMultiArch = "contributed-base-image-multi-arch";
 
         internal PipelineStack(
             Construct scope, 


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*

## Motivation

Lambda team requires a different prefix for .NET 6 images to differentiate between tags used internally.

## Changes

This change adds `contributed-base-image` prefix for .NET 6 images. Therefore, .NET 6 will look like
- x86: `contributed-base-image-x86_64`
- arm: `contributed-base-image-arm64`
- multiarch: `contributed-base-image-multi-arch`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
