### PR TITLE
Fixed issue with .NET 7 test tool looking for binaries in .NET 6 build folder

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj
@@ -6,7 +6,7 @@
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET Core AWS Lambda functions locally.</Description>
     <LangVersion>Latest</LangVersion>
-    <VersionPrefix>0.12.6</VersionPrefix>
+    <VersionPrefix>0.12.7</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
@@ -29,7 +29,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.0-rc.2.22476.2" />
+		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.0" />
     </ItemGroup>		
 
   <ItemGroup>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester31-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester31-pack.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET Core 3.1 AWS Lambda functions locally.</Description>
-    <VersionPrefix>0.12.6</VersionPrefix>
+    <VersionPrefix>0.12.7</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester50-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester50-pack.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET 5.0 AWS Lambda functions locally.</Description>
-    <VersionPrefix>0.12.6</VersionPrefix>
+    <VersionPrefix>0.12.7</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester60-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester60-pack.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET 6.0 AWS Lambda functions locally.</Description>
-    <VersionPrefix>0.12.6</VersionPrefix>
+    <VersionPrefix>0.12.7</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester70-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester70-pack.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET 7.0 AWS Lambda functions locally.</Description>
-    <VersionPrefix>0.12.6</VersionPrefix>
+    <VersionPrefix>0.12.7</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
@@ -22,7 +22,7 @@
 
   <ItemGroup>
       <PackageReference Include="Blazored.Modal" Version="3.1.2" />
-	  <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.0-rc.2.22476.2" /> 
+	  <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.0" /> 
 	  <ProjectReference Include="..\Amazon.Lambda.TestTool\Amazon.Lambda.TestTool.csproj" />
   </ItemGroup>
 

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\..\..\buildtools\common.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <Description>Common code for the AWS .NET Core Lambda Mock Test Tool.</Description>
     <NoWarn>1701;1702;1591;1587;3021;NU5100;CS1591</NoWarn>
   </PropertyGroup>
@@ -41,6 +41,9 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
 	</ItemGroup>
 
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
+	</ItemGroup>
 
 	<ItemGroup>
     <EmbeddedResource Include="Resources\**" />


### PR DESCRIPTION
*Description of changes:*
As part of .NET 7 we added a .NET version of the tool. When the tool is run from the project directory it will automatically look in the project's build output folder for the binaries to load. There is a separate version of the test tool for each framework and based on framework the test tool is compiled with. For example for .NET Core 3.1 the tool looks at `bin/Debug/netcoreapp3.1` and for .NET 6 it looks at `bin/Debug/net6.0`. For .NET 7 it should be looking at `bin/Debug/<runtime>/net7.0`. Runtime in the path is a new behavior of .NET 7.

The main UI project was updated to target .NET 7 but the child project that has the directory logic was not updated to target .NET 7. So even though build command said target .NET 7 that only affected the UI project but the child project was compiled for .NET 6 so the #if clause in the child project resolved to `bin/Debug/net6.0`.

The fix is just to add .NET 7 to the child project.

I also updated our package references for `Microsoft.Extensions.FileProviders.Embedded` to the GA version of the package.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
