### PR TITLE
docs: Fix broken header link in Lambda Annotations readme

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations/README.md
+++ b/Libraries/src/Amazon.Lambda.Annotations/README.md
@@ -11,7 +11,7 @@ Topics:
 * [Getting build information](#getting-build-information)
 * [Amazon API Gateway example](#amazon-api-gateway-example)
 * [Amazon S3 example](#amazon-s3-example)
-* [Lambda .NET Attributes Reference](#lambda.net-attributes-reference)
+* [Lambda .NET Attributes Reference](#lambda-net-attributes-reference)
 
 ## How does Lambda Annotations work?
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Fix the broken anchor link in the Lambda Annotations readme.

Targeting `dev` as usual, but let me know if safe to target `master` so it'd appear fixed prior to the next release.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
