### PR TITLE
Fix file descriptor log stream tests

### DIFF
--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/FileDescriptorLogStreamTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/FileDescriptorLogStreamTests.cs
@@ -33,9 +33,9 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             });
             TextWriter writer = FileDescriptorLogFactory.InitializeWriter(stream);
             // assert that initializing the stream does not result in UTF-8 preamble log entry
-            Assert.Equal(0, counts.Count);
-            Assert.Equal(0, offsets.Count);
-            Assert.Equal(0, logs.Count);
+            Assert.Empty(counts);
+            Assert.Empty(offsets);
+            Assert.Empty(logs);
 
             const string logMessage = "hello world\nsomething else on a new line.";
             int logMessageLength = logMessage.Length;
@@ -81,9 +81,9 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             });
             TextWriter writer = FileDescriptorLogFactory.InitializeWriter(stream);
             // assert that initializing the stream does not result in UTF-8 preamble log entry
-            Assert.Equal(0, counts.Count);
-            Assert.Equal(0, offsets.Count);
-            Assert.Equal(0, logs.Count);
+            Assert.Empty(counts);
+            Assert.Empty(offsets);
+            Assert.Empty(logs);
 
             string logMessage = new string('a', LogEntryMaxLength - 1) + "b";
             writer.Write(logMessage);
@@ -128,9 +128,9 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             });
             TextWriter writer = FileDescriptorLogFactory.InitializeWriter(stream);
             // assert that initializing the stream does not result in UTF-8 preamble log entry
-            Assert.Equal(0, counts.Count);
-            Assert.Equal(0, offsets.Count);
-            Assert.Equal(0, logs.Count);
+            Assert.Empty(counts);
+            Assert.Empty(offsets);
+            Assert.Empty(logs);
 
             string logMessage = new string('a', LogEntryMaxLength) + "b";
             writer.Write(logMessage);
@@ -163,7 +163,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             Assert.Equal(HeaderLength, headerLogEntry.Length);
             Assert.Equal(LogEntryMaxLength, consoleLogEntry.Length);
             Assert.Equal(HeaderLength, headerLogSecondEntry.Length);
-            Assert.Equal(1, consoleLogSecondEntry.Length);
+            Assert.Single(consoleLogSecondEntry);
 
             byte[] expectedLengthBytes =
             {
@@ -185,7 +185,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
         private static void AssertHeaderBytes(byte[] buf, byte[] expectedLengthBytes)
         {
             byte[] actualHeaderMagicBytes = buf.Take(4).ToArray();
-            byte[] actualHeaderLengthBytes = buf.TakeLast(4).ToArray();
+            byte[] actualHeaderLengthBytes = buf.Skip(4).Take(4).ToArray();
             Assert.Equal(ExpectedMagicBytes, actualHeaderMagicBytes);
             Assert.Equal(expectedLengthBytes, actualHeaderLengthBytes);
         }


### PR DESCRIPTION
**Note:** Builds on #1404 - needs to be rebased and merged after it. Only the top commit is new.

*Description of changes:*
1. Now that we're emitting the timestamp in the log message headers, `AssertHeaderBytes` needed to be updated to extract the _next 4_ bytes for the message length, as opposed to the _last 4_  (which are now the timestamp).
2. Addressed build warnings on this file around collection assertions.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
