### PR TITLE
Update container image based blueprints to use .NET 7

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/Dockerfile
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:6
+FROM public.ecr.aws/lambda/dotnet:7
 
 WORKDIR /var/task
 

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -44,9 +44,9 @@ Alternatively the Docker file could be written to use [multi-stage](https://docs
 have the .NET project built inside the container. Below is an example of building the .NET project inside the image.
 
 ```dockerfile
-FROM public.ecr.aws/lambda/dotnet:6 AS base
+FROM public.ecr.aws/lambda/dotnet:7 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim as build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.csproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.csproj"

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/Dockerfile
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:6
+FROM public.ecr.aws/lambda/dotnet:7
 
 WORKDIR /var/task
 

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/Readme.md
@@ -51,9 +51,9 @@ Alternatively the Docker file could be written to use [multi-stage](https://docs
 have the .NET project built inside the container. Below is an example of building the .NET project inside the image.
 
 ```dockerfile
-FROM public.ecr.aws/lambda/dotnet:6 AS base
+FROM public.ecr.aws/lambda/dotnet:7 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim as build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.csproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.csproj"

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": ".NET 6 (Container Image)",
+  "display-name": ".NET 7 (Container Image)",
   "system-name": "EmptyImageFunction",
-  "description": "A .NET 6 Lambda function packaged as a container image.",
+  "description": "A .NET 7 Lambda function packaged as a container image.",
   "sort-order": 225,
   "hidden-tags": [
     "F#",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Function"
   ],
-  "name": "Lambda Empty Function (.NET 6 Container Image)",
+  "name": "Lambda Empty Function (.NET 7 Container Image)",
   "identity": "AWS.Lambda.Function.Image.Empty.FSharp",
   "groupIdentity": "AWS.Lambda.Function.Image.Empty",
   "shortName": "lambda.image.EmptyFunction",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/Dockerfile
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:6
+FROM public.ecr.aws/lambda/dotnet:7
 
 WORKDIR /var/task
 

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -22,9 +22,9 @@ Alternatively the Docker file could be written to use [multi-stage](https://docs
 have the .NET project built inside the container. Below is an example of building the .NET project inside the image.
 
 ```dockerfile
-FROM public.ecr.aws/lambda/dotnet:6 AS base
+FROM public.ecr.aws/lambda/dotnet:7 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim as build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.fsproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.fsproj"

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="FunctionTest.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": ".NET 6 (Container Image)",
+  "display-name": ".NET 7 (Container Image)",
   "system-name": "EmptyImageFunction",
-  "description": "A .NET 6 Lambda function packaged as a container image.",
+  "description": "A .NET 7 Lambda function packaged as a container image.",
   "sort-order": 225,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Function"
   ],
-  "name": "Lambda Empty Function (.NET 6 Container Image)",
+  "name": "Lambda Empty Function (.NET 7 Container Image)",
   "identity": "AWS.Lambda.Function.Image.Empty.CSharp",
   "groupIdentity": "AWS.Lambda.Function.Image.Empty",
   "shortName": "lambda.image.EmptyFunction",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/Dockerfile
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:6
+FROM public.ecr.aws/lambda/dotnet:7
 
 WORKDIR /var/task
 

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/Readme.md
@@ -22,9 +22,9 @@ Alternatively the Docker file could be written to use [multi-stage](https://docs
 have the .NET project built inside the container. Below is an example of building the .NET project inside the image.
 
 ```dockerfile
-FROM public.ecr.aws/lambda/dotnet:6 AS base
+FROM public.ecr.aws/lambda/dotnet:7 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim as build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.csproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.csproj"

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable> 
   </PropertyGroup>

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": ".NET 6 (Container Image) Serverless Application",
+  "display-name": ".NET 7 (Container Image) Serverless Application",
   "system-name": "EmptyImageServerless",
-  "description": ".NET 6 Lambda function packaged as a container image and deploy through AWS CloudFormation.",
+  "description": ".NET 7 Lambda function packaged as a container image and deploy through AWS CloudFormation.",
   "sort-order": 225,
   "hidden-tags": [
     "F#",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Lambda Empty Serverless (.NET 6 Container Image)",
+  "name": "Lambda Empty Serverless (.NET 7 Container Image)",
   "identity": "AWS.Lambda.Serverless.Image.Empty.FSharp",
   "groupIdentity": "AWS.Lambda.Image.Serverless.Empty",
   "shortName": "serverless.image.EmptyServerless",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/Dockerfile
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:6
+FROM public.ecr.aws/lambda/dotnet:7
 
 WORKDIR /var/task
 

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -24,9 +24,9 @@ Alternatively the Docker file could be written to use [multi-stage](https://docs
 have the .NET project built inside the container. Below is an example of building the .NET project inside the image.
 
 ```dockerfile
-FROM public.ecr.aws/lambda/dotnet:6 AS base
+FROM public.ecr.aws/lambda/dotnet:7 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim as build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.csproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.csproj"

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="FunctionsTest.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": ".NET 6 (Container Image) Serverless Application",
+  "display-name": ".NET 7 (Container Image) Serverless Application",
   "system-name": "EmptyImageServerless",
-  "description": ".NET 6 Lambda function packaged as a container image and deploy through AWS CloudFormation.",
+  "description": ".NET 7 Lambda function packaged as a container image and deploy through AWS CloudFormation.",
   "sort-order": 225,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Lambda Empty Serverless (.NET 6 Container Image)",
+  "name": "Lambda Empty Serverless (.NET 7 Container Image)",
   "identity": "AWS.Lambda.Serverless.Image.Empty.CSharp",
   "groupIdentity": "AWS.Lambda.Image.Serverless.Empty",
   "shortName": "serverless.image.EmptyServerless",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/Dockerfile
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:6
+FROM public.ecr.aws/lambda/dotnet:7
 
 WORKDIR /var/task
 

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/Readme.md
@@ -24,9 +24,9 @@ Alternatively the Docker file could be written to use [multi-stage](https://docs
 have the .NET project built inside the container. Below is an example of building the .NET project inside the image.
 
 ```dockerfile
-FROM public.ecr.aws/lambda/dotnet:6 AS base
+FROM public.ecr.aws/lambda/dotnet:7 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim as build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.csproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.csproj"

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
*Description of changes:*
Update container based blueprints to target the new .NET 7 base images. There is a C# and F# blueprint for deploying straight to Lambda and a C# and F# blueprint for deploying via CloudFormation, the "serverless" blueprints.

Norm

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
