### PR TITLE
chore: Add third party licenses

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.nuspec
+++ b/Libraries/src/Amazon.Lambda.Annotations.nuspec
@@ -16,8 +16,9 @@
     </metadata>
 
     <files>
-		<file src="..\..\icon.png" target="images\" />
-		<file src="Amazon.Lambda.Annotations\README.md" target="docs\" />
+        <file src="..\..\icon.png" target="images\" />
+        <file src="Amazon.Lambda.Annotations\README.md" target="docs\" />
+        <file src="Amazon.Lambda.Annotations\THIRD_PARTY_LICENSES" target="THIRD_PARTY_LICENSES" />
 
         <!-- Dependencies to make sure attributes are available in consuming csproj, this ensures packaged version of customer code have all the dependencies needed. -->
         <file src="Amazon.Lambda.Annotations\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.dll" target="lib/net6.0" />

--- a/Libraries/src/Amazon.Lambda.Annotations/THIRD_PARTY_LICENSES
+++ b/Libraries/src/Amazon.Lambda.Annotations/THIRD_PARTY_LICENSES
@@ -1,0 +1,23 @@
+﻿** YamlDotNet; version 12.0.0 -- https://github.com/aaubry/YamlDotNet
+Copyright (c) 2008, 2009, 2010, 2011, 2012, 2013, 2014 Antoine Aubry and
+contributors
+** Newtonsoft.Json; version 13.0.1 -- https://www.nuget.org/packages/Newtonsoft.Json/
+Copyright (c) 2007 James Newton-King
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6199

*Description of changes:*
This PR adds the THIRD_PARTY_LICENSES to attribute all third party packages that are bundled inside the final NuGet package


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
