### PR TITLE
Update blueprints to latest dependencies

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2017/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
     <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.2.0" />
   </ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.9.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -43,7 +43,7 @@ type Function(s3Client: IAmazonS3, rekognitionClient: IAmazonRekognition, minCon
     /// <param name="context"></param>
     /// <returns></returns>
     member __.FunctionHandler (input: S3Event) (context: ILambdaContext) =
-        let isSupportedImageType (record: S3EventNotification.S3EventNotificationRecord) =
+        let isSupportedImageType (record: S3Event.S3EventNotificationRecord) =
             match Set.contains (Path.GetExtension record.S3.Object.Key) supportedImageTypes with
             | true -> true
             | false ->
@@ -51,7 +51,7 @@ type Function(s3Client: IAmazonS3, rekognitionClient: IAmazonRekognition, minCon
                 |> context.Logger.LogLine
                 false
 
-        let processRecordAsync (record: S3EventNotification.S3EventNotificationRecord) (context: ILambdaContext) = async {
+        let processRecordAsync (record: S3Event.S3EventNotificationRecord) (context: ILambdaContext) = async {
             sprintf "Looking for labels in image %s:%s" record.S3.Bucket.Name record.S3.Object.Key
             |> context.Logger.LogLine
 

--- a/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabels-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
+++ b/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabels-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
@@ -37,10 +37,10 @@ module FunctionTest =
                 |> Async.AwaitTask
 
             let eventRecords = [
-                S3EventNotification.S3EventNotificationRecord(
-                    S3 = S3EventNotification.S3Entity(
-                        Bucket = S3EventNotification.S3BucketEntity (Name = bucketName),
-                        Object = S3EventNotification.S3ObjectEntity (Key = fileName)
+                S3Event.S3EventNotificationRecord(
+                    S3 = S3Event.S3Entity(
+                        Bucket = S3Event.S3BucketEntity (Name = bucketName),
+                        Object = S3Event.S3ObjectEntity (Key = fileName)
                     )
                 )
             ]

--- a/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabels/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabels/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.9.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabels/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabels/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
@@ -42,14 +42,14 @@ namespace BlueprintBaseName._1.Tests
                 // the bucket was configured as an event source.
                 var s3Event = new S3Event
                 {
-                    Records = new List<S3EventNotification.S3EventNotificationRecord>
+                    Records = new List<S3Event.S3EventNotificationRecord>
                     {
-                        new S3EventNotification.S3EventNotificationRecord
+                        new S3Event.S3EventNotificationRecord
                         {
-                            S3 = new S3EventNotification.S3Entity
+                            S3 = new S3Event.S3Entity
                             {
-                                Bucket = new S3EventNotification.S3BucketEntity {Name = bucketName },
-                                Object = new S3EventNotification.S3ObjectEntity {Key = fileName }
+                                Bucket = new S3Event.S3BucketEntity {Name = bucketName },
+                                Object = new S3Event.S3ObjectEntity {Key = fileName }
                             }
                         }
                     }

--- a/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.9.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -43,7 +43,7 @@ type Function(s3Client: IAmazonS3, rekognitionClient: IAmazonRekognition, minCon
     /// <param name="context"></param>
     /// <returns></returns>
     member __.FunctionHandler (input: S3Event) (context: ILambdaContext) =
-        let isSupportedImageType (record: S3EventNotification.S3EventNotificationRecord) =
+        let isSupportedImageType (record: S3Event.S3EventNotificationRecord) =
             match Set.contains (Path.GetExtension record.S3.Object.Key) supportedImageTypes with
             | true -> true
             | false ->
@@ -51,7 +51,7 @@ type Function(s3Client: IAmazonS3, rekognitionClient: IAmazonRekognition, minCon
                 |> context.Logger.LogLine
                 false
 
-        let processRecordAsync (record: S3EventNotification.S3EventNotificationRecord) (context: ILambdaContext) = async {
+        let processRecordAsync (record: S3Event.S3EventNotificationRecord) (context: ILambdaContext) = async {
             sprintf "Looking for labels in image %s:%s" record.S3.Bucket.Name record.S3.Object.Key
             |> context.Logger.LogLine
 

--- a/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
+++ b/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
@@ -37,10 +37,10 @@ module FunctionTest =
                 |> Async.AwaitTask
 
             let eventRecords = [
-                S3EventNotification.S3EventNotificationRecord(
-                    S3 = S3EventNotification.S3Entity(
-                        Bucket = S3EventNotification.S3BucketEntity (Name = bucketName),
-                        Object = S3EventNotification.S3ObjectEntity (Key = fileName)
+                S3Event.S3EventNotificationRecord(
+                    S3 = S3Event.S3Entity(
+                        Bucket = S3Event.S3BucketEntity (Name = bucketName),
+                        Object = S3Event.S3ObjectEntity (Key = fileName)
                     )
                 )
             ]

--- a/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.9.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
@@ -42,14 +42,14 @@ namespace BlueprintBaseName._1.Tests
                 // the bucket was configured as an event source.
                 var s3Event = new S3Event
                 {
-                    Records = new List<S3EventNotification.S3EventNotificationRecord>
+                    Records = new List<S3Event.S3EventNotificationRecord>
                     {
-                        new S3EventNotification.S3EventNotificationRecord
+                        new S3Event.S3EventNotificationRecord
                         {
-                            S3 = new S3EventNotification.S3Entity
+                            S3 = new S3Event.S3Entity
                             {
-                                Bucket = new S3EventNotification.S3BucketEntity {Name = bucketName },
-                                Object = new S3EventNotification.S3ObjectEntity {Key = fileName }
+                                Bucket = new S3Event.S3BucketEntity {Name = bucketName },
+                                Object = new S3Event.S3ObjectEntity {Key = fileName }
                             }
                         }
                     }

--- a/Blueprints/BlueprintDefinitions/vs2017/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,7 +7,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.64" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.64" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.64" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.64" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.64" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -24,7 +24,7 @@ type Function(s3Client: IAmazonS3) =
     /// <param name="context"></param>
     /// <returns></returns>
     member __.FunctionHandler (event: S3Event) (context: ILambdaContext) =
-        let fetchContentType (s3Event: S3EventNotification.S3Entity) = async {
+        let fetchContentType (s3Event: S3Event.S3Entity) = async {
             sprintf "Processing object %s from bucket %s" s3Event.Object.Key s3Event.Bucket.Name
             |> context.Logger.LogLine
 

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
@@ -38,10 +38,10 @@ module FunctionTest =
                 |> Async.AwaitTask
 
             let eventRecords = [
-                S3EventNotification.S3EventNotificationRecord(
-                    S3 = S3EventNotification.S3Entity(
-                        Bucket = S3EventNotification.S3BucketEntity (Name = bucketName),
-                        Object = S3EventNotification.S3ObjectEntity (Key = key)
+                S3Event.S3EventNotificationRecord(
+                    S3 = S3Event.S3Entity(
+                        Bucket = S3Event.S3BucketEntity (Name = bucketName),
+                        Object = S3Event.S3ObjectEntity (Key = key)
                     )
                 )
             ]

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
@@ -42,14 +42,14 @@ namespace BlueprintBaseName._1.Tests
                 // Setup the S3 event object that S3 notifications would create with the fields used by the Lambda function.
                 var s3Event = new S3Event
                 {
-                    Records = new List<S3EventNotification.S3EventNotificationRecord>
+                    Records = new List<S3Event.S3EventNotificationRecord>
                     {
-                        new S3EventNotification.S3EventNotificationRecord
+                        new S3Event.S3EventNotificationRecord
                         {
-                            S3 = new S3EventNotification.S3Entity
+                            S3 = new S3Event.S3Entity
                             {
-                                Bucket = new S3EventNotification.S3BucketEntity {Name = bucketName },
-                                Object = new S3EventNotification.S3ObjectEntity {Key = key }
+                                Bucket = new S3Event.S3BucketEntity {Name = bucketName },
+                                Object = new S3Event.S3ObjectEntity {Key = key }
                             }
                         }
                     }

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -24,7 +24,7 @@ type Function(s3Client: IAmazonS3) =
     /// <param name="context"></param>
     /// <returns></returns>
     member __.FunctionHandler (event: S3Event) (context: ILambdaContext) =
-        let fetchContentType (s3Event: S3EventNotification.S3Entity) = async {
+        let fetchContentType (s3Event: S3Event.S3Entity) = async {
             sprintf "Processing object %s from bucket %s" s3Event.Object.Key s3Event.Bucket.Name
             |> context.Logger.LogLine
 

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
@@ -38,10 +38,10 @@ module FunctionTest =
                 |> Async.AwaitTask
 
             let eventRecords = [
-                S3EventNotification.S3EventNotificationRecord(
-                    S3 = S3EventNotification.S3Entity(
-                        Bucket = S3EventNotification.S3BucketEntity (Name = bucketName),
-                        Object = S3EventNotification.S3ObjectEntity (Key = key)
+                S3Event.S3EventNotificationRecord(
+                    S3 = S3Event.S3Entity(
+                        Bucket = S3Event.S3BucketEntity (Name = bucketName),
+                        Object = S3Event.S3ObjectEntity (Key = key)
                     )
                 )
             ]

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
@@ -42,14 +42,14 @@ namespace BlueprintBaseName._1.Tests
                 // Setup the S3 event object that S3 notifications would create with the fields used by the Lambda function.
                 var s3Event = new S3Event
                 {
-                    Records = new List<S3EventNotification.S3EventNotificationRecord>
+                    Records = new List<S3Event.S3EventNotificationRecord>
                     {
-                        new S3EventNotification.S3EventNotificationRecord
+                        new S3Event.S3EventNotificationRecord
                         {
-                            S3 = new S3EventNotification.S3Entity
+                            S3 = new S3Event.S3Entity
                             {
-                                Bucket = new S3EventNotification.S3BucketEntity {Name = bucketName },
-                                Object = new S3EventNotification.S3ObjectEntity {Key = key }
+                                Bucket = new S3Event.S3BucketEntity {Name = bucketName },
+                                Object = new S3Event.S3ObjectEntity {Key = key }
                             }
                         }
                     }

--- a/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.9.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -43,7 +43,7 @@ type Function(s3Client: IAmazonS3, rekognitionClient: IAmazonRekognition, minCon
     /// <param name="context"></param>
     /// <returns></returns>
     member __.FunctionHandler (input: S3Event) (context: ILambdaContext) =
-        let isSupportedImageType (record: S3EventNotification.S3EventNotificationRecord) =
+        let isSupportedImageType (record: S3Event.S3EventNotificationRecord) =
             match Set.contains (Path.GetExtension record.S3.Object.Key) supportedImageTypes with
             | true -> true
             | false ->
@@ -51,7 +51,7 @@ type Function(s3Client: IAmazonS3, rekognitionClient: IAmazonRekognition, minCon
                 |> context.Logger.LogLine
                 false
 
-        let processRecordAsync (record: S3EventNotification.S3EventNotificationRecord) (context: ILambdaContext) = async {
+        let processRecordAsync (record: S3Event.S3EventNotificationRecord) (context: ILambdaContext) = async {
             sprintf "Looking for labels in image %s:%s" record.S3.Bucket.Name record.S3.Object.Key
             |> context.Logger.LogLine
 

--- a/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabels-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
+++ b/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabels-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
@@ -37,10 +37,10 @@ module FunctionTest =
                 |> Async.AwaitTask
 
             let eventRecords = [
-                S3EventNotification.S3EventNotificationRecord(
-                    S3 = S3EventNotification.S3Entity(
-                        Bucket = S3EventNotification.S3BucketEntity (Name = bucketName),
-                        Object = S3EventNotification.S3ObjectEntity (Key = fileName)
+                S3Event.S3EventNotificationRecord(
+                    S3 = S3Event.S3Entity(
+                        Bucket = S3Event.S3BucketEntity (Name = bucketName),
+                        Object = S3Event.S3ObjectEntity (Key = fileName)
                     )
                 )
             ]

--- a/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabels/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabels/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.9.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabels/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabels/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
@@ -42,14 +42,14 @@ namespace BlueprintBaseName._1.Tests
                 // the bucket was configured as an event source.
                 var s3Event = new S3Event
                 {
-                    Records = new List<S3EventNotification.S3EventNotificationRecord>
+                    Records = new List<S3Event.S3EventNotificationRecord>
                     {
-                        new S3EventNotification.S3EventNotificationRecord
+                        new S3Event.S3EventNotificationRecord
                         {
-                            S3 = new S3EventNotification.S3Entity
+                            S3 = new S3Event.S3Entity
                             {
-                                Bucket = new S3EventNotification.S3BucketEntity {Name = bucketName },
-                                Object = new S3EventNotification.S3ObjectEntity {Key = fileName }
+                                Bucket = new S3Event.S3BucketEntity {Name = bucketName },
+                                Object = new S3Event.S3ObjectEntity {Key = fileName }
                             }
                         }
                     }

--- a/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.9.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -43,7 +43,7 @@ type Function(s3Client: IAmazonS3, rekognitionClient: IAmazonRekognition, minCon
     /// <param name="context"></param>
     /// <returns></returns>
     member __.FunctionHandler (input: S3Event) (context: ILambdaContext) =
-        let isSupportedImageType (record: S3EventNotification.S3EventNotificationRecord) =
+        let isSupportedImageType (record: S3Event.S3EventNotificationRecord) =
             match Set.contains (Path.GetExtension record.S3.Object.Key) supportedImageTypes with
             | true -> true
             | false ->
@@ -51,7 +51,7 @@ type Function(s3Client: IAmazonS3, rekognitionClient: IAmazonRekognition, minCon
                 |> context.Logger.LogLine
                 false
 
-        let processRecordAsync (record: S3EventNotification.S3EventNotificationRecord) (context: ILambdaContext) = async {
+        let processRecordAsync (record: S3Event.S3EventNotificationRecord) (context: ILambdaContext) = async {
             sprintf "Looking for labels in image %s:%s" record.S3.Bucket.Name record.S3.Object.Key
             |> context.Logger.LogLine
 

--- a/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
+++ b/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
@@ -37,10 +37,10 @@ module FunctionTest =
                 |> Async.AwaitTask
 
             let eventRecords = [
-                S3EventNotification.S3EventNotificationRecord(
-                    S3 = S3EventNotification.S3Entity(
-                        Bucket = S3EventNotification.S3BucketEntity (Name = bucketName),
-                        Object = S3EventNotification.S3ObjectEntity (Key = fileName)
+                S3Event.S3EventNotificationRecord(
+                    S3 = S3Event.S3Entity(
+                        Bucket = S3Event.S3BucketEntity (Name = bucketName),
+                        Object = S3Event.S3ObjectEntity (Key = fileName)
                     )
                 )
             ]

--- a/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.9.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
@@ -42,14 +42,14 @@ namespace BlueprintBaseName._1.Tests
                 // the bucket was configured as an event source.
                 var s3Event = new S3Event
                 {
-                    Records = new List<S3EventNotification.S3EventNotificationRecord>
+                    Records = new List<S3Event.S3EventNotificationRecord>
                     {
-                        new S3EventNotification.S3EventNotificationRecord
+                        new S3Event.S3EventNotificationRecord
                         {
-                            S3 = new S3EventNotification.S3Entity
+                            S3 = new S3Event.S3Entity
                             {
-                                Bucket = new S3EventNotification.S3BucketEntity {Name = bucketName },
-                                Object = new S3EventNotification.S3ObjectEntity {Key = fileName }
+                                Bucket = new S3Event.S3BucketEntity {Name = bucketName },
+                                Object = new S3Event.S3ObjectEntity {Key = fileName }
                             }
                         }
                     }

--- a/Blueprints/BlueprintDefinitions/vs2019/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,7 +7,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.64" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.64" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.64" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.64" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.64" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -24,7 +24,7 @@ type Function(s3Client: IAmazonS3) =
     /// <param name="context"></param>
     /// <returns></returns>
     member __.FunctionHandler (event: S3Event) (context: ILambdaContext) =
-        let fetchContentType (s3Event: S3EventNotification.S3Entity) = async {
+        let fetchContentType (s3Event: S3Event.S3Entity) = async {
             sprintf "Processing object %s from bucket %s" s3Event.Object.Key s3Event.Bucket.Name
             |> context.Logger.LogLine
 

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
@@ -38,10 +38,10 @@ module FunctionTest =
                 |> Async.AwaitTask
 
             let eventRecords = [
-                S3EventNotification.S3EventNotificationRecord(
-                    S3 = S3EventNotification.S3Entity(
-                        Bucket = S3EventNotification.S3BucketEntity (Name = bucketName),
-                        Object = S3EventNotification.S3ObjectEntity (Key = key)
+                S3Event.S3EventNotificationRecord(
+                    S3 = S3Event.S3Entity(
+                        Bucket = S3Event.S3BucketEntity (Name = bucketName),
+                        Object = S3Event.S3ObjectEntity (Key = key)
                     )
                 )
             ]

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
@@ -42,14 +42,14 @@ namespace BlueprintBaseName._1.Tests
                 // Setup the S3 event object that S3 notifications would create with the fields used by the Lambda function.
                 var s3Event = new S3Event
                 {
-                    Records = new List<S3EventNotification.S3EventNotificationRecord>
+                    Records = new List<S3Event.S3EventNotificationRecord>
                     {
-                        new S3EventNotification.S3EventNotificationRecord
+                        new S3Event.S3EventNotificationRecord
                         {
-                            S3 = new S3EventNotification.S3Entity
+                            S3 = new S3Event.S3Entity
                             {
-                                Bucket = new S3EventNotification.S3BucketEntity {Name = bucketName },
-                                Object = new S3EventNotification.S3ObjectEntity {Key = key }
+                                Bucket = new S3Event.S3BucketEntity {Name = bucketName },
+                                Object = new S3Event.S3ObjectEntity {Key = key }
                             }
                         }
                     }

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -24,7 +24,7 @@ type Function(s3Client: IAmazonS3) =
     /// <param name="context"></param>
     /// <returns></returns>
     member __.FunctionHandler (event: S3Event) (context: ILambdaContext) =
-        let fetchContentType (s3Event: S3EventNotification.S3Entity) = async {
+        let fetchContentType (s3Event: S3Event.S3Entity) = async {
             sprintf "Processing object %s from bucket %s" s3Event.Object.Key s3Event.Bucket.Name
             |> context.Logger.LogLine
 

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
@@ -38,10 +38,10 @@ module FunctionTest =
                 |> Async.AwaitTask
 
             let eventRecords = [
-                S3EventNotification.S3EventNotificationRecord(
-                    S3 = S3EventNotification.S3Entity(
-                        Bucket = S3EventNotification.S3BucketEntity (Name = bucketName),
-                        Object = S3EventNotification.S3ObjectEntity (Key = key)
+                S3Event.S3EventNotificationRecord(
+                    S3 = S3Event.S3Entity(
+                        Bucket = S3Event.S3BucketEntity (Name = bucketName),
+                        Object = S3Event.S3ObjectEntity (Key = key)
                     )
                 )
             ]

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
@@ -42,14 +42,14 @@ namespace BlueprintBaseName._1.Tests
                 // Setup the S3 event object that S3 notifications would create with the fields used by the Lambda function.
                 var s3Event = new S3Event
                 {
-                    Records = new List<S3EventNotification.S3EventNotificationRecord>
+                    Records = new List<S3Event.S3EventNotificationRecord>
                     {
-                        new S3EventNotification.S3EventNotificationRecord
+                        new S3Event.S3EventNotificationRecord
                         {
-                            S3 = new S3EventNotification.S3Entity
+                            S3 = new S3Event.S3Entity
                             {
-                                Bucket = new S3EventNotification.S3BucketEntity {Name = bucketName },
-                                Object = new S3EventNotification.S3ObjectEntity {Key = key }
+                                Bucket = new S3Event.S3BucketEntity {Name = bucketName },
+                                Object = new S3Event.S3ObjectEntity {Key = key }
                             }
                         }
                     }

--- a/Blueprints/BlueprintDefinitions/vs2019/WebSocketAPIServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/WebSocketAPIServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
-    <PackageReference Include="AWSSDK.ApiGatewayManagementApi" Version="3.7.0.189" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.64" />
+    <PackageReference Include="AWSSDK.ApiGatewayManagementApi" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -15,6 +15,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
-    <PackageReference Include="Amazon.Lambda.Annotations" Version="0.6.0-preview" />
+    <PackageReference Include="Amazon.Lambda.Annotations" Version="0.9.0-preview" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -9,8 +9,8 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.9.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -44,7 +44,7 @@ type Function(s3Client: IAmazonS3, rekognitionClient: IAmazonRekognition, minCon
     /// <returns></returns>
     member __.FunctionHandler (input: S3Event) (context: ILambdaContext) = task {
 
-        let isSupportedImageType (record: S3EventNotification.S3EventNotificationRecord) =
+        let isSupportedImageType (record: S3Event.S3EventNotificationRecord) =
             match Set.contains (Path.GetExtension record.S3.Object.Key) supportedImageTypes with
             | true -> true
             | false ->
@@ -52,7 +52,7 @@ type Function(s3Client: IAmazonS3, rekognitionClient: IAmazonRekognition, minCon
                 |> context.Logger.LogInformation
                 false
 
-        let processRecordAsync (record: S3EventNotification.S3EventNotificationRecord) (context: ILambdaContext) = task {
+        let processRecordAsync (record: S3Event.S3EventNotificationRecord) (context: ILambdaContext) = task {
             sprintf "Looking for labels in image %s:%s" record.S3.Bucket.Name record.S3.Object.Key
             |> context.Logger.LogInformation
 

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
@@ -36,10 +36,10 @@ module FunctionTest =
                 |> Async.AwaitTask
 
             let eventRecords = [
-                S3EventNotification.S3EventNotificationRecord(
-                    S3 = S3EventNotification.S3Entity(
-                        Bucket = S3EventNotification.S3BucketEntity (Name = bucketName),
-                        Object = S3EventNotification.S3ObjectEntity (Key = fileName)
+                S3Event.S3EventNotificationRecord(
+                    S3 = S3Event.S3Entity(
+                        Bucket = S3Event.S3BucketEntity (Name = bucketName),
+                        Object = S3Event.S3ObjectEntity (Key = fileName)
                     )
                 )
             ]

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -11,8 +11,8 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.9.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
@@ -36,14 +36,14 @@ public class FunctionTest
             // the bucket was configured as an event source.
             var s3Event = new S3Event
             {
-                Records = new List<S3EventNotification.S3EventNotificationRecord>
+                Records = new List<S3Event.S3EventNotificationRecord>
                 {
-                    new S3EventNotification.S3EventNotificationRecord
+                    new S3Event.S3EventNotificationRecord
                     {
-                        S3 = new S3EventNotification.S3Entity
+                        S3 = new S3Event.S3Entity
                         {
-                            Bucket = new S3EventNotification.S3BucketEntity {Name = bucketName },
-                            Object = new S3EventNotification.S3ObjectEntity {Key = fileName }
+                            Bucket = new S3Event.S3BucketEntity {Name = bucketName },
+                            Object = new S3Event.S3ObjectEntity {Key = fileName }
                         }
                     }
                 }

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -9,8 +9,8 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.9.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -43,7 +43,7 @@ type Function(s3Client: IAmazonS3, rekognitionClient: IAmazonRekognition, minCon
     /// <returns></returns>
     member __.FunctionHandler (input: S3Event) (context: ILambdaContext) = task {
 
-        let isSupportedImageType (record: S3EventNotification.S3EventNotificationRecord) =
+        let isSupportedImageType (record: S3Event.S3EventNotificationRecord) =
             match Set.contains (Path.GetExtension record.S3.Object.Key) supportedImageTypes with
             | true -> true
             | false ->
@@ -51,7 +51,7 @@ type Function(s3Client: IAmazonS3, rekognitionClient: IAmazonRekognition, minCon
                 |> context.Logger.LogInformation
                 false
 
-        let processRecordAsync (record: S3EventNotification.S3EventNotificationRecord) (context: ILambdaContext) = task {
+        let processRecordAsync (record: S3Event.S3EventNotificationRecord) (context: ILambdaContext) = task {
             sprintf "Looking for labels in image %s:%s" record.S3.Bucket.Name record.S3.Object.Key
             |> context.Logger.LogInformation
 

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
@@ -36,10 +36,10 @@ module FunctionTest =
                 |> Async.AwaitTask
 
             let eventRecords = [
-                S3EventNotification.S3EventNotificationRecord(
-                    S3 = S3EventNotification.S3Entity(
-                        Bucket = S3EventNotification.S3BucketEntity (Name = bucketName),
-                        Object = S3EventNotification.S3ObjectEntity (Key = fileName)
+                S3Event.S3EventNotificationRecord(
+                    S3 = S3Event.S3Entity(
+                        Bucket = S3Event.S3BucketEntity (Name = bucketName),
+                        Object = S3Event.S3ObjectEntity (Key = fileName)
                     )
                 )
             ]

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -11,8 +11,8 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.9.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
@@ -36,14 +36,14 @@ public class FunctionTest
             // the bucket was configured as an event source.
             var s3Event = new S3Event
             {
-                Records = new List<S3EventNotification.S3EventNotificationRecord>
+                Records = new List<S3Event.S3EventNotificationRecord>
                 {
-                    new S3EventNotification.S3EventNotificationRecord
+                    new S3Event.S3EventNotificationRecord
                     {
-                        S3 = new S3EventNotification.S3Entity
+                        S3 = new S3Event.S3Entity
                         {
-                            Bucket = new S3EventNotification.S3BucketEntity {Name = bucketName },
-                            Object = new S3EventNotification.S3ObjectEntity {Key = fileName }
+                            Bucket = new S3Event.S3BucketEntity {Name = bucketName },
+                            Object = new S3Event.S3ObjectEntity {Key = fileName }
                         }
                     }
                 }

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.64" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.64" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -14,6 +14,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.64" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.64" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
@@ -38,10 +38,10 @@ module FunctionTest =
                 |> Async.AwaitTask
 
             let eventRecords = [
-                S3EventNotification.S3EventNotificationRecord(
-                    S3 = S3EventNotification.S3Entity(
-                        Bucket = S3EventNotification.S3BucketEntity (Name = bucketName),
-                        Object = S3EventNotification.S3ObjectEntity (Key = key)
+                S3Event.S3EventNotificationRecord(
+                    S3 = S3Event.S3Entity(
+                        Bucket = S3Event.S3BucketEntity (Name = bucketName),
+                        Object = S3Event.S3ObjectEntity (Key = key)
                     )
                 )
             ]

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -14,6 +14,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
@@ -8,6 +8,7 @@ using Amazon;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Amazon.S3.Util;
+using System.Collections.Generic;
 
 namespace BlueprintBaseName._1.Tests;
 
@@ -35,14 +36,14 @@ public class FunctionTest
             // Setup the S3 event object that S3 notifications would create with the fields used by the Lambda function.
             var s3Event = new S3Event
             {
-                Records = new List<S3EventNotification.S3EventNotificationRecord>
+                Records = new List<S3Event.S3EventNotificationRecord>
                 {
-                    new S3EventNotification.S3EventNotificationRecord
+                    new S3Event.S3EventNotificationRecord
                     {
-                        S3 = new S3EventNotification.S3Entity
+                        S3 = new S3Event.S3Entity
                         {
-                            Bucket = new S3EventNotification.S3BucketEntity {Name = bucketName },
-                            Object = new S3EventNotification.S3ObjectEntity {Key = key }
+                            Bucket = new S3Event.S3BucketEntity {Name = bucketName },
+                            Object = new S3Event.S3ObjectEntity {Key = key }
                         }
                     }
                 }

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
@@ -37,10 +37,10 @@ module FunctionTest =
                 |> Async.AwaitTask
 
             let eventRecords = [
-                S3EventNotification.S3EventNotificationRecord(
-                    S3 = S3EventNotification.S3Entity(
-                        Bucket = S3EventNotification.S3BucketEntity (Name = bucketName),
-                        Object = S3EventNotification.S3ObjectEntity (Key = key)
+                S3Event.S3EventNotificationRecord(
+                    S3 = S3Event.S3Entity(
+                        Bucket = S3Event.S3BucketEntity (Name = bucketName),
+                        Object = S3Event.S3ObjectEntity (Key = key)
                     )
                 )
             ]

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -14,6 +14,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.35" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
@@ -8,6 +8,7 @@ using Amazon;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Amazon.S3.Util;
+using System.Collections.Generic;
 
 namespace BlueprintBaseName._1.Tests;
 
@@ -35,14 +36,14 @@ public class FunctionTest
             // Setup the S3 event object that S3 notifications would create with the fields used by the Lambda function.
             var s3Event = new S3Event
             {
-                Records = new List<S3EventNotification.S3EventNotificationRecord>
+                Records = new List<S3Event.S3EventNotificationRecord>
                 {
-                    new S3EventNotification.S3EventNotificationRecord
+                    new S3Event.S3EventNotificationRecord
                     {
-                        S3 = new S3EventNotification.S3Entity
+                        S3 = new S3Event.S3Entity
                         {
-                            Bucket = new S3EventNotification.S3BucketEntity {Name = bucketName },
-                            Object = new S3EventNotification.S3ObjectEntity {Key = key }
+                            Bucket = new S3Event.S3BucketEntity {Name = bucketName },
+                            Object = new S3Event.S3ObjectEntity {Key = key }
                         }
                     }
                 }

--- a/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
-    <PackageReference Include="AWSSDK.ApiGatewayManagementApi" Version="3.7.0.189" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.64" />
+    <PackageReference Include="AWSSDK.ApiGatewayManagementApi" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/template.nuspec
+++ b/Blueprints/BlueprintDefinitions/vs2022/template.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Amazon.Lambda.Templates</id>
-    <version>6.5.0</version>
+    <version>6.6.0</version>
     <authors>Amazon Web Services</authors>
     <tags>AWS Amazon Lambda</tags>
     <description>AWS Lambda templates for Microsoft Template Engine accessible with the dotnet CLI's new command</description>


### PR DESCRIPTION
*Description of changes:*
Using the `/t:package-blueprints` msbuild target that updates the AWS packagesreferences in the Lambda blueprints. Confirmed all blueprints compile using the `/t:test-blueprints-dotnew` msbuild target.

Since the last time the blueprints have been released version 3.0.0 of Amazon.Lambda.S3Events has been released that had a breaking change. The S3 blueprints were updated to handle the breaking change.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
