### PR TITLE
Do not log preamble Unicode byte order mark

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/FileDescriptorLogStream.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/FileDescriptorLogStream.cs
@@ -15,6 +15,11 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
     {
         private readonly static ConcurrentDictionary<string, StreamWriter> _writers = new ConcurrentDictionary<string, StreamWriter>();
 
+        // max cloudwatch log event size, 256k - 26 bytes of overhead.
+        internal const int MaxCloudWatchLogEventSize = 256 * 1024 - 26;
+        internal const int LambdaTelemetryLogHeaderLength = 8;
+        internal const uint LambdaTelemetryLogHeaderFrameType = 0xa55a0001;
+
         /// <summary>
         /// Get the StreamWriter for the particular file descriptor ID. If the same ID is passed the same StreamWriter instance is returned.
         /// </summary>
@@ -22,10 +27,27 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
         /// <returns></returns>
         public static StreamWriter GetWriter(string fileDescriptorId)
         {
+            SafeFileHandle handle = new SafeFileHandle(new IntPtr(int.Parse(fileDescriptorId)), false);
+            var writer = _writers.GetOrAdd(fileDescriptorId,
+                (x) => InitializeWriter(new FileStream(handle, FileAccess.Write)));
+            return writer;
+        }
+
+        /// <summary>
+        /// Initialize a StreamWriter for the given Stream.
+        /// This method is internal as it is tested in Amazon.RuntimeSupport.Tests
+        /// </summary>
+        /// <param name="fileDescriptorStream"></param>
+        /// <returns></returns>
+        internal static StreamWriter InitializeWriter(Stream fileDescriptorStream)
+        {
             // AutoFlush must be turned out otherwise the StreamWriter might not send the data to the stream before the Lambda function completes.
             // Set the buffer size to the same max size as CloudWatch Logs records.
-            var writer = _writers.GetOrAdd(fileDescriptorId, (x) => new StreamWriter(new FileDescriptorLogStream(fileDescriptorId), Encoding.UTF8, 256 * 1024) { AutoFlush = true });
-            return writer;
+            // Encoder has encoderShouldEmitUTF8Identifier = false as Lambda FD will assume UTF-8 so there is no need to emit an extra log entry.
+            // In fact this extra log entry is cast to UTF-8 and results in an empty log entry which will be rejected by CloudWatch Logs.
+            return new StreamWriter(new FileDescriptorLogStream(fileDescriptorStream),
+                    new UTF8Encoding(false), MaxCloudWatchLogEventSize)
+                { AutoFlush = true };
         }
 
         /// <summary>
@@ -40,16 +62,14 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
         /// </summary>
         private class FileDescriptorLogStream : Stream
         {
-            private const uint FRAME_TYPE = 0xa55a0001;
             private readonly Stream _fileDescriptorStream;
             private readonly byte[] _frameTypeBytes;
 
-            public FileDescriptorLogStream(string fileDescriptorId)
+            public FileDescriptorLogStream(Stream logStream)
             {
-                SafeFileHandle handle = new SafeFileHandle(new IntPtr(int.Parse(fileDescriptorId)), false);
-                _fileDescriptorStream = new FileStream(handle, FileAccess.Write);
+                _fileDescriptorStream = logStream;
 
-                _frameTypeBytes = BitConverter.GetBytes(FRAME_TYPE);
+                _frameTypeBytes = BitConverter.GetBytes(LambdaTelemetryLogHeaderFrameType);
                 if (BitConverter.IsLittleEndian)
                 {
                     Array.Reverse(_frameTypeBytes);
@@ -69,7 +89,7 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
                     Array.Reverse(messageLengthBytes);
                 }
 
-                var typeAndLength = ArrayPool<byte>.Shared.Rent(8);
+                var typeAndLength = ArrayPool<byte>.Shared.Rent(LambdaTelemetryLogHeaderLength);
                 try
                 {
                     Buffer.BlockCopy(_frameTypeBytes, 0, typeAndLength, 0, 4);

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/FileDescriptorLogStream.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/FileDescriptorLogStream.cs
@@ -27,9 +27,11 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
         /// <returns></returns>
         public static StreamWriter GetWriter(string fileDescriptorId)
         {
-            SafeFileHandle handle = new SafeFileHandle(new IntPtr(int.Parse(fileDescriptorId)), false);
-            var writer = _writers.GetOrAdd(fileDescriptorId,
-                (x) => InitializeWriter(new FileStream(handle, FileAccess.Write)));
+            var writer = _writers.GetOrAdd(fileDescriptorId, 
+                (x) => {
+                    SafeFileHandle handle = new SafeFileHandle(new IntPtr(int.Parse(fileDescriptorId)), false);
+                    return InitializeWriter(new FileStream(handle, FileAccess.Write));
+                });
             return writer;
         }
 

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/FileDescriptorLogStreamTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/FileDescriptorLogStreamTests.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Amazon.Lambda.RuntimeSupport.Helpers;
+using Amazon.Lambda.RuntimeSupport.UnitTests.TestHelpers;
+using Xunit;
+
+namespace Amazon.Lambda.RuntimeSupport.UnitTests
+{
+    public class FileDescriptorLogStreamTests
+    {
+        private const int HeaderLength = FileDescriptorLogFactory.LambdaTelemetryLogHeaderLength;
+        private const int LogEntryMaxLength = FileDescriptorLogFactory.MaxCloudWatchLogEventSize;
+
+        private static readonly byte[] ExpectedMagicBytes =
+        {
+            0xA5, 0x5A, 0x00, 0x01
+        };
+
+        [Fact]
+        public void MultilineLoggingInSingleLogEntryWithTlvFormat()
+        {
+            var logs = new List<byte[]>();
+            var offsets = new List<int>();
+            var counts = new List<int>();
+            var stream = new TestFileStream((log, offset, count) =>
+            {
+                logs.Add(log);
+                offsets.Add(offset);
+                counts.Add(count);
+            });
+            TextWriter writer = FileDescriptorLogFactory.InitializeWriter(stream);
+            // assert that initializing the stream does not result in UTF-8 preamble log entry
+            Assert.Equal(0, counts.Count);
+            Assert.Equal(0, offsets.Count);
+            Assert.Equal(0, logs.Count);
+
+            const string logMessage = "hello world\nsomething else on a new line.";
+            int logMessageLength = logMessage.Length;
+            writer.Write(logMessage);
+
+            Assert.Equal(2, offsets.Count);
+            int headerLogEntryOffset = offsets[0];
+            int consoleLogEntryOffset = offsets[1];
+            Assert.Equal(0, headerLogEntryOffset);
+            Assert.Equal(0, consoleLogEntryOffset);
+
+            Assert.Equal(2, counts.Count);
+            int headerLogEntrySize = counts[0];
+            int consoleLogEntrySize = counts[1];
+            Assert.Equal(HeaderLength, headerLogEntrySize);
+            Assert.Equal(logMessageLength, consoleLogEntrySize);
+
+            Assert.Equal(2, logs.Count);
+            byte[] headerLogEntry = logs[0];
+            byte[] consoleLogEntry = logs[1];
+            Assert.Equal(HeaderLength, headerLogEntry.Length);
+            Assert.Equal(logMessageLength, consoleLogEntry.Length);
+
+            byte[] expectedLengthBytes =
+            {
+                0x00, 0x00, 0x00, 0x29
+            };
+            AssertHeaderBytes(headerLogEntry, expectedLengthBytes);
+            Assert.Equal(logMessage, Encoding.UTF8.GetString(consoleLogEntry));
+        }
+
+        [Fact]
+        public void MaxSizeProducesOneLogFrame()
+        {
+            var logs = new List<byte[]>();
+            var offsets = new List<int>();
+            var counts = new List<int>();
+            var stream = new TestFileStream((log, offset, count) =>
+            {
+                logs.Add(log);
+                offsets.Add(offset);
+                counts.Add(count);
+            });
+            TextWriter writer = FileDescriptorLogFactory.InitializeWriter(stream);
+            // assert that initializing the stream does not result in UTF-8 preamble log entry
+            Assert.Equal(0, counts.Count);
+            Assert.Equal(0, offsets.Count);
+            Assert.Equal(0, logs.Count);
+
+            string logMessage = new string('a', LogEntryMaxLength - 1) + "b";
+            writer.Write(logMessage);
+
+            Assert.Equal(2, offsets.Count);
+            int headerLogEntryOffset = offsets[0];
+            int consoleLogEntryOffset = offsets[1];
+            Assert.Equal(0, headerLogEntryOffset);
+            Assert.Equal(0, consoleLogEntryOffset);
+
+            Assert.Equal(2, counts.Count);
+            int headerLogEntrySize = counts[0];
+            int consoleLogEntrySize = counts[1];
+            Assert.Equal(HeaderLength, headerLogEntrySize);
+            Assert.Equal(LogEntryMaxLength, consoleLogEntrySize);
+
+            Assert.Equal(2, logs.Count);
+            byte[] headerLogEntry = logs[0];
+            byte[] consoleLogEntry = logs[1];
+            Assert.Equal(HeaderLength, headerLogEntry.Length);
+            Assert.Equal(LogEntryMaxLength, consoleLogEntry.Length);
+
+            byte[] expectedLengthBytes =
+            {
+                0x00, 0x03, 0xFF, 0xE6
+            };
+            AssertHeaderBytes(headerLogEntry, expectedLengthBytes);
+            Assert.Equal(logMessage, Encoding.UTF8.GetString(consoleLogEntry));
+        }
+
+        [Fact]
+        public void LogEntryAboveMaxSizeProducesMultipleLogFrames()
+        {
+            var logs = new List<byte[]>();
+            var offsets = new List<int>();
+            var counts = new List<int>();
+            var stream = new TestFileStream((log, offset, count) =>
+            {
+                logs.Add(log);
+                offsets.Add(offset);
+                counts.Add(count);
+            });
+            TextWriter writer = FileDescriptorLogFactory.InitializeWriter(stream);
+            // assert that initializing the stream does not result in UTF-8 preamble log entry
+            Assert.Equal(0, counts.Count);
+            Assert.Equal(0, offsets.Count);
+            Assert.Equal(0, logs.Count);
+
+            string logMessage = new string('a', LogEntryMaxLength) + "b";
+            writer.Write(logMessage);
+
+            Assert.Equal(4, offsets.Count);
+            int headerLogEntryOffset = offsets[0];
+            int consoleLogEntryOffset = offsets[1];
+            int headerLogSecondEntryOffset = offsets[2];
+            int consoleLogSecondEntryOffset = offsets[3];
+            Assert.Equal(0, headerLogEntryOffset);
+            Assert.Equal(0, consoleLogEntryOffset);
+            Assert.Equal(0, headerLogSecondEntryOffset);
+            Assert.Equal(0, consoleLogSecondEntryOffset);
+
+            Assert.Equal(4, counts.Count);
+            int headerLogEntrySize = counts[0];
+            int consoleLogEntrySize = counts[1];
+            int headerLogSecondEntrySize = counts[2];
+            int consoleLogSecondEntrySize = counts[3];
+            Assert.Equal(HeaderLength, headerLogEntrySize);
+            Assert.Equal(LogEntryMaxLength, consoleLogEntrySize);
+            Assert.Equal(HeaderLength, headerLogSecondEntrySize);
+            Assert.Equal(1, consoleLogSecondEntrySize);
+
+            Assert.Equal(4, logs.Count);
+            byte[] headerLogEntry = logs[0];
+            byte[] consoleLogEntry = logs[1];
+            byte[] headerLogSecondEntry = logs[2];
+            byte[] consoleLogSecondEntry = logs[3];
+            Assert.Equal(HeaderLength, headerLogEntry.Length);
+            Assert.Equal(LogEntryMaxLength, consoleLogEntry.Length);
+            Assert.Equal(HeaderLength, headerLogSecondEntry.Length);
+            Assert.Equal(1, consoleLogSecondEntry.Length);
+
+            byte[] expectedLengthBytes =
+            {
+                0x00, 0x03, 0xFF, 0xE6
+            };
+            AssertHeaderBytes(headerLogEntry, expectedLengthBytes);
+
+            byte[] expectedLengthBytesSecondEntry =
+            {
+                0x00, 0x00, 0x00, 0x01
+            };
+            AssertHeaderBytes(headerLogSecondEntry, expectedLengthBytesSecondEntry);
+            string expectedLogEntry = logMessage.Substring(0, LogEntryMaxLength);
+            string expectedSecondLogEntry = logMessage.Substring(LogEntryMaxLength);
+            Assert.Equal(expectedLogEntry, Encoding.UTF8.GetString(consoleLogEntry));
+            Assert.Equal(expectedSecondLogEntry, Encoding.UTF8.GetString(consoleLogSecondEntry));
+        }
+
+        private static void AssertHeaderBytes(byte[] buf, byte[] expectedLengthBytes)
+        {
+            byte[] actualHeaderMagicBytes = buf.Take(4).ToArray();
+            byte[] actualHeaderLengthBytes = buf.TakeLast(4).ToArray();
+            Assert.Equal(ExpectedMagicBytes, actualHeaderMagicBytes);
+            Assert.Equal(expectedLengthBytes, actualHeaderLengthBytes);
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestFileStream.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestFileStream.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Amazon.Lambda.RuntimeSupport.UnitTests.TestHelpers
+{
+    public class TestFileStream : FileStream
+    {
+        private Action<byte[], int, int> WriteAction { get; }
+
+        public TestFileStream(Action<byte[], int, int> writeAction)
+            : base(Path.GetTempFileName(), FileMode.Append, FileAccess.Write)
+        {
+            WriteAction = writeAction;
+        }
+
+        public override bool CanWrite => true;
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            WriteAction(TrimTrailingNullBytes(buffer).Take(count).ToArray(), offset, count);
+        }
+
+        private static IEnumerable<byte> TrimTrailingNullBytes(IEnumerable<byte> buffer)
+        {
+            // Trim trailing null bytes to make testing assertions easier
+            return buffer.Reverse().SkipWhile(x => x == 0).Reverse();
+        }
+    }
+}

--- a/Tools/LambdaTestTool/README.md
+++ b/Tools/LambdaTestTool/README.md
@@ -108,7 +108,7 @@ These options are valid in the no web interface mode.
 </pre>
 
 For command line arguments not set the defaults and config file will be used to determine the .NET Lambda code to run. For example if you just use the <b>--no-ui</b> argument then the
-<b>aws-lambda-tools-defaults.json</b> will be searched for and used if found. The tool when then use the function handler, profile and region specified in the configuration file to run
+<b>aws-lambda-tools-defaults.json</b> will be searched for and used if found. The tool will then use the function handler, profile and region specified in the configuration file to run
 .NET Lambda code.
 
 Here is an example of a <b>launchSettings.json</b> file configured to use this tool without the web interface. Only <b>--no-ui</b> and <b>--payload</b> are set turning off the web interface


### PR DESCRIPTION
The log entry will be ignored by the Lambda Platform as UTF-8 is assumed for the log entry content and decoding this entry results in an empty log entry being written.

Added unit tests to validate logger behavior.

CloudWatch limit references:
- Event size: 256kb (ref. https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html)
- Overhead per log event: 26 bytes (ref. BatchSize in https://docs.aws.amazon.com/opsworks/latest/APIReference/API_CloudWatchLogsLogStream.html)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
