### PR TITLE
Update Lambda blueprints to have latest AWS package versions

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2017/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -17,7 +17,7 @@
     <None Include="serverless.template" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.2.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2017/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.2.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.3.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2017/AspNetCoreWebApp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/AspNetCoreWebApp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,7 +7,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.2.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.101.16" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabels/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabels/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.101.16" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.101.16" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.101.16" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2017/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,7 +7,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.2" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />

--- a/Blueprints/BlueprintDefinitions/vs2017/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Giraffe" Version="3.4.0" />
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.2.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.3.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppHandlers.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.2" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -17,6 +17,6 @@
     <None Include="serverless.template" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.2.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.3.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -17,6 +17,6 @@
     <None Include="serverless.template" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.2.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.3.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,6 +7,6 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.2.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.3.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,6 +7,6 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.2.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.3.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebApp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/AspNetCoreWebApp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,7 +7,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.2.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.3.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="wwwroot\images\" />

--- a/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.101.16" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabels/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabels/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.101.16" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.101.16" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,8 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.101.16" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2019/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/DynamoDBBlogAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -7,7 +7,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.2" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />

--- a/Blueprints/BlueprintDefinitions/vs2019/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Giraffe" Version="3.4.0" />
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.2.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.3.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppHandlers.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.2" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2019/WebSocketAPIServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2019/WebSocketAPIServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
-    <PackageReference Include="AWSSDK.ApiGatewayManagementApi" Version="3.7.100.3" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.ApiGatewayManagementApi" Version="3.7.100.32" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.2" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -15,6 +15,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
-    <PackageReference Include="Amazon.Lambda.Annotations" Version="0.9.0-preview" />
+    <PackageReference Include="Amazon.Lambda.Annotations" Version="0.10.0-preview" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -18,6 +18,6 @@
     <None Include="serverless.template" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.2.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.3.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -18,6 +18,6 @@
     <None Include="serverless.template" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.2.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.3.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -12,6 +12,6 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.2.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.3.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI.MinimalAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI.MinimalAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -11,6 +11,6 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.3.1" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.4.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -12,6 +12,6 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.2.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.3.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebApp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebApp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -12,7 +12,7 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.2.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.3.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="wwwroot\images\" />

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -9,8 +9,8 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.101.16" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -11,8 +11,8 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.101.16" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -9,8 +9,8 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.101.16" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -11,8 +11,8 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.101.16" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />

--- a/Blueprints/BlueprintDefinitions/vs2022/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Giraffe" Version="5.0.0" />
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.2.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.3.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppHandlers.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -14,6 +14,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.2" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -14,6 +14,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -14,6 +14,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.3" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.32" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
-    <PackageReference Include="AWSSDK.ApiGatewayManagementApi" Version="3.7.100.3" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100.3" />
+    <PackageReference Include="AWSSDK.ApiGatewayManagementApi" Version="3.7.100.32" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.2" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/template.nuspec
+++ b/Blueprints/BlueprintDefinitions/vs2022/template.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Amazon.Lambda.Templates</id>
-    <version>6.8.1</version>
+    <version>6.9.0</version>
     <authors>Amazon Web Services</authors>
     <tags>AWS Amazon Lambda</tags>
     <description>AWS Lambda templates for Microsoft Template Engine accessible with the dotnet CLI's new command</description>


### PR DESCRIPTION
*Description of changes:*
Update all of the `PackageReferences` to AWS packages in the Lambda blueprints to the latest version. This was done using the msbuild target `/t:package-blueprints /p:UpdateBlueprintPackageVersions=true` as we usually do and manually updating the annotations blueprint to `0.10.0-preview` since our custom target doesn't handle preview packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
