### PR TITLE
fix: pin CDK CLI version to 1.159.0

### DIFF
--- a/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/PipelineStack.cs
+++ b/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/PipelineStack.cs
@@ -71,10 +71,13 @@ namespace Infrastructure
                 .OrderBy(variable => variable);
 
             // Self mutation
+            // TODO: DOTNET-6085 - Migration from CDKPipeline to CodePipeline
+            const string cdkCliVersion = "1.159.0";
             var pipeline = new CdkPipeline(this, "Pipeline", new CdkPipelineProps
             {
                 PipelineName = $"{id}-{framework}",
                 CloudAssemblyArtifact = outputArtifact,
+                CdkCliVersion = cdkCliVersion,
 
                 SourceAction = new CodeCommitSourceAction(new CodeCommitSourceActionProps
                 {
@@ -94,7 +97,7 @@ namespace Infrastructure
                     Subdirectory = "LambdaRuntimeDockerfiles/Infrastructure",
                     InstallCommands = new[]
                     {
-                        "npm install -g aws-cdk",
+                        $"npm install -g aws-cdk@{cdkCliVersion}",
                     },
                     BuildCommands = new[] {"dotnet build"},
                     SynthCommand = "cdk synth",


### PR DESCRIPTION
## Motivation
https://github.com/aws/aws-cdk/issues/20739

## Change
Pin CDK version to 1.159.0. Once CodeBuild starts supporting NodeJS 14 LTS, this can be removed.

## Result
Self mutation succeeds.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
