### PR TITLE
Example of removing trim warnings from RuntimeSupport Library

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
@@ -4,9 +4,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
-    <VersionPrefix>1.8.2</VersionPrefix>
+    <VersionPrefix>1.8.3</VersionPrefix>
     <Description>Provides a bootstrap and Lambda Runtime API Client to help you to develop custom .NET Core Lambda Runtimes.</Description>
-    <VersionPrefix>1.8.2</VersionPrefix>
+    <VersionPrefix>1.8.3</VersionPrefix>
     <Description>Provides a bootstrap and Lambda Runtime API Client to help you  to develop custom .NET Core Lambda Runtimes.</Description>
     <AssemblyTitle>Amazon.Lambda.RuntimeSupport</AssemblyTitle>
     <AssemblyName>Amazon.Lambda.RuntimeSupport</AssemblyName>
@@ -31,7 +31,12 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Text.Json" Version="6.0.0" />
-  </ItemGroup>	
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+	<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <IsTrimmable>true</IsTrimmable>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Amazon.Lambda.Core\Amazon.Lambda.Core.csproj" />

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/InternalClientAdapted.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/InternalClientAdapted.cs
@@ -587,38 +587,48 @@ namespace Amazon.Lambda.RuntimeSupport
             }
         }
 
-        private string ConvertToString(object value, System.Globalization.CultureInfo cultureInfo)
+        private string ConvertToString(string value, System.Globalization.CultureInfo cultureInfo)
         {
-            if (value is System.Enum)
-            {
-                string name = System.Enum.GetName(value.GetType(), value);
-                if (name != null)
-                {
-                    var field = System.Reflection.IntrospectionExtensions.GetTypeInfo(value.GetType()).GetDeclaredField(name);
-                    if (field != null)
-                    {
-                        var attribute = System.Reflection.CustomAttributeExtensions.GetCustomAttribute(field, typeof(System.Runtime.Serialization.EnumMemberAttribute))
-                            as System.Runtime.Serialization.EnumMemberAttribute;
-                        if (attribute != null)
-                        {
-                            return attribute.Value;
-                        }
-                    }
-                }
-            }
-            else if (value is bool)
-            {
-                return System.Convert.ToString(value, cultureInfo).ToLowerInvariant();
-            }
-            else if (value is byte[])
-            {
-                return System.Convert.ToBase64String((byte[])value);
-            }
-            else if (value != null && value.GetType().IsArray)
-            {
-                var array = System.Linq.Enumerable.OfType<object>((System.Array)value);
-                return string.Join(",", System.Linq.Enumerable.Select(array, o => ConvertToString(o, cultureInfo)));
-            }
+            // It seems like this is never being called from the outside without a string, so I'm not sure what this other code was doing.
+
+            // This needs to be removed because:
+            //      Trim analysis warning IL2075: Amazon.Lambda.RuntimeSupport.InternalRunTimeApiClient.ConvertToString(Object, CultureInfo):
+            //      'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicFields', 'DynamicallyAccessedMemberTypes.NonPublicFields'
+            //      in call to 'System.Reflection.TypeInfo.GetDeclaredField(String)'. The return value of method 'System.Object.GetType()'
+            //      does not have matching annotations. The source value must declare at least the same requirements as those declared on the
+            //      target location it is assigned to.
+
+
+            //if (value is System.Enum)
+            //{
+            //    string name = System.Enum.GetName(value.GetType(), value);
+            //    if (name != null)
+            //    {
+            //        var field = System.Reflection.IntrospectionExtensions.GetTypeInfo(value.GetType()).GetDeclaredField(name);
+            //        if (field != null)
+            //        {
+            //            var attribute = System.Reflection.CustomAttributeExtensions.GetCustomAttribute(field, typeof(System.Runtime.Serialization.EnumMemberAttribute))
+            //                as System.Runtime.Serialization.EnumMemberAttribute;
+            //            if (attribute != null)
+            //            {
+            //                return attribute.Value;
+            //            }
+            //        }
+            //    }
+            //}
+            //else if (value is bool)
+            //{
+            //    return System.Convert.ToString(value, cultureInfo).ToLowerInvariant();
+            //}
+            //else if (value is byte[])
+            //{
+            //    return System.Convert.ToBase64String((byte[])value);
+            //}
+            //else if (value != null && value.GetType().IsArray)
+            //{
+            //    var array = System.Linq.Enumerable.OfType<object>((System.Array)value);
+            //    return string.Join(",", System.Linq.Enumerable.Select(array, o => ConvertToString(o, cultureInfo)));
+            //}
 
             return System.Convert.ToString(value, cultureInfo);
         }

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/ExceptionHandling/ExceptionInfo.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/ExceptionHandling/ExceptionInfo.cs
@@ -29,7 +29,11 @@ namespace Amazon.Lambda.RuntimeSupport
     {
         public string ErrorMessage { get; set; }
         public string ErrorType { get; set; }
-        public StackFrameInfo[] StackFrames { get; set; }
+
+// Can't use StackFrames because:
+// StackFrameInfo.StackFrameInfo(StackFrame): Using member 'System.Diagnostics.StackFrame.GetMethod()'
+// which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
+        //public StackFrameInfo[] StackFrames { get; set; }
         public string StackTrace { get; set; }
 
         public ExceptionInfo InnerException { get; set; }
@@ -47,26 +51,27 @@ namespace Amazon.Lambda.RuntimeSupport
             ErrorType = exception.GetType().Name;
             ErrorMessage = exception.Message;
 
-            if (!string.IsNullOrEmpty(exception.StackTrace))
-            {
-                StackTrace stackTrace = new StackTrace(exception, true);
-                StackTrace = stackTrace.ToString();
+            //if (!string.IsNullOrEmpty(exception.StackTrace))
+            //{
+            //    StackTrace stackTrace = new StackTrace(exception, true);
+            //    StackTrace = stackTrace.ToString();
 
-                // Only extract the stack frames like this for the top-level exception
-                // This is used for Xray Exception serialization
-                if (isNestedException || stackTrace?.GetFrames() == null)
-                {
-                    StackFrames = new StackFrameInfo[0];
-                }
-                else
-                {
-                    StackFrames = (
-                        from sf in stackTrace.GetFrames()
-                        where sf != null
-                        select new StackFrameInfo(sf)
-                    ).ToArray();
-                }
-            }
+            //    // Only extract the stack frames like this for the top-level exception
+            //    // This is used for Xray Exception serialization
+            //    if (isNestedException || stackTrace?.GetFrames() == null)
+            //    {
+            //        StackFrames = new StackFrameInfo[0];
+            //    }
+            //    else
+            //    {
+            //        var a = stackTrace.
+            //        StackFrames = (
+            //            from sf in stackTrace.GetFrames()
+            //            where sf != null
+            //            select new StackFrameInfo(sf)
+            //        ).ToArray();
+            //    }
+            //}
 
             if (exception.InnerException != null)
             {

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/ExceptionHandling/StackFrameInfo.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/ExceptionHandling/StackFrameInfo.cs
@@ -33,7 +33,7 @@ namespace Amazon.Lambda.RuntimeSupport
             Path = stackFrame.GetFileName();
             Line = stackFrame.GetFileLineNumber();
 
-            var method = stackFrame.GetMethod();
+            Type method = null;// This isn't used anymore because it causes trim warnings. stackFrame.GetMethod();
             if (method != null)
             {
                 var methodTypeName = method.DeclaringType?.Name;


### PR DESCRIPTION
### Overview

As a test to see how hard it is to prepare a [library for trimming](https://docs.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming), I made these changes and then published a NativeAOT binary from a sample lambda.CustomRuntime template. With these changes, the RuntimeSupport library no longer gives any trim warnings. (The Lambda serialization library still warns).

In some parts of the code, mainly error reporting, I just removed calls to reflection and replaced them with something else. These aren't production ready and would take a bit more though to really make work.

In other parts of the code, mainly the RunAsync, I just created a new code path that NativeAOT code can use instead which avoids reflection. This was possible, since the main RunAysnc code was using reflection to pre-JIT things, which wouldn't be needed anyway with NativeAOT.

This only fixes 100% of trim warnings when using the code below, if you're calling other parts of the library, you might get other trim warnings. It would be important to eventually cover all entry points into the library.

```
        Func<string, ILambdaContext, Task<string>> handler = FunctionHandler;
        await LambdaBootstrapBuilder.Create(handler, new DefaultLambdaJsonSerializer())
            .Build()
            .RunNativeAotAsync();
```
### Runtime Errors

This should make the code a bit safer, although I need to do further testing to see what the real results to x-ray logging are when a trimmed type is attempted to be used. I have previously hit missing metadata exceptions in test Lambdas and didn't notice any issues in the logs, so I'm not sure how much this change actually helps. 

### Binary Size

For code size, I wasn't able to actually get the binary file to change size with or without trimming (using IsTrimmable in the RuntimeSupport csproj, might be a bug in NativeAOT). I tried publishing the lib natively on it's own but it needs to pull in the whole .NET runtime with it, so it's hard to tell what Lambda is adding. However, with some very loose assumptions below, we can estimate that we could reduce file size by 1 to 2 MB.


In testing, a pretty much empty, Hello World .NET app in Release config came out as 4583KB.
A Hello World Custom Runtime Lambda in Release config came out as 13389KB.
So all of the Lambda code added about 9MB and probably came from from these 5 sources:
1. Amazon.Lambda.Core
2. Amazon.Lambda.RuntimeSupport
3. Amazon.Lambda.Serialization.Json
4. (Maybe Newtonsoft.Json, which Amazon.Lambda.Serialization.Json depends on)
5. All the parts of .NET that these depend on, that a basic .NET HelloWorld doesn't already.

If we assume (and this is a big assumption) that Amazon.Lambda.RuntimeSupport code was only 20% of the 9MB, then RuntimeSupport only added 1.8MB. However we won't ever be able to trim out all the RuntimeSupport  code, so if we assume we can only trim 75% of the code, that leaves us with 1.35MB trimmed. So by enabling trimming in this library and we can hope to reduce the final binary size by a very-loose estimate of 1 to 2 MB. For reference the limit for a Lambda binary is 250MB. 

(These numbers were taken from a Windows file system, I'm not sure if that changes any of this based kilobyte vs kibibytes)
