### PR TITLE
Remove useless null checks

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/InternalClientAdapted.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/InternalClientAdapted.cs
@@ -243,9 +243,6 @@ namespace Amazon.Lambda.RuntimeSupport
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
-
-                        // NOTE: response_.Content can never be null (See: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Http/src/System/Net/Http/HttpResponseMessage.cs#L42)
-                        // NOTE: response_.Content.Headers can never be null (See: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Http/src/System/Net/Http/HttpContent.cs#L112)
                         foreach (var item_ in response_.Content.Headers)
                                 headers_[item_.Key] = item_.Value;
 

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/InternalClientAdapted.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/InternalClientAdapted.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License").
@@ -243,11 +243,11 @@ namespace Amazon.Lambda.RuntimeSupport
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
-                        if (response_.Content != null && response_.Content.Headers != null)
-                        {
-                            foreach (var item_ in response_.Content.Headers)
+
+                        // NOTE: response_.Content can never be null (See: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Http/src/System/Net/Http/HttpResponseMessage.cs#L42)
+                        // NOTE: response_.Content.Headers can never be null (See: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Http/src/System/Net/Http/HttpContent.cs#L112)
+                        foreach (var item_ in response_.Content.Headers)
                                 headers_[item_.Key] = item_.Value;
-                        }
 
                         if (response_.StatusCode == HttpStatusCode.OK)
                         {


### PR DESCRIPTION
*Description of changes:*

Remove `null` checks since they are not useful. The `Content` and `Headers` properties can never be null.

See:
* https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Http/src/System/Net/Http/HttpResponseMessage.cs#L42
* https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Http/src/System/Net/Http/HttpContent.cs#L112

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
