### PR TITLE
Fixed the type of LexV2Interpretation.NluConfidence to double in Amazon.Lambda.LexV2Events package.

### DIFF
--- a/Libraries/src/Amazon.Lambda.LexV2Events/Amazon.Lambda.LexV2Events.csproj
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/Amazon.Lambda.LexV2Events.csproj
@@ -6,7 +6,7 @@
     <Description>Amazon Lambda .NET Core support - Amazon Lex V2 package.</Description>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.LexV2Events</AssemblyTitle>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <AssemblyName>Amazon.Lambda.LexV2Events</AssemblyName>
     <PackageId>Amazon.Lambda.LexV2Events</PackageId>
     <PackageTags>AWS;Amazon;Lambda;Lex;LexV2</PackageTags>

--- a/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Interpretation.cs
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/LexV2Interpretation.cs
@@ -12,29 +12,17 @@
         public LexV2Intent Intent { get; set; }
 
         /// <summary>
-        /// Determines the threshold where Amazon Lex V2 will insert the <c>AMAZON.FallbackIntent</c>, <c>AMAZON.KendraSearchIntent</c>, or both when returning 
-        /// alternative intents in a response. <c>AMAZON.FallbackIntent</c> and <c>AMAZON.KendraSearchIntent</c> are only inserted if they are configured for the bot.
+        /// Represents a score that indicates the confidence that Amazon Lex V2 has that an intent is the one that satisfies the user's intent. Determines the threshold 
+        /// where Amazon Lex V2 will insert the <c>AMAZON.FallbackIntent</c>, <c>AMAZON.KendraSearchIntent</c>, or both when returning alternative intents in a response. 
+        /// <c>AMAZON.FallbackIntent</c> and <c>AMAZON.KendraSearchIntent</c> are only inserted if they are configured for the bot.
         /// </summary>
-        public LexV2ConfidenceScore NluConfidence { get; set; }
+        public double? NluConfidence { get; set; }
 
         /// <summary>
         /// The sentiment expressed in an utterance.
         /// </summary>
         /// 
         public LexV2SentimentResponse SentimentResponse { get; set; }
-    }
-
-    /// <summary>
-    /// The class that represents a score that indicates the confidence that Amazon Lex V2 has that an intent is the one that satisfies the user's intent.
-    /// https://docs.aws.amazon.com/lexv2/latest/dg/API_runtime_ConfidenceScore.html
-    /// </summary>
-    public class LexV2ConfidenceScore
-    {
-        /// <summary>
-        /// A score that indicates how confident Amazon Lex V2 is that an intent satisfies the user's intent. 
-        /// Ranges between 0.00 and 1.00. Higher scores indicate higher confidence.
-        /// </summary>
-        public double? Score { get; set; }
     }
 
     /// <summary>

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -1370,7 +1370,7 @@ namespace Amazon.Lambda.Tests
                 Assert.Null(lexV2Event.Interpretations[0].Intent.Slots["ActionTime"]);
                 Assert.Equal("InProgress", lexV2Event.Interpretations[0].Intent.State);
                 Assert.Equal("None", lexV2Event.Interpretations[0].Intent.ConfirmationState);
-                Assert.Equal(1.0, lexV2Event.Interpretations[0].NluConfidence.Score);
+                Assert.Equal(0.79, lexV2Event.Interpretations[0].NluConfidence);
                 Assert.Equal("testsentiment", lexV2Event.Interpretations[0].SentimentResponse.Sentiment);
                 Assert.Equal(0.1, lexV2Event.Interpretations[0].SentimentResponse.SentimentScore.Mixed);
                 Assert.Equal(0.1, lexV2Event.Interpretations[0].SentimentResponse.SentimentScore.Negative);

--- a/Libraries/test/EventsTests.Shared/lexv2-event.json
+++ b/Libraries/test/EventsTests.Shared/lexv2-event.json
@@ -45,9 +45,7 @@
         "state": "InProgress",
         "confirmationState": "None"
       },
-      "nluConfidence": {
-        "score": 1.0
-      },
+      "nluConfidence": 0.79,
       "sentimentResponse": {
         "sentiment": "testsentiment",
         "sentimentScore": {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-lambda-dotnet/issues/1248

*Description of changes:*
Fixed the type of `LexV2Interpretation.NluConfidence` to `double` in `Amazon.Lambda.LexV2Events` package.

___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
