### PR TITLE
Fixed issue with creating projects from Lambda templates with .NET 7 installed.

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/src/BlueprintBaseName.1/serverless.template
@@ -20,7 +20,7 @@
           "AWSLambdaBasicExecutionRole"
         ],
         "PackageType": "Zip",
-        "Handler": "BlueprintBaseName._1::BlueprintBaseName._1.Functions_Default_Generated::Default",
+        "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Functions_Default_Generated::Default",
         "Events": {
           "RootGet": {
             "Type": "HttpApi",
@@ -50,7 +50,7 @@
           "AWSLambdaBasicExecutionRole"
         ],
         "PackageType": "Zip",
-        "Handler": "BlueprintBaseName._1::BlueprintBaseName._1.Functions_Add_Generated::Add",
+        "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Functions_Add_Generated::Add",
         "Events": {
           "RootGet": {
             "Type": "HttpApi",
@@ -80,7 +80,7 @@
           "AWSLambdaBasicExecutionRole"
         ],
         "PackageType": "Zip",
-        "Handler": "BlueprintBaseName._1::BlueprintBaseName._1.Functions_Subtract_Generated::Subtract",
+        "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Functions_Subtract_Generated::Subtract",
         "Events": {
           "RootGet": {
             "Type": "HttpApi",
@@ -110,7 +110,7 @@
           "AWSLambdaBasicExecutionRole"
         ],
         "PackageType": "Zip",
-        "Handler": "BlueprintBaseName._1::BlueprintBaseName._1.Functions_Multiply_Generated::Multiply",
+        "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Functions_Multiply_Generated::Multiply",
         "Events": {
           "RootGet": {
             "Type": "HttpApi",
@@ -140,7 +140,7 @@
           "AWSLambdaBasicExecutionRole"
         ],
         "PackageType": "Zip",
-        "Handler": "BlueprintBaseName._1::BlueprintBaseName._1.Functions_Divide_Generated::Divide",
+        "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Functions_Divide_Generated::Divide",
         "Events": {
           "RootGet": {
             "Type": "HttpApi",

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-FSharp/template/.template.config/template.json
@@ -30,15 +30,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/.template.config/template.json
@@ -30,15 +30,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/.template.config/template.json
@@ -30,15 +30,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI.MinimalAPI/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI.MinimalAPI/template/.template.config/template.json
@@ -30,15 +30,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI/template/.template.config/template.json
@@ -30,15 +30,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebApp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebApp/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/ChatBotTutorial/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/ChatBotTutorial/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction-FSharp/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels-FSharp/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-FSharp/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,7 +8,7 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "function-architecture" : "x86_64",
+  "function-architecture": "x86_64",
   "function-runtime": "dotnet6",
   "function-memory-size": 256,
   "function-timeout": 30,

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-FSharp/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless/template/src/BlueprintBaseName.1/serverless.template
@@ -6,7 +6,9 @@
     "Get": {
       "Type": "AWS::Serverless::Function",
       "Properties": {
-        "Architectures": ["x86_64"],
+        "Architectures": [
+          "x86_64"
+        ],
         "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Functions::Get",
         "Runtime": "dotnet6",
         "CodeUri": "",

--- a/Blueprints/BlueprintDefinitions/vs2022/GiraffeWebApp-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/GiraffeWebApp-FSharp/template/.template.config/template.json
@@ -30,15 +30,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/LexBookTripSample/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/LexBookTripSample/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleApplicationLoadBalancer/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleApplicationLoadBalancer/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFirehoseFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFirehoseFunction/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFunction-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFunction-FSharp/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFunction/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleSNSFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleSNSFunction/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleSQSFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleSQSFunction/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld-FSharp/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/TopLevelStatementsFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/TopLevelStatementsFunction/template/.template.config/template.json
@@ -30,15 +30,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/template/.template.config/template.json
@@ -29,15 +29,6 @@
       "datatype": "string",
       "replaces": "DefaultRegion",
       "defaultValue": ""
-    },
-    "safe-sourcename": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "safe_namespace",
-        "fallbackVariableName": "safe_name"
-      },
-      "replaces": "BlueprintBaseName._1"
     }
   },
   "primaryOutputs": [

--- a/Blueprints/BlueprintDefinitions/vs2022/template.nuspec
+++ b/Blueprints/BlueprintDefinitions/vs2022/template.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Amazon.Lambda.Templates</id>
-    <version>6.3.0</version>
+    <version>6.4.0</version>
     <authors>Amazon Web Services</authors>
     <tags>AWS Amazon Lambda</tags>
     <description>AWS Lambda templates for Microsoft Template Engine accessible with the dotnet CLI's new command</description>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1317

*Description of changes:*
The Lambda templates were using a "deprecated" feature to handle the things like namespaces and filenames allowed different characters. For example if you create a project like `Test-Test` that is a valid name for the files and directories but due to the `-` it is an invalid namespace name. The original work around was to use a `safe-sourcename` replacement parameter using `safe_namespace` and `safe_name` macros. 

For quite some time the .NET templating engine now handles this safe name logic automatically and the `safe_namespace` and `safe_name` macros no longer due anything. There was an intended change in the .NET 7 RC that broke those macros triggering a NPE. It sounds like the .NET templating engine will revert that change in a future release but since there is no need for our templates to use those macros I have stripped their usages out to unblock users with .NET 7 RC installed.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
