### PR TITLE
Add .NET 7 version of Mock Lambda Test Tool

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj
@@ -12,7 +12,7 @@
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
     <NoWarn>1701;1702;1591;1587;3021;NU5100;CS1591</NoWarn>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
-	<TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+	<TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>  
 
 
@@ -26,7 +26,11 @@
 	
     <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.0" />
-    </ItemGroup>	
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.0-rc.2.22476.2" />
+    </ItemGroup>		
 
   <ItemGroup>
 	  <PackageReference Include="Blazored.Modal" Version="3.1.2" />

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester70-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester70-pack.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <Import Project="..\..\..\..\buildtools\common.props" />
+  
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Description>A tool to help debug and test your .NET 7.0 AWS Lambda functions locally.</Description>
+    <VersionPrefix>0.12.6</VersionPrefix>
+    <Product>AWS .NET Lambda Test Tool</Product>
+    <Copyright>Apache 2</Copyright>
+    <PackageTags>AWS;Amazon;Lambda</PackageTags>
+    <TargetFramework>net7.0</TargetFramework>
+    <ToolCommandName>dotnet-lambda-test-tool-7.0</ToolCommandName>	
+    <IsPackable>true</IsPackable>
+    <PackAsTool>true</PackAsTool>
+    <PackageId>Amazon.Lambda.TestTool-7.0</PackageId>
+	<AssemblyName>Amazon.Lambda.TestTool.BlazorTester</AssemblyName>
+	<RootNamespace>Amazon.Lambda.TestTool.BlazorTester</RootNamespace>	
+	<GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
+	<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
+  </PropertyGroup>
+
+  <ItemGroup>
+      <PackageReference Include="Blazored.Modal" Version="3.1.2" />
+	  <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.0-rc.2.22476.2" /> 
+	  <ProjectReference Include="..\Amazon.Lambda.TestTool\Amazon.Lambda.TestTool.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="wwwroot\**" />
+  </ItemGroup>
+  
+</Project>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Constants.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Constants.cs
@@ -11,6 +11,8 @@ namespace Amazon.Lambda.TestTool.BlazorTester
         public const string PRODUCT_NAME = "AWS .NET Core 5.0 Mock Lambda Test Tool";
 #elif NET6_0
         public const string PRODUCT_NAME = "AWS .NET Core 6.0 Mock Lambda Test Tool";
+#elif NET7_0
+        public const string PRODUCT_NAME = "AWS .NET Core 7.0 Mock Lambda Test Tool";
 #else
         Update for new target framework!!!
 #endif

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/TestToolStartup.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/TestToolStartup.cs
@@ -56,6 +56,8 @@ namespace Amazon.Lambda.TestTool
                 var targetFramework = "net5.0";
 #elif NET6_0
                 var targetFramework = "net6.0";
+#elif NET7_0
+                var targetFramework = "net7.0";
 #endif
 
                 // Check to see if running in debug mode from this project's directory which means the test tool is being debugged.
@@ -73,6 +75,8 @@ namespace Amazon.Lambda.TestTool
                 {
                     lambdaAssemblyDirectory = Path.Combine(lambdaAssemblyDirectory, $"bin/Debug/{targetFramework}");
                 }
+
+                lambdaAssemblyDirectory = Utils.SearchLatestCompilationDirectory(lambdaAssemblyDirectory);
 
                 localLambdaOptions.LambdaRuntime = LocalLambdaRuntime.Initialize(lambdaAssemblyDirectory);
                 runConfiguration.OutputWriter.WriteLine($"Loaded local Lambda runtime from project output {lambdaAssemblyDirectory}");

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Utils.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Utils.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -221,6 +222,24 @@ namespace Amazon.Lambda.TestTool
                 return $"http://{defaultHost}:{port}";
 
             return $"http://{host}:{port}";
+        }
+
+        /// <summary>
+        /// From the debug directory look to see where the latest compilation occurred for debugging. This can vary between the
+        /// root debug directory and the runtime specific subfolders. Starting with .NET 7 SDK if ready 2 run is enabled then 
+        /// project compiles into the runtime specific folder.
+        /// </summary>
+        /// <param name="debugDirectory"></param>
+        /// <returns></returns>
+        public static string SearchLatestCompilationDirectory(string debugDirectory)
+        {
+            var depsFile = new DirectoryInfo(debugDirectory).GetFiles("*.deps.json", SearchOption.AllDirectories)
+                                    .OrderByDescending(x => x.LastWriteTime).ToList();
+
+            if (depsFile.Count == 0)
+                return debugDirectory;
+
+            return depsFile[0].Directory.FullName;            
         }
     }
 }

--- a/buildtools/build.proj
+++ b/buildtools/build.proj
@@ -171,6 +171,7 @@
         <Exec Command="$(PackCommand) Amazon.Lambda.TestTool.BlazorTester31-pack.csproj" WorkingDirectory="..\Tools\LambdaTestTool\src\Amazon.Lambda.TestTool.BlazorTester"/>
 		<Exec Command="$(PackCommand) Amazon.Lambda.TestTool.BlazorTester50-pack.csproj" WorkingDirectory="..\Tools\LambdaTestTool\src\Amazon.Lambda.TestTool.BlazorTester"/>		
 		<Exec Command="$(PackCommand) Amazon.Lambda.TestTool.BlazorTester60-pack.csproj" WorkingDirectory="..\Tools\LambdaTestTool\src\Amazon.Lambda.TestTool.BlazorTester"/>		
+		<Exec Command="$(PackCommand) Amazon.Lambda.TestTool.BlazorTester70-pack.csproj" WorkingDirectory="..\Tools\LambdaTestTool\src\Amazon.Lambda.TestTool.BlazorTester"/>	
     </Target>
     <Target Name="build-lambda-test-tool-package-cicd" DependsOnTargets="init">
         <Exec Command="dotnet msbuild -restore /p:Configuration=$(Configuration) /p:AssemblyOriginatorKeyFile=$(AssemblyOriginatorKeyFile) /p:SignAssembly=$(SignAssembly)" WorkingDirectory="..\Tools\LambdaTestTool"/>


### PR DESCRIPTION
*Description of changes:*
Add .NET 7 version of Mock Lambda Test Tool. There isn't a .NET 7 managed runtime but this will be helpful for users using .NET 7 custom runtimes or .NET 7 OCI images.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
