### PR TITLE
Add documentation for API Gateway attributes for Lambda Annotations

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations/APIGateway/FromBodyAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/APIGateway/FromBodyAttribute.cs
@@ -2,6 +2,12 @@ using System;
 
 namespace Amazon.Lambda.Annotations.APIGateway
 {
+    /// <summary>
+    /// Maps this parameter to the HTTP request body
+    /// </summary>
+    /// <remarks>
+    /// If the parameter is a complex type then the request body will be assumed to be JSON and deserialized into the type.
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Parameter)]
     public class FromBodyAttribute : Attribute
     {

--- a/Libraries/src/Amazon.Lambda.Annotations/APIGateway/FromHeaderAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/APIGateway/FromHeaderAttribute.cs
@@ -2,9 +2,15 @@ using System;
 
 namespace Amazon.Lambda.Annotations.APIGateway
 {
+    /// <summary>
+    /// Maps this parameter to an HTTP header value
+    /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
     public class FromHeaderAttribute : Attribute, INamedAttribute
     {
+        /// <summary>
+        /// Name of the parameter
+        /// </summary>
         public string Name { get; set; }
     }
 }

--- a/Libraries/src/Amazon.Lambda.Annotations/APIGateway/FromQueryAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/APIGateway/FromQueryAttribute.cs
@@ -2,9 +2,15 @@ using System;
 
 namespace Amazon.Lambda.Annotations.APIGateway
 {
+    /// <summary>
+    /// Maps this parameter to a query string parameter
+    /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
     public class FromQueryAttribute : Attribute, INamedAttribute
     {
+        /// <summary>
+        /// Name of the parameter
+        /// </summary>
         public string Name { get; set; }
     }
 }

--- a/Libraries/src/Amazon.Lambda.Annotations/APIGateway/FromRouteAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/APIGateway/FromRouteAttribute.cs
@@ -2,9 +2,15 @@ using System;
 
 namespace Amazon.Lambda.Annotations.APIGateway
 {
+    /// <summary>
+    /// Maps this parameter to a resource path segment
+    /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
     public class FromRouteAttribute : Attribute, INamedAttribute
     {
+        /// <summary>
+        /// Name of the parameter
+        /// </summary>
         public string Name { get; set; }
     }
 }

--- a/Libraries/src/Amazon.Lambda.Annotations/APIGateway/HttpApiAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/APIGateway/HttpApiAttribute.cs
@@ -2,11 +2,24 @@ using System;
 
 namespace Amazon.Lambda.Annotations.APIGateway
 {
+    /// <summary>
+    /// Configures the Lambda function to be called from an API Gateway HTTP API
+    /// </summary>
+    /// <remarks>
+    /// The HTTP method, HTTP API payload version and resource path are required to be set on the attribute.
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Method)]
     public class HttpApiAttribute : Attribute
     {
+        /// <inheritdoc cref="HttpApiVersion"/>
         public HttpApiVersion Version { get; set; } = HttpApiVersion.V2;
+
+        /// <summary>
+        /// Resource path
+        /// </summary>
         public string Template { get; set; }
+
+        /// <inheritdoc cref="LambdaHttpMethod"/>
         public LambdaHttpMethod Method { get; set; }
 
         public HttpApiAttribute(LambdaHttpMethod method, string template)

--- a/Libraries/src/Amazon.Lambda.Annotations/APIGateway/HttpApiVersion.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/APIGateway/HttpApiVersion.cs
@@ -1,5 +1,9 @@
 namespace Amazon.Lambda.Annotations.APIGateway
 {
+    /// <summary>
+    /// The <see href="https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format">
+    /// Payload Format Version</see> for an API Gateway HTTP API.
+    /// </summary>
     public enum HttpApiVersion
     {
         V1,

--- a/Libraries/src/Amazon.Lambda.Annotations/APIGateway/LambdaHttpMethod.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/APIGateway/LambdaHttpMethod.cs
@@ -1,5 +1,8 @@
 namespace Amazon.Lambda.Annotations.APIGateway
 {
+    /// <summary>
+    /// HTTP Method/Verb
+    /// </summary>
     public enum LambdaHttpMethod
     {
         Any,

--- a/Libraries/src/Amazon.Lambda.Annotations/APIGateway/RestApiAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/APIGateway/RestApiAttribute.cs
@@ -2,10 +2,21 @@ using System;
 
 namespace Amazon.Lambda.Annotations.APIGateway
 {
+    /// <summary>
+    /// Configures the Lambda function to be called from an API Gateway REST API
+    /// </summary>
+    /// <remarks>
+    /// The HTTP method and resource path are required to be set on the attribute.
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Method)]
     public class RestApiAttribute : Attribute
     {
+        /// <summary>
+        /// Resource path
+        /// </summary>
         public string Template { get; set; }
+
+        /// <inheritdoc cref="LambdaHttpMethod" />
         public LambdaHttpMethod Method { get; set; }
 
         public RestApiAttribute(LambdaHttpMethod method, string template)

--- a/Libraries/src/Amazon.Lambda.Annotations/FromServicesAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/FromServicesAttribute.cs
@@ -2,6 +2,13 @@ using System;
 
 namespace Amazon.Lambda.Annotations
 {
+    /// <summary>
+    /// Indicates that this service parameter will be injected into the Lambda function invocation.
+    /// </summary>
+    /// <remarks>
+    /// Services injected using the FromServices attribute are created within the scope 
+    /// that is created for each Lambda invocation.
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Parameter)]
     public class FromServicesAttribute : Attribute
     {

--- a/Libraries/src/Amazon.Lambda.Annotations/LambdaFunctionAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/LambdaFunctionAttribute.cs
@@ -1,9 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Amazon.Lambda.Annotations
 {
+    /// <summary>
+    /// Indicates this method should be exposed as a Lambda function
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     public class LambdaFunctionAttribute : Attribute
     {
@@ -32,10 +33,7 @@ namespace Amazon.Lambda.Annotations
         /// </summary>
         public string Policies { get; set; }
 
-        /// <summary>
-        /// The deployment package type of the Lambda function. The supported values are Zip or Image. The default value is Zip.
-        /// For more information, see <a href="https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-package.html">here</a>
-        /// </summary>
+        /// <inheritdoc cref="LambdaPackageType" />
         public LambdaPackageType PackageType { get; set; }
     }
 }

--- a/Libraries/src/Amazon.Lambda.Annotations/LambdaPackageType.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/LambdaPackageType.cs
@@ -1,5 +1,9 @@
 ﻿namespace Amazon.Lambda.Annotations
 {
+    /// <summary>
+    /// The deployment package type of the Lambda function. The supported values are Zip or Image. The default value is Zip.
+    /// For more information, see <a href="https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-package.html">here</a>
+    /// </summary>
     public enum LambdaPackageType
     {
         Zip=0,

--- a/Libraries/src/Amazon.Lambda.Annotations/LambdaStartupAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/LambdaStartupAttribute.cs
@@ -2,6 +2,14 @@
 
 namespace Amazon.Lambda.Annotations
 {
+    /// <summary>
+    /// Indicates that the class will be used for registering services that 
+    /// can be injected into Lambda functions.
+    /// </summary>
+    /// <remarks>
+    /// The class should implement a ConfigureServices method that 
+    /// adds one or more services to an IServiceCollection.
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Class)]
     public class LambdaStartupAttribute : Attribute
     {


### PR DESCRIPTION
*Issue #, if available:* DOTNET-6235

*Description of changes:* Backfilling documentation for Lambda Annotations attributes, especially in the API Gateway namespace. Most of this was copied from the README then adjusted


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
