### PR TITLE
New command line parameter "lambdas-file" to force lambdas assembly context

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/CommandLineOptions.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/CommandLineOptions.cs
@@ -22,6 +22,8 @@ namespace Amazon.Lambda.TestTool
         public string AWSProfile { get; set; }
         
         public string AWSRegion { get; set; }
+
+        public string LambdasFile { get; set; }
         
         public bool ShowHelp { get; set; }
 
@@ -83,6 +85,10 @@ namespace Amazon.Lambda.TestTool
                         break;
                     case "--payload":
                         options.Payload = GetNextStringValue(i);
+                        i++;
+                        break;
+                    case "--lambdas-file":
+                        options.LambdasFile = GetNextStringValue(i);
                         i++;
                         break;
                     case "--pause-exit":

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/TestToolStartup.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/TestToolStartup.cs
@@ -76,7 +76,7 @@ namespace Amazon.Lambda.TestTool
                     lambdaAssemblyDirectory = Path.Combine(lambdaAssemblyDirectory, $"bin/Debug/{targetFramework}");
                 }
 
-                localLambdaOptions.LambdaRuntime = LocalLambdaRuntime.Initialize(lambdaAssemblyDirectory);
+                localLambdaOptions.LambdaRuntime = LocalLambdaRuntime.Initialize(lambdaAssemblyDirectory, commandOptions.LambdasFile);
                 runConfiguration.OutputWriter.WriteLine($"Loaded local Lambda runtime from project output {lambdaAssemblyDirectory}");
 
                 if (commandOptions.NoUI)

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/Amazon.Lambda.TestTool.Tests.Shared.projitems
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/Amazon.Lambda.TestTool.Tests.Shared.projitems
@@ -15,6 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)DefaultsFileParseTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DlqMonitorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)InvokeFunctionTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)LoadLambdasDllFileTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LoadLambdaFunctionTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NoUiStartupTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SampleRequestTests.cs" />

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/LoadLambdasDllFileTests.cs
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/LoadLambdasDllFileTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.IO;
+using Xunit;
+
+using Amazon.Lambda.TestTool.Runtime;
+
+namespace Amazon.Lambda.TestTool.Tests
+{
+    public class LoadLambdasDllFileTests
+    {
+        
+        [Fact]
+        public void InitializeLambdaRuntimeWithSpecificDllFilename()
+        {
+            var configFile = TestUtils.GetLambdaFunctionSourceFile("ToUpperFunc", "aws-lambda-tools-defaults.json");
+            var buildPath = TestUtils.GetLambdaFunctionBuildPath("ToUpperFunc");
+
+            var configInfo = LambdaDefaultsConfigFileParser.LoadFromFile(configFile);
+            Assert.Single(configInfo.FunctionInfos);
+            
+            var runtime = LocalLambdaRuntime.Initialize(buildPath, "ToUpperFunc.dll");
+
+            var functions = runtime.LoadLambdaFunctions(configInfo.FunctionInfos);
+            
+            Assert.Equal(1, functions.Count);
+
+            var function = functions[0];
+            Assert.True(function.IsSuccess);
+            Assert.NotNull(function.LambdaAssembly);
+            Assert.NotNull(function.LambdaType);
+            Assert.NotNull(function.LambdaMethod);
+            
+            Assert.NotNull(function.Serializer);
+        }
+
+        [Fact]
+        public void InitializeLambdaRuntimeWithIncorrectDllFilename()
+        {
+            var configFile = TestUtils.GetLambdaFunctionSourceFile("ToUpperFunc", "aws-lambda-tools-defaults.json");
+            var buildPath = TestUtils.GetLambdaFunctionBuildPath("ToUpperFunc");
+
+            var configInfo = LambdaDefaultsConfigFileParser.LoadFromFile(configFile);
+            Assert.Single(configInfo.FunctionInfos);
+
+            Assert.ThrowsAny<Exception>(() =>
+                LocalLambdaRuntime.Initialize(buildPath, "incorrect-assembly.dll")
+            );
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
I didn't find any issue open for this problem. 

When the project that contains the lambdas references other projects in the same solution sometimes it fails to load the `FunctionHandler` because the first `deps.json` file returned is not always the one for the project itself, since there are other deps.json files for other projects in the same directory.

`Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LocalLambdaRuntime.cs, 56` 

So, if we run the test tool it throws a `FileNotFoundException` even though the assembly described in `serverless.template`  exists in the working directory.

*Description of changes:*

- Introduced a new `lambdas-file` parameter so we can specify exactly which DLL file we want the test tool to point at to extract the function handlers
- Included an additional logic to ignore `deps.json` files if a specific file was provided
- Two new tests to cover the new logic


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
