### PR TITLE
Feature request 1279: Added http end point for executing lambda funct…

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -9,7 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="YamlDotNet.Signed" Version="5.2.1" />
 

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/LocalLambdaOptions.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/LocalLambdaOptions.cs
@@ -45,7 +45,7 @@ namespace Amazon.Lambda.TestTool
         public LambdaFunction LoadLambdaFuntion(LambdaConfigInfo configInfo, string functionHandler)
         {
             var functionInfo = configInfo.FunctionInfos.FirstOrDefault(x =>
-                string.Equals(functionHandler, x.Handler, StringComparison.OrdinalIgnoreCase));
+                string.Equals(functionHandler, functionHandler.Contains("::") ? x.Handler : x.Name, StringComparison.OrdinalIgnoreCase));
             if (functionInfo == null)
             {
                 throw new Exception($"Failed to find function {functionHandler}");

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaDefaultsConfigFileParser.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaDefaultsConfigFileParser.cs
@@ -189,12 +189,47 @@ namespace Amazon.Lambda.TestTool.Runtime
                 
                 if (handler == null) continue;
                 if (string.IsNullOrEmpty(handler)) continue;
-                
-                
+
+                var events = resourceBody.Children.ContainsKey("events") ?
+                                ((YamlSequenceNode)resourceBody.Children["events"]) : null;
+
+
+                var path = string.Empty;
+                var method = string.Empty;
+
+                if (events != null)
+                {
+                    foreach (var evt in events)
+                    {
+                        var mapping = evt as YamlMappingNode;
+                        foreach (var pair in mapping)
+                        {
+                            var keyScalar = pair.Key as YamlScalarNode;
+                            if (keyScalar?.Value == "http")
+                            {
+                                var keyValue = pair.Value as YamlMappingNode;
+                                foreach (var child in keyValue)
+                                {
+                                    var childScalar = child.Key as YamlScalarNode;
+                                    if (childScalar?.Value == "path")
+                                    {
+                                        path = child.Value.ToString();
+                                    }
+                                    if (childScalar?.Value == "method")
+                                    {
+                                        method = child.Value.ToString();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
                 var functionInfo = new LambdaFunctionInfo
                 {
                     Name = resource.Key.ToString(),
-                    Handler = handler
+                    Handler = handler,
+                    Method = method,
+                    Path = path
                 };
 
                 configInfo.FunctionInfos.Add(functionInfo);

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaFunctionInfo.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaFunctionInfo.cs
@@ -11,5 +11,15 @@
         /// The Lambda function handler string.
         /// </summary>
         public string Handler { get; set; }
+
+        /// <summary>
+        /// http path for the lambda function
+        /// </summary>
+        public string Path { get; set; }
+
+        /// <summary>
+        /// The Lambda function method name.
+        /// </summary>
+        public string Method { get; set; }
     }
 }

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Services/AwsProfileConfig.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Services/AwsProfileConfig.cs
@@ -1,0 +1,97 @@
+﻿using Amazon.Lambda.TestTool.Runtime;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace Amazon.Lambda.TestTool.Services
+{
+    public class AwsProfileConfig : IAwsProfileConfig
+    {
+        private IList<string> availableAWSProfiles;
+
+        private IList<LambdaFunction> availableFunctions;
+
+        private LambdaConfigInfo lamdaConfigInfo;
+
+        private string configFile;
+
+        private readonly LocalLambdaOptions _options;
+
+        public AwsProfileConfig(LocalLambdaOptions options)
+        {
+            _options = options;
+        }
+
+        public string ConfigFile()
+        {
+            if (string.IsNullOrEmpty(configFile))
+            {
+                if (_options.LambdaConfigFiles.Count > 0)
+                {
+                    try
+                    {
+                        configFile = _options.LambdaConfigFiles[0];
+                    }
+                    catch (Exception)
+                    {
+
+                    }
+                }
+
+            }
+            return configFile;
+        }
+
+        public LambdaConfigInfo LambdaConfigInfo()
+        {
+            if (lamdaConfigInfo == null)
+            {
+                try
+                {
+                    lamdaConfigInfo = LambdaDefaultsConfigFileParser.LoadFromFile(ConfigFile());
+
+                }
+                catch (Exception)
+                {
+
+                }
+            }
+            return lamdaConfigInfo;
+        }
+
+        public IList<LambdaFunction> AvailableFunctions()
+        {
+            if (availableFunctions == null)
+            {
+                try
+                {
+                    availableFunctions = this._options.LambdaRuntime.LoadLambdaFunctions(LambdaConfigInfo().FunctionInfos);
+
+                }
+                catch (Exception)
+                {
+
+                }
+            }
+            return availableFunctions;
+        }
+
+        public IList<string> AvailableAWSProfiles()
+        {
+            if (availableAWSProfiles == null)
+            {
+                try
+                {
+                    availableAWSProfiles = this._options.LambdaRuntime.AWSService.ListProfiles();
+
+                }
+                catch (Exception)
+                {
+
+                }
+            }
+            return availableAWSProfiles;
+        }
+    }
+}

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Services/IAwsProfileConfig.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Services/IAwsProfileConfig.cs
@@ -1,0 +1,15 @@
+﻿using Amazon.Lambda.TestTool.Runtime;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Amazon.Lambda.TestTool.Services
+{
+    public interface IAwsProfileConfig
+    {
+        string ConfigFile();
+        LambdaConfigInfo LambdaConfigInfo();
+        IList<LambdaFunction> AvailableFunctions();
+        IList<string> AvailableAWSProfiles();
+    }
+}

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Services/ILamdaService.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Services/ILamdaService.cs
@@ -1,0 +1,16 @@
+﻿using Amazon.Lambda.TestTool.Runtime;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Amazon.Lambda.TestTool.Services
+{
+    public interface ILamdaService
+    {
+        Task<ExecutionResponse> Execute(string functionName, HttpContext context, IDictionary<string, string> pathParameters);
+
+    }
+}

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Services/LamdaService.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Services/LamdaService.cs
@@ -1,0 +1,93 @@
+﻿using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.TestTool.Runtime;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Amazon.Lambda.TestTool.Services
+{
+    public class LamdaService : ILamdaService
+    {
+        private readonly LocalLambdaOptions _options;
+        private readonly IAwsProfileConfig _awsProfileConfig;
+
+        public LamdaService(LocalLambdaOptions options, IAwsProfileConfig awsProfileConfig)
+        {
+            _options = options;
+            _awsProfileConfig = awsProfileConfig;
+        }
+
+        public async Task<ExecutionResponse> Execute(string functionName, HttpContext context, IDictionary<string, string> pathParameters)
+        {
+            var awsProfile = "default";
+            var awsRegion = string.Empty;
+
+            var parameters = context.Request.Query;
+
+            using var reader = new StreamReader(context.Request.Body);
+            var body = await reader.ReadToEndAsync();
+
+            var json = body;
+
+            var configFile = _awsProfileConfig.ConfigFile();
+            var lamdaConfigInfo = _awsProfileConfig.LambdaConfigInfo();
+
+            var availableAwsProfile = _awsProfileConfig.AvailableAWSProfiles();
+
+            var availableFunctions = _awsProfileConfig.AvailableFunctions();
+            if (lamdaConfigInfo.AWSProfile != null && availableAwsProfile.Contains(lamdaConfigInfo.AWSProfile))
+            {
+                awsProfile = lamdaConfigInfo.AWSProfile;
+            }
+
+            if (!string.IsNullOrEmpty(lamdaConfigInfo.AWSRegion))
+            {
+                awsRegion = lamdaConfigInfo.AWSRegion;
+            };
+
+            var dictParameters = context.Request.Query.ToDictionary(item => item.Key.ToString(), item => item.Value.ToString());
+            var headers = context.Request.Headers.ToDictionary(item => item.Key.ToString(), item => item.Value.ToString());
+
+            var payload = GetPayload(pathParameters, dictParameters, json, headers, context.Request.Method);
+
+            var function = this._options.LoadLambdaFuntion(configFile, functionName);
+            var request = new ExecutionRequest()
+            {
+                Function = function,
+                AWSProfile = awsProfile,
+                AWSRegion = awsRegion,
+                Payload = payload
+            };
+            var response = await _options.LambdaRuntime.ExecuteLambdaFunctionAsync(request);
+
+            return response;
+        }
+
+        private string GetPayload(IDictionary<string, string> pathParameters, IDictionary<string, string> queryParameters, string json, IDictionary<string, string> headers, string httpMethod)
+        {
+            //APIGatewayProxyRequest APIGatewayProxyResponse
+            var authorizer = new APIGatewayCustomAuthorizerContext();
+            authorizer.Add("principalId", 3);
+            var request = new APIGatewayProxyRequest
+            {
+                Body = json,
+                Headers = headers,
+                HttpMethod = httpMethod,
+                PathParameters = pathParameters,
+                Path = "/path/to/resource",
+                QueryStringParameters = queryParameters,
+                RequestContext = new APIGatewayProxyRequest.ProxyRequestContext
+                {
+                    Authorizer = authorizer
+                }
+            };
+            var response = JsonConvert.SerializeObject(request);
+            return response;
+        }
+    }
+}


### PR DESCRIPTION
Reg feature request 1279, this PR contains the code which would enable this tool to have the feature where `Lambda functions` can be called through `http` also. So instead of using the web page provided by this tool and clicking on `Execute` button, users can also use `postman` or some other `services` in their `echo system` to call `Lambda functions` using `http`. This would be similar to calling `web api` end point in `.net`

*Issue #, [Feature Request 1279:](https://github.com/aws/aws-lambda-dotnet/issues/1279)*

*Description of changes:*
Ability to accept `http route path` configured in `serverless.yml` file and calling the corresponding `Lambda function`.
Able to read all type of `parameters` like `query`, `path` and `body` and pass it to `Lambda function`.
Able to accept `http verbs` `GET`, `POST`, `PUT` and `DELETE`. Whatever is configured in `serverless.yml` file, this tool can accept that `request`
No change has been done in the existing functionality

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
