### PR TITLE
Remove unused netcoreapp2.1 Microsoft.AspNetCore.All dependency from TestWebApp

### DIFF
--- a/Libraries/test/TestWebApp/TestWebApp.csproj
+++ b/Libraries/test/TestWebApp/TestWebApp.csproj
@@ -8,9 +8,6 @@
     <PackageId>TestWebApp</PackageId>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <DefineConstants>NETCOREAPP_2_1</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>NETCOREAPP_3_1</DefineConstants>
   </PropertyGroup>
@@ -19,13 +16,7 @@
     <ProjectReference Include="..\..\src\Amazon.Lambda.AspNetCoreServer\Amazon.Lambda.AspNetCoreServer.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5">
-<Publish Condition="'%(PackageReference.Version)' == ''">true</Publish>
-</PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="1.1.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Swashbuckle.AspNetCore" Version="1.1.0" />
   </ItemGroup>
   


### PR DESCRIPTION
*Description of changes:* Supersedes https://github.com/aws/aws-lambda-dotnet/pull/1234 by removing the unused dependency entirely since this project no longer targets .NET Core 2.1 instead of just bumping it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
