### PR TITLE
Fix issue of syncing CF template when all LambdaFunctions are removed.

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/CloudFormationTemplateFinder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/CloudFormationTemplateFinder.cs
@@ -35,11 +35,27 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
 
         public string FindCloudFormationTemplate(string projectRootDirectory)
         {
+            var templateAbsolutePath = DetermineCloudFormationTemplatePath(projectRootDirectory);
+
+            if (!_fileManager.Exists(templateAbsolutePath))
+                _fileManager.Create(templateAbsolutePath).Close();
+            
+            return templateAbsolutePath;
+        }
+
+        public bool DoesCloudFormationTemplateExist(string projectRootDirectory)
+        {
+            var templateAbsolutePath = DetermineCloudFormationTemplatePath(projectRootDirectory);
+            return _fileManager.Exists(templateAbsolutePath);
+        }
+
+        private string DetermineCloudFormationTemplatePath(string projectRootDirectory)
+        {
             if (!_directoryManager.Exists(projectRootDirectory))
                 throw new DirectoryNotFoundException("Failed to find the project root directory");
 
             var templateAbsolutePath = string.Empty;
-            
+
             var defaultConfigFile = _directoryManager.GetFiles(projectRootDirectory, "aws-lambda-tools-defaults.json", SearchOption.AllDirectories)
                 .FirstOrDefault();
 
@@ -51,10 +67,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
             // set the template path inside the project root directory. 
             if (string.IsNullOrEmpty(templateAbsolutePath))
                 templateAbsolutePath = Path.Combine(projectRootDirectory, "serverless.template");
-                
-            if (!_fileManager.Exists(templateAbsolutePath))
-                _fileManager.Create(templateAbsolutePath).Close();
-            
+
             return templateAbsolutePath;
         }
 


### PR DESCRIPTION
*Description of changes:*
Fix an issue when all of the remaining `LambdaFunction` are removed from the project the CF template is not synced leaving the Lambda functions defined in the template.

The fix has the following changes:
* Move the computation of the project directory. It used to be computed from the first `LambdaFunction` but since there might not be any `LambdaFunction` it was moved to the syntax visitor and where it can be computed on the first class that was found.
* Change the Generator's short circuit from there being no `LambdaFunction` which caused the bug to only short circuit if the project directory was not calculated. That would happen if there are no classes in the project.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
