### PR TITLE
In the LambdaTestTool, adding the possibility to order functions by name in an alphabetical …

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/FunctionPickerComponent.razor
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/FunctionPickerComponent.razor
@@ -15,7 +15,10 @@
         </div>
     </div>
     <div class="col-sm form-group">
-        <label class="col-xs-3 control-label" for="functions-picker">Function</label>
+        <div class="col-xs-5">
+            <label class="control-label" for="functions-picker">Function</label>
+            <button class="float-right btn btn-primary btn-sm" id="functions-picker-sort-order" @onclick="SortFunctionsClicked" >Sort Functions</button>
+        </div>
         <div class="col-xs-5">
             <select class="form-control" name="color" @bind="FunctionHandler">
                 @if (AvailableFunctions != null)
@@ -101,6 +104,11 @@
             this._functionHandler = value;
             OnChangeAsync?.Invoke();
         }
+    }
+    
+    void SortFunctionsClicked()
+    {
+        AvailableFunctions = AvailableFunctions?.OrderBy(x => x?.FunctionInfo?.Name).ToList();
     }
 
     IList<string> AvailableAWSProfiles;

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/FunctionPickerComponent.razor
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/FunctionPickerComponent.razor
@@ -15,10 +15,7 @@
         </div>
     </div>
     <div class="col-sm form-group">
-        <div class="col-xs-5">
-            <label class="control-label" for="functions-picker">Function</label>
-            <button class="float-right btn btn-primary btn-sm" id="functions-picker-sort-order" @onclick="SortFunctionsClicked" >Sort Functions</button>
-        </div>
+        <label class="col-xs-3 control-label" for="functions-picker">Function</label>
         <div class="col-xs-5">
             <select class="form-control" name="color" @bind="FunctionHandler">
                 @if (AvailableFunctions != null)
@@ -104,11 +101,6 @@
             this._functionHandler = value;
             OnChangeAsync?.Invoke();
         }
-    }
-    
-    void SortFunctionsClicked()
-    {
-        AvailableFunctions = AvailableFunctions?.OrderBy(x => x?.FunctionInfo?.Name).ToList();
     }
 
     IList<string> AvailableAWSProfiles;

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaDefaultsConfigFileParser.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaDefaultsConfigFileParser.cs
@@ -72,7 +72,7 @@ namespace Amazon.Lambda.TestTool.Runtime
             
                 configInfo.FunctionInfos.Add(info);
             }
-            
+            configInfo.FunctionInfos.Sort((x, y ) => string.CompareOrdinal(x.Name, y.Name));
             return configInfo;
         }
 

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/DefaultsFileParseTests.cs
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/DefaultsFileParseTests.cs
@@ -125,18 +125,21 @@ namespace Amazon.Lambda.TestTool.Tests
 
             var configInfo = LambdaDefaultsConfigFileParser.LoadFromFile(defaultsFilePath);
             
-            Assert.Equal(3, configInfo.FunctionInfos.Count);
+            Assert.Equal(4, configInfo.FunctionInfos.Count);
             Assert.Equal("default", configInfo.AWSProfile);
             Assert.Equal("us-west-2", configInfo.AWSRegion);
             
-            Assert.Equal("MyHelloWorld", configInfo.FunctionInfos[0].Name);
-            Assert.Equal("ServerlessTemplateExample::ServerlessTemplateExample.Functions::HelloWorld", configInfo.FunctionInfos[0].Handler);
+            Assert.Equal("AFunction", configInfo.FunctionInfos[0].Name);
+            Assert.Equal("ServerlessTemplateExample::ServerlessTemplateExample.Functions::AFunction", configInfo.FunctionInfos[0].Handler);
+            
+            Assert.Equal("MyHelloWorld", configInfo.FunctionInfos[1].Name);
+            Assert.Equal("ServerlessTemplateExample::ServerlessTemplateExample.Functions::HelloWorld", configInfo.FunctionInfos[1].Handler);
 
-            Assert.Equal("MyHelloWorldImageCommand", configInfo.FunctionInfos[1].Name);
-            Assert.Equal("ServerlessTemplateExample::ServerlessTemplateExample.Functions::HelloWorldImageFunction", configInfo.FunctionInfos[1].Handler);
+            Assert.Equal("MyHelloWorldImageCommand", configInfo.FunctionInfos[2].Name);
+            Assert.Equal("ServerlessTemplateExample::ServerlessTemplateExample.Functions::HelloWorldImageFunction", configInfo.FunctionInfos[2].Handler);
 
-            Assert.Equal("MyToUpper", configInfo.FunctionInfos[2].Name);
-            Assert.Equal("ServerlessTemplateExample::ServerlessTemplateExample.Functions::ToUpper", configInfo.FunctionInfos[2].Handler);
+            Assert.Equal("MyToUpper", configInfo.FunctionInfos[3].Name);
+            Assert.Equal("ServerlessTemplateExample::ServerlessTemplateExample.Functions::ToUpper", configInfo.FunctionInfos[3].Handler);
 
         }
         
@@ -147,18 +150,21 @@ namespace Amazon.Lambda.TestTool.Tests
 
             var configInfo = LambdaDefaultsConfigFileParser.LoadFromFile(defaultsFilePath);
             
-            Assert.Equal(3, configInfo.FunctionInfos.Count);
+            Assert.Equal(4, configInfo.FunctionInfos.Count);
             Assert.Equal("default", configInfo.AWSProfile);
             Assert.Equal("us-west-2", configInfo.AWSRegion);
             
-            Assert.Equal("MyHelloWorld", configInfo.FunctionInfos[0].Name);
-            Assert.Equal("ServerlessTemplateYamlExample::ServerlessTemplateYamlExample.Functions::HelloWorld", configInfo.FunctionInfos[0].Handler);
+            Assert.Equal("AFunction", configInfo.FunctionInfos[0].Name);
+            Assert.Equal("ServerlessTemplateYamlExample::ServerlessTemplateYamlExample.Functions::AFunction", configInfo.FunctionInfos[0].Handler);
 
-            Assert.Equal("MyHelloWorldImageCommand", configInfo.FunctionInfos[1].Name);
-            Assert.Equal("ServerlessTemplateExample::ServerlessTemplateExample.Functions::HelloWorldImageFunction", configInfo.FunctionInfos[1].Handler);
+            Assert.Equal("MyHelloWorld", configInfo.FunctionInfos[1].Name);
+            Assert.Equal("ServerlessTemplateYamlExample::ServerlessTemplateYamlExample.Functions::HelloWorld", configInfo.FunctionInfos[1].Handler);
 
-            Assert.Equal("MyToUpper", configInfo.FunctionInfos[2].Name);
-            Assert.Equal("ServerlessTemplateYamlExample::ServerlessTemplateYamlExample.Functions::ToUpper", configInfo.FunctionInfos[2].Handler);
+            Assert.Equal("MyHelloWorldImageCommand", configInfo.FunctionInfos[2].Name);
+            Assert.Equal("ServerlessTemplateExample::ServerlessTemplateExample.Functions::HelloWorldImageFunction", configInfo.FunctionInfos[2].Handler);
+
+            Assert.Equal("MyToUpper", configInfo.FunctionInfos[3].Name);
+            Assert.Equal("ServerlessTemplateYamlExample::ServerlessTemplateYamlExample.Functions::ToUpper", configInfo.FunctionInfos[3].Handler);
 
         }        
 

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/ServerlessTemplateExample/serverless.template
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/ServerlessTemplateExample/serverless.template
@@ -77,7 +77,28 @@
       },
       "MissingProperties":{ 
          "Type":"AWS::Lambda::Function"
-      }
+      },
+      "AFunction":{ 
+               "Type":"AWS::Serverless::Function",
+               "Properties":{ 
+                  "Handler":"ServerlessTemplateExample::ServerlessTemplateExample.Functions::AFunction",
+                  "Runtime":"dotnetcore3.1",
+                  "CodeUri":"",
+                  "Description":"",
+                  "MemorySize":256,
+                  "Timeout":30,
+                  "Role":null,
+                  "Policies":[ 
+                     "AWSLambda_FullAccess"
+                  ],
+                  "Environment":{ 
+      
+                  },
+                  "Events":{ 
+      
+                  }
+               }
+            }
    },
    "Outputs":{ 
 

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/ServerlessTemplateYamlExample/serverless.yaml
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/netcore31/ServerlessTemplateYamlExample/serverless.yaml
@@ -45,4 +45,13 @@ Resources:
       Policies:
       - AWSLambdaBasicExecutionRole
   MissingProperties:
-    Type: AWS::Serverless::Function
+    Type: AWS::Serverless::Function    
+  AFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: ServerlessTemplateYamlExample::ServerlessTemplateYamlExample.Functions::AFunction
+      CodeUri: ''
+      MemorySize: 256
+      Timeout: 30
+      Policies:
+        - AWSLambdaBasicExecutionRole


### PR DESCRIPTION
*Description of changes:*

Feature to allow the possibility to order the dropdown of functions by name. Making it easier to navigate and test in repositories with lots of functions where functions isn't sorted by default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
