### PR TITLE
Add raw data logging support for LambdaLogger

### DIFF
--- a/Libraries/src/Amazon.Lambda.Core/LambdaLogger.cs
+++ b/Libraries/src/Amazon.Lambda.Core/LambdaLogger.cs
@@ -12,11 +12,40 @@ namespace Amazon.Lambda.Core
         // Logging action, logs to Console by default
         private static Action<string> _loggingAction = LogToConsole;
 
+#if NET6_0_OR_GREATER
+        private static System.Buffers.ReadOnlySpanAction<byte, object> _dataLoggingAction = LogUtf8BytesToConsole;
+#endif
+
         // Logs message to console
         private static void LogToConsole(string message)
         {
             Console.WriteLine(message);
         }
+
+#if NET6_0_OR_GREATER
+        private static void LogUtf8BytesToConsole(ReadOnlySpan<byte> utf8Message, object state)
+        {
+            try
+            {
+                Console.WriteLine(Console.OutputEncoding.GetString(utf8Message));
+            }
+            catch
+            {
+                // ignore any encoding error
+            }
+        }
+
+        /// <summary>
+        /// Logs a message to AWS CloudWatch Logs. <br/>
+        /// Logging will not be done:
+        /// If the role provided to the function does not have sufficient permissions.
+        /// </summary>
+        /// <param name="utf8Message">The message as UTF-8 encoded data.</param>
+        public static void Log(ReadOnlySpan<byte> utf8Message)
+        {
+            _dataLoggingAction(utf8Message, null);
+        }
+#endif
 
         /// <summary>
         /// Logs a message to AWS CloudWatch Logs.

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
@@ -107,6 +107,25 @@ namespace Amazon.Lambda.RuntimeSupport
         }
 
         /// <summary>
+        /// Create a LambdaBootstrap that will call the given initializer and handler.
+        /// </summary>
+        /// <param name="httpClient">The HTTP client to use with the Lambda runtime.</param>
+        /// <param name="handler">Delegate called for each invocation of the Lambda function.</param>
+        /// <param name="initializer">Delegate called to initialize the Lambda function.  If not provided the initialization step is skipped.</param>
+        /// <param name="ownsHttpClient">Whether the instance owns the HTTP client and should dispose of it.</param>
+        /// <param name="runtimeApiClient">Instance of <see cref="IRuntimeApiClient"/> to call the runtime API.</param>
+        /// <returns></returns>
+        internal LambdaBootstrap(HttpClient httpClient, LambdaBootstrapHandler handler, LambdaBootstrapInitializer initializer, bool ownsHttpClient, IRuntimeApiClient runtimeApiClient)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+            _ownsHttpClient = ownsHttpClient;
+            _initializer = initializer;
+            _httpClient.Timeout = RuntimeApiHttpTimeout;
+            Client = runtimeApiClient;
+        }
+
+        /// <summary>
         /// Run the initialization Func if provided.
         /// Then run the invoke loop, calling the handler for each invocation.
         /// </summary>

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/ConsoleLoggerWriter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/ConsoleLoggerWriter.cs
@@ -344,15 +344,15 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
 
             internal void FormattedWriteBytes(string level, ReadOnlySpan<byte> message)
             {
+                if (_innerOutputStream is null)
+                {
+                    // the telemetry FD output stream is not present, we delegate to FormattedWriteLine()
+                    FormattedWriteLine(level, _innerWriter.Encoding.GetString(message));
+                    return;
+                }
+
                 lock (LockObject)
                 {
-                    if (_innerOutputStream is null)
-                    {
-                        // the telemetry FD output stream is not present, we delegate to WriteLine()
-                        _innerWriter.WriteLine(_innerWriter.Encoding.GetString(message));
-                        return;
-                    }
-
                     var displayLevel = level;
                     if (Enum.TryParse<LogLevel>(level, true, out var levelEnum))
                     {

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/Amazon.Lambda.RuntimeSupport.UnitTests.csproj
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/Amazon.Lambda.RuntimeSupport.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/FileDescriptorLogStreamTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/FileDescriptorLogStreamTests.cs
@@ -19,6 +19,166 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             0xA5, 0x5A, 0x00, 0x01
         };
 
+#if NET6_0_OR_GREATER
+        [Fact]
+        public void MultiLineLogDataInSingleLogEntryWithTlvFormat()
+        {
+            var logs = new List<byte[]>();
+            var offsets = new List<int>();
+            var counts = new List<int>();
+            var stream = new TestFileStream((log, offset, count) =>
+            {
+                logs.Add(log);
+                offsets.Add(offset);
+                counts.Add(count);
+            });
+            var writer = FileDescriptorLogFactory.InitializeWriter(stream);
+            var writerStream = writer.BaseStream;
+            // assert that initializing the stream does not result in UTF-8 preamble log entry
+            Assert.Empty(counts);
+            Assert.Empty(offsets);
+            Assert.Empty(logs);
+
+            const string logMessage = "hello world\nsomething else on a new line.";
+            int logMessageLength = logMessage.Length;
+            writerStream.Write(writer.Encoding.GetBytes(logMessage).AsSpan());
+
+            Assert.Equal(2, offsets.Count);
+            int headerLogEntryOffset = offsets[0];
+            int consoleLogEntryOffset = offsets[1];
+            Assert.Equal(0, headerLogEntryOffset);
+            Assert.Equal(0, consoleLogEntryOffset);
+
+            Assert.Equal(2, counts.Count);
+            int headerLogEntrySize = counts[0];
+            int consoleLogEntrySize = counts[1];
+            Assert.Equal(HeaderLength, headerLogEntrySize);
+            Assert.Equal(logMessageLength, consoleLogEntrySize);
+
+            Assert.Equal(2, logs.Count);
+            byte[] headerLogEntry = logs[0];
+            byte[] consoleLogEntry = logs[1];
+            Assert.Equal(HeaderLength, headerLogEntry.Length);
+            Assert.Equal(logMessageLength, consoleLogEntry.Length);
+
+            byte[] expectedLengthBytes =
+            {
+                0x00, 0x00, 0x00, 0x29
+            };
+            AssertHeaderBytes(headerLogEntry, expectedLengthBytes);
+            Assert.Equal(logMessage, Encoding.UTF8.GetString(consoleLogEntry));
+        }
+
+        [Fact]
+        public void LogDataMaxSizeProducesOneLogFrame()
+        {
+            var logs = new List<byte[]>();
+            var offsets = new List<int>();
+            var counts = new List<int>();
+            var stream = new TestFileStream((log, offset, count) =>
+            {
+                logs.Add(log);
+                offsets.Add(offset);
+                counts.Add(count);
+            });
+            var writer = FileDescriptorLogFactory.InitializeWriter(stream);
+            var writerStream = writer.BaseStream;
+
+            string logMessage = new string('a', LogEntryMaxLength - 1) + "b";
+            writerStream.Write(writer.Encoding.GetBytes(logMessage).AsSpan());
+
+            Assert.Equal(2, offsets.Count);
+            int headerLogEntryOffset = offsets[0];
+            int consoleLogEntryOffset = offsets[1];
+            Assert.Equal(0, headerLogEntryOffset);
+            Assert.Equal(0, consoleLogEntryOffset);
+
+            Assert.Equal(2, counts.Count);
+            int headerLogEntrySize = counts[0];
+            int consoleLogEntrySize = counts[1];
+            Assert.Equal(HeaderLength, headerLogEntrySize);
+            Assert.Equal(LogEntryMaxLength, consoleLogEntrySize);
+
+            Assert.Equal(2, logs.Count);
+            byte[] headerLogEntry = logs[0];
+            byte[] consoleLogEntry = logs[1];
+            Assert.Equal(HeaderLength, headerLogEntry.Length);
+            Assert.Equal(LogEntryMaxLength, consoleLogEntry.Length);
+
+            byte[] expectedLengthBytes =
+            {
+                0x00, 0x03, 0xFF, 0xE6
+            };
+            AssertHeaderBytes(headerLogEntry, expectedLengthBytes);
+            Assert.Equal(logMessage, Encoding.UTF8.GetString(consoleLogEntry));
+        }
+
+        [Fact]
+        public void LogDataAboveMaxSizeProducesMultipleLogFrames()
+        {
+            var logs = new List<byte[]>();
+            var offsets = new List<int>();
+            var counts = new List<int>();
+            var stream = new TestFileStream((log, offset, count) =>
+            {
+                logs.Add(log);
+                offsets.Add(offset);
+                counts.Add(count);
+            });
+            var writer = FileDescriptorLogFactory.InitializeWriter(stream);
+            var writerStream = writer.BaseStream;
+
+            string logMessage = new string('a', LogEntryMaxLength) + "b";
+            writerStream.Write(writer.Encoding.GetBytes(logMessage).AsSpan());
+
+            Assert.Equal(4, offsets.Count);
+            int headerLogEntryOffset = offsets[0];
+            int consoleLogEntryOffset = offsets[1];
+            int headerLogSecondEntryOffset = offsets[2];
+            int consoleLogSecondEntryOffset = offsets[3];
+            Assert.Equal(0, headerLogEntryOffset);
+            Assert.Equal(0, consoleLogEntryOffset);
+            Assert.Equal(0, headerLogSecondEntryOffset);
+            Assert.Equal(0, consoleLogSecondEntryOffset);
+
+            Assert.Equal(4, counts.Count);
+            int headerLogEntrySize = counts[0];
+            int consoleLogEntrySize = counts[1];
+            int headerLogSecondEntrySize = counts[2];
+            int consoleLogSecondEntrySize = counts[3];
+            Assert.Equal(HeaderLength, headerLogEntrySize);
+            Assert.Equal(LogEntryMaxLength, consoleLogEntrySize);
+            Assert.Equal(HeaderLength, headerLogSecondEntrySize);
+            Assert.Equal(1, consoleLogSecondEntrySize);
+
+            Assert.Equal(4, logs.Count);
+            byte[] headerLogEntry = logs[0];
+            byte[] consoleLogEntry = logs[1];
+            byte[] headerLogSecondEntry = logs[2];
+            byte[] consoleLogSecondEntry = logs[3];
+            Assert.Equal(HeaderLength, headerLogEntry.Length);
+            Assert.Equal(LogEntryMaxLength, consoleLogEntry.Length);
+            Assert.Equal(HeaderLength, headerLogSecondEntry.Length);
+            Assert.Single(consoleLogSecondEntry);
+
+            byte[] expectedLengthBytes =
+            {
+                0x00, 0x03, 0xFF, 0xE6
+            };
+            AssertHeaderBytes(headerLogEntry, expectedLengthBytes);
+
+            byte[] expectedLengthBytesSecondEntry =
+            {
+                0x00, 0x00, 0x00, 0x01
+            };
+            AssertHeaderBytes(headerLogSecondEntry, expectedLengthBytesSecondEntry);
+            string expectedLogEntry = logMessage.Substring(0, LogEntryMaxLength);
+            string expectedSecondLogEntry = logMessage.Substring(LogEntryMaxLength);
+            Assert.Equal(expectedLogEntry, Encoding.UTF8.GetString(consoleLogEntry));
+            Assert.Equal(expectedSecondLogEntry, Encoding.UTF8.GetString(consoleLogSecondEntry));
+        }
+#endif
+
         [Fact]
         public void MultilineLoggingInSingleLogEntryWithTlvFormat()
         {

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/HandlerTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/HandlerTests.cs
@@ -389,10 +389,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 var userCodeLoader = new UserCodeLoader(handler, _internalLogger);
                 var handlerWrapper = HandlerWrapper.GetHandlerWrapper(userCodeLoader.Invoke);
                 var initializer = new UserCodeInitializer(userCodeLoader, _internalLogger);
-                var bootstrap = new LambdaBootstrap(handlerWrapper, initializer.InitializeAsync)
-                {
-                    Client = testRuntimeApiClient
-                };
+                using var bootstrap = new LambdaBootstrap(new System.Net.Http.HttpClient(), handlerWrapper.Handler, initializer.InitializeAsync, true, testRuntimeApiClient);
 
                 if (assertLoggedByInitialize != null)
                 {

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LogLevelLoggerWriterTest.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LogLevelLoggerWriterTest.cs
@@ -1,0 +1,87 @@
+﻿#if NET6_0_OR_GREATER
+using Amazon.Lambda.Core;
+using Amazon.Lambda.RuntimeSupport.Helpers;
+using System;
+using System.Buffers.Binary;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Amazon.Lambda.RuntimeSupport.UnitTests
+{
+    public class LogLevelLoggerWriterTest
+    {
+        [Fact]
+        public void WriteBytesUnformattedShouldWriteLogFrame()
+        {
+            using var outputStream = new MemoryStream();
+            using var streamWriter = FileDescriptorLogFactory.InitializeWriter(outputStream);
+
+            const string logMessage = "hello world\nsomething else on a new line.";
+            var loggerWriter = new LogLevelLoggerWriter(streamWriter, streamWriter, streamWriter.BaseStream);
+            loggerWriter.SetLogFormatType(LogFormatType.Unformatted);
+            loggerWriter.FormattedWriteBytes(null, streamWriter.Encoding.GetBytes(logMessage));
+
+            AssertLogFrame(outputStream.ToArray(), m => Assert.Equal(m, logMessage));
+        }
+
+        [Fact]
+        public void WriteBytesFormattedShouldWriteFormattedLogFrame()
+        {
+            const string logMessage = "hello world\nsomething else on a new line.";
+
+            using var outputStream = new MemoryStream();
+            using var streamWriter = FileDescriptorLogFactory.InitializeWriter(outputStream);
+
+            var requestId = Guid.NewGuid().ToString();
+            var loggerWriter = new LogLevelLoggerWriter(streamWriter, streamWriter, streamWriter.BaseStream);
+            loggerWriter.SetCurrentAwsRequestId(requestId);
+            loggerWriter.SetLogFormatType(LogFormatType.Default);
+            loggerWriter.FormattedWriteBytes(null, streamWriter.Encoding.GetBytes(logMessage));
+
+            AssertLogFrame(outputStream.ToArray(), actualMsg =>
+            {
+                // make sure that the message starts with a valid datetime
+                const string dateFormat = "yyyy-MM-ddTHH:mm:ss.fffZ";
+                var dateString = actualMsg.Substring(0, dateFormat.Length);
+                DateTime.ParseExact(dateString, dateFormat, CultureInfo.InvariantCulture);
+
+                // output should contains request ID
+                Assert.Contains(requestId, actualMsg);
+
+                // output should end with the actual message
+                Assert.EndsWith(logMessage, actualMsg);
+            });
+        }
+
+        [Fact]
+        public void LambdaLoggerShouldWriteToLogLevelLoggerWriter()
+        {
+            using var outputStream = new MemoryStream();
+            using var streamWriter = FileDescriptorLogFactory.InitializeWriter(outputStream);
+
+            const string logMessage = "hello world\nsomething else on a new line.";
+            var loggerWriter = new LogLevelLoggerWriter(streamWriter, streamWriter, streamWriter.BaseStream);
+            loggerWriter.SetLogFormatType(LogFormatType.Unformatted);
+
+            LambdaLogger.Log(streamWriter.Encoding.GetBytes(logMessage));
+
+            // verify that the log message is directed to LogLevelLoggerWriter 
+            AssertLogFrame(outputStream.ToArray(), m => Assert.Equal(m, logMessage));
+        }
+
+        private static void AssertLogFrame(ReadOnlySpan<byte> frame, Action<string> messageAssertion)
+        {
+            Assert.True(frame.Length >= 8);
+
+            var frameType = BinaryPrimitives.ReadUInt32BigEndian(frame.Slice(0, 4));
+            Assert.Equal(frameType, FileDescriptorLogFactory.LambdaTelemetryLogHeaderFrameType);
+
+            var length = BinaryPrimitives.ReadInt32BigEndian(frame.Slice(4, 4));
+            var actualMessage = new UTF8Encoding(false, false).GetString(frame.Slice(8, length));
+            messageAssertion(actualMessage);
+        }
+    }
+}
+#endif

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestFileStream.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestFileStream.cs
@@ -22,6 +22,11 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests.TestHelpers
             WriteAction(TrimTrailingNullBytes(buffer).Take(count).ToArray(), offset, count);
         }
 
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            Write(buffer.ToArray(), 0, buffer.Length);
+        }
+
         private static IEnumerable<byte> TrimTrailingNullBytes(IEnumerable<byte> buffer)
         {
             // Trim trailing null bytes to make testing assertions easier

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/CustomRuntimeFunctionTest/CustomRuntimeFunction.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/CustomRuntimeFunctionTest/CustomRuntimeFunction.cs
@@ -170,6 +170,8 @@ namespace CustomRuntimeFunctionTest
 
             Amazon.Lambda.Core.LambdaLogger.Log("A fake message level");
 
+            Amazon.Lambda.Core.LambdaLogger.Log(Encoding.UTF8.GetBytes("a fake new message \n hello"));
+
             return Task.FromResult(GetInvocationResponse(nameof(LoggingTest), true));
         }
 

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/CustomRuntimeFunctionTest/CustomRuntimeFunction.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/CustomRuntimeFunctionTest/CustomRuntimeFunction.cs
@@ -170,8 +170,6 @@ namespace CustomRuntimeFunctionTest
 
             Amazon.Lambda.Core.LambdaLogger.Log("A fake message level");
 
-            Amazon.Lambda.Core.LambdaLogger.Log(Encoding.UTF8.GetBytes("a fake new message \n hello"));
-
             return Task.FromResult(GetInvocationResponse(nameof(LoggingTest), true));
         }
 


### PR DESCRIPTION
*Issue #, if available:* : https://github.com/aws/aws-lambda-dotnet/issues/1232

*Description of changes:* Add an overload to `LambdaLogger.Log()` to allow logging using raw data.

## Overview 
In https://github.com/aws/aws-lambda-dotnet/issues/1232 we brought up our use case of `ILogger` interface. Before we can implement such a logger we need to have a way to forward raw UTF8 data to the output. In this PR we propose that an overload is  added to `LambdaLogger`  (for .NET 6 runtime only)
```csharp
#if NET6_0_OR_GREATER
/// <summary>
/// Logs a message to AWS CloudWatch Logs. <br/>
/// Logging will not be done:
/// If the role provided to the function does not have sufficient permissions.
/// </summary>
/// <param name="utf8Message">The message as UTF-8 encoded data.</param>
public static void Log(ReadOnlySpan<byte> utf8Message)
#endif
```
This will be implemented in a similar fashion to `Log(string)`: it's delegated to a default method but `LogLevelLoggerWriter` will replace that method with the formatted version using reflection.  
To do this the output `Stream` is passed to `WrapperTextWriter`. If the Telemetry logging file descriptor is available this will be the `FileStream` wrapper for that FD, otherwise the stream is set to `NULL` and the logging action is delegated back to `FormattedWriteLine()`

## Testing
Because this new function is only supported on .NET 6 and higher we added `net6.0` target to `Amazon.Lambda.RuntimeSupport.UnitTests.csproj`.   
We added equivalent tests to existing tests for `FileDescriptorLogFactory.FileDescriptorLogStream` (raw data writing variant). We also added several unit tests to `LogLevelLoggerWriter`.  
We also **fixed a failing test** : `HandlerTests.PositiveHandlerTestsAsync`. This test is failing for .NET 6 because by default the `LambdaBootstrap` always initializes the `LogLevelLoggerWriter` instance, which in turn redirects the `LambdaLogger` output, causing the logs to not be redirected to the test. This is fixed by creating another constructor for `LambdaBootstrap` to accept a `IConsoleLoggerWriter` instance which the test itself provides.

## Remarks
There are two places whether the logging action of `LambdaLogger` is set. The first place is `LogLevelLoggerWriter` which we include in this PR. The second place is in `UserCodeLoader.SetCustomerLoggerLogAction()`. We are still not sure what the usage of this method. I'm happy to hear about this usage and amend the PR.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
