### PR TITLE
Add CLI help documentation and fix documentation spelling

### DIFF
--- a/Tools/LambdaTestTool/README.md
+++ b/Tools/LambdaTestTool/README.md
@@ -87,7 +87,8 @@ These options are valid for either mode the Lambda test tool is running in.
 These options are valid when using the web interface to select and execute the Lambda code.
 
         --host &lt;hostname-or-ip-address&gt;       The hostname or IP address used for the test tool's web interface.                                                    
-                                                    Any host other than an explicit IP address or localhost (e.g. '*', '+' or 'example.com') binds to all public IPv4 and IPv6 addresses. 
+                                              Any host other than an explicit IP address or localhost (e.g. '*', '+' or 'example.com') 
+                                              binds to all public IPv4 and IPv6 addresses. 
         --port &lt;port-number&gt;                  The port number used for the test tool's web interface.
         --no-launch-window                    Disable auto launching the test tool's web interface in a browser.
 
@@ -109,7 +110,7 @@ These options are valid in the no web interface mode.
                                               executing the Lambda code. The default value is true.
 </pre>
 
-**Note**: The `--host` argument do not to bind to specific hostname as it's value is largely ignored by [web hosting](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints?view=aspnetcore-6.0#url-prefixes-1). This is mostly used to expose web interface through docker by binding to all public IP addresses.
+**Note**: The `--host` argument do not bind to specific hostname as it's value is largely ignored by [web hosting](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints?view=aspnetcore-6.0#url-prefixes-1). This is mostly used to expose web interface through docker by binding to all public IP addresses.
 
 For command line arguments not set the defaults and config file will be used to determine the .NET Lambda code to run. For example if you just use the <b>--no-ui</b> argument then the
 <b>aws-lambda-tools-defaults.json</b> will be searched for and used if found. The tool will then use the function handler, profile and region specified in the configuration file to run

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Documentation.razor
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Documentation.razor
@@ -98,7 +98,8 @@ These options are valid for either mode the Lambda test tool is running in.
 These options are valid when using the web interface to select and execute the Lambda code.
 
         --host &lt;hostname-or-ip-address&gt;       The hostname or IP address used for the test tool's web interface.
-                                              Any host other than an explicit IP address or localhost (e.g. '*', '+' or 'example.com') binds to all public IPv4 and IPv6 addresses. 
+                                              Any host other than an explicit IP address or localhost (e.g. '*', '+' or 'example.com') 
+                                              binds to all public IPv4 and IPv6 addresses. 
         --port &lt;port-number&gt;                  The port number used for the test tool's web interface.
         --no-launch-window                    Disable auto launching the test tool's web interface in a browser.
 
@@ -121,7 +122,7 @@ These options are valid in the no web interface mode.
 </pre>
 
 <p>
-    <i>Note</i>: The <b>--host</b> argument do not to bind to specific hostname as it's value is largely ignored by 
+    <i>Note</i>: The <b>--host</b> argument do not bind to specific hostname as it's value is largely ignored by 
     <a href="https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints?view=aspnetcore-6.0#url-prefixes-1" target="_blank">web hosting</a>. 
     This is mostly used to expose web interface through docker by binding to all public IP addresses.
 </p>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/CommandLineOptions.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/CommandLineOptions.cs
@@ -149,6 +149,9 @@ namespace Amazon.Lambda.TestTool
 
             Console.WriteLine("These options are valid when using the web interface to select and execute the Lambda code.");
             Console.WriteLine();
+            Console.WriteLine("\t--host <hostname-or-ip-address>       The port number used for the test tool's web interface.");
+            Console.WriteLine("\t                                      Any host other than an explicit IP address or localhost (e.g. '*', '+' or 'example.com')");
+            Console.WriteLine("\t                                      binds to all public IPv4 and IPv6 addresses.");
             Console.WriteLine("\t--port <port-number>                  The port number used for the test tool's web interface.");
             Console.WriteLine("\t--no-launch-window                    Disable auto launching the test tool's web interface in a browser.");
             Console.WriteLine();


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-lambda-dotnet/issues/805

*Description of changes:*
This pull-request has no functional changes. 
It only provides cleanup for the Amazon.Lambda.TestTool projects related to newly added `--host` parameter (cf PR #1253), including:

- Add CLI help documentation for `--host` parameter (forgot it, my bad)
- Fixed documentation typo and format

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.