### PR TITLE
Breaking Change: Move all APIGateway attributes to a their own namespace

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/AttributeModelBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/AttributeModelBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using Amazon.Lambda.Annotations.APIGateway;
 using Microsoft.CodeAnalysis;
 
 namespace Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/FromHeaderAttributeBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/FromHeaderAttributeBuilder.cs
@@ -1,3 +1,4 @@
+using Amazon.Lambda.Annotations.APIGateway;
 using Microsoft.CodeAnalysis;
 
 namespace Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/FromQueryAttributeBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/FromQueryAttributeBuilder.cs
@@ -1,3 +1,4 @@
+using Amazon.Lambda.Annotations.APIGateway;
 using Microsoft.CodeAnalysis;
 
 namespace Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/FromRouteAttributeBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/FromRouteAttributeBuilder.cs
@@ -1,3 +1,4 @@
+using Amazon.Lambda.Annotations.APIGateway;
 using Microsoft.CodeAnalysis;
 
 namespace Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/HttpApiAttributeBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/HttpApiAttributeBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Amazon.Lambda.Annotations.APIGateway;
 using Microsoft.CodeAnalysis;
 
 namespace Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/RestApiAttributeBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/RestApiAttributeBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using Amazon.Lambda.Annotations.APIGateway;
 using Microsoft.CodeAnalysis;
 
 namespace Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/TemplateParametersExtension.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/TemplateParametersExtension.cs
@@ -1,3 +1,4 @@
+using Amazon.Lambda.Annotations.APIGateway;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/GeneratedMethodModelBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/GeneratedMethodModelBuilder.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Amazon.Lambda.Annotations;
+using Amazon.Lambda.Annotations.APIGateway;
 using Amazon.Lambda.Annotations.SourceGenerator.Extensions;
 using Microsoft.CodeAnalysis;
 

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.cs
@@ -264,8 +264,8 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
 
                 return p.Name;
             }));
-        var restApiAttribute = _model.LambdaMethod.Attributes.FirstOrDefault(att => att.Type.FullName == TypeFullNames.RestApiAttribute) as AttributeModel<RestApiAttribute>;
-        var httpApiAttribute = _model.LambdaMethod.Attributes.FirstOrDefault(att => att.Type.FullName == TypeFullNames.HttpApiAttribute) as AttributeModel<HttpApiAttribute>;
+        var restApiAttribute = _model.LambdaMethod.Attributes.FirstOrDefault(att => att.Type.FullName == TypeFullNames.RestApiAttribute) as AttributeModel<Amazon.Lambda.Annotations.APIGateway.RestApiAttribute>;
+        var httpApiAttribute = _model.LambdaMethod.Attributes.FirstOrDefault(att => att.Type.FullName == TypeFullNames.HttpApiAttribute) as AttributeModel<Amazon.Lambda.Annotations.APIGateway.HttpApiAttribute>;
 
         if (restApiAttribute != null && httpApiAttribute != null)
         {
@@ -326,7 +326,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             }
             else if (parameter.Attributes.Any(att => att.Type.FullName == TypeFullNames.FromQueryAttribute))
             {
-                var fromQueryAttribute = parameter.Attributes.First(att => att.Type.FullName == TypeFullNames.FromQueryAttribute) as AttributeModel<FromQueryAttribute>;
+                var fromQueryAttribute = parameter.Attributes.First(att => att.Type.FullName == TypeFullNames.FromQueryAttribute) as AttributeModel<Amazon.Lambda.Annotations.APIGateway.FromQueryAttribute>;
 
                 // Use parameter name as key, if Name has not specified explicitly in the attribute definition.
                 var parameterKey = fromQueryAttribute?.Data?.Name ?? parameter.Name;
@@ -362,14 +362,14 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
                     // Therefore, it is required to split the string to convert to an enumerable
                     // and convert individual item to target data type.
                     var commaSplit = "";
-                    if (httpApiAttribute?.Data.Version == HttpApiVersion.V2)
+                    if (httpApiAttribute?.Data.Version == Amazon.Lambda.Annotations.APIGateway.HttpApiVersion.V2)
                     {
                         commaSplit = @".Split("","")";
                     }
 
                     // HTTP API V1 and Rest API, multiple values for the same parameter are provided
                     // dedicated dictionary of string key and list value.
-                    if (restApiAttribute != null || httpApiAttribute?.Data.Version == HttpApiVersion.V1)
+                    if (restApiAttribute != null || httpApiAttribute?.Data.Version == Amazon.Lambda.Annotations.APIGateway.HttpApiVersion.V1)
                     {
                         queryStringParameters = "MultiValueQueryStringParameters";
                     }
@@ -553,7 +553,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             {
                 var fromHeaderAttribute =
                     parameter.Attributes.First(att => att.Type.FullName == TypeFullNames.FromHeaderAttribute) as
-                        AttributeModel<FromHeaderAttribute>;
+                        AttributeModel<Amazon.Lambda.Annotations.APIGateway.FromHeaderAttribute>;
 
                 // Use parameter name as key, if Name has not specified explicitly in the attribute definition.
                 var headerKey = fromHeaderAttribute?.Data?.Name ?? parameter.Name;
@@ -589,14 +589,14 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
                     // Therefore, it is required to split the string to convert to an enumerable
                     // and convert individual item to target data type.
                     var commaSplit = "";
-                    if (httpApiAttribute?.Data.Version == HttpApiVersion.V2)
+                    if (httpApiAttribute?.Data.Version == Amazon.Lambda.Annotations.APIGateway.HttpApiVersion.V2)
                     {
                         commaSplit = @".Split("","")";
                     }
 
                     // HTTP API V1 and Rest API, multiple values for the same header are provided
                     // dedicated dictionary of string key and list value.
-                    if (restApiAttribute != null || httpApiAttribute?.Data.Version == HttpApiVersion.V1)
+                    if (restApiAttribute != null || httpApiAttribute?.Data.Version == Amazon.Lambda.Annotations.APIGateway.HttpApiVersion.V1)
                     {
                         headers = "MultiValueHeaders";
                     }
@@ -847,7 +847,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             }
             else if (parameter.Attributes.Any(att => att.Type.FullName == TypeFullNames.FromRouteAttribute) || routeParameters.Contains(parameter.Name))
             {
-                var fromRouteAttribute = parameter.Attributes?.FirstOrDefault(att => att.Type.FullName == TypeFullNames.FromRouteAttribute) as AttributeModel<FromRouteAttribute>;
+                var fromRouteAttribute = parameter.Attributes?.FirstOrDefault(att => att.Type.FullName == TypeFullNames.FromRouteAttribute) as AttributeModel<Amazon.Lambda.Annotations.APIGateway.FromRouteAttribute>;
 
                 // Use parameter name as key, if Name has not specified explicitly in the attribute definition.
                 var routeKey = fromRouteAttribute?.Data?.Name ?? parameter.Name;

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.tt
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.tt
@@ -97,8 +97,8 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
 
                 return p.Name;
             }));
-        var restApiAttribute = _model.LambdaMethod.Attributes.FirstOrDefault(att => att.Type.FullName == TypeFullNames.RestApiAttribute) as AttributeModel<RestApiAttribute>;
-        var httpApiAttribute = _model.LambdaMethod.Attributes.FirstOrDefault(att => att.Type.FullName == TypeFullNames.HttpApiAttribute) as AttributeModel<HttpApiAttribute>;
+        var restApiAttribute = _model.LambdaMethod.Attributes.FirstOrDefault(att => att.Type.FullName == TypeFullNames.RestApiAttribute) as AttributeModel<Amazon.Lambda.Annotations.APIGateway.RestApiAttribute>;
+        var httpApiAttribute = _model.LambdaMethod.Attributes.FirstOrDefault(att => att.Type.FullName == TypeFullNames.HttpApiAttribute) as AttributeModel<Amazon.Lambda.Annotations.APIGateway.HttpApiAttribute>;
 
         if (restApiAttribute != null && httpApiAttribute != null)
         {
@@ -136,7 +136,7 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
             }
             else if (parameter.Attributes.Any(att => att.Type.FullName == TypeFullNames.FromQueryAttribute))
             {
-                var fromQueryAttribute = parameter.Attributes.First(att => att.Type.FullName == TypeFullNames.FromQueryAttribute) as AttributeModel<FromQueryAttribute>;
+                var fromQueryAttribute = parameter.Attributes.First(att => att.Type.FullName == TypeFullNames.FromQueryAttribute) as AttributeModel<Amazon.Lambda.Annotations.APIGateway.FromQueryAttribute>;
 
                 // Use parameter name as key, if Name has not specified explicitly in the attribute definition.
                 var parameterKey = fromQueryAttribute?.Data?.Name ?? parameter.Name;
@@ -153,14 +153,14 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
                     // Therefore, it is required to split the string to convert to an enumerable
                     // and convert individual item to target data type.
                     var commaSplit = "";
-                    if (httpApiAttribute?.Data.Version == HttpApiVersion.V2)
+                    if (httpApiAttribute?.Data.Version == Amazon.Lambda.Annotations.APIGateway.HttpApiVersion.V2)
                     {
                         commaSplit = @".Split("","")";
                     }
 
                     // HTTP API V1 and Rest API, multiple values for the same parameter are provided
                     // dedicated dictionary of string key and list value.
-                    if (restApiAttribute != null || httpApiAttribute?.Data.Version == HttpApiVersion.V1)
+                    if (restApiAttribute != null || httpApiAttribute?.Data.Version == Amazon.Lambda.Annotations.APIGateway.HttpApiVersion.V1)
                     {
                         queryStringParameters = "MultiValueQueryStringParameters";
                     }
@@ -217,7 +217,7 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
             {
                 var fromHeaderAttribute =
                     parameter.Attributes.First(att => att.Type.FullName == TypeFullNames.FromHeaderAttribute) as
-                        AttributeModel<FromHeaderAttribute>;
+                        AttributeModel<Amazon.Lambda.Annotations.APIGateway.FromHeaderAttribute>;
 
                 // Use parameter name as key, if Name has not specified explicitly in the attribute definition.
                 var headerKey = fromHeaderAttribute?.Data?.Name ?? parameter.Name;
@@ -234,14 +234,14 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
                     // Therefore, it is required to split the string to convert to an enumerable
                     // and convert individual item to target data type.
                     var commaSplit = "";
-                    if (httpApiAttribute?.Data.Version == HttpApiVersion.V2)
+                    if (httpApiAttribute?.Data.Version == Amazon.Lambda.Annotations.APIGateway.HttpApiVersion.V2)
                     {
                         commaSplit = @".Split("","")";
                     }
 
                     // HTTP API V1 and Rest API, multiple values for the same header are provided
                     // dedicated dictionary of string key and list value.
-                    if (restApiAttribute != null || httpApiAttribute?.Data.Version == HttpApiVersion.V1)
+                    if (restApiAttribute != null || httpApiAttribute?.Data.Version == Amazon.Lambda.Annotations.APIGateway.HttpApiVersion.V1)
                     {
                         headers = "MultiValueHeaders";
                     }
@@ -321,7 +321,7 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
             }
             else if (parameter.Attributes.Any(att => att.Type.FullName == TypeFullNames.FromRouteAttribute) || routeParameters.Contains(parameter.Name))
             {
-                var fromRouteAttribute = parameter.Attributes?.FirstOrDefault(att => att.Type.FullName == TypeFullNames.FromRouteAttribute) as AttributeModel<FromRouteAttribute>;
+                var fromRouteAttribute = parameter.Attributes?.FirstOrDefault(att => att.Type.FullName == TypeFullNames.FromRouteAttribute) as AttributeModel<Amazon.Lambda.Annotations.APIGateway.FromRouteAttribute>;
 
                 // Use parameter name as key, if Name has not specified explicitly in the attribute definition.
                 var routeKey = fromRouteAttribute?.Data?.Name ?? parameter.Name;

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/TypeFullNames.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/TypeFullNames.cs
@@ -7,24 +7,27 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
     /// </summary>
     public static class TypeFullNames
     {
-        public const string RestApiAttribute = "Amazon.Lambda.Annotations.RestApiAttribute";
-        public const string HttpApiAttribute = "Amazon.Lambda.Annotations.HttpApiAttribute";
+        public const string IEnumerable = "System.Collections.IEnumerable";
+        public const string Task1 = "System.Threading.Tasks.Task`1";
+        public const string Task = "System.Threading.Tasks.Task";
+        public const string MemoryStream = "System.IO.MemoryStream";
+
+        public const string ILambdaContext = "Amazon.Lambda.Core.ILambdaContext";
         public const string APIGatewayProxyRequest = "Amazon.Lambda.APIGatewayEvents.APIGatewayProxyRequest";
         public const string APIGatewayProxyResponse = "Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse";
         public const string APIGatewayHttpApiV2ProxyRequest = "Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyRequest";
         public const string APIGatewayHttpApiV2ProxyResponse = "Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyResponse";
-        public const string MemoryStream = "System.IO.MemoryStream";
-        public const string HttpApiVersion = "Amazon.Lambda.Annotations.HttpApiVersion";
+
         public const string LambdaFunctionAttribute = "Amazon.Lambda.Annotations.LambdaFunctionAttribute";
-        public const string FromQueryAttribute = "Amazon.Lambda.Annotations.FromQueryAttribute";
-        public const string FromHeaderAttribute = "Amazon.Lambda.Annotations.FromHeaderAttribute";
-        public const string FromBodyAttribute = "Amazon.Lambda.Annotations.FromBodyAttribute";
-        public const string FromRouteAttribute = "Amazon.Lambda.Annotations.FromRouteAttribute";
         public const string FromServiceAttribute = "Amazon.Lambda.Annotations.FromServicesAttribute";
-        public const string ILambdaContext = "Amazon.Lambda.Core.ILambdaContext";
-        public const string IEnumerable = "System.Collections.IEnumerable";
-        public const string Task1 = "System.Threading.Tasks.Task`1";
-        public const string Task = "System.Threading.Tasks.Task";
+
+        public const string HttpApiVersion = "Amazon.Lambda.Annotations.APIGateway.HttpApiVersion";
+        public const string RestApiAttribute = "Amazon.Lambda.Annotations.APIGateway.RestApiAttribute";
+        public const string HttpApiAttribute = "Amazon.Lambda.Annotations.APIGateway.HttpApiAttribute";
+        public const string FromQueryAttribute = "Amazon.Lambda.Annotations.APIGateway.FromQueryAttribute";
+        public const string FromHeaderAttribute = "Amazon.Lambda.Annotations.APIGateway.FromHeaderAttribute";
+        public const string FromBodyAttribute = "Amazon.Lambda.Annotations.APIGateway.FromBodyAttribute";
+        public const string FromRouteAttribute = "Amazon.Lambda.Annotations.APIGateway.FromRouteAttribute";
 
         public static HashSet<string> Requests = new HashSet<string>
         {

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Validation/RouteParametersValidator.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Validation/RouteParametersValidator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Amazon.Lambda.Annotations.APIGateway;
 using Amazon.Lambda.Annotations.SourceGenerator.Models;
 using Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes;
 

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Writers/CloudFormationJsonWriter.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Writers/CloudFormationJsonWriter.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using Amazon.Lambda.Annotations.APIGateway;
 using Amazon.Lambda.Annotations.SourceGenerator.Diagnostics;
 using Amazon.Lambda.Annotations.SourceGenerator.FileIO;
 using Amazon.Lambda.Annotations.SourceGenerator.Models;

--- a/Libraries/src/Amazon.Lambda.Annotations/APIGateway/FromBodyAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/APIGateway/FromBodyAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Amazon.Lambda.Annotations
+namespace Amazon.Lambda.Annotations.APIGateway
 {
     [AttributeUsage(AttributeTargets.Parameter)]
     public class FromBodyAttribute : Attribute

--- a/Libraries/src/Amazon.Lambda.Annotations/APIGateway/FromHeaderAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/APIGateway/FromHeaderAttribute.cs
@@ -1,9 +1,9 @@
 using System;
 
-namespace Amazon.Lambda.Annotations
+namespace Amazon.Lambda.Annotations.APIGateway
 {
     [AttributeUsage(AttributeTargets.Parameter)]
-    public class FromQueryAttribute : Attribute, INamedAttribute
+    public class FromHeaderAttribute : Attribute, INamedAttribute
     {
         public string Name { get; set; }
     }

--- a/Libraries/src/Amazon.Lambda.Annotations/APIGateway/FromQueryAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/APIGateway/FromQueryAttribute.cs
@@ -1,9 +1,9 @@
 using System;
 
-namespace Amazon.Lambda.Annotations
+namespace Amazon.Lambda.Annotations.APIGateway
 {
     [AttributeUsage(AttributeTargets.Parameter)]
-    public class FromHeaderAttribute : Attribute, INamedAttribute
+    public class FromQueryAttribute : Attribute, INamedAttribute
     {
         public string Name { get; set; }
     }

--- a/Libraries/src/Amazon.Lambda.Annotations/APIGateway/FromRouteAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/APIGateway/FromRouteAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Amazon.Lambda.Annotations
+namespace Amazon.Lambda.Annotations.APIGateway
 {
     [AttributeUsage(AttributeTargets.Parameter)]
     public class FromRouteAttribute : Attribute, INamedAttribute

--- a/Libraries/src/Amazon.Lambda.Annotations/APIGateway/HttpApiAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/APIGateway/HttpApiAttribute.cs
@@ -1,12 +1,12 @@
 using System;
 
-namespace Amazon.Lambda.Annotations
+namespace Amazon.Lambda.Annotations.APIGateway
 {
     [AttributeUsage(AttributeTargets.Method)]
     public class HttpApiAttribute : Attribute
     {
         public HttpApiVersion Version { get; set; } = HttpApiVersion.V2;
-        public string Template { get; set;  }
+        public string Template { get; set; }
         public LambdaHttpMethod Method { get; set; }
 
         public HttpApiAttribute(LambdaHttpMethod method, string template)

--- a/Libraries/src/Amazon.Lambda.Annotations/APIGateway/HttpApiVersion.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/APIGateway/HttpApiVersion.cs
@@ -1,4 +1,4 @@
-namespace Amazon.Lambda.Annotations
+namespace Amazon.Lambda.Annotations.APIGateway
 {
     public enum HttpApiVersion
     {

--- a/Libraries/src/Amazon.Lambda.Annotations/APIGateway/LambdaHttpMethod.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/APIGateway/LambdaHttpMethod.cs
@@ -1,4 +1,4 @@
-namespace Amazon.Lambda.Annotations
+namespace Amazon.Lambda.Annotations.APIGateway
 {
     public enum LambdaHttpMethod
     {

--- a/Libraries/src/Amazon.Lambda.Annotations/APIGateway/RestApiAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/APIGateway/RestApiAttribute.cs
@@ -1,11 +1,11 @@
 using System;
 
-namespace Amazon.Lambda.Annotations
+namespace Amazon.Lambda.Annotations.APIGateway
 {
     [AttributeUsage(AttributeTargets.Method)]
     public class RestApiAttribute : Attribute
     {
-        public string Template { get; set;  }
+        public string Template { get; set; }
         public LambdaHttpMethod Method { get; set; }
 
         public RestApiAttribute(LambdaHttpMethod method, string template)

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/CSharpSourceGeneratorVerifier.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/CSharpSourceGeneratorVerifier.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Immutable;
+using Amazon.Lambda.Annotations.APIGateway;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.Core;
 using Amazon.Lambda.Serialization.SystemTextJson;

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/RouteParameterValidatorTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/RouteParameterValidatorTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Amazon.Lambda.Annotations.APIGateway;
 using Amazon.Lambda.Annotations.SourceGenerator;
 using Amazon.Lambda.Annotations.SourceGenerator.Models;
 using Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes;

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/CloudFormationJsonWriterTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/CloudFormationJsonWriterTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Amazon.Lambda.Annotations.APIGateway;
 using Amazon.Lambda.Annotations.SourceGenerator.Diagnostics;
 using Amazon.Lambda.Annotations.SourceGenerator.FileIO;
 using Amazon.Lambda.Annotations.SourceGenerator.Models;

--- a/Libraries/test/TestServerlessApp/ComplexCalculator.cs
+++ b/Libraries/test/TestServerlessApp/ComplexCalculator.cs
@@ -5,6 +5,7 @@ using System.Numerics;
 using System.Text.Json;
 using System.Threading;
 using Amazon.Lambda.Annotations;
+using Amazon.Lambda.Annotations.APIGateway;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.Core;
 

--- a/Libraries/test/TestServerlessApp/Greeter.cs
+++ b/Libraries/test/TestServerlessApp/Greeter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Amazon.Lambda.Annotations;
+using Amazon.Lambda.Annotations.APIGateway;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.Core;
 

--- a/Libraries/test/TestServerlessApp/SimpleCalculator.cs
+++ b/Libraries/test/TestServerlessApp/SimpleCalculator.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Amazon.Lambda.Core;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.Annotations;
+using Amazon.Lambda.Annotations.APIGateway;
 using TestServerlessApp.Services;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.


### PR DESCRIPTION
*Description of changes:*
There is concern as we add more service support for special events like we have for API Gateway that having all of those attributes at the root namespace of Amazon.Lambda.Annotations will cause too much clutter and possibly conflict in this namespace.

This PR makes a breaking change, while we are still in preview, to move all of the API Gateway specific attributes to the `Amazon.Lambda.Annotations.APIGateway` namespace.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
