### PR TITLE
Fix issue with test tool and Lambda functions using source generator serializer

### DIFF
--- a/Tools/LambdaTestTool/aws-lambda-test-tool-netcore.sln
+++ b/Tools/LambdaTestTool/aws-lambda-test-tool-netcore.sln
@@ -38,13 +38,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCoreAPIExample", "tests\LambdaFunctions\netcore31\AspNetCoreAPIExample\AspNetCoreAPIExample.csproj", "{5E1FF56C-9691-45B4-A961-24950A2C106C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.Lambda.TestTool.BlazorTester.Tests", "tests\Amazon.Lambda.TestTool.BlazorTester.Tests\Amazon.Lambda.TestTool.BlazorTester.Tests.csproj", "{0CA7DDC6-A1C5-467C-9CBF-8B4290D56D4A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.Lambda.TestTool.BlazorTester.Tests", "tests\Amazon.Lambda.TestTool.BlazorTester.Tests\Amazon.Lambda.TestTool.BlazorTester.Tests.csproj", "{0CA7DDC6-A1C5-467C-9CBF-8B4290D56D4A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "net6", "net6", "{F08BF489-BD05-4DC1-9772-AB5E137B87B8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SourceGeneratorExample", "tests\LambdaFunctions\net6\SourceGeneratorExample\SourceGeneratorExample.csproj", "{9F8D7697-46FC-45E4-B795-11CCDA2B68B3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.Lambda.TestTool.Tests.NET6", "tests\Amazon.Lambda.TestTool.Tests.NET6\Amazon.Lambda.TestTool.Tests.NET6.csproj", "{2C69BEB2-858E-43E3-9951-74E780FEB1BF}"
 EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		tests\Amazon.Lambda.TestTool.Tests.Shared\Amazon.Lambda.TestTool.Tests.Shared.projitems*{70aff681-844a-428c-aba2-7053e61d39c8}*SharedItemsImports = 13
-		tests\Amazon.Lambda.TestTool.Tests.Shared\Amazon.Lambda.TestTool.Tests.Shared.projitems*{e57abb02-e8fc-4011-95d3-e9cb9412edcb}*SharedItemsImports = 5
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -94,6 +96,14 @@ Global
 		{0CA7DDC6-A1C5-467C-9CBF-8B4290D56D4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0CA7DDC6-A1C5-467C-9CBF-8B4290D56D4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0CA7DDC6-A1C5-467C-9CBF-8B4290D56D4A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9F8D7697-46FC-45E4-B795-11CCDA2B68B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9F8D7697-46FC-45E4-B795-11CCDA2B68B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9F8D7697-46FC-45E4-B795-11CCDA2B68B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9F8D7697-46FC-45E4-B795-11CCDA2B68B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C69BEB2-858E-43E3-9951-74E780FEB1BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C69BEB2-858E-43E3-9951-74E780FEB1BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C69BEB2-858E-43E3-9951-74E780FEB1BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C69BEB2-858E-43E3-9951-74E780FEB1BF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -113,8 +123,15 @@ Global
 		{E57ABB02-E8FC-4011-95D3-E9CB9412EDCB} = {28C935E3-4FB4-4B09-A9DB-26A1EB04CDE0}
 		{5E1FF56C-9691-45B4-A961-24950A2C106C} = {0B078893-2F43-4C0C-88FE-98D0839ED7A9}
 		{0CA7DDC6-A1C5-467C-9CBF-8B4290D56D4A} = {28C935E3-4FB4-4B09-A9DB-26A1EB04CDE0}
+		{F08BF489-BD05-4DC1-9772-AB5E137B87B8} = {BFD718DB-4526-4BED-B2B0-BB446EDFFEA1}
+		{9F8D7697-46FC-45E4-B795-11CCDA2B68B3} = {F08BF489-BD05-4DC1-9772-AB5E137B87B8}
+		{2C69BEB2-858E-43E3-9951-74E780FEB1BF} = {28C935E3-4FB4-4B09-A9DB-26A1EB04CDE0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E6C77567-6F16-4EE3-8743-ADE6B68434FD}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		tests\Amazon.Lambda.TestTool.Tests.Shared\Amazon.Lambda.TestTool.Tests.Shared.projitems*{70aff681-844a-428c-aba2-7053e61d39c8}*SharedItemsImports = 13
+		tests\Amazon.Lambda.TestTool.Tests.Shared\Amazon.Lambda.TestTool.Tests.Shared.projitems*{e57abb02-e8fc-4011-95d3-e9cb9412edcb}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj
@@ -6,7 +6,7 @@
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET Core AWS Lambda functions locally.</Description>
     <LangVersion>Latest</LangVersion>
-    <VersionPrefix>0.12.4</VersionPrefix>
+    <VersionPrefix>0.12.5</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester31-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester31-pack.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET Core 3.1 AWS Lambda functions locally.</Description>
-    <VersionPrefix>0.12.4</VersionPrefix>
+    <VersionPrefix>0.12.5</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester50-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester50-pack.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET 5.0 AWS Lambda functions locally.</Description>
-    <VersionPrefix>0.12.4</VersionPrefix>
+    <VersionPrefix>0.12.5</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester60-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester60-pack.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET 6.0 AWS Lambda functions locally.</Description>
-    <VersionPrefix>0.12.4</VersionPrefix>
+    <VersionPrefix>0.12.5</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/Amazon.Lambda.TestTool.Tests.NET6.csproj
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/Amazon.Lambda.TestTool.Tests.NET6.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Amazon.Lambda.TestTool\Amazon.Lambda.TestTool.csproj" />
+    <ProjectReference Include="..\LambdaFunctions\net6\SourceGeneratorExample\SourceGeneratorExample.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/SourceGeneratorTests.cs
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/SourceGeneratorTests.cs
@@ -1,0 +1,19 @@
+namespace Amazon.Lambda.TestTool.Tests.NET6
+{
+    public class SourceGeneratorTests
+    {
+        [Fact]
+        public void DirectFunctionCallFromConfig()
+        {
+            var runConfiguration = new TestToolStartup.RunConfiguration
+            {
+                Mode = TestToolStartup.RunConfiguration.RunMode.Test,
+                OutputWriter = new StringWriter()
+            };
+            var buildPath = Path.GetFullPath($"../../../../LambdaFunctions/net6/SourceGeneratorExample/bin/debug/net6.0");
+
+            TestToolStartup.Startup("Unit Tests", null, new string[] { "--path", buildPath, "--no-ui", "--payload", "{\"Name\" : \"FooBar\"}" }, runConfiguration);
+            Assert.Contains("Response = FooBar", runConfiguration.OutputWriter.ToString());
+        }
+    }
+}

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/Usings.cs
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/net6/SourceGeneratorExample/Function.cs
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/net6/SourceGeneratorExample/Function.cs
@@ -1,0 +1,33 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.Serialization.SystemTextJson;
+using System.Text.Json.Serialization;
+
+[assembly: LambdaSerializer(typeof(SourceGeneratorLambdaJsonSerializer<SourceGeneratorExample.CustomTypesSerializerContext>))]
+
+namespace SourceGeneratorExample;
+
+[JsonSerializable(typeof(Input))]
+[JsonSerializable(typeof(Output))]
+public partial class CustomTypesSerializerContext : JsonSerializerContext
+{
+}
+
+
+public class Input
+{
+    public string Name { get; set; }
+}
+
+public class Output
+{
+    public string Response { get; set;}
+}
+
+public class Function
+{
+
+    public Output FunctionHandler(Input request, ILambdaContext context)
+    {
+        return new Output { Response = "Response = " + request.Name};
+    }
+}

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/net6/SourceGeneratorExample/SourceGeneratorExample.csproj
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/net6/SourceGeneratorExample/SourceGeneratorExample.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AWSProjectType>Lambda</AWSProjectType>
+    <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!-- Generate ready to run images during publishing to improve cold start time. -->
+    <PublishReadyToRun>true</PublishReadyToRun>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
+  </ItemGroup>
+</Project>

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/net6/SourceGeneratorExample/aws-lambda-tools-defaults.json
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/net6/SourceGeneratorExample/aws-lambda-tools-defaults.json
@@ -1,0 +1,15 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+    "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+    "dotnet lambda help",
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+  "profile": "default",
+  "region": "us-west-2",
+  "configuration": "Release",
+  "function-runtime": "dotnet6",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "function-handler": "SourceGeneratorExample::SourceGeneratorExample.Function::FunctionHandler"
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1124

*Description of changes:*
The test tool uses reflection to call the Lambda function. This means when we get the response back from the Lambda function we get the response back as an object from the reflection API. The tool then sends the object into the ILambdaSerializer to convert the POCO into a stream. The serialize method is a generic method but since we have an object variable the generic parameter gets treated as a object instead of the actual type of the response. Using object as the generic parameter breaks the source generator based serializer because it uses the type information to look up the serialization code.

The fix is to use the reflection API on the ILambdaSerializer to turn the Serialize method into the correct generic method based on the runtime type of the Lambda response object.

The fix is in the `LambdaExecutor.cs` class. The rest of the changes are to add a test case and version bump the test tool. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
