### PR TITLE
Copy XML documentation for Amazon.Lambda.Annotations into nupkg to drive IntelliSense

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.nuspec
+++ b/Libraries/src/Amazon.Lambda.Annotations.nuspec
@@ -21,6 +21,7 @@
 
         <!-- Dependencies to make sure attributes are available in consuming csproj, this ensures packaged version of customer code have all the dependencies needed. -->
         <file src="Amazon.Lambda.Annotations\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.dll" target="lib/net6.0" />
+        <file src="Amazon.Lambda.Annotations\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.xml" target="lib/net6.0" />
 
         <!-- Include every dependency manually for analyzer, whenever a new dependency is added, it has to be added here. -->
         <!-- NOTE: Project dependencies should come from their own bin folder to make sure a code signed binary is packed -->

--- a/Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj
+++ b/Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyVersion>0.7.0.0</AssemblyVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
*Issue #, if available:* DOTNET-6235

*Description of changes:* This is a follow-up PR to https://github.com/aws/aws-lambda-dotnet/pull/1289. When I went to test that once it shipped in `0.7.0-preview`, I still wasn't seeing IntelliSense in Visual Studio on the Lambda attributes.

I believe this is because the documentation wasn't making its way into the nupkg. This PR is adding the `GenerateDocumentationFile` option to fix that.

**Note: I did not add this to the Source Generator project as I don't believe that has public-facing classes, but let me know if that's incorrect.**

I've tested this with the following, and confirm I see the IntelliSense in Visual Studio now.
```
dotnet build .\Libraries\Libraries.sln -p:Configuration=Release
<tweaked version number in nuspec>
nuget pack .\Libraries\src\Amazon.Lambda.Annotations.nuspec
nuget add .\Amazon.Lambda.Annotations.0.7.0-withdocs.nupkg -source <LOCAL FOLDER>
```

Here's a local build if you want to verify:
[Amazon.Lambda.Annotations.0.7.0-withdocs.nupkg.zip](https://github.com/aws/aws-lambda-dotnet/files/9453647/Amazon.Lambda.Annotations.0.7.0-withdocs.nupkg.zip)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
