### PR TITLE
Add DynamicallyAccessedMembers attribute for SourceGeneratorLambdaJsonSerializer

### DIFF
--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/SourceGeneratorLambdaJsonSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/SourceGeneratorLambdaJsonSerializer.cs
@@ -1,5 +1,6 @@
 ﻿#if NET6_0_OR_GREATER
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -27,7 +28,7 @@ namespace Amazon.Lambda.Serialization.SystemTextJson
     /// will avoid any reflection based serialization.
     /// </summary>
     /// <typeparam name="TSGContext"></typeparam>
-    public class SourceGeneratorLambdaJsonSerializer<TSGContext> : AbstractLambdaJsonSerializer, ILambdaSerializer where TSGContext : JsonSerializerContext
+    public class SourceGeneratorLambdaJsonSerializer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TSGContext> : AbstractLambdaJsonSerializer, ILambdaSerializer where TSGContext : JsonSerializerContext
     {
         TSGContext _jsonSerializerContext;
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/dotnet-nativeaot-labs/issues/8

*Description of changes:* This tells the trimmer not to trim the constructor off of the type that will be TSGContext . This is necessary because we call `typeof(TSGContext).GetConstructor` below in the file


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
