### PR TITLE
Allow host to be configurable on Amazon.Lambda.TestTool

### DIFF
--- a/Tools/LambdaTestTool/README.md
+++ b/Tools/LambdaTestTool/README.md
@@ -86,6 +86,8 @@ These options are valid for either mode the Lambda test tool is running in.
 
 These options are valid when using the web interface to select and execute the Lambda code.
 
+        --host &lt;hostname-or-ip-address&gt;       The hostname or IP address used for the test tool's web interface.                                                    
+                                                    Any host other than an explicit IP address or localhost (e.g. '*', '+' or 'example.com') binds to all public IPv4 and IPv6 addresses. 
         --port &lt;port-number&gt;                  The port number used for the test tool's web interface.
         --no-launch-window                    Disable auto launching the test tool's web interface in a browser.
 
@@ -106,6 +108,8 @@ These options are valid in the no web interface mode.
                                               when executing from an IDE so you can avoid having the output window immediately disappear after
                                               executing the Lambda code. The default value is true.
 </pre>
+
+**Note**: The `--host` argument do not to bind to specific hostname as it's value is largely ignored by [web hosting](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints?view=aspnetcore-6.0#url-prefixes-1). This is mostly used to expose web interface through docker by binding to all public IP addresses.
 
 For command line arguments not set the defaults and config file will be used to determine the .NET Lambda code to run. For example if you just use the <b>--no-ui</b> argument then the
 <b>aws-lambda-tools-defaults.json</b> will be searched for and used if found. The tool will then use the function handler, profile and region specified in the configuration file to run

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Constants.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Constants.cs
@@ -3,6 +3,7 @@ namespace Amazon.Lambda.TestTool.BlazorTester
     public class Constants
     {
         public const int DEFAULT_PORT = 5050;
+        public const string DEFAULT_HOST = "localhost";
 
 #if NETCOREAPP3_1
         public const string PRODUCT_NAME = "AWS .NET Core 3.1 Mock Lambda Test Tool";
@@ -13,13 +14,13 @@ namespace Amazon.Lambda.TestTool.BlazorTester
 #else
         Update for new target framework!!!
 #endif
-      
-        public const string ResponseSuccessStyle = "white-space: pre-wrap; height: min-content; font-size: 75%; color: black"; 
+
+        public const string ResponseSuccessStyle = "white-space: pre-wrap; height: min-content; font-size: 75%; color: black";
         public const string ResponseErrorStyle = "white-space: pre-wrap; height: min-content; font-size: 75%; color: red";
-            
-        public const string ResponseSuccessStyleSizeConstraint = "white-space: pre-wrap; height: 300px; font-size: 75%; color: black"; 
+
+        public const string ResponseSuccessStyleSizeConstraint = "white-space: pre-wrap; height: 300px; font-size: 75%; color: black";
         public const string ResponseErrorStyleSizeConstraint = "white-space: pre-wrap; height: 300px; font-size: 75%; color: red";
-          
+
 
         public const string LINK_GITHUB_TEST_TOOL = "https://github.com/aws/aws-lambda-dotnet/tree/master/Tools/LambdaTestTool";
         public const string LINK_GITHUB_TEST_TOOL_INSTALL_AND_RUN = "https://github.com/aws/aws-lambda-dotnet/tree/master/Tools/LambdaTestTool#installing-and-running";

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Documentation.razor
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Documentation.razor
@@ -33,7 +33,7 @@
 <h4>Connect Executable Assembly Functions</h4>
 <p>
     To test Lambda function built as an executable assembly the environment variable <b>AWS_LAMBDA_RUNTIME_API</b> must be set to 
-    <b>localhost:@httpContextAccessor.HttpContext.Connection.LocalPort</b>. This will tell Amazon.Lambda.RuntimeSupport to connect to this instance of the test tool for Lambda
+    <b>@httpContextAccessor.HttpContext.Request.Host</b>. This will tell Amazon.Lambda.RuntimeSupport to connect to this instance of the test tool for Lambda
     events to process. To configure AWS credentials and region for the function the environment variables <b>AWS_PROFILE</b> and <b>AWS_REGION</b> can be set. 
 </p>
 <p>
@@ -45,7 +45,7 @@
     "Lambda Runtime API": {
       "commandName": "Project",
       "environmentVariables": {
-        "AWS_LAMBDA_RUNTIME_API": "localhost:5050"
+        "AWS_LAMBDA_RUNTIME_API": "@httpContextAccessor.HttpContext.Request.Host"
         "AWS_PROFILE": "test-profile"
         "AWS_REGION": "us-west-2"
       }
@@ -54,7 +54,7 @@
 }
     </pre>
 <h4>Programmatically Queue Events</h4>
-To queue an event to be processed without using the UI send a <b>POST</b> request to <b>http://localhost:@httpContextAccessor.HttpContext.Connection.LocalPort/runtime/test-event</b> with the 
+To queue an event to be processed without using the UI send a <b>POST</b> request to <b>http://@httpContextAccessor.HttpContext.Request.Host/runtime/test-event</b> with the 
 JSON Lambda event document as the POST request's body.
 </p>
 
@@ -97,6 +97,8 @@ These options are valid for either mode the Lambda test tool is running in.
 
 These options are valid when using the web interface to select and execute the Lambda code.
 
+        --host &lt;hostname-or-ip-address&gt;       The hostname or IP address used for the test tool's web interface.
+                                              Any host other than an explicit IP address or localhost (e.g. '*', '+' or 'example.com') binds to all public IPv4 and IPv6 addresses. 
         --port &lt;port-number&gt;                  The port number used for the test tool's web interface.
         --no-launch-window                    Disable auto launching the test tool's web interface in a browser.
 
@@ -117,6 +119,12 @@ These options are valid in the no web interface mode.
                                               when executing from an IDE so you can avoid having the output window immediately disappear after
                                               executing the Lambda code. The default value is true.
 </pre>
+
+<p>
+    <i>Note</i>: The <b>--host</b> argument do not to bind to specific hostname as it's value is largely ignored by 
+    <a href="https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints?view=aspnetcore-6.0#url-prefixes-1" target="_blank">web hosting</a>. 
+    This is mostly used to expose web interface through docker by binding to all public IP addresses.
+</p>
 
 <p class="faq-answer">
     For command line arguments not set the defaults and config file will be used to determine the .NET Lambda code to run. For example if you just use the <b>--no-ui</b> argument then the

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Runtime.razor
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Runtime.razor
@@ -13,7 +13,7 @@
 
 <p>
     For Lambda functions written as executable assemblies, i.e. custom runtimes functions and top level statement functions, this page can be used for testing the functions locally. 
-    Set the <b>AWS_LAMBDA_RUNTIME_API</b> environment variable to <b>localhost:@httpContextAccessor.HttpContext.Connection.LocalPort</b> while debugging executable assembly 
+    Set the <b>AWS_LAMBDA_RUNTIME_API</b> environment variable to <b>@httpContextAccessor.HttpContext.Request.Host</b> while debugging executable assembly 
     Lambda function. More information can be found in the <a href="/documentation">documentation</a>.
 </p>
 

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/CommandLineOptions.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/CommandLineOptions.cs
@@ -1,12 +1,13 @@
 ﻿using System;
-using System.IO;
 
 namespace Amazon.Lambda.TestTool
 {
     public class CommandLineOptions
     {
+        public string Host { get; set; }
+
         public int? Port { get; set; }
-        
+
         public bool NoLaunchWindow { get; set; }
 
         public string Path { get; set; }
@@ -20,9 +21,9 @@ namespace Amazon.Lambda.TestTool
         public string Payload { get; set; }
 
         public string AWSProfile { get; set; }
-        
+
         public string AWSRegion { get; set; }
-        
+
         public bool ShowHelp { get; set; }
 
         public bool PauseExit { get; set; } = true;
@@ -38,10 +39,14 @@ namespace Amazon.Lambda.TestTool
                 {
                     case "--help":
                         options.ShowHelp = GetNextBoolValue(i, out skipAhead);
-                        if(skipAhead)
+                        if (skipAhead)
                         {
                             i++;
                         }
+                        break;
+                    case "--host":
+                        options.Host = GetNextStringValue(i);
+                        i++;
                         break;
                     case "--port":
                         options.Port = GetNextIntValue(i);
@@ -49,15 +54,15 @@ namespace Amazon.Lambda.TestTool
                         break;
                     case "--no-launch-window":
                         options.NoLaunchWindow = GetNextBoolValue(i, out skipAhead);
-                        if(skipAhead)
+                        if (skipAhead)
                         {
                             i++;
                         }
                         break;
                     case "--path":
-                      options.Path = GetNextStringValue(i);
-                      i++;
-                      break;
+                        options.Path = GetNextStringValue(i);
+                        i++;
+                        break;
                     case "--profile":
                         options.AWSProfile = GetNextStringValue(i);
                         i++;
@@ -94,15 +99,15 @@ namespace Amazon.Lambda.TestTool
                         break;
                 }
             }
-            
+
             return options;
 
             string GetNextStringValue(int currentIndex)
             {
                 var valueIndex = currentIndex + 1;
-                if(valueIndex == args.Length)
+                if (valueIndex == args.Length)
                     throw new CommandLineParseException($"Missing value for {args[currentIndex]}");
-                
+
                 return args[valueIndex];
             }
 
@@ -114,7 +119,7 @@ namespace Amazon.Lambda.TestTool
                 }
                 throw new CommandLineParseException($"Value for {args[currentIndex]} is not a valid integer");
             }
-            
+
             bool GetNextBoolValue(int currentIndex, out bool skipAhead)
             {
                 if (currentIndex + 1 < args.Length && !args[currentIndex + 1].StartsWith("--") && bool.TryParse(GetNextStringValue(currentIndex), out var value))
@@ -136,7 +141,7 @@ namespace Amazon.Lambda.TestTool
             Console.WriteLine("to execute with in the Lambda test tool. The second mode skips using the web interface and the Lambda code is identified");
             Console.WriteLine("using the commandline switches as described below. To switch to the no web interface mode use the --no-ui command line switch.");
             Console.WriteLine();
-            
+
             Console.WriteLine("These options are valid for either mode the Lambda test tool is running in.");
             Console.WriteLine();
             Console.WriteLine("\t--path <directory>                    The path to the lambda project to execute. If not set then the current directory will be used.");
@@ -147,7 +152,7 @@ namespace Amazon.Lambda.TestTool
             Console.WriteLine("\t--port <port-number>                  The port number used for the test tool's web interface.");
             Console.WriteLine("\t--no-launch-window                    Disable auto launching the test tool's web interface in a browser.");
             Console.WriteLine();
-            
+
             Console.WriteLine("These options are valid in the no web interface mode.");
             Console.WriteLine();
             Console.WriteLine("\t--no-ui                               Disable launching the web interface and immediately execute the Lambda code.");

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/LocalLambdaOptions.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/LocalLambdaOptions.cs
@@ -1,15 +1,15 @@
-﻿using System;
+﻿using Amazon.Lambda.TestTool.Runtime;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
-
-using Amazon.Lambda.TestTool.Runtime;
 
 namespace Amazon.Lambda.TestTool
 {
     public class LocalLambdaOptions
     {
+        public string Host { get; set; }
+
         public int? Port { get; set; }
 
         public IList<string> LambdaConfigFiles { get; set; }
@@ -24,7 +24,7 @@ namespace Amazon.Lambda.TestTool
             {
                 throw new Exception($"{configFile} is not a config file for this project");
             }
-            
+
             var configInfo = LambdaDefaultsConfigFileParser.LoadFromFile(fullConfigFilePath);
             return LoadLambdaFuntion(configInfo, functionHandler);
         }
@@ -53,7 +53,7 @@ namespace Amazon.Lambda.TestTool
 
             var function = this.LambdaRuntime.LoadLambdaFunction(functionInfo);
             return function;
-        }        
+        }
 
         /// <summary>
         /// The directory to store in local settings for a Lambda project for example saved Lambda requests.
@@ -70,7 +70,7 @@ namespace Amazon.Lambda.TestTool
                 currentDirectory = this.LambdaRuntime.LambdaAssemblyDirectory;
 
             var preferenceDirectory = Path.Combine(currentDirectory, ".lambda-test-tool");
-            if(createIfNotExist && !Directory.Exists(preferenceDirectory))
+            if (createIfNotExist && !Directory.Exists(preferenceDirectory))
             {
                 Directory.CreateDirectory(preferenceDirectory);
             }

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/TestToolStartup.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/TestToolStartup.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Amazon.Lambda.TestTool.Runtime;
+using Amazon.Lambda.TestTool.SampleRequests;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
-
-using Amazon.Lambda.TestTool.Runtime;
-using Amazon.Lambda.TestTool.SampleRequests;
 
 namespace Amazon.Lambda.TestTool
 {
@@ -14,7 +11,7 @@ namespace Amazon.Lambda.TestTool
     {
         public class RunConfiguration
         {
-            public enum RunMode { Normal, Test};
+            public enum RunMode { Normal, Test };
 
             /// <summary>
             /// If this is set to Test then that disables any interactive activity or any calls to Environment.Exit which wouldn't work well during a test run.
@@ -47,6 +44,7 @@ namespace Amazon.Lambda.TestTool
 
                 var localLambdaOptions = new LocalLambdaOptions()
                 {
+                    Host = commandOptions.Host,
                     Port = commandOptions.Port
                 };
 
@@ -122,12 +120,12 @@ namespace Amazon.Lambda.TestTool
             }
         }
 
-        
+
         public static void ExecuteWithNoUi(LocalLambdaOptions localLambdaOptions, CommandLineOptions commandOptions, string lambdaAssemblyDirectory, RunConfiguration runConfiguration)
         {
             runConfiguration.OutputWriter.WriteLine("Executing Lambda function without web interface");
             var lambdaProjectDirectory = Utils.FindLambdaProjectDirectory(lambdaAssemblyDirectory);
-            
+
             string configFile = DetermineConfigFile(commandOptions, lambdaAssemblyDirectory: lambdaAssemblyDirectory, lambdaProjectDirectory: lambdaProjectDirectory);
             LambdaConfigInfo configInfo = LoadLambdaConfigInfo(configFile, commandOptions, lambdaAssemblyDirectory: lambdaAssemblyDirectory, lambdaProjectDirectory: lambdaProjectDirectory, runConfiguration);
             LambdaFunction lambdaFunction = LoadLambdaFunction(configInfo, localLambdaOptions, commandOptions, lambdaAssemblyDirectory: lambdaAssemblyDirectory, lambdaProjectDirectory: lambdaProjectDirectory, runConfiguration);

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Utils.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Utils.cs
@@ -1,12 +1,13 @@
-﻿using Amazon.Lambda.TestTool.Runtime;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Net;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
+using Amazon.Lambda.TestTool.Runtime;
 
 namespace Amazon.Lambda.TestTool
 {
@@ -31,7 +32,7 @@ namespace Amazon.Lambda.TestTool
 
             return attribute?.InformationalVersion;
         }
-        
+
         /// <summary>
         /// A collection of known paths for common utilities that are usually not found in the path
         /// </summary>
@@ -54,7 +55,7 @@ namespace Amazon.Lambda.TestTool
 
             if (string.Equals(command, "dotnet.exe"))
             {
-                if(!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     command = "dotnet";
                 }
@@ -99,10 +100,10 @@ namespace Amazon.Lambda.TestTool
 
         public static bool IsProjectDirectory(string directory)
         {
-            if(Directory.GetFiles(directory, "*.csproj").Length > 0 ||
+            if (Directory.GetFiles(directory, "*.csproj").Length > 0 ||
                 Directory.GetFiles(directory, "*.fsproj").Length > 0 ||
                 Directory.GetFiles(directory, "*.vbproj").Length > 0)
-                {
+            {
                 return true;
             }
 
@@ -113,10 +114,10 @@ namespace Amazon.Lambda.TestTool
         {
             if (string.IsNullOrEmpty(lambdaAssemblyDirectory))
                 return null;
-            
+
             if (IsProjectDirectory(lambdaAssemblyDirectory))
                 return lambdaAssemblyDirectory;
-            
+
             return FindLambdaProjectDirectory(Directory.GetParent(lambdaAssemblyDirectory)?.FullName);
         }
 
@@ -143,10 +144,10 @@ namespace Amazon.Lambda.TestTool
                             Console.WriteLine($"Found Lambda config file {file}");
                             configFiles.Add(file);
                         }
-                        else if(!string.IsNullOrEmpty(configFile.Template) && File.Exists(Path.Combine(lambdaFunctionDirectory, configFile.Template)))
+                        else if (!string.IsNullOrEmpty(configFile.Template) && File.Exists(Path.Combine(lambdaFunctionDirectory, configFile.Template)))
                         {
                             var config = LambdaDefaultsConfigFileParser.LoadFromFile(configFile);
-                            if(config.FunctionInfos?.Count > 0)
+                            if (config.FunctionInfos?.Count > 0)
                             {
                                 Console.WriteLine($"Found Lambda config file {file}");
                                 configFiles.Add(file);
@@ -211,6 +212,15 @@ namespace Amazon.Lambda.TestTool
                 return false;
 #endif
             }
+        }
+
+        public static string DetermineLaunchUrl(string host, int port, string defaultHost)
+        {
+            if (!IPAddress.TryParse(host, out _))
+                // Any host other than explicit IP will be redirected to default host (i.e. localhost)
+                return $"http://{defaultHost}:{port}";
+
+            return $"http://{host}:{port}";
         }
     }
 }

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/CommandLineParserTests.cs
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/CommandLineParserTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Xunit;
+﻿using Xunit;
 
 namespace Amazon.Lambda.TestTool.Tests
 {
@@ -8,12 +7,12 @@ namespace Amazon.Lambda.TestTool.Tests
         [Fact]
         public void AllValuesGetSet()
         {
-            var options = CommandLineOptions.Parse(new string[] {"--help", "--port", "1111", "--no-launch-window", 
+            var options = CommandLineOptions.Parse(new string[] {"--help", "--host", "example.com", "--port", "1111", "--no-launch-window",
                                                                 "--path", "./foo", "--profile", "test", "--region", "special-region",
                                                                 "--no-ui", "--config-file", "test-config.json", "--payload", "myfile.json", "--pause-exit", "false" });
 
-
             Assert.True(options.ShowHelp);
+            Assert.Equal("example.com", options.Host);
             Assert.Equal(1111, options.Port);
             Assert.True(options.NoLaunchWindow);
             Assert.Equal("./foo", options.Path);
@@ -32,24 +31,24 @@ namespace Amazon.Lambda.TestTool.Tests
             var options = CommandLineOptions.Parse(new string[0]);
             Assert.NotNull(options);
         }
-        
+
         [Fact]
         public void ParseIntValueForSwitch()
         {
-            var options = CommandLineOptions.Parse(new string[]{"--port", "8080"});
-            Assert.Equal(8080, options.Port);            
+            var options = CommandLineOptions.Parse(new string[] { "--port", "8080" });
+            Assert.Equal(8080, options.Port);
         }
 
         [Fact]
         public void MissingValue()
         {
-            Assert.Throws<CommandLineParseException>(() =>  CommandLineOptions.Parse(new string[]{"--port"}));
+            Assert.Throws<CommandLineParseException>(() => CommandLineOptions.Parse(new string[] { "--port" }));
         }
 
         [Fact]
         public void ValueNotAnInt()
         {
-            Assert.Throws<CommandLineParseException>(() =>  CommandLineOptions.Parse(new string[]{"--port", "aaa"}));
+            Assert.Throws<CommandLineParseException>(() => CommandLineOptions.Parse(new string[] { "--port", "aaa" }));
         }
 
 
@@ -74,7 +73,7 @@ namespace Amazon.Lambda.TestTool.Tests
             var options = CommandLineOptions.Parse(new string[0]);
             Assert.True(options.PauseExit);
 
-            options = CommandLineOptions.Parse(new string[] { "--pause-exit", "false"});
+            options = CommandLineOptions.Parse(new string[] { "--pause-exit", "false" });
             Assert.False(options.PauseExit);
         }
 


### PR DESCRIPTION
*Issue #, if available:* #805

*Description of changes:* 
- Add '--host' command line argument support

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

