### PR TITLE
Update custom runtime blueprint to target .NET 7

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction-FSharp/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction-FSharp/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
   "display-name": "Custom Runtime Function",
   "system-name": "CustomRuntimeFunction",
-  "description": "Use Lambda Custom Runtime feature to build Lambda functions using .NET 6.",
+  "description": "Use Lambda Custom Runtime feature to build Lambda functions using .NET 7.",
   "sort-order": 400,
   "hidden-tags": [
     "F#",

--- a/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction-FSharp/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Function"
   ],
-  "name": "Lambda Custom Runtime Function (.NET 6)",
+  "name": "Lambda Custom Runtime Function (.NET 7)",
   "identity": "AWS.Lambda.Function.CustomRuntimeFunction.FSharp",
   "groupIdentity": "AWS.Lambda.Function.CustomRuntimFunction",
   "shortName": "lambda.CustomRuntimeFunction",

--- a/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AWSProjectType>Lambda</AWSProjectType>
     <AssemblyName>bootstrap</AssemblyName>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->

--- a/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -43,7 +43,8 @@ Deploy function to AWS Lambda
 
 ## Arm64
 
-If you want to run your Lambda on an Arm64 processor, all you need is to do is add `"function-architecture": "arm64"` to the `aws-lambda-tools-defaults.json` file. Then deploy as described above.
+.NET 7 ARM requires a newer version of GLIBC than is available in the provided.al2 Lambda runtime. .NET 7 functions that are deployed using
+the Arm64 architecture will fail to start with a runtime error about the GLIBC version being below the required version for .NET 7.
 
 ## Improve Cold Start
 

--- a/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="FunctionTest.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
   "display-name": "Custom Runtime Function",
   "system-name": "CustomRuntimeFunction",
-  "description": "Use Lambda Custom Runtime feature to build Lambda functions using .NET 6.",
+  "description": "Use Lambda Custom Runtime feature to build Lambda functions using .NET 7.",
   "sort-order": 400,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Function"
   ],
-  "name": "Lambda Custom Runtime Function (.NET 6)",
+  "name": "Lambda Custom Runtime Function (.NET 7)",
   "identity": "AWS.Lambda.Function.CustomRuntimeFunction.CSharp",
   "groupIdentity": "AWS.Lambda.Function.CustomRuntimFunction",
   "shortName": "lambda.CustomRuntimeFunction",

--- a/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AWSProjectType>Lambda</AWSProjectType>

--- a/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction/template/src/BlueprintBaseName.1/Readme.md
@@ -44,9 +44,8 @@ Deploy function to AWS Lambda
 
 ## Arm64
 
-Arm64 support is provided by the AWS Graviton2 processor. For many Lambda workloads Graviton2 provides the best price performance.
-
-If you want to run your Lambda on an Arm64 processor, all you need to do is replace `x86_64` with `arm64` under `"function-architecture": ` in the `aws-lambda-tools-defaults.json` file. Then deploy as described above
+.NET 7 ARM requires a newer version of GLIBC than is available in the provided.al2 Lambda runtime. .NET 7 functions that are deployed using
+the Arm64 architecture will fail to start with a runtime error about the GLIBC version being below the required version for .NET 7.
 
 ## Improve Cold Start
 

--- a/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>  
   </PropertyGroup>


### PR DESCRIPTION
*Description of changes:*
Update custom runtime blueprints to target .NET 7. There are 2 blueprints a C# and F# blueprint.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
