### PR TITLE
docs: update aspnetcorewebapi and F# readme to reference appsettings.…

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2017/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2017/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -10,7 +10,7 @@ This project shows how to run an ASP.NET Core Web API project as an AWS Lambda e
 * LambdaEntryPoint.fs - type that derives from **Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction**. The code in this file bootstraps the ASP.NET Core hosting framework. The Lambda function is defined in the base class.
 * LocalEntryPoint.fs - for local development this contains the executable Main function which bootstraps the ASP.NET Core hosting framework with Kestrel, as for typical ASP.NET Core applications.
 * Startup.fs - usual ASP.NET Core Startup type used to configure the services ASP.NET Core will use.
-* web.config - used for local development.
+* appsettings.json - used for local development.
 * Controllers\ValuesController.fs - example Web API controller
 
 You may also have a test project depending on the options selected.

--- a/Blueprints/BlueprintDefinitions/vs2017/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2017/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/Readme.md
@@ -35,7 +35,7 @@ Change the base class to **Amazon.Lambda.AspNetCoreServer.ApplicationLoadBalance
 Application Load Balancer.
 * LocalEntryPoint.cs - for local development this contains the executable Main function which bootstraps the ASP.NET Core hosting framework with Kestrel, as for typical ASP.NET Core applications.
 * Startup.cs - usual ASP.NET Core Startup class used to configure the services ASP.NET Core will use.
-* web.config - used for local development.
+* appsettings.json - used for local development.
 * Controllers\S3ProxyController - Web API controller for proxying an S3 bucket
 * Controllers\ValuesController - example Web API controller
 

--- a/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -10,7 +10,7 @@ This project shows how to run an ASP.NET Core Web API project as an AWS Lambda e
 * LambdaEntryPoint.fs - type that derives from **Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction**. The code in this file bootstraps the ASP.NET Core hosting framework. The Lambda function is defined in the base class.
 * LocalEntryPoint.fs - for local development this contains the executable Main function which bootstraps the ASP.NET Core hosting framework with Kestrel, as for typical ASP.NET Core applications.
 * Startup.fs - usual ASP.NET Core Startup type used to configure the services ASP.NET Core will use.
-* web.config - used for local development.
+* appsettings.json - used for local development.
 * Controllers\ValuesController.fs - example Web API controller
 
 You may also have a test project depending on the options selected.

--- a/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/Readme.md
@@ -31,7 +31,7 @@ Change the base class to **Amazon.Lambda.AspNetCoreServer.ApplicationLoadBalance
 Application Load Balancer.
 * LocalEntryPoint.cs - for local development this contains the executable Main function which bootstraps the ASP.NET Core hosting framework with Kestrel, as for typical ASP.NET Core applications.
 * Startup.cs - usual ASP.NET Core Startup class used to configure the services ASP.NET Core will use.
-* web.config - used for local development.
+* appsettings.json - used for local development.
 * Controllers\ValuesController - example Web API controller
 
 You may also have a test project depending on the options selected.

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -10,7 +10,7 @@ This project shows how to run an ASP.NET Core Web API project as an AWS Lambda e
 * LambdaEntryPoint.fs - type that derives from **Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction**. The code in this file bootstraps the ASP.NET Core hosting framework. The Lambda function is defined in the base class.
 * LocalEntryPoint.fs - for local development this contains the executable Main function which bootstraps the ASP.NET Core hosting framework with Kestrel, as for typical ASP.NET Core applications.
 * Startup.fs - usual ASP.NET Core Startup type used to configure the services ASP.NET Core will use.
-* web.config - used for local development.
+* appsettings.json - used for local development.
 * Controllers\ValuesController.fs - example Web API controller
 
 You may also have a test project depending on the options selected.

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/Readme.md
@@ -31,7 +31,7 @@ Change the base class to **Amazon.Lambda.AspNetCoreServer.ApplicationLoadBalance
 Application Load Balancer.
 * LocalEntryPoint.cs - for local development this contains the executable Main function which bootstraps the ASP.NET Core hosting framework with Kestrel, as for typical ASP.NET Core applications.
 * Startup.cs - usual ASP.NET Core Startup class used to configure the services ASP.NET Core will use.
-* web.config - used for local development.
+* appsettings.json - used for local development.
 * Controllers\ValuesController - example Web API controller
 
 You may also have a test project depending on the options selected.


### PR DESCRIPTION
…json

*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1299

*Description of changes:*
Change README.md in AspNetCoreWebAPI and AspNetCoreWebApiF# to reference appsettings.json instead of web.config

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
