### PR TITLE
Corrected the type ContainerOverride.Environment to NameValue for ECSTaskStateChangeEvent.

### DIFF
--- a/Libraries/src/Amazon.Lambda.CloudWatchEvents/Amazon.Lambda.CloudWatchEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.CloudWatchEvents/Amazon.Lambda.CloudWatchEvents.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <Description>Amazon Lambda .NET Core support - CloudWatchEvents package.</Description>
     <AssemblyTitle>Amazon.Lambda.CloudWatchEvents</AssemblyTitle>
-    <VersionPrefix>4.0.0</VersionPrefix>
+    <VersionPrefix>4.0.1</VersionPrefix>
     <AssemblyName>Amazon.Lambda.CloudWatchEvents</AssemblyName>
     <PackageId>Amazon.Lambda.CloudWatchEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Libraries/src/Amazon.Lambda.CloudWatchEvents/ECSEvents/ContainerOverride.cs
+++ b/Libraries/src/Amazon.Lambda.CloudWatchEvents/ECSEvents/ContainerOverride.cs
@@ -27,7 +27,7 @@ namespace Amazon.Lambda.CloudWatchEvents.ECSEvents
         /// which are added to the container at launch, or you can override the existing environment
         /// variables from the Docker image or the task definition. You must also specify a container name.
         /// </summary>
-        public List<KeyValuePair<string, string>> Environment { get; set; }
+        public List<NameValue> Environment { get; set; }
 
         /// <summary>
         /// The hard limit (in MiB) of memory to present to the container, instead of the default value

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -2107,6 +2107,9 @@ namespace Amazon.Lambda.Tests
 
                 Assert.Equal(ecsEvent.Detail.Overrides.ContainerOverrides.Count, 1);
                 Assert.Equal(ecsEvent.Detail.Overrides.ContainerOverrides[0].Name, "FargateApp");
+                Assert.Equal(ecsEvent.Detail.Overrides.ContainerOverrides[0].Environment.Count, 1);
+                Assert.Equal(ecsEvent.Detail.Overrides.ContainerOverrides[0].Environment[0].Name, "testname");
+                Assert.Equal(ecsEvent.Detail.Overrides.ContainerOverrides[0].Environment[0].Value, "testvalue");
 
                 Assert.Equal(ecsEvent.Detail.Connectivity, "CONNECTED");
                 Assert.Equal(ecsEvent.Detail.ConnectivityAt.ToUniversalTime(), DateTime.Parse("2020-01-23T17:57:38.453Z").ToUniversalTime());

--- a/Libraries/test/EventsTests.Shared/ecs-task-state-change-event.json
+++ b/Libraries/test/EventsTests.Shared/ecs-task-state-change-event.json
@@ -65,7 +65,13 @@
     "overrides": {
       "containerOverrides": [
         {
-          "name": "FargateApp"
+          "name": "FargateApp",
+          "environment": [
+            {
+              "name": "testname",
+              "value": "testvalue"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
*Issue #, if available:* #1406

*Description of changes:*
The type used for `ContainerOverride.Environment` array is incorrect.
- Per https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerOverride.html, `environment` property is an array of [KeyValuePair](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_KeyValuePair.html) objects.
- Per https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_KeyValuePair.html, `KeyValuePair` has `name` and `value` properties.

This change uses the previously implemented `NameValue` type.

___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
