### PR TITLE
fix: added support for dynamic type in lambda annotations

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/TypeModelBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/TypeModelBuilder.cs
@@ -11,14 +11,34 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
     {
         public static TypeModel Build(ITypeSymbol symbol, GeneratorExecutionContext context)
         {
+            bool isGenericType;
+            if (symbol is INamedTypeSymbol)
+                isGenericType = ((INamedTypeSymbol)symbol)?.IsGenericType ?? false;
+            else
+                isGenericType = false;
+
+            IList<TypeModel> typeArguments;
+            if (symbol is INamedTypeSymbol)
+                typeArguments = ((INamedTypeSymbol)symbol)?.TypeArguments.Select(arg => Build(arg, context)).ToList();
+            else
+                typeArguments = new List<TypeModel>();
+
+            bool isEnumerable;
+            if (symbol is INamedTypeSymbol)
+                isEnumerable = ((INamedTypeSymbol)symbol)?.Interfaces.Any(it => it.Equals(context.Compilation.GetTypeByMetadataName(TypeFullNames.IEnumerable), SymbolEqualityComparer.Default)) ?? false;
+            else if (symbol is IDynamicTypeSymbol)
+                isEnumerable = ((IDynamicTypeSymbol)symbol)?.Interfaces.Any(it => it.Equals(context.Compilation.GetTypeByMetadataName(TypeFullNames.IEnumerable), SymbolEqualityComparer.Default)) ?? false;
+            else
+                isEnumerable = false;
+
             var model = new TypeModel
             {
                 Name = symbol.Name,
                 FullName = symbol.ToDisplayString(),
                 IsValueType = symbol.IsValueType,
-                IsGenericType = ((INamedTypeSymbol)symbol)?.IsGenericType ?? false,
-                TypeArguments = ((INamedTypeSymbol)symbol)?.TypeArguments.Select(arg => Build(arg, context)).ToList(),
-                IsEnumerable = ((INamedTypeSymbol)symbol)?.Interfaces.Any(it => it.Equals(context.Compilation.GetTypeByMetadataName(TypeFullNames.IEnumerable), SymbolEqualityComparer.Default)) ?? false
+                IsGenericType = isGenericType,
+                TypeArguments = typeArguments,
+                IsEnumerable = isEnumerable
             };
 
             return model;

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
@@ -58,6 +58,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <None Remove="Snapshots\ServerlessTemplates\dynamicexample.template" />
       <None Remove="Snapshots\ServerlessTemplates\subnamespace.template" />
       <None Remove="Snapshots\ServerlessTemplates\taskexample.template" />
       <None Remove="Snapshots\ServerlessTemplates\voidexample.template" />

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/DynamicExample_DynamicInput_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/DynamicExample_DynamicInput_Generated.g.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text;
+using Amazon.Lambda.Core;
+
+namespace TestServerlessApp
+{
+    public class DynamicExample_DynamicInput_Generated
+    {
+        private readonly DynamicExample dynamicExample;
+
+        public DynamicExample_DynamicInput_Generated()
+        {
+            SetExecutionEnvironment();
+            dynamicExample = new DynamicExample();
+        }
+
+        public string DynamicInput(dynamic text, Amazon.Lambda.Core.ILambdaContext __context__)
+        {
+            return dynamicExample.DynamicInput(text, __context__);
+        }
+
+        private static void SetExecutionEnvironment()
+        {
+            const string envName = "AWS_EXECUTION_ENV";
+
+            var envValue = new StringBuilder();
+
+            // If there is an existing execution environment variable add the annotations package as a suffix.
+            if(!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(envName)))
+            {
+                envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
+            }
+
+            envValue.Append("amazon-lambda-annotations_0.9.0.0");
+
+            Environment.SetEnvironmentVariable(envName, envValue.ToString());
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/DynamicExample_DynamicReturn_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/DynamicExample_DynamicReturn_Generated.g.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text;
+using Amazon.Lambda.Core;
+
+namespace TestServerlessApp
+{
+    public class DynamicExample_DynamicReturn_Generated
+    {
+        private readonly DynamicExample dynamicExample;
+
+        public DynamicExample_DynamicReturn_Generated()
+        {
+            SetExecutionEnvironment();
+            dynamicExample = new DynamicExample();
+        }
+
+        public dynamic DynamicReturn(string text, Amazon.Lambda.Core.ILambdaContext __context__)
+        {
+            return dynamicExample.DynamicReturn(text, __context__);
+        }
+
+        private static void SetExecutionEnvironment()
+        {
+            const string envName = "AWS_EXECUTION_ENV";
+
+            var envValue = new StringBuilder();
+
+            // If there is an existing execution environment variable add the annotations package as a suffix.
+            if(!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(envName)))
+            {
+                envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
+            }
+
+            envValue.Append("amazon-lambda-annotations_0.9.0.0");
+
+            Environment.SetEnvironmentVariable(envName, envValue.ToString());
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/dynamicexample.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/dynamicexample.template
@@ -1,0 +1,46 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Transform": "AWS::Serverless-2016-10-31",
+  "Resources": {
+    "TestServerlessAppDynamicExampleDynamicReturnGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations"
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestProject::TestServerlessApp.DynamicExample_DynamicReturn_Generated::DynamicReturn"
+          ]
+        }
+      }
+    },
+    "TestServerlessAppDynamicExampleDynamicInputGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations"
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestProject::TestServerlessApp.DynamicExample_DynamicInput_Generated::DynamicInput"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
@@ -319,5 +319,48 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
             var actualTemplateContent = File.ReadAllText(Path.Combine("TestServerlessApp", "serverless.template"));
             Assert.Equal(expectedTemplateContent, actualTemplateContent);
         }
+
+        [Fact]
+        public async Task VerifyFunctionDynamic()
+        {
+            var expectedTemplateContent = File.ReadAllText(Path.Combine("Snapshots", "ServerlessTemplates", "dynamicexample.template")).ToEnvironmentLineEndings();
+            var expectedSubNamespaceGenerated_DynamicReturn = File.ReadAllText(Path.Combine("Snapshots", "DynamicExample_DynamicReturn_Generated.g.cs")).ToEnvironmentLineEndings();
+            var expectedSubNamespaceGenerated_DynamicInput = File.ReadAllText(Path.Combine("Snapshots", "DynamicExample_DynamicInput_Generated.g.cs")).ToEnvironmentLineEndings();
+
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        (Path.Combine("TestServerlessApp", "DynamicExample.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "DynamicExample.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"))),
+                    },
+                    GeneratedSources =
+                    {
+                        (
+                            typeof(SourceGenerator.Generator),
+                            "DynamicExample_DynamicReturn_Generated.g.cs",
+                            SourceText.From(expectedSubNamespaceGenerated_DynamicReturn, Encoding.UTF8, SourceHashAlgorithm.Sha256)
+                        ),
+                        (
+                            typeof(SourceGenerator.Generator),
+                            "DynamicExample_DynamicInput_Generated.g.cs",
+                            SourceText.From(expectedSubNamespaceGenerated_DynamicInput, Encoding.UTF8, SourceHashAlgorithm.Sha256)
+                        )
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("DynamicExample_DynamicReturn_Generated.g.cs", expectedSubNamespaceGenerated_DynamicReturn),
+                        new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments($"TestServerlessApp{Path.DirectorySeparatorChar}serverless.template", expectedTemplateContent),
+                        new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("DynamicExample_DynamicInput_Generated.g.cs", expectedSubNamespaceGenerated_DynamicInput)
+                    }
+                }
+            }.RunAsync();
+
+            var actualTemplateContent = File.ReadAllText(Path.Combine("TestServerlessApp", "serverless.template"));
+            Assert.Equal(expectedTemplateContent, actualTemplateContent);
+        }
     }
 }

--- a/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixture.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixture.cs
@@ -55,7 +55,7 @@ namespace TestServerlessApp.IntegrationTests
 
             Assert.Equal(StackStatus.CREATE_COMPLETE, await _cloudFormationHelper.GetStackStatusAsync(_stackName));
             Assert.True(await _s3Helper.BucketExistsAsync(_bucketName));
-            Assert.Equal(14, LambdaFunctions.Count);
+            Assert.Equal(16, LambdaFunctions.Count);
             Assert.False(string.IsNullOrEmpty(RestApiUrlPrefix));
             Assert.False(string.IsNullOrEmpty(RestApiUrlPrefix));
 

--- a/Libraries/test/TestServerlessApp/DynamicExample.cs
+++ b/Libraries/test/TestServerlessApp/DynamicExample.cs
@@ -1,0 +1,23 @@
+﻿using Amazon.Lambda.Annotations;
+using Amazon.Lambda.Core;
+using System.Threading.Tasks;
+
+namespace TestServerlessApp
+{
+    public class DynamicExample
+    {
+        [LambdaFunction(PackageType = LambdaPackageType.Image)]
+        public dynamic DynamicReturn(string text, ILambdaContext context)
+        {
+            context.Logger.LogLine(text);
+            return text;
+        }
+
+        [LambdaFunction(PackageType = LambdaPackageType.Image)]
+        public string DynamicInput(dynamic text, ILambdaContext context)
+        {
+            context.Logger.LogLine(text);
+            return text;
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp/serverless.template
+++ b/Libraries/test/TestServerlessApp/serverless.template
@@ -405,6 +405,46 @@
           ]
         }
       }
+    },
+    "TestServerlessAppDynamicExampleDynamicReturnGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations"
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.DynamicExample_DynamicReturn_Generated::DynamicReturn"
+          ]
+        }
+      }
+    },
+    "TestServerlessAppDynamicExampleDynamicInputGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations"
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.DynamicExample_DynamicInput_Generated::DynamicInput"
+          ]
+        }
+      }
     }
   },
   "Outputs": {


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6342
Fixes #1304 

*Description of changes:*
The Lambda Annotations Source Generator was failing with the error
```
Unable to cast object of type 'Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel.DynamicTypeSymbol' to type 'Microsoft.CodeAnalysis.INamedTypeSymbol'.   at Amazon.Lambda.Annotations.SourceGenerator.Models.TypeModelBuilder.Build(ITypeSymbol symbol, GeneratorExecutionContext context) [<path to csproj>]
```
This happens when the type `dynamic` is used in a `LambdaFunction` such as
```
[LambdaFunction(PackageType = LambdaPackageType.Image)]
public dynamic DynamicReturn(string text, ILambdaContext context)
{
    context.Logger.LogLine(text);
    return text;
}

[LambdaFunction(PackageType = LambdaPackageType.Image)]
public string DynamicInput(dynamic text, ILambdaContext context)
{
    context.Logger.LogLine(text);
    return text;
}
```
The issue happens due to us casting to an `INamedTypeSymbol` in all cases.
This PR fixes the issue by casting to `INamedTypeSymbol` or `IDynamicTypeSymbol` when applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
