### PR TITLE
Adds metadata to KinesisFirehose response record to support dynamic partitioning 

### DIFF
--- a/Libraries/src/Amazon.Lambda.KinesisFirehoseEvents/KinesisFirehoseResponse.cs
+++ b/Libraries/src/Amazon.Lambda.KinesisFirehoseEvents/KinesisFirehoseResponse.cs
@@ -93,6 +93,16 @@ namespace Amazon.Lambda.KinesisFirehoseEvents
             public string Base64EncodedData { get; set; }
 
             /// <summary>
+            /// The response record metadata.
+            /// </summary>
+            [DataMember(Name = "metadata")]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("metadata")]
+#endif
+            public FirehoseResponseRecordMetadata Metadata { get; set; }
+
+
+            /// <summary>
             /// Base64 encodes the data and sets the Base64EncodedData property.
             /// </summary>
             /// <param name="data">The data to be base64 encoded.</param>
@@ -100,6 +110,23 @@ namespace Amazon.Lambda.KinesisFirehoseEvents
             {
                 this.Base64EncodedData = Convert.ToBase64String(Encoding.UTF8.GetBytes(data));
             }
+        }
+
+        /// <summary>
+        /// The response record metadata after processing KinesisFirehoseEvent.Records
+        /// </summary>
+        [DataContract]
+        public class FirehoseResponseRecordMetadata
+        {
+            /// <summary>
+            /// Key Value pairs used for Dynamic Partitioning
+            /// https://docs.aws.amazon.com/firehose/latest/dev/dynamic-partitioning.html
+            /// </summary>
+            [DataMember(Name = "partitionKeys")]
+#if NETCOREAPP_3_1
+            [System.Text.Json.Serialization.JsonPropertyName("partitionKeys")]
+#endif
+            public Dictionary<string, string> PartitionKeys { get; set; }
         }
     }
 }

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -1559,7 +1559,8 @@ namespace Amazon.Lambda.Tests
                 Assert.Equal("49572672223665514422805246926656954630972486059535892482", kinesisResponse.Records[0].RecordId);
                 Assert.Equal(KinesisFirehoseResponse.TRANSFORMED_STATE_OK, kinesisResponse.Records[0].Result);
                 Assert.Equal("SEVMTE8gV09STEQ=", kinesisResponse.Records[0].Base64EncodedData);
-
+                Assert.Equal("iamValue1", kinesisResponse.Records[0].Metadata.PartitionKeys["iamKey1"]);
+                Assert.Equal("iamValue2", kinesisResponse.Records[0].Metadata.PartitionKeys["iamKey2"]);
 
 
                 MemoryStream ms = new MemoryStream();

--- a/Libraries/test/EventsTests.Shared/kinesis-firehose-response.json
+++ b/Libraries/test/EventsTests.Shared/kinesis-firehose-response.json
@@ -3,7 +3,13 @@
     {
       "recordId": "49572672223665514422805246926656954630972486059535892482",
       "result": "Ok",
-      "data": "SEVMTE8gV09STEQ="
+      "data": "SEVMTE8gV09STEQ=",
+      "metadata": {
+        "partitionKeys": {
+          "iamKey1": "iamValue1",
+          "iamKey2": "iamValue2"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Fixes https://github.com/aws/aws-lambda-dotnet/issues/1345

Adds metadata to KinesisFirehose response record to support dynamic partitioning https://docs.aws.amazon.com/firehose/latest/dev/dynamic-partitioning.html


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
