### PR TITLE
Fix spelling from substract to subtract

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/src/BlueprintBaseName.1/Functions.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/src/BlueprintBaseName.1/Functions.cs
@@ -33,7 +33,7 @@ namespace BlueprintBaseName._1
             var docs = @"Lambda Calculator Home:
 You can make the following requests to invoke other Lambda functions perform calculator operations:
 /add/{x}/{y}
-/substract/{x}/{y}
+/subtract/{x}/{y}
 /multiply/{x}/{y}
 /divide/{x}/{y}
 ";
@@ -67,12 +67,12 @@ You can make the following requests to invoke other Lambda functions perform cal
         /// </summary>
         /// <param name="x"></param>
         /// <param name="y"></param>
-        /// <returns>x substract y</returns>
+        /// <returns>x subtract y</returns>
         [LambdaFunction()]
-        [HttpApi(LambdaHttpMethod.Get, "/substract/{x}/{y}")]
-        public int Substract(int x, int y, ILambdaContext context)
+        [HttpApi(LambdaHttpMethod.Get, "/subtract/{x}/{y}")]
+        public int Subtract(int x, int y, ILambdaContext context)
         {
-            context.Logger.LogInformation($"{x} substract {y} is {x - y}");
+            context.Logger.LogInformation($"{x} subtract {y} is {x - y}");
             return x - y;
         }
 

--- a/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/src/BlueprintBaseName.1/serverless.template
@@ -63,7 +63,7 @@
         }
       }
     },
-    "BlueprintBaseName1FunctionsSubstractGenerated": {
+    "BlueprintBaseName1FunctionsSubtractGenerated": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
         "Tool": "Amazon.Lambda.Annotations",
@@ -80,12 +80,12 @@
           "AWSLambdaBasicExecutionRole"
         ],
         "PackageType": "Zip",
-        "Handler": "BlueprintBaseName._1::BlueprintBaseName._1.Functions_Substract_Generated::Substract",
+        "Handler": "BlueprintBaseName._1::BlueprintBaseName._1.Functions_Subtract_Generated::Subtract",
         "Events": {
           "RootGet": {
             "Type": "HttpApi",
             "Properties": {
-              "Path": "/substract/{x}/{y}",
+              "Path": "/subtract/{x}/{y}",
               "Method": "GET",
               "PayloadFormatVersion": "2.0"
             }

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI.MinimalAPI/template/src/BlueprintBaseName.1/Controllers/CalculatorController.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI.MinimalAPI/template/src/BlueprintBaseName.1/Controllers/CalculatorController.cs
@@ -21,7 +21,7 @@ public class CalculatorController : ControllerBase
         return x + y;
     }
 
-    // GET calculator/substract/4/2/
+    // GET calculator/subtract/4/2/
     [HttpGet("subtract/{x}/{y}")]
     public int Subtract(int x, int y)
     {


### PR DESCRIPTION

*Description of changes:*
While using the Annotations template, I noticed a spelling mistake in the work subtract. I've fixed it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
