### PR TITLE
Typos, Missing Copyright Headers, and Unused Namespaces in Amazon.Lambda.RuntimeSupport

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/Constants.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/Constants.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 using System.Reflection;
 
 namespace Amazon.Lambda.RuntimeSupport.Bootstrap
@@ -7,7 +22,7 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
         // For local debugging purposes this environment variable can be set to run a Lambda executable assembly and process one event
         // and then shut down cleanly. Useful for profiling or running local tests with the .NET Lambda Test Tool. This environment
         // variable should never be set when function is deployed to Lambda.
-        internal const string ENVIRONMENT_VARIANLE_AWS_LAMBDA_DOTNET_DEBUG_RUN_ONCE = "AWS_LAMBDA_DOTNET_DEBUG_RUN_ONCE";
+        internal const string ENVIRONMENT_VARIABLE_AWS_LAMBDA_DOTNET_DEBUG_RUN_ONCE = "AWS_LAMBDA_DOTNET_DEBUG_RUN_ONCE";
 
         internal const string ENVIRONMENT_VARIABLE_AWS_LAMBDA_DOTNET_PREJIT = "AWS_LAMBDA_DOTNET_PREJIT";
         internal const string ENVIRONMENT_VARIABLE_AWS_LAMBDA_INITIALIZATION_TYPE = "AWS_LAMBDA_INITIALIZATION_TYPE";

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/HandlerWrapper.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/HandlerWrapper.cs
@@ -1,22 +1,21 @@
 ﻿/*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
 using Amazon.Lambda.Core;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Amazon.Lambda.RuntimeSupport

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
@@ -1,21 +1,21 @@
 ﻿/*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
 using System;
 using System.IO;
 using System.Net.Http;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.Lambda.RuntimeSupport.Bootstrap;
@@ -126,7 +126,7 @@ namespace Amazon.Lambda.RuntimeSupport
             // For local debugging purposes this environment variable can be set to run a Lambda executable assembly and process one event
             // and then shut down cleanly. Useful for profiling or running local tests with the .NET Lambda Test Tool. This environment
             // variable should never be set when function is deployed to Lambda.
-            var runOnce = string.Equals(Environment.GetEnvironmentVariable(Constants.ENVIRONMENT_VARIANLE_AWS_LAMBDA_DOTNET_DEBUG_RUN_ONCE), "true", StringComparison.OrdinalIgnoreCase);
+            var runOnce = string.Equals(Environment.GetEnvironmentVariable(Constants.ENVIRONMENT_VARIABLE_AWS_LAMBDA_DOTNET_DEBUG_RUN_ONCE), "true", StringComparison.OrdinalIgnoreCase);
 
             bool doStartInvokeLoop = _initializer == null || await InitializeAsync();
 
@@ -139,7 +139,7 @@ namespace Amazon.Lambda.RuntimeSupport
                     {
                         _logger.LogInformation("Exiting Lambda processing loop because the run once environment variable was set.");
                         return;
-                    }    
+                    }
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
@@ -233,7 +233,7 @@ namespace Amazon.Lambda.RuntimeSupport
 
         private void WriteUnhandledExceptionToLog(Exception exception)
         {
-            // Console.Error.WriteLine are redirected to the IConsoleLoggerWriter which 
+            // Console.Error.WriteLine are redirected to the IConsoleLoggerWriter which
             // will take care of writing to the function's log stream.
             Console.Error.WriteLine(exception);
         }

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrapBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrapBuilder.cs
@@ -1,22 +1,21 @@
 ﻿/*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
 using System;
 using System.IO;
 using System.Net.Http;
-using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeLoader.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeLoader.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
@@ -91,17 +91,17 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
             }
             catch (FileNotFoundException fex)
             {
-                _logger.LogError(fex, "An error occured on UCL Init");
+                _logger.LogError(fex, "An error occurred on UCL Init");
                 throw LambdaExceptions.ValidationException(Errors.UserCodeLoader.CouldNotFindHandlerAssembly, fex.FileName);
             }
             catch (LambdaValidationException validationException)
             {
-                _logger.LogError(validationException, "An error occured on UCL Init");
+                _logger.LogError(validationException, "An error occurred on UCL Init");
                 throw;
             }
             catch (Exception exception)
             {
-                _logger.LogError(exception, "An error occured on UCL Init");
+                _logger.LogError(exception, "An error occurred on UCL Init");
                 throw LambdaExceptions.ValidationException(Errors.UserCodeLoader.UnableToLoadAssembly, _handler.AssemblyName);
             }
 

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/IRuntimeApiClient.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/IRuntimeApiClient.cs
@@ -1,24 +1,20 @@
 ﻿/*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-using Amazon.Lambda.Core;
+
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/InternalClientAdapted.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/InternalClientAdapted.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License").
@@ -263,7 +263,7 @@ namespace Amazon.Lambda.RuntimeSupport
 #if NET6_0_OR_GREATER
                                 result_ = JsonSerializer.Deserialize<ErrorResponse>(responseData_, RuntimeApiSerializationContext.Default.ErrorResponse);
 #else
-                                    result_ = JsonSerializer.Deserialize<ErrorResponse>(responseData_);
+                                result_ = JsonSerializer.Deserialize<ErrorResponse>(responseData_);
 #endif
                             }
                             catch (System.Exception exception_)

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/InvocationResponse.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/InvocationResponse.cs
@@ -1,18 +1,18 @@
 ﻿/*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-using Amazon.Lambda.Core;
+
 using System;
 using System.IO;
 

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/RuntimeApiClient.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/RuntimeApiClient.cs
@@ -1,24 +1,21 @@
 ﻿/*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-using Amazon.Lambda.Core;
+
 using Amazon.Lambda.RuntimeSupport.Helpers;
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Context/CognitoIdentity.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Context/CognitoIdentity.cs
@@ -1,19 +1,19 @@
 ﻿/*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
 using Amazon.Lambda.Core;
-using System;
 using System.Text.Json;
 
 namespace Amazon.Lambda.RuntimeSupport
@@ -31,7 +31,7 @@ namespace Amazon.Lambda.RuntimeSupport
             if (!string.IsNullOrWhiteSpace(json))
             {
                 var jsonData = JsonDocument.Parse(json).RootElement;
-                
+
                 if(jsonData.TryGetProperty("cognitoIdentityId", out var cognitoIdentityId))
                     result.IdentityId = cognitoIdentityId.GetString();
                 if(jsonData.TryGetProperty("cognitoIdentityPoolId", out var cognitoIdentityPoolId))

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Context/LambdaContext.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Context/LambdaContext.cs
@@ -1,21 +1,20 @@
 ﻿/*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
 using Amazon.Lambda.Core;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using Amazon.Lambda.RuntimeSupport.Helpers;
 
 namespace Amazon.Lambda.RuntimeSupport

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Context/LambdaEnvironment.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Context/LambdaEnvironment.cs
@@ -1,18 +1,18 @@
 ﻿/*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-using System;
+
 using System.Linq;
 using System.Reflection;
 
@@ -32,7 +32,7 @@ namespace Amazon.Lambda.RuntimeSupport
         internal const string EnvVarLogStreamName = "AWS_LAMBDA_LOG_STREAM_NAME";
         internal const string EnvVarServerHostAndPort = "AWS_LAMBDA_RUNTIME_API";
         internal const string EnvVarTraceId = "_X_AMZN_TRACE_ID";
-        
+
         internal const string AwsLambdaDotnetCustomRuntime = "AWS_Lambda_dotnet_custom";
         internal const string AmazonLambdaRuntimeSupportMarker = "amazonlambdaruntimesupport";
 

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/ExceptionHandling/ExceptionInfo.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/ExceptionHandling/ExceptionInfo.cs
@@ -1,23 +1,22 @@
 ﻿/*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 
 namespace Amazon.Lambda.RuntimeSupport
 {

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/ExceptionHandling/JsonExceptionWriterHelpers.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/ExceptionHandling/JsonExceptionWriterHelpers.cs
@@ -1,19 +1,18 @@
 ﻿/*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-using System;
-using System.Collections.Generic;
+
 using System.Text;
 
 namespace Amazon.Lambda.RuntimeSupport

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/ExceptionHandling/LambdaXRayExceptionWriter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/ExceptionHandling/LambdaXRayExceptionWriter.cs
@@ -1,5 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 using System.Linq;
 using System.Text;
 

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/ExceptionHandling/MeteredStringBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/ExceptionHandling/MeteredStringBuilder.cs
@@ -1,19 +1,19 @@
 ﻿/*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
 using System;
-using System.Collections.Generic;
 using System.Text;
 
 namespace Amazon.Lambda.RuntimeSupport

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/ExceptionHandling/StackFrameInfo.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/ExceptionHandling/StackFrameInfo.cs
@@ -1,21 +1,19 @@
 ﻿/*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-using System;
-using System.Collections.Generic;
+
 using System.Diagnostics;
-using System.Text;
 
 namespace Amazon.Lambda.RuntimeSupport
 {

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/ConsoleLoggerWriter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/ConsoleLoggerWriter.cs
@@ -1,4 +1,19 @@
-﻿using Amazon.Lambda.RuntimeSupport.Bootstrap;
+﻿/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Amazon.Lambda.RuntimeSupport.Bootstrap;
 using System;
 using System.IO;
 using System.Reflection;
@@ -9,7 +24,7 @@ using System.Threading.Tasks;
 namespace Amazon.Lambda.RuntimeSupport.Helpers
 {
     /// <summary>
-    /// Interface used by bootstrap to format logging message as well as Console Writeline messages.
+    /// Interface used by bootstrap to format logging message as well as Console WriteLine messages.
     /// </summary>
     public interface IConsoleLoggerWriter
     {
@@ -34,7 +49,7 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
     }
 
     /// <summary>
-    /// Simple logger to maintain compatiblity with verisons of .NET before .NET 6
+    /// Simple logger to maintain compatibility with versions of .NET before .NET 6
     /// </summary>
     public class SimpleLoggerWriter : IConsoleLoggerWriter
     {
@@ -128,10 +143,10 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
         WrapperTextWriter _wrappedStdErrorWriter;
 
         /// <summary>
-        /// Constructor used by bootstrap to put in place a wrapper TextWriter around stdout and stderror so all Console.Writeline calls
+        /// Constructor used by bootstrap to put in place a wrapper TextWriter around stdout and stderror so all Console.WriteLine calls
         /// will be formatted.
-        /// 
-        /// Stdoud will default log messages to be Information
+        ///
+        /// Stdout will default log messages to be Information
         /// Stderror will default log messages to be Error
         /// </summary>
         public LogLevelLoggerWriter()
@@ -219,8 +234,8 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
 
 
         /// <summary>
-        /// Wraps around a provided TextWriter. In normal usage the wrapped TextWriter will either be stdout or stderr. 
-        /// For all calls besides Writeline and WritelineAsync call into the wrapped TextWriter. For the Writeline and WritelineAsync
+        /// Wraps around a provided TextWriter. In normal usage the wrapped TextWriter will either be stdout or stderr.
+        /// For all calls besides WriteLine and WriteLineAsync call into the wrapped TextWriter. For the WriteLine and WriteLineAsync
         /// format the message with time, request id, log level and the provided message.
         /// </summary>
         class WrapperTextWriter : TextWriter
@@ -228,8 +243,8 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
             private readonly TextWriter _innerWriter;
             private string _defaultLogLevel;
 
-            const string LOG_LEVEL_ENVIRONMENT_VARAIBLE = "AWS_LAMBDA_HANDLER_LOG_LEVEL";
-            const string LOG_FORMAT_ENVIRONMENT_VARAIBLE = "AWS_LAMBDA_HANDLER_LOG_FORMAT";
+            const string LOG_LEVEL_ENVIRONMENT_VARIABLE = "AWS_LAMBDA_HANDLER_LOG_LEVEL";
+            const string LOG_FORMAT_ENVIRONMENT_VARIABLE = "AWS_LAMBDA_HANDLER_LOG_FORMAT";
 
             private LogLevel _minmumLogLevel = LogLevel.Information;
 
@@ -241,9 +256,9 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
 
             /// <summary>
             /// This is typically set to either Console.Out or Console.Error to make sure we acquiring a lock
-            /// on that object whenever we are going through FormattedWriteLine. This is important for 
+            /// on that object whenever we are going through FormattedWriteLine. This is important for
             /// logging that goes through ILambdaLogger that skips going through Console.WriteX. Without
-            /// this ILambdaLogger only acquries one lock but Console.WriteX acquires 2 locks and we can get deadlocks.
+            /// this ILambdaLogger only acquires one lock but Console.WriteX acquires 2 locks and we can get deadlocks.
             /// </summary>
             internal object LockObject { get; set; } = new object();
 
@@ -252,7 +267,7 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
                 _innerWriter = innerWriter;
                 _defaultLogLevel = defaultLogLevel;
 
-                var envLogLevel = Environment.GetEnvironmentVariable(LOG_LEVEL_ENVIRONMENT_VARAIBLE);
+                var envLogLevel = Environment.GetEnvironmentVariable(LOG_LEVEL_ENVIRONMENT_VARIABLE);
                 if (!string.IsNullOrEmpty(envLogLevel))
                 {
                     if (Enum.TryParse<LogLevel>(envLogLevel, true, out var result))
@@ -261,7 +276,7 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
                     }
                 }
 
-                var envLogFormat = Environment.GetEnvironmentVariable(LOG_FORMAT_ENVIRONMENT_VARAIBLE);
+                var envLogFormat = Environment.GetEnvironmentVariable(LOG_FORMAT_ENVIRONMENT_VARIABLE);
                 if (!string.IsNullOrEmpty(envLogFormat))
                 {
                     if (Enum.TryParse<LogFormatType>(envLogFormat, true, out var result))

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/FileDescriptorLogStream.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/FileDescriptorLogStream.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
 using System.IO;
 using System.Buffers;
 using System.Text;
@@ -27,7 +42,7 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
         /// <returns></returns>
         public static StreamWriter GetWriter(string fileDescriptorId)
         {
-            var writer = _writers.GetOrAdd(fileDescriptorId, 
+            var writer = _writers.GetOrAdd(fileDescriptorId,
                 (x) => {
                     SafeFileHandle handle = new SafeFileHandle(new IntPtr(int.Parse(fileDescriptorId)), false);
                     return InitializeWriter(new FileStream(handle, FileAccess.Write));

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/RuntimeSupportDebugAttacher.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/RuntimeSupportDebugAttacher.cs
@@ -1,4 +1,18 @@
-﻿using Amazon.Lambda.Core;
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
@@ -50,7 +64,7 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
             }
             catch (Exception ex)
             {
-                _internalLogger.LogInformation($"An exception occured while waiting for a debugger to attach. The exception details are as follows:\n{ex}");
+                _internalLogger.LogInformation($"An exception occurred while waiting for a debugger to attach. The exception details are as follows:\n{ex}");
             }
         }
     }

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Types.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Types.cs
@@ -14,7 +14,6 @@
  */
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Program.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Program.cs
@@ -1,5 +1,19 @@
-﻿using System;
-using System.IO;
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
 using System.Threading.Tasks;
 
 namespace Amazon.Lambda.RuntimeSupport
@@ -11,7 +25,7 @@ namespace Amazon.Lambda.RuntimeSupport
             if (args.Length == 0)
             {
                 throw new ArgumentException("The function handler was not provided via command line arguments.", nameof(args));
-;           }
+            }
 
             var handler = args[0];
 

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/RuntimeSupportInitializer.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/RuntimeSupportInitializer.cs
@@ -1,22 +1,33 @@
-﻿using Amazon.Lambda.Core;
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 using Amazon.Lambda.RuntimeSupport.Bootstrap;
 using Amazon.Lambda.RuntimeSupport.Helpers;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Amazon.Lambda.RuntimeSupport
 {
     /// <summary>
-    /// RuntimeSuportInitializer class responsible for initializing the UserCodeLoader and LambdaBootstrap given a function handler.
+    /// RuntimeSupportInitializer class responsible for initializing the UserCodeLoader and LambdaBootstrap given a function handler.
     /// </summary>
     public class RuntimeSupportInitializer
     {
         private readonly string _handler;
         private readonly InternalLogger _logger;
         private readonly RuntimeSupportDebugAttacher _debugAttacher;
-        
 
         /// <summary>
         /// Class constructor that takes a Function Handler and initializes the class.


### PR DESCRIPTION
*Description of changes:*

This pull-request has no functional changes. It's only clean-up changes for the _Amazon.Lambda.RuntimeSupport_ project, including:
* Fixed typos
* Added missing copyright headers
* Removed unused namespaces
* Removed trailing whitespace

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
