### PR TITLE
Fixed issue with incorrect class name for S3 blueprint

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/src/BlueprintBaseName.1/Function.cs
@@ -8,7 +8,7 @@ using Amazon.S3.Util;
 
 namespace BlueprintBaseName._1;
 
-public class Functions
+public class Function
 {
     IAmazonS3 S3Client { get; set; }
 
@@ -17,7 +17,7 @@ public class Functions
     /// the AWS credentials will come from the IAM role associated with the function and the AWS region will be set to the
     /// region the Lambda function is executed in.
     /// </summary>
-    public Functions()
+    public Function()
     {
         S3Client = new AmazonS3Client();
     }
@@ -26,7 +26,7 @@ public class Functions
     /// Constructs an instance with a preconfigured S3 client. This can be used for testing outside of the Lambda environment.
     /// </summary>
     /// <param name="s3Client"></param>
-    public Functions(IAmazonS3 s3Client)
+    public Function(IAmazonS3 s3Client)
     {
         this.S3Client = s3Client;
     }

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace BlueprintBaseName._1.Tests;
 
-public class FunctionsTest
+public class FunctionTest
 {
     [Fact]
     public async Task TestS3EventLambdaFunction()
@@ -44,7 +44,7 @@ public class FunctionsTest
             Logger = testLambdaLogger
         };
 
-        var function = new Functions(mockS3Client.Object);
+        var function = new Function(mockS3Client.Object);
         await function.FunctionHandler(s3Event, testLambdaContext);
 
         Assert.Equal("text/plain", ((TestLambdaLogger)testLambdaLogger).Buffer.ToString().Trim());

--- a/Blueprints/BlueprintDefinitions/vs2022/template.nuspec
+++ b/Blueprints/BlueprintDefinitions/vs2022/template.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Amazon.Lambda.Templates</id>
-    <version>6.8.0</version>
+    <version>6.8.1</version>
     <authors>Amazon Web Services</authors>
     <tags>AWS Amazon Lambda</tags>
     <description>AWS Lambda templates for Microsoft Template Engine accessible with the dotnet CLI's new command</description>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1377

*Description of changes:*
The S3 Lambda blueprint was incorrectly using the class name `Functions` but in the `aws-lambda-tools-defaults.json` file the `function-handler` property was using the `Function` with out the plural. I have updated the class name to be `Function` matching the other blueprints that deploy straight to Lambda where you can only deploy a single function.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
