### PR TITLE
Increase log buffer size to avoid log message from being broken over multiple CWL records

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer.Hosting/Amazon.Lambda.AspNetCoreServer.Hosting.csproj
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer.Hosting/Amazon.Lambda.AspNetCoreServer.Hosting.csproj
@@ -7,7 +7,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<Version>1.3.0</Version>
+	<Version>1.3.1</Version>
 	<PackageReadmeFile>README.md</PackageReadmeFile>
     <AssemblyName>Amazon.Lambda.AspNetCoreServer.Hosting</AssemblyName>
     <PackageId>Amazon.Lambda.AspNetCoreServer.Hosting</PackageId>	  

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
@@ -4,9 +4,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
-    <VersionPrefix>1.8.0</VersionPrefix>
+    <VersionPrefix>1.8.1</VersionPrefix>
     <Description>Provides a bootstrap and Lambda Runtime API Client to help you to develop custom .NET Core Lambda Runtimes.</Description>
-    <VersionPrefix>1.8.0</VersionPrefix>
+    <VersionPrefix>1.8.1</VersionPrefix>
     <Description>Provides a bootstrap and Lambda Runtime API Client to help you  to develop custom .NET Core Lambda Runtimes.</Description>
     <AssemblyTitle>Amazon.Lambda.RuntimeSupport</AssemblyTitle>
     <AssemblyName>Amazon.Lambda.RuntimeSupport</AssemblyName>

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/FileDescriptorLogStream.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/FileDescriptorLogStream.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Buffers;
+using System.Text;
 using Microsoft.Win32.SafeHandles;
 using System.Collections.Concurrent;
 
@@ -22,7 +23,8 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
         public static StreamWriter GetWriter(string fileDescriptorId)
         {
             // AutoFlush must be turned out otherwise the StreamWriter might not send the data to the stream before the Lambda function completes.
-            var writer = _writers.GetOrAdd(fileDescriptorId, (x) => new StreamWriter(new FileDescriptorLogStream(fileDescriptorId)) { AutoFlush = true });
+            // Set the buffer size to the same max size as CloudWatch Logs records.
+            var writer = _writers.GetOrAdd(fileDescriptorId, (x) => new StreamWriter(new FileDescriptorLogStream(fileDescriptorId), Encoding.UTF8, 256 * 1024) { AutoFlush = true });
             return writer;
         }
 


### PR DESCRIPTION
*Description of changes:*
In the previous PR https://github.com/aws/aws-lambda-dotnet/pull/1165 logging was switched to write log message to the Lambda telemetry file descriptor so log messages with newlines will not get broken up over multiple CloudWatch Log records. This triggered a side effect that if the log message was greater then the default StreamWriter buffer size the log message would get broken up over multiple writes to the telemetry file descriptor causing the message to be broken up over multiple records.

This change adjust the buffer size of the StreamWriter to match the max size of the CWL record size to avoid unattended message breaks. I have confirmed there was no noticeable affects to cold start time by increasing the buffer size.

Version number of Amazon.Lambda.AspNetCoreServerHosting was increased because it takes a direct dependency on Amazon.Lambda.RuntimeSupport.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
