### PR TITLE
Adds non greedy parameter values into the path when {proxy+}

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -168,8 +168,7 @@ namespace Amazon.Lambda.AspNetCoreServer
                         path = path.Replace($"{{{pathParameter.Key}}}", pathParameter.Value);
                     }
                 }
-                // As a matter of fact, is there a reason for the if clause above? A simpler/faster solution would be to straight on replace the path as below
-
+ 
                 if (string.IsNullOrEmpty(path))
                 {
                     path = apiGatewayRequest.Path;

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -154,12 +154,21 @@ namespace Amazon.Lambda.AspNetCoreServer
                 requestFeatures.Method = apiGatewayRequest.HttpMethod;
 
                 string path = null;
+
+                // Replaces {proxy+} in path, if exists
                 if (apiGatewayRequest.PathParameters != null && apiGatewayRequest.PathParameters.TryGetValue("proxy", out var proxy) &&
                     !string.IsNullOrEmpty(apiGatewayRequest.Resource))
                 {
                     var proxyPath = proxy;
                     path = apiGatewayRequest.Resource.Replace("{proxy+}", proxyPath);
+
+                    // Adds all the rest of non greedy parameters in apiGateway.Resource to the path
+                    foreach (var pathParameter in apiGatewayRequest.PathParameters.Where(pp => pp.Key != "proxy"))
+                    {
+                        path = path.Replace($"{{{pathParameter.Key}}}", pathParameter.Value);
+                    }
                 }
+                // As a matter of fact, is there a reason for the if clause above? A simpler/faster solution would be to straight on replace the path as below
 
                 if (string.IsNullOrEmpty(path))
                 {
@@ -253,7 +262,7 @@ namespace Amazon.Lambda.AspNetCoreServer
             }
 
             {
-                var tlsConnectionFeature = (ITlsConnectionFeature) features;
+                var tlsConnectionFeature = (ITlsConnectionFeature)features;
                 var clientCertPem = apiGatewayRequest?.RequestContext?.Identity?.ClientCert?.ClientCertPem;
                 if (clientCertPem != null)
                 {

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/Amazon.Lambda.AspNetCoreServer.Test.csproj
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/Amazon.Lambda.AspNetCoreServer.Test.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="additional-path-parameters-in-non-proxy-path.json" />
     <None Remove="additional-path-parameters-in-proxy-path.json" />
     <None Remove="authtest-access-request.json" />
     <None Remove="missing-resource-request.json" />

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/Amazon.Lambda.AspNetCoreServer.Test.csproj
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/Amazon.Lambda.AspNetCoreServer.Test.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="additional-path-parameters-in-proxy-path.json" />
     <None Remove="authtest-access-request.json" />
     <None Remove="missing-resource-request.json" />
     <None Remove="values-get-all-httpapi-request.json" />

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
@@ -281,6 +281,16 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
         }
 
         [Fact]
+        public async Task TestAdditionalPathParametersInNonProxyPath()
+        {
+            var response = await this.InvokeAPIGatewayRequest("additional-path-parameters-in-non-proxy-path.json");
+            Assert.Equal(200, response.StatusCode);
+
+            var root = JsonSerializer.Deserialize<JsonObject>(response.Body);
+            Assert.Equal("/path/bar/api", root?["Path"]?.ToString());
+        }
+
+        [Fact]
         public async Task TestSpaceInResourcePathAndQueryString()
         {
             var response = await this.InvokeAPIGatewayRequest("encode-space-in-resource-path-and-query.json");

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
@@ -271,6 +271,16 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
         }
 
         [Fact]
+        public async Task TestAdditionalPathParametersInProxyPath()
+        {
+            var response = await this.InvokeAPIGatewayRequest("additional-path-parameters-in-proxy-path.json");
+            Assert.Equal(200, response.StatusCode);
+
+            var root = JsonSerializer.Deserialize<JsonObject>(response.Body);
+            Assert.Equal("/path/bar/api", root?["Path"]?.ToString());
+        }
+
+        [Fact]
         public async Task TestSpaceInResourcePathAndQueryString()
         {
             var response = await this.InvokeAPIGatewayRequest("encode-space-in-resource-path-and-query.json");

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/additional-path-parameters-in-non-proxy-path.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/additional-path-parameters-in-non-proxy-path.json
@@ -1,0 +1,58 @@
+﻿{
+  "resource": "/path/{foo}/api",
+  "path": "path/bar/api",
+  "httpMethod": "GET",
+  "headers": {
+    "Accept": "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,*\/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, br",
+    "Accept-Language": "en-US,en;q=0.9",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "m1138alqlk.execute-api.us-west-2.amazonaws.com",
+    "upgrade-insecure-requests": "1",
+    "User-Agent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/64.0.3282.140 Safari\/537.36",
+    "Via": "2.0 ce270f4a88edde7438864bc44406e83a.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "_3bfLvO5mG_QItkPQ80NiKlmrwbYanuQBlSy8QyZAvGRQKDr0B2dIg==",
+    "X-Amzn-Trace-Id": "Root=1-5a98f3fa-80b360c0b7a112d97f0679ca",
+    "X-Forwarded-For": "50.35.77.7, 54.182.214.94",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "queryStringParameters": null,
+  "pathParameters": {
+    "foo": "bar"
+  },
+  "stageVariables": null,
+  "requestContext": {
+    "requestTime": "02\/Mar\/2018:06:49:30 +0000",
+    "path": "/path/bar/api",
+    "accountId": "626492997873",
+    "protocol": "HTTP\/1.1",
+    "resourceId": "fm247q",
+    "stage": "Prod",
+    "requestTimeEpoch": 1519973370547,
+    "requestId": "dbb330b2-1de5-11e8-b1a9-3f92103b3613",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "sourceIp": "50.35.77.7",
+      "accessKey": null,
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36",
+      "user": null
+    },
+    "resourcePath": "/path/{foo}/api",
+    "httpMethod": "GET",
+    "apiId": "m1138alqlk"
+  },
+  "body": null,
+  "isBase64Encoded": false
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/additional-path-parameters-in-proxy-path.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/additional-path-parameters-in-proxy-path.json
@@ -1,0 +1,59 @@
+﻿{
+  "resource": "/path/{foo}/{proxy+}",
+  "path": "path/bar/api",
+  "httpMethod": "GET",
+  "headers": {
+    "Accept": "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,*\/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, br",
+    "Accept-Language": "en-US,en;q=0.9",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "m1138alqlk.execute-api.us-west-2.amazonaws.com",
+    "upgrade-insecure-requests": "1",
+    "User-Agent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/64.0.3282.140 Safari\/537.36",
+    "Via": "2.0 ce270f4a88edde7438864bc44406e83a.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "_3bfLvO5mG_QItkPQ80NiKlmrwbYanuQBlSy8QyZAvGRQKDr0B2dIg==",
+    "X-Amzn-Trace-Id": "Root=1-5a98f3fa-80b360c0b7a112d97f0679ca",
+    "X-Forwarded-For": "50.35.77.7, 54.182.214.94",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "queryStringParameters": null,
+  "pathParameters": {
+    "proxy": "api",
+    "foo": "bar"
+  },
+  "stageVariables": null,
+  "requestContext": {
+    "requestTime": "02\/Mar\/2018:06:49:30 +0000",
+    "path": "/path/bar/api",
+    "accountId": "626492997873",
+    "protocol": "HTTP\/1.1",
+    "resourceId": "fm247q",
+    "stage": "Prod",
+    "requestTimeEpoch": 1519973370547,
+    "requestId": "dbb330b2-1de5-11e8-b1a9-3f92103b3613",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "sourceIp": "50.35.77.7",
+      "accessKey": null,
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36",
+      "user": null
+    },
+    "resourcePath": "/path/{foo}/{proxy+}",
+    "httpMethod": "GET",
+    "apiId": "m1138alqlk"
+  },
+  "body": null,
+  "isBase64Encoded": false
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1233

A confirmed bug since July, that has not been fixed yet, and has taken me a whole day until I realised what the problem is.
Basically, when {proxy+}, the values of the non-greedy parameters are not picked up from the request path. 

So the following scenario **_fails_**:

Given an API Gateway resource set up as `/path/{foo}/bar/{proxy+}`
When I make a request to path `/path/afoo/bar/subpath`
Then the `foo` variable in my controller action should be equal to `afoo`

What actually happens is that my controller's `foo` variable contains the value `{foo}`

*Description of changes:*
Added code that will actually replace the non-greedy parameters with their values in the path.
In order to keep changes as small as possible, I just added a loop, but I think it would be better optimised if the path was replaced straight away with the incoming request's path - that's already what happens with non-proxy requests ((line 176). I added a comment about that.

The pull request refers to lines `156-177` of `ApiGatewayProxyFunction.cs`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
