### PR TITLE
Set the HttpContext.TraceIdentifier to the trace id for the Lambda invocation

### DIFF
--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestApiGatewayHttpApiV2Calls.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestApiGatewayHttpApiV2Calls.cs
@@ -235,6 +235,29 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
             Assert.Equal("TestValue3", response.Body);
         }
 
+        [Fact]
+        public async Task TestTraceIdSetFromLambdaContext()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("_X_AMZN_TRACE_ID", "MyTraceId-1");
+                var response = await this.InvokeAPIGatewayRequest("traceid-get-httpapi-v2-request.json");
+                Assert.Equal("MyTraceId-1", response.Body);
+
+                Environment.SetEnvironmentVariable("_X_AMZN_TRACE_ID", "MyTraceId-2");
+                response = await this.InvokeAPIGatewayRequest("traceid-get-httpapi-v2-request.json");
+                Assert.Equal("MyTraceId-2", response.Body);
+
+                Environment.SetEnvironmentVariable("_X_AMZN_TRACE_ID", null);
+                response = await this.InvokeAPIGatewayRequest("traceid-get-httpapi-v2-request.json");
+                Assert.True(!string.IsNullOrEmpty(response.Body) && !string.Equals(response.Body, "MyTraceId-2"));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("_X_AMZN_TRACE_ID", null);
+            }
+        }
+
         private async Task<APIGatewayHttpApiV2ProxyResponse> InvokeAPIGatewayRequest(string fileName)
         {
             return await InvokeAPIGatewayRequestWithContent(new TestLambdaContext(), GetRequestContent(fileName));

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
@@ -12,8 +12,9 @@ using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.AspNetCoreServer.Internal;
 using Amazon.Lambda.TestUtilities;
-
+using Microsoft.AspNetCore.Http.Features;
 using TestWebApp;
 
 using Xunit;
@@ -425,6 +426,20 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
 
             Assert.Equal(200, response.StatusCode);
             Assert.Equal("Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceProviderEngineScope", response.Body);
+        }
+
+        /// <summary>
+        /// This test is ensuring when we don't use the Lambda trace id and fallback to ASP.NET Core trace id generator
+        /// logic we keep returning the same value each time. This was addressing a PR comment for the trace id PR.
+        /// </summary>
+        [Fact]
+        public void EnsureTraceIdStaysTheSame()
+        {
+            var features = new InvokeFeatures() as IHttpRequestIdentifierFeature;
+
+            var traceId1 = features.TraceIdentifier;
+            var traceId2 = features.TraceIdentifier;
+            Assert.Equal(traceId1, traceId2);
         }
 
         private async Task<APIGatewayProxyResponse> InvokeAPIGatewayRequest(string fileName)

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/traceid-get-httpapi-v2-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/traceid-get-httpapi-v2-request.json
@@ -1,0 +1,41 @@
+﻿{
+  "version": "2.0",
+  "routeKey": "ANY /{proxy+}",
+  "rawPath": "/api/tracetests",
+  "rawQueryString": "",
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip, deflate",
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "host": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "postman-token": "cf1272a5-6626-4957-badc-c8c93726578a",
+    "user-agent": "PostmanRuntime/7.20.1",
+    "x-amzn-trace-id": "Root=1-5e7a98e3-da5ec4c6555f976320f6ab34",
+    "x-forwarded-for": "192.182.149.40",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "requestContext": {
+    "accountId": "626492997873",
+    "apiId": "uo9pe23ec6",
+    "domainName": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "uo9pe23ec6",
+    "http": {
+      "method": "GET",
+      "path": "/api/tracetests",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "192.182.149.40",
+      "userAgent": "PostmanRuntime/7.20.1"
+    },
+    "requestId": "J6zTog-0oAMEJCQ=",
+    "routeKey": "ANY /{proxy+}",
+    "stage": "$default",
+    "time": "24/Mar/2020:23:33:55 +0000",
+    "timeEpoch": 1585092835963
+  },
+  "pathParameters": {
+    "proxy": "api/tracetests"
+  },
+  "isBase64Encoded": false
+}

--- a/Libraries/test/TestWebApp/Controllers/TraceTestsController.cs
+++ b/Libraries/test/TestWebApp/Controllers/TraceTestsController.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace TestWebApp.Controllers
+{
+    [Route("api/[controller]")]
+    public class TraceTestsController : Controller
+    {
+        [HttpGet]
+        public string GetTraceId()
+        {
+            return this.HttpContext.TraceIdentifier;
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1148

*Description of changes:*
For ASP.NET Core Lambda function use Lambda's trace id that can be found in the `_X_AMZN_TRACE_ID` environment variable and set it as the `HttpContext.TraceIdentifier`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
