### PR TITLE
fix: source for annotations assembly in nuspec

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.nuspec
+++ b/Libraries/src/Amazon.Lambda.Annotations.nuspec
@@ -23,7 +23,8 @@
         <file src="Amazon.Lambda.Annotations\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.dll" target="lib/net6.0" />
 
         <!-- Include every dependency manually for analyzer, whenever a new dependency is added, it has to be added here. -->
-        <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.dll" target="analyzers\dotnet\cs" />
+        <!-- NOTE: Project dependencies should come from their own bin folder to make sure a code signed binary is packed -->
+        <file src="Amazon.Lambda.Annotations\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.dll" target="analyzers\dotnet\cs" />
         <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.SourceGenerator.dll" target="analyzers\dotnet\cs" />
         <file src="Amazon.Lambda.Annotations.SourceGenerator\bin\Release\netstandard2.0\Newtonsoft.Json.dll" target="analyzers\dotnet\cs" />
     </files>


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Change the source path for `Amazon.Lambda.Annotations.dll` to make sure that the code signed version will be added to the package similar as it is in line 23.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
