### PR TITLE
Lambda Annotations: Add support for returning non 200 responses.

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/AnalyzerReleases.Unshipped.md
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/AnalyzerReleases.Unshipped.md
@@ -6,3 +6,4 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 AWSLambda0104 | AWSLambdaCSharpGenerator | Error | Missing reference to a required dependency
+AWSLambda0105 | AWSLambdaCSharpGenerator | Error | Invalid return type IHttpResult

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/DiagnosticDescriptors.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/DiagnosticDescriptors.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.CodeAnalysis;
+using Amazon.Lambda.Annotations.APIGateway;
 
 namespace Amazon.Lambda.Annotations.SourceGenerator.Diagnostics
 {
@@ -44,5 +45,11 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Diagnostics
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
+        public static readonly DiagnosticDescriptor HttpResultsOnNonApiFunction = new DiagnosticDescriptor(id: "AWSLambda0105",
+            title: $"Invalid return type {nameof(IHttpResult)}",
+            messageFormat: $"{nameof(IHttpResult)} is not a valid return type for LambdaFunctions without {nameof(HttpApiAttribute)} or {nameof(RestApiAttribute)} attributes",
+            category: "AWSLambdaCSharpGenerator",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
     }
 }

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/LambdaMethodModel.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/LambdaMethodModel.cs
@@ -12,10 +12,6 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
     {
         private AttributeModel<LambdaFunctionAttribute> _lambdaFunctionAttribute;
 
-        /// <summary>
-        /// Returns true if original method is an async method
-        /// </summary>
-        public bool IsAsync { get; set; }
 
         /// <summary>
         /// Returns true if original method returns void
@@ -25,12 +21,48 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
         /// <summary>
         /// Returns true if original method returns <see cref="System.Threading.Tasks.Task"/>
         /// </summary>
-        public bool ReturnsTask { get; set; }
+        public bool ReturnsVoidTask { get; set; }
+
+        /// <summary>
+        /// Returns true if original method returns <see cref="System.Threading.Tasks.Task<T>"/>
+        /// </summary>
+        public bool ReturnsGenericTask { get; set; }
+
+        /// <summary>
+        /// Returns true if either the ReturnsVoidTask or ReturnsGenericTask are true
+        /// </summary>
+        public bool ReturnsVoidOrGenericTask => ReturnsVoidTask || ReturnsGenericTask;
 
         /// <summary>
         /// Gets or sets the return type of the method.
         /// </summary>
         public TypeModel ReturnType { get; set; }
+
+        /// <summary>
+        /// Returns true if the Lambda function returns either IHttpResult or Task<IHttpResult>
+        /// </summary>
+        public bool ReturnsIHttpResults
+        {
+            get
+            {
+                if(ReturnsVoid)
+                {
+                    return false;
+                }
+
+                if(ReturnType.FullName == TypeFullNames.IHttpResult)
+                {
+                    return true;
+                }
+                if(ReturnsGenericTask && ReturnType.TypeArguments.Count == 1 && ReturnType.TypeArguments[0].FullName == TypeFullNames.IHttpResult) 
+                {
+                    return true;
+                }
+
+
+                return false;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the parameters of original method. If this method has no parameters, returns

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/LambdaMethodModelBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/LambdaMethodModelBuilder.cs
@@ -16,10 +16,10 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
         {
             var model = new LambdaMethodModel
             {
-                IsAsync = lambdaMethodSymbol.IsAsync,
                 ReturnType = TypeModelBuilder.Build(lambdaMethodSymbol.ReturnType, context),
                 ReturnsVoid = lambdaMethodSymbol.ReturnsVoid,
-                ReturnsTask = lambdaMethodSymbol.ReturnType.Equals(context.Compilation.GetTypeByMetadataName("System.Threading.Tasks.Task"), SymbolEqualityComparer.Default),
+                ReturnsVoidTask = lambdaMethodSymbol.ReturnType.Equals(context.Compilation.GetTypeByMetadataName("System.Threading.Tasks.Task"), SymbolEqualityComparer.Default),
+                ReturnsGenericTask = (lambdaMethodSymbol.ReturnType.BaseType?.Equals(context.Compilation.GetTypeByMetadataName("System.Threading.Tasks.Task"), SymbolEqualityComparer.Default)).GetValueOrDefault(),
                 Parameters = ParameterModelBuilder.Build(lambdaMethodSymbol, context),
                 Name = lambdaMethodSymbol.Name,
                 ContainingAssembly = lambdaMethodSymbol.ContainingAssembly.Name,

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.cs
@@ -189,7 +189,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             this.Write("        }\r\n\r\n        public ");
             
             #line 66 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.IsAsync ? "async " : ""));
+            this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.ReturnsVoidOrGenericTask ? "async " : ""));
             
             #line default
             #line hidden
@@ -942,10 +942,11 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line default
             #line hidden
             this.Write("            // return 400 Bad Request if there exists a validation error\r\n       " +
-                    "     if (validationErrors.Any())\r\n            {\r\n                return new ");
+                    "     if (validationErrors.Any())\r\n            {\r\n                var errorResult" +
+                    " = new ");
             
             #line 356 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.IsAsync ? _model.GeneratedMethod.ReturnType.TaskTypeArgument : _model.GeneratedMethod.ReturnType.FullName));
+            this.Write(this.ToStringHelper.ToStringWithCulture(restApiAttribute != null || httpApiAttribute?.Data.Version == Amazon.Lambda.Annotations.APIGateway.HttpApiVersion.V1 ? "Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse" : "Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyResponse"));
             
             #line default
             #line hidden
@@ -959,15 +960,101 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
                     },
                     StatusCode = 400
                 };
-            }
-
 ");
             
-            #line 368 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 366 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+
+                if(_model.LambdaMethod.ReturnsIHttpResults)
+                {
+
+            
+            #line default
+            #line hidden
+            this.Write("                var errorStream = new System.IO.MemoryStream();\r\n                " +
+                    "System.Text.Json.JsonSerializer.Serialize(errorStream, errorResult);\r\n          " +
+                    "      return errorStream;\r\n");
+            
+            #line 373 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+
+                }
+                else
+                {
+
+            
+            #line default
+            #line hidden
+            this.Write("                return errorResult;\r\n");
+            
+            #line 379 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+
+                }
+
+            
+            #line default
+            #line hidden
+            this.Write("            }\r\n\r\n");
+            
+            #line 384 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
         }
 
-        if (_model.LambdaMethod.ReturnsVoid)
+        if (_model.LambdaMethod.ReturnsIHttpResults)
+        {
+
+            
+            #line default
+            #line hidden
+            this.Write("            var httpResults = ");
+            
+            #line 390 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.ReturnsGenericTask ? "await " : ""));
+            
+            #line default
+            #line hidden
+            
+            #line 390 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.ContainingType.Name.ToCamelCase()));
+            
+            #line default
+            #line hidden
+            this.Write(".");
+            
+            #line 390 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.Name));
+            
+            #line default
+            #line hidden
+            this.Write("(");
+            
+            #line 390 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(parameters));
+            
+            #line default
+            #line hidden
+            this.Write(");\r\n            HttpResultSerializationOptions.ProtocolFormat serializationFormat" +
+                    " = ");
+            
+            #line 391 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(restApiAttribute != null ? "HttpResultSerializationOptions.ProtocolFormat.RestApi" : "HttpResultSerializationOptions.ProtocolFormat.HttpApi"));
+            
+            #line default
+            #line hidden
+            this.Write(";\r\n            HttpResultSerializationOptions.ProtocolVersion serializationVersio" +
+                    "n = ");
+            
+            #line 392 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(restApiAttribute != null || httpApiAttribute?.Data.Version == Amazon.Lambda.Annotations.APIGateway.HttpApiVersion.V1 ? "HttpResultSerializationOptions.ProtocolVersion.V1" : "HttpResultSerializationOptions.ProtocolVersion.V2"));
+            
+            #line default
+            #line hidden
+            this.Write(";\r\n            var serializationOptions = new HttpResultSerializationOptions { Fo" +
+                    "rmat = serializationFormat, Version = serializationVersion };\r\n            var r" +
+                    "esponse = httpResults.Serialize(serializationOptions);\r\n");
+            
+            #line 395 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+
+        }
+        else if (_model.LambdaMethod.ReturnsVoid)
         {
 
             
@@ -975,31 +1062,31 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("            ");
             
-            #line 374 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 400 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.ContainingType.Name.ToCamelCase()));
             
             #line default
             #line hidden
             this.Write(".");
             
-            #line 374 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 400 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.Name));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 374 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 400 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(parameters));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 375 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 401 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
         }
-        else if (_model.LambdaMethod.ReturnsTask)
+        else if (_model.LambdaMethod.ReturnsVoidTask)
         {
 
             
@@ -1007,28 +1094,28 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("            await ");
             
-            #line 380 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 406 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.ContainingType.Name.ToCamelCase()));
             
             #line default
             #line hidden
             this.Write(".");
             
-            #line 380 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 406 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.Name));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 380 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 406 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(parameters));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 381 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 407 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
         }
         else
@@ -1039,38 +1126,38 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("            var response = ");
             
-            #line 386 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.IsAsync ? "await " : ""));
+            #line 412 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.ReturnsGenericTask ? "await " : ""));
             
             #line default
             #line hidden
             
-            #line 386 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 412 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.ContainingType.Name.ToCamelCase()));
             
             #line default
             #line hidden
             this.Write(".");
             
-            #line 386 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 412 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.Name));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 386 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 412 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(parameters));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 387 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 413 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
         }
 
-        if (_model.GeneratedMethod.ReturnType.FullName == _model.LambdaMethod.ReturnType.FullName)
+        if (_model.GeneratedMethod.ReturnType.FullName == _model.LambdaMethod.ReturnType.FullName || _model.LambdaMethod.ReturnsIHttpResults)
         {
 
             
@@ -1078,12 +1165,12 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("            return response;\r\n");
             
-            #line 394 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 420 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
         }
         else
         {
-            if (!_model.LambdaMethod.ReturnsVoid && !_model.LambdaMethod.ReturnsTask)
+            if (!_model.LambdaMethod.ReturnsVoid && !_model.LambdaMethod.ReturnsVoidTask)
             {
                 if (_model.LambdaMethod.ReturnType.IsValueType)
                 {
@@ -1093,7 +1180,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("\r\n            var body = response.ToString();\r\n");
             
-            #line 405 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 431 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
                 }
                 else if (_model.LambdaMethod.ReturnType.IsString())
@@ -1108,14 +1195,14 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("\r\n            var body = ");
             
-            #line 415 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 441 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.Serializer));
             
             #line default
             #line hidden
             this.Write(".Serialize(response);\r\n");
             
-            #line 416 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 442 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
                 }
             }
@@ -1125,16 +1212,16 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("\r\n            return new ");
             
-            #line 421 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.IsAsync ? _model.GeneratedMethod.ReturnType.TaskTypeArgument : _model.GeneratedMethod.ReturnType.FullName));
+            #line 447 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.ReturnsVoidOrGenericTask ? _model.GeneratedMethod.ReturnType.TaskTypeArgument : _model.GeneratedMethod.ReturnType.FullName));
             
             #line default
             #line hidden
             this.Write("\r\n            {\r\n");
             
-            #line 423 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 449 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
-            if (!_model.LambdaMethod.ReturnsVoid && !_model.LambdaMethod.ReturnsTask)
+            if (!_model.LambdaMethod.ReturnsVoid && !_model.LambdaMethod.ReturnsVoidTask)
             {
 
             
@@ -1142,7 +1229,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("                Body = ");
             
-            #line 427 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 453 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.ReturnType.IsString() ? "response" : "body"));
             
             #line default
@@ -1150,14 +1237,14 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             this.Write(",\r\n                Headers = new Dictionary<string, string>\r\n                {\r\n " +
                     "                   {\"Content-Type\", ");
             
-            #line 430 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 456 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.ReturnType.IsString() ? "\"text/plain\"" : "\"application/json\""));
             
             #line default
             #line hidden
             this.Write("}\r\n                },\r\n");
             
-            #line 432 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 458 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
             }
 
@@ -1166,7 +1253,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("                StatusCode = 200\r\n            };\r\n");
             
-            #line 437 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 463 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
         }
     }
@@ -1194,21 +1281,21 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("            var ");
             
-            #line 459 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 485 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(parameter.Name));
             
             #line default
             #line hidden
             this.Write(" = scope.ServiceProvider.GetRequiredService<");
             
-            #line 459 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 485 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(parameter.Type.FullName));
             
             #line default
             #line hidden
             this.Write(">();\r\n");
             
-            #line 460 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 486 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
             }
         }
@@ -1221,31 +1308,31 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("            ");
             
-            #line 467 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 493 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.ContainingType.Name.ToCamelCase()));
             
             #line default
             #line hidden
             this.Write(".");
             
-            #line 467 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 493 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.Name));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 467 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 493 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(parameters));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 468 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 494 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
         }
-        else if (_model.LambdaMethod.ReturnsTask)
+        else if (_model.LambdaMethod.ReturnsVoidTask)
         {
 
             
@@ -1253,28 +1340,28 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("            await ");
             
-            #line 473 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 499 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.ContainingType.Name.ToCamelCase()));
             
             #line default
             #line hidden
             this.Write(".");
             
-            #line 473 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 499 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.Name));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 473 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 499 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(parameters));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 474 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 500 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
         }
         else
@@ -1285,34 +1372,34 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             #line hidden
             this.Write("            return ");
             
-            #line 479 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.IsAsync ? "await " : ""));
+            #line 505 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.ReturnsGenericTask ? "await " : ""));
             
             #line default
             #line hidden
             
-            #line 479 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 505 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.ContainingType.Name.ToCamelCase()));
             
             #line default
             #line hidden
             this.Write(".");
             
-            #line 479 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 505 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.LambdaMethod.Name));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 479 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 505 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(parameters));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 480 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 506 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
 
         }
     }
@@ -1336,7 +1423,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
 
             envValue.Append(""amazon-lambda-annotations_");
             
-            #line 498 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
+            #line 524 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\LambdaFunctionTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_model.SourceGeneratorVersion));
             
             #line default

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.tt
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/LambdaFunctionTemplate.tt
@@ -63,7 +63,7 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
 #>
         }
 
-        public <#= _model.LambdaMethod.IsAsync ? "async " : "" #><#= _model.GeneratedMethod.ReturnType.FullName #> <#= _model.LambdaMethod.Name #>(<#= string.Join(", ", _model.GeneratedMethod.Parameters.Select(p => $"{p.Type.FullName} {p.Name}")) #>)
+        public <#= _model.LambdaMethod.ReturnsVoidOrGenericTask ? "async " : "" #><#= _model.GeneratedMethod.ReturnType.FullName #> <#= _model.LambdaMethod.Name #>(<#= string.Join(", ", _model.GeneratedMethod.Parameters.Select(p => $"{p.Type.FullName} {p.Name}")) #>)
         {
 <#
     if (_model.LambdaMethod.UsingDependencyInjection)
@@ -353,7 +353,7 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
             // return 400 Bad Request if there exists a validation error
             if (validationErrors.Any())
             {
-                return new <#= _model.LambdaMethod.IsAsync ? _model.GeneratedMethod.ReturnType.TaskTypeArgument : _model.GeneratedMethod.ReturnType.FullName #>
+                var errorResult = new <#= restApiAttribute != null || httpApiAttribute?.Data.Version == Amazon.Lambda.Annotations.APIGateway.HttpApiVersion.V1 ? "Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse" : "Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyResponse" #>
                 {
                     Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
                     Headers = new Dictionary<string, string>
@@ -363,18 +363,44 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
                     },
                     StatusCode = 400
                 };
+<#
+                if(_model.LambdaMethod.ReturnsIHttpResults)
+                {
+#>
+                var errorStream = new System.IO.MemoryStream();
+                System.Text.Json.JsonSerializer.Serialize(errorStream, errorResult);
+                return errorStream;
+<#
+                }
+                else
+                {
+#>
+                return errorResult;
+<#
+                }
+#>
             }
 
 <#
         }
 
-        if (_model.LambdaMethod.ReturnsVoid)
+        if (_model.LambdaMethod.ReturnsIHttpResults)
+        {
+#>
+            var httpResults = <#= _model.LambdaMethod.ReturnsGenericTask ? "await " : "" #><#= _model.LambdaMethod.ContainingType.Name.ToCamelCase() #>.<#= _model.LambdaMethod.Name #>(<#= parameters #>);
+            HttpResultSerializationOptions.ProtocolFormat serializationFormat = <#= restApiAttribute != null ? "HttpResultSerializationOptions.ProtocolFormat.RestApi" : "HttpResultSerializationOptions.ProtocolFormat.HttpApi"#>;
+            HttpResultSerializationOptions.ProtocolVersion serializationVersion = <#= restApiAttribute != null || httpApiAttribute?.Data.Version == Amazon.Lambda.Annotations.APIGateway.HttpApiVersion.V1 ? "HttpResultSerializationOptions.ProtocolVersion.V1" : "HttpResultSerializationOptions.ProtocolVersion.V2"#>;
+            var serializationOptions = new HttpResultSerializationOptions { Format = serializationFormat, Version = serializationVersion };
+            var response = httpResults.Serialize(serializationOptions);
+<#
+        }
+        else if (_model.LambdaMethod.ReturnsVoid)
         {
 #>
             <#= _model.LambdaMethod.ContainingType.Name.ToCamelCase() #>.<#= _model.LambdaMethod.Name #>(<#= parameters #>);
 <#
         }
-        else if (_model.LambdaMethod.ReturnsTask)
+        else if (_model.LambdaMethod.ReturnsVoidTask)
         {
 #>
             await <#= _model.LambdaMethod.ContainingType.Name.ToCamelCase() #>.<#= _model.LambdaMethod.Name #>(<#= parameters #>);
@@ -383,11 +409,11 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
         else
         {
 #>
-            var response = <#= _model.LambdaMethod.IsAsync ? "await " : "" #><#= _model.LambdaMethod.ContainingType.Name.ToCamelCase() #>.<#= _model.LambdaMethod.Name #>(<#= parameters #>);
+            var response = <#= _model.LambdaMethod.ReturnsGenericTask ? "await " : "" #><#= _model.LambdaMethod.ContainingType.Name.ToCamelCase() #>.<#= _model.LambdaMethod.Name #>(<#= parameters #>);
 <#
         }
 
-        if (_model.GeneratedMethod.ReturnType.FullName == _model.LambdaMethod.ReturnType.FullName)
+        if (_model.GeneratedMethod.ReturnType.FullName == _model.LambdaMethod.ReturnType.FullName || _model.LambdaMethod.ReturnsIHttpResults)
         {
 #>
             return response;
@@ -395,7 +421,7 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
         }
         else
         {
-            if (!_model.LambdaMethod.ReturnsVoid && !_model.LambdaMethod.ReturnsTask)
+            if (!_model.LambdaMethod.ReturnsVoid && !_model.LambdaMethod.ReturnsVoidTask)
             {
                 if (_model.LambdaMethod.ReturnType.IsValueType)
                 {
@@ -418,10 +444,10 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
             }
 #>
 
-            return new <#= _model.LambdaMethod.IsAsync ? _model.GeneratedMethod.ReturnType.TaskTypeArgument : _model.GeneratedMethod.ReturnType.FullName #>
+            return new <#= _model.LambdaMethod.ReturnsVoidOrGenericTask ? _model.GeneratedMethod.ReturnType.TaskTypeArgument : _model.GeneratedMethod.ReturnType.FullName #>
             {
 <#
-            if (!_model.LambdaMethod.ReturnsVoid && !_model.LambdaMethod.ReturnsTask)
+            if (!_model.LambdaMethod.ReturnsVoid && !_model.LambdaMethod.ReturnsVoidTask)
             {
 #>
                 Body = <#= _model.LambdaMethod.ReturnType.IsString() ? "response" : "body" #>,
@@ -467,7 +493,7 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
             <#= _model.LambdaMethod.ContainingType.Name.ToCamelCase() #>.<#= _model.LambdaMethod.Name #>(<#= parameters #>);
 <#
         }
-        else if (_model.LambdaMethod.ReturnsTask)
+        else if (_model.LambdaMethod.ReturnsVoidTask)
         {
 #>
             await <#= _model.LambdaMethod.ContainingType.Name.ToCamelCase() #>.<#= _model.LambdaMethod.Name #>(<#= parameters #>);
@@ -476,7 +502,7 @@ namespace <#= _model.LambdaMethod.ContainingNamespace #>
         else
         {
 #>
-            return <#= _model.LambdaMethod.IsAsync ? "await " : "" #><#= _model.LambdaMethod.ContainingType.Name.ToCamelCase() #>.<#= _model.LambdaMethod.Name #>(<#= parameters #>);
+            return <#= _model.LambdaMethod.ReturnsGenericTask ? "await " : "" #><#= _model.LambdaMethod.ContainingType.Name.ToCamelCase() #>.<#= _model.LambdaMethod.Name #>(<#= parameters #>);
 <#
         }
     }

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/TypeFullNames.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/TypeFullNames.cs
@@ -11,12 +11,15 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
         public const string Task1 = "System.Threading.Tasks.Task`1";
         public const string Task = "System.Threading.Tasks.Task";
         public const string MemoryStream = "System.IO.MemoryStream";
+        public const string Stream = "System.IO.Stream";
 
         public const string ILambdaContext = "Amazon.Lambda.Core.ILambdaContext";
         public const string APIGatewayProxyRequest = "Amazon.Lambda.APIGatewayEvents.APIGatewayProxyRequest";
         public const string APIGatewayProxyResponse = "Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse";
         public const string APIGatewayHttpApiV2ProxyRequest = "Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyRequest";
         public const string APIGatewayHttpApiV2ProxyResponse = "Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyResponse";
+
+        public const string IHttpResult = "Amazon.Lambda.Annotations.APIGateway.IHttpResult";
 
         public const string LambdaFunctionAttribute = "Amazon.Lambda.Annotations.LambdaFunctionAttribute";
         public const string FromServiceAttribute = "Amazon.Lambda.Annotations.FromServicesAttribute";

--- a/Libraries/src/Amazon.Lambda.Annotations.nuspec
+++ b/Libraries/src/Amazon.Lambda.Annotations.nuspec
@@ -21,8 +21,8 @@
         <file src="Amazon.Lambda.Annotations\THIRD_PARTY_LICENSES" target="THIRD_PARTY_LICENSES" />
 
         <!-- Dependencies to make sure attributes are available in consuming csproj, this ensures packaged version of customer code have all the dependencies needed. -->
-        <file src="Amazon.Lambda.Annotations\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.dll" target="lib/net6.0" />
-        <file src="Amazon.Lambda.Annotations\bin\Release\netstandard2.0\Amazon.Lambda.Annotations.xml" target="lib/net6.0" />
+        <file src="Amazon.Lambda.Annotations\bin\Release\net6.0\Amazon.Lambda.Annotations.dll" target="lib/net6.0" />
+        <file src="Amazon.Lambda.Annotations\bin\Release\net6.0\Amazon.Lambda.Annotations.xml" target="lib/net6.0" />
 
         <!-- Include every dependency manually for analyzer, whenever a new dependency is added, it has to be added here. -->
         <!-- NOTE: Project dependencies should come from their own bin folder to make sure a code signed binary is packed -->

--- a/Libraries/src/Amazon.Lambda.Annotations/APIGateway/HttpResults.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/APIGateway/HttpResults.cs
@@ -1,0 +1,465 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+#if NET6_0_OR_GREATER
+using System.Buffers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+#endif
+
+// This assembly is also used in the source generator which needs the .NET attributes and type infos defined in this project.
+// The source generator requires all dependencies to target .NET Standard 2.0 to be compatible with .NET Framework used
+// by Visual Studio. Several APIs are used in this file that are not available in .NET Standard 2.0 but the source
+// generator doesn't use the methods that use those .NET APIs. Several areas in this file put stub implementations
+// for .NET Standard 2.0 to allow the types to be available in the source generator but the implementations
+// are not actually called in the source generator.
+
+
+namespace Amazon.Lambda.Annotations.APIGateway
+{
+    /// <summary>
+    /// The options used by the IHttpResult to serialize into the required format for the event source of the Lambda funtion.
+    /// </summary>
+    public class HttpResultSerializationOptions
+    {
+        /// <summary>
+        /// The API Gateway protocol format used as the event source.
+        /// </summary>
+        public enum ProtocolFormat { 
+            /// <summary>
+            /// Used when a function is defined with the RestApiAttribute.
+            /// </summary>
+            RestApi, 
+            /// <summary>
+            /// Used when a function is defined with the HttpApiAttribute.
+            /// </summary>
+            HttpApi 
+        }
+
+        /// <summary>
+        /// The API Gateway protocol version.
+        /// </summary>
+        public enum ProtocolVersion {
+            /// <summary>
+            /// V1 format for API Gateway Proxy responses. Used for functions defined with RestApiAttribute or HttpApiAttribute with explicit setting to V1.
+            /// </summary>
+            V1, 
+            /// <summary>
+            /// V2 format for API Gateway Proxy responses. Used for functions defined with HttpApiAttribute with an implicit version of an explicit setting to V2.
+            /// </summary>
+            V2 
+        }
+
+        /// <summary>
+        /// The API Gateway protocol used as the event source. 
+        ///     RestApi -> RestApiAttrbute
+        ///     HttpApi -> HttpApiAttribute
+        /// </summary>
+        public ProtocolFormat Format { get; set; }
+
+        /// <summary>
+        /// The API Gateway protocol version used as the event source. 
+        ///     V1 -> RestApi or HttpApi specifically set as V1
+        ///     V2 -> HttpApi either implicit or explicit set to V2
+        /// </summary>
+        public ProtocolVersion Version { get; set; }
+    }
+
+    /// <summary>
+    /// If this inteface is returned for an API Gateway Lambda function it will serialize itself to the correct JSON format for the 
+    /// configured event source's protocol format and version.
+    /// 
+    /// Users should use the implementation class HttpResults to construct an instance of IHttpResult with the configured, status code, response body and headers.
+    /// </summary>
+    /// <example>
+    /// return HttpResults.Ok("All Good")
+    ///                   .AddHeader("Custom-Header", "FooBar");
+    /// 
+    /// </example>
+    public interface IHttpResult
+    {
+        /// <summary>
+        /// Used by the Lambda Annotations framework to serialize the IHttpResult to the correct JSON response.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        Stream Serialize(HttpResultSerializationOptions options);
+
+        /// <summary>
+        /// Add header to the IHttpResult. The AddHeader method can be called multiple times for the same header to add multi values for a header.
+        /// HTTP header names are case insensitive and the AddHeader method will normalize header name casing by calling ToLower on them.
+        /// </summary>
+        /// <param name="name">HTTP header name</param>
+        /// <param name="value">HTTP header value</param>
+        /// <returns>The same instance to allow fluent call pattern.</returns>
+        IHttpResult AddHeader(string name, string value);
+    }
+
+    /// <summary>
+    /// Implementation class for IHttpResult. Consumers should use one of the static methods to create the a result with the desired status code.
+    /// </summary>
+    /// <remarks>
+    /// If a response body is provided it is format using the following rules:
+    /// <list type="bullet">
+    ///     <item>
+    ///         <description>For string then returned as is.</description>
+    ///     </item>
+    ///     <item>
+    ///         <description>For Stream, byte[] or IList&lt;byte&gt; the data is consided binary and base 64 encoded.</description>
+    ///     </item>
+    ///     <item>
+    ///         <description>Anything other type is serialized to JSON.</description>
+    ///     </item>
+    /// </list>
+    /// </remarks>
+    /// <example>
+    /// return HttpResults.Ok("All Good")
+    ///                   .AddHeader("Custom-Header", "FooBar");
+    /// 
+    /// </example>
+    public class HttpResults : IHttpResult
+    {
+        private const string HEADER_NAME_CONTENT_TYPE = "content-type";
+        private const string CONTENT_TYPE_APPLICATION_JSON = "application/json";
+        private const string CONTENT_TYPE_TEXT_PLAIN = "text/plain";
+        private const string CONTENT_TYPE_APPLICATION_OCTET_STREAM = "application/octet-stream";
+
+        private HttpStatusCode _statusCode;
+        private string _body;
+        private IDictionary<string, IList<string>> _headers;
+        private bool _isBase64Encoded;
+        private string _defaultContentType;
+
+        private HttpResults(HttpStatusCode statusCode, object body = null)
+        {
+            _statusCode = statusCode;
+
+            FormatBody(body);
+        }
+
+        /// <inheritdoc/>
+        public IHttpResult AddHeader(string name, string value)
+        {
+            name = name.ToLower();
+
+            if (_headers == null)
+            {
+                _headers = new Dictionary<string, IList<string>>();
+            }
+
+            if (!_headers.TryGetValue(name, out var values))
+            {
+                values = new List<string>();
+                _headers[name] = values;
+            }
+            values.Add(value);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Creates an IHttpResult for a Accepted (202) status code.
+        /// </summary>
+        /// <param name="body">Optional response body</param>
+        /// <returns></returns>
+        public static IHttpResult Accepted(object body = null)
+        {
+            return new HttpResults(HttpStatusCode.Accepted, body);
+        }
+
+        /// <summary>
+        /// Creates an IHttpResult for a BadRequest (400) status code.
+        /// </summary>
+        /// <param name="body">Optional response body</param>
+        /// <returns></returns>
+        public static IHttpResult BadRequest(object body = null)
+        {
+            return new HttpResults(HttpStatusCode.BadRequest, body);
+        }
+
+        /// <summary>
+        /// Creates an IHttpResult for a Conflict (409) status code.
+        /// </summary>
+        /// <param name="body">Optional response body</param>
+        /// <returns></returns>
+        public static IHttpResult Conflict(object body = null)
+        {
+            return new HttpResults(HttpStatusCode.Conflict, body);
+        }
+
+        /// <summary>
+        /// Creates an IHttpResult for a Created (201) status code.
+        /// </summary>
+        /// <param name="uri">Optional URI for the created resource. The value is set to the Location response header.</param>
+        /// <param name="body">Optional response body</param>
+        /// <returns></returns>
+        public static IHttpResult Created(string uri = null, object body = null)
+        {
+            var result = new HttpResults(HttpStatusCode.Created, body);
+            if (uri != null)
+            {
+                result.AddHeader("location", uri);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates an IHttpResult for a Forbidden (403) status code.
+        /// </summary>
+        /// <param name="body">Optional response body</param>
+        /// <returns></returns>
+        public static IHttpResult Forbid(object body = null)
+        {
+            return new HttpResults(HttpStatusCode.Forbidden, body);
+        }
+
+        /// <summary>
+        /// Creates an IHttpResult for a NotFound (404) status code.
+        /// </summary>
+        /// <param name="body">Optional response body</param>
+        /// <returns></returns>
+        public static IHttpResult NotFound(object body = null)
+        {
+            return new HttpResults(HttpStatusCode.NotFound, body);
+        }
+
+        /// <summary>
+        /// Creates an IHttpResult for a Ok (200) status code.
+        /// </summary>
+        /// <param name="body">Optional response body</param>
+        /// <returns></returns>
+        public static IHttpResult Ok(object body = null)
+        {
+            return new HttpResults(HttpStatusCode.OK, body);
+        }
+
+        /// <summary>
+        /// Creates an IHttpResult for redirect responses.
+        /// </summary>
+        /// <remarks>
+        /// This method uses the same logic for determing the the Http status code as the Microsoft.AspNetCore.Http.TypedResults.Redirect uses.
+        /// https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.typedresults.redirect
+        /// </remarks>
+        /// <param name="uri">The URI to redirect to. The value will be set in the location header.</param>
+        /// <param name="permanent">Whether the redirect should be a permanet (301) or temporary (302) redirect.</param>
+        /// <param name="preserveMethod">Whether the request method should be preserved. If set to true use 308 for permanent or 307 for temporary redirects.</param>
+        /// <returns></returns>
+        public static IHttpResult Redirect(string uri, bool permanent = false, bool preserveMethod = false)
+        {
+            HttpStatusCode code;
+            if (permanent && preserveMethod)
+            {
+                code = (HttpStatusCode)308; // .NET Standard 2.0 does not have the enum value for PermanentRedirect so using direct number;
+            }
+            else if (!permanent && preserveMethod)
+            {
+                code = HttpStatusCode.TemporaryRedirect;
+            }
+            else if (permanent && !preserveMethod)
+            {
+                code = HttpStatusCode.MovedPermanently;
+            }
+            else
+            {
+                code = HttpStatusCode.Redirect;
+            }
+
+
+            var result = new HttpResults(code, null);
+            if (uri != null)
+            {
+                result.AddHeader("location", uri);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates an IHttpResult for a Unauthorized (401) status code.
+        /// </summary>
+        /// <returns></returns>
+        public static IHttpResult Unauthorized()
+        {
+            return new HttpResults(HttpStatusCode.Unauthorized);
+        }
+
+        /// <summary>
+        /// Creates an IHttpResult for the specified status code.
+        /// </summary>
+        /// <param name="statusCode">Http status code used to create the IHttpResult instance.</param>
+        /// <param name="body">Optional response body</param>
+        /// <returns></returns>
+        public static IHttpResult NewResult(HttpStatusCode statusCode, object body = null)
+        {
+            return new HttpResults(statusCode, body);
+        }
+
+
+    #region Serialization
+
+        // See comment in class documentation on the rules for serializing. If any changes are made in this method be sure to update
+        // the comment above.
+        private void FormatBody(object body)
+        {
+        // See comment at the top about .NET Standard 2.0
+#if NETSTANDARD2_0
+            throw new NotImplementedException();
+#else
+
+            if (body == null)
+                return;
+
+            if (body is string str)
+            {
+                _defaultContentType = CONTENT_TYPE_TEXT_PLAIN;
+                _body = str;
+            }
+            else if (body is Stream stream)
+            {
+                _defaultContentType = CONTENT_TYPE_APPLICATION_OCTET_STREAM;
+                _isBase64Encoded = true;
+                var buffer = ArrayPool<byte>.Shared.Rent((int)stream.Length);
+                try
+                {
+                    var readLength = stream.Read(buffer, 0, buffer.Length);
+                    _body = Convert.ToBase64String(buffer, 0, readLength);
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
+                }
+            }
+            else if (body is byte[] binaryData)
+            {
+                _defaultContentType = CONTENT_TYPE_APPLICATION_OCTET_STREAM;
+                _isBase64Encoded = true;
+                _body = Convert.ToBase64String(binaryData, 0, binaryData.Length);
+            }
+            else if (body is IList<byte> listBinaryData)
+            {
+                _defaultContentType = CONTENT_TYPE_APPLICATION_OCTET_STREAM;
+                _isBase64Encoded = true;
+                _body = Convert.ToBase64String(listBinaryData.ToArray(), 0, listBinaryData.Count);
+            }
+            else
+            {
+                _defaultContentType = CONTENT_TYPE_APPLICATION_JSON;
+                _body = JsonSerializer.Serialize(body);
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Serialize the IHttpResult into the expect format for the event source.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        public Stream Serialize(HttpResultSerializationOptions options)
+        {
+        // See comment at the top about .NET Standard 2.0
+#if NETSTANDARD2_0
+            throw new NotImplementedException();
+#else
+            // If the user didn't explicit set the content type then default to application/json
+            if(!string.IsNullOrEmpty(_body) && (_headers == null || !_headers.ContainsKey(HEADER_NAME_CONTENT_TYPE)))
+            {
+                AddHeader(HEADER_NAME_CONTENT_TYPE, _defaultContentType);
+            }
+
+            var stream = new MemoryStream();
+            if (options.Format == HttpResultSerializationOptions.ProtocolFormat.RestApi ||
+                (options.Format == HttpResultSerializationOptions.ProtocolFormat.HttpApi && options.Version == HttpResultSerializationOptions.ProtocolVersion.V1))
+            {
+                var response = new APIGatewayV1Response
+                {
+                    StatusCode = (int)_statusCode,
+                    Body = _body,
+                    MultiValueHeaders = _headers,
+                    IsBase64Encoded = _isBase64Encoded
+                };
+
+                JsonSerializer.Serialize(stream, response);
+            }
+            else
+            {
+                var response = new APIGatewayV2Response
+                {
+                    StatusCode = (int)_statusCode,
+                    Body = _body,
+                    Headers = ConvertToV2MultiValueHeaders(_headers),
+                    IsBase64Encoded = _isBase64Encoded
+                };
+
+                JsonSerializer.Serialize(stream, response);
+            }
+
+            stream.Position = 0;
+            return stream;
+#endif
+        }
+
+        /// <summary>
+        /// The V2 format used by HttpApi handles multi value headers by having the value be comma delimited. This 
+        /// utility method handles converting the collection from the V1 format to the V2.
+        /// </summary>
+        /// <param name="v1MultiHeaders"></param>
+        /// <returns></returns>
+        private static IDictionary<string, string> ConvertToV2MultiValueHeaders(IDictionary<string, IList<string>> v1MultiHeaders)
+        {
+            if (v1MultiHeaders == null)
+                return null;
+
+            var v2MultiHeaders = new Dictionary<string, string>();
+            foreach (var kvp in v1MultiHeaders)
+            {
+                var values = string.Join(",", kvp.Value);
+                v2MultiHeaders[kvp.Key] = values;
+            }
+
+            return v2MultiHeaders;
+        }
+
+        // See comment at the top about .NET Standard 2.0
+#if !NETSTANDARD2_0
+        // Class representing the V1 API Gateway response. Very similiar to Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse but this library can
+        // not take a dependency on Amazon.Lambda.APIGatewayEvents so it has to have its own version.
+        private class APIGatewayV1Response
+        {
+            [JsonPropertyName("statusCode")]
+            public int StatusCode { get; set; }
+
+            [JsonPropertyName("multiValueHeaders")]
+            public IDictionary<string, IList<string>> MultiValueHeaders { get; set; }
+
+            [JsonPropertyName("body")]
+            public string Body { get; set; }
+
+            [JsonPropertyName("isBase64Encoded")]
+            public bool IsBase64Encoded { get; set; }
+        }
+
+        // Class representing the V2 API Gateway response. Very similiar to Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyResponse but this library can
+        // not take a dependency on Amazon.Lambda.APIGatewayEvents so it has to have its own version.
+        private class APIGatewayV2Response
+        {
+            [JsonPropertyName("statusCode")]
+            public int StatusCode { get; set; }
+
+            [JsonPropertyName("headers")]
+            public IDictionary<string, string> Headers { get; set; }
+
+            public string[] Cookies { get; set; }
+
+            [JsonPropertyName("body")]
+            public string Body { get; set; }
+
+            [JsonPropertyName("isBase64Encoded")]
+            public bool IsBase64Encoded { get; set; }
+        }
+#endif
+#endregion
+    }
+}

--- a/Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj
+++ b/Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyVersion>0.10.0.0</AssemblyVersion>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/Libraries/src/Amazon.Lambda.Annotations/README.md
+++ b/Libraries/src/Amazon.Lambda.Annotations/README.md
@@ -737,6 +737,45 @@ parameter to the `LambdaFunction` must be the event object and the event source 
 * FromServices
     * Map method parameter to registered service in IServiceProvider
 
+### Customizing responses for API Gateway Lambda functions
+
+The attributes `RestApi` or `HttpApi` configure a `LambdaFunction` method to use API Gateway as the event source for the function. By default these methods return an 
+HTTP status code of 200. To customize the HTTP response, including adding HTTP headers, the method signature must return an `Amazon.Lambda.Annotations.APIGateway.IHttpResult`
+or `Task<Amazon.Lambda.Annotations.APIGateway.IHttpResult>`.
+The `Amazon.Lambda.Annotations.APIGateway.HttpResults` class contains static methods for creating an instance of `IHttpResult` with the appropriate HTTP status code and headers.
+
+The example below shows how to return a HTTP status code 404 with a response body and custom header.
+
+```
+[LambdaFunction(PackageType = LambdaPackageType.Image)]
+[HttpApi(LambdaHttpMethod.Get, "/resource/{id}")]
+public IHttpResult NotFoundResponseWithHeaderV2(int id, ILambdaContext context)
+{
+    return HttpResults.NotFound($"Resource with id {id} could not be found")
+                        .AddHeader("Custom-Header1", "Value1");
+}
+```
+
+Available static methods for creating an instance of `IHttpResult`.
+* HttpResults.Accepted()
+* HttpResults.BadRequest()
+* HttpResults.Conflict()
+* HttpResults.Created()
+* HttpResults.Forbid()
+* HttpResults.NotFound()
+* HttpResults.Ok()
+* HttpResults.Redirect()
+* HttpResults.Unauthorized()
+* HttpResults.NewResult()
+
+#### Content-Type
+`HttpResults` will automatically assign a content-type for the response if there is a response body and content type was not specified using the `AddHeader` method.
+The content type is determined using the following rules.
+
+* Content type will be set to `text/plain` when the response body is a string.
+* Content type will be set to `application/octet-stream` when the response body is a `Stream`, `byte[]` or `IList<byte>`.
+* For any other response body the content type is set to `application/json`.
+
 
 ## Project References
 

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
@@ -1,28 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-        <PackageReference Include="Moq" Version="4.16.1" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="System.Memory" Version="4.5.4" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <PackageReference Include="System.Memory" Version="4.5.5" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="AWSSDK.Core" Version="3.7.3.15" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-		<PackageReference Include="YamlDotNet" Version="12.0.0" />
+        <PackageReference Include="AWSSDK.Core" Version="3.7.103.24" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.1" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+		<PackageReference Include="YamlDotNet" Version="12.3.1" />
 	</ItemGroup>
 
     <ItemGroup>
@@ -58,6 +58,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <None Remove="Snapshots\ServerlessTemplates\customizeResponse.template" />
       <None Remove="Snapshots\ServerlessTemplates\dynamicexample.template" />
       <None Remove="Snapshots\ServerlessTemplates\subnamespace.template" />
       <None Remove="Snapshots\ServerlessTemplates\taskexample.template" />

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/HttpResultsTest.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/HttpResultsTest.cs
@@ -1,0 +1,351 @@
+﻿using System;
+using System.Net;
+using System.Collections.Generic;
+using System.Text.Json;
+using Amazon.Lambda.Annotations.APIGateway;
+using Xunit;
+using System.IO;
+using System.Text.Json.Nodes;
+using System.Linq;
+
+namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
+{
+    public class HttpResultsTest
+    {
+        [Fact]
+        public void OkNoBody()
+        {
+            var result = HttpResults.Ok();
+            ValidateResult(result, HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public void OkStringBody()
+        {
+            var body = "Hello World";
+            var result = HttpResults.Ok(body);
+            ValidateResult(result, HttpStatusCode.OK, body, headers: new Dictionary<string, IList<string>>
+                            {
+                                { "content-type", new List<string> { "text/plain" } }
+                            }
+                );
+        }
+
+        [Fact]
+        public void OverrideContentType()
+        {
+            var body = "Hello World";
+            var result = HttpResults.Ok(body).AddHeader("content-type", "custom/foo");
+            ValidateResult(result, HttpStatusCode.OK, body, headers: new Dictionary<string, IList<string>>
+                            {
+                                { "content-type", new List<string> { "custom/foo" } }
+                            }
+                );
+        }
+
+        [Fact]
+        public void OkByteArrayBody()
+        {
+            var body = new byte[] { 0x01, 0x02 };
+
+            var result = HttpResults.Ok(body);
+            ValidateResult(result, HttpStatusCode.OK, Convert.ToBase64String(body), isBase64Encoded: true, headers: new Dictionary<string, IList<string>>
+                            {
+                                { "content-type", new List<string> { "application/octet-stream" } }
+                            }
+                );
+        }
+
+        [Fact]
+        public void OkStreamBody()
+        {
+            var body = new byte[] { 0x01, 0x02 };
+            var result = HttpResults.Ok(new MemoryStream(body));
+            ValidateResult(result, HttpStatusCode.OK, Convert.ToBase64String(body), isBase64Encoded: true, headers: new Dictionary<string, IList<string>>
+                            {
+                                { "content-type", new List<string> { "application/octet-stream" } }
+                            }
+                );
+        }
+
+        [Fact]
+        public void OkListOfBytesBody()
+        {
+            var body = new byte[] { 0x01, 0x02 };
+            var result = HttpResults.Ok(new List<byte>(body));
+            ValidateResult(result, HttpStatusCode.OK, Convert.ToBase64String(body), isBase64Encoded: true, headers: new Dictionary<string, IList<string>>
+                            {
+                                { "content-type", new List<string> { "application/octet-stream" } }
+                            }
+                );
+        }
+
+        [Fact]
+        public void OkWithTypeBody()
+        {
+            var body = new FakeBody();
+            var result = HttpResults.Ok(body);
+            ValidateResult(result, HttpStatusCode.OK, "{\"Id\":1}", isBase64Encoded: false, headers: new Dictionary<string, IList<string>>
+                            {
+                                { "content-type", new List<string> { "application/json" } }
+                            }
+                );
+        }
+
+        [Fact]
+        public void OkWithSingleValueHeader()
+        {
+            var result = HttpResults.Ok()
+                                    .AddHeader("header1", "value1")
+                                    .AddHeader("header2", "value2");
+
+            ValidateResult(result, HttpStatusCode.OK, 
+                headers: new Dictionary<string, IList<string>> 
+                            { 
+                                { "header1", new List<string> { "value1" } }, 
+                                { "header2", new List<string> { "value2" } } 
+                            }
+                );
+        }
+
+        [Fact]
+        public void OkWithMultiValueHeader()
+        {
+            var result = HttpResults.Ok()
+                                    .AddHeader("header1", "foo1")
+                                    .AddHeader("header1", "foo2")
+                                    .AddHeader("header2", "bar1")
+                                    .AddHeader("header2", "bar2");
+
+            ValidateResult(result, HttpStatusCode.OK,
+                headers: new Dictionary<string, IList<string>>
+                            {
+                                { "header1", new List<string> { "foo1", "foo2" } },
+                                { "header2", new List<string> { "bar1", "bar2" } }
+                            }
+                );
+        }
+
+        [Fact]
+        public void Accepted()
+        {
+            var result = HttpResults.Accepted();
+            ValidateResult(result, HttpStatusCode.Accepted);
+        }
+
+        [Fact]
+        public void BadRequest()
+        {
+            var result = HttpResults.BadRequest();
+            ValidateResult(result, HttpStatusCode.BadRequest);
+        }
+
+        [Fact]
+        public void Conflict()
+        {
+            var result = HttpResults.Conflict();
+            ValidateResult(result, HttpStatusCode.Conflict);
+        }
+
+        [Fact]
+        public void Created()
+        {
+            var result = HttpResults.Created();
+            ValidateResult(result, HttpStatusCode.Created);
+        }
+
+        [Fact]
+        public void CreatedWithUriAndBody()
+        {
+            var result = HttpResults.Created("http://localhost/foo", "Resource Created");
+            ValidateResult(result, HttpStatusCode.Created, "Resource Created",
+                headers: new Dictionary<string, IList<string>>
+                            {
+                                { "content-type", new List<string> { "text/plain" } },
+                                { "location", new List<string> { "http://localhost/foo" } }
+                            }
+                );
+        }
+
+        [Fact]
+        public void Forbid()
+        {
+            var result = HttpResults.Forbid();
+            ValidateResult(result, HttpStatusCode.Forbidden);
+        }
+
+        [Fact]
+        public void Redirect_PermanentRedirect()
+        {
+            var result = HttpResults.Redirect("http://localhost/foo", permanent: true, preserveMethod: true);
+            ValidateResult(result, HttpStatusCode.PermanentRedirect,
+                headers: new Dictionary<string, IList<string>>
+                            {
+                                { "location", new List<string> { "http://localhost/foo" } }
+                            }
+                );
+        }
+
+        [Fact]
+        public void Redirect_MovedPermanently()
+        {
+            var result = HttpResults.Redirect("http://localhost/foo", permanent: true, preserveMethod: false);
+            ValidateResult(result, HttpStatusCode.MovedPermanently,
+                headers: new Dictionary<string, IList<string>>
+                            {
+                                { "location", new List<string> { "http://localhost/foo" } }
+                            }
+                );
+        }
+
+        [Fact]
+        public void Redirect_TemporaryRedirect()
+        {
+            var result = HttpResults.Redirect("http://localhost/foo", permanent: false, preserveMethod: true);
+            ValidateResult(result, HttpStatusCode.TemporaryRedirect,
+                headers: new Dictionary<string, IList<string>>
+                            {
+                                { "location", new List<string> { "http://localhost/foo" } }
+                            }
+                );
+        }
+
+        [Fact]
+        public void Redirect_Redirect()
+        {
+            var result = HttpResults.Redirect("http://localhost/foo", permanent: false, preserveMethod: false);
+            ValidateResult(result, HttpStatusCode.Redirect,
+                headers: new Dictionary<string, IList<string>>
+                            {
+                                { "location", new List<string> { "http://localhost/foo" } }
+                            }
+                );
+        }
+
+        [Fact]
+        public void NotFound()
+        {
+            var result = HttpResults.NotFound();
+            ValidateResult(result, HttpStatusCode.NotFound);
+        }
+
+        [Fact]
+        public void Unauthorized()
+        {
+            var result = HttpResults.Unauthorized();
+            ValidateResult(result, HttpStatusCode.Unauthorized);
+        }
+
+        [Fact]
+        public void MixCaseHeaders()
+        {
+            var result = HttpResults.Ok()
+                                    .AddHeader("key", "value1")
+                                    .AddHeader("key", "value2")
+                                    .AddHeader("KEY", "VALUE3");
+
+            ValidateResult(result, HttpStatusCode.OK, headers: new Dictionary<string, IList<string>>
+            {
+                {"key", new List<string> {"value1", "value2", "VALUE3"} }
+            });
+        }
+
+
+        private void ValidateResult(IHttpResult result, HttpStatusCode statusCode, string body = null, bool isBase64Encoded = false, IDictionary<string, IList<string>> headers = null)
+        {
+            var testScenarios = new List<Tuple<HttpResultSerializationOptions.ProtocolFormat, HttpResultSerializationOptions.ProtocolVersion>>
+            {
+                new (HttpResultSerializationOptions.ProtocolFormat.RestApi, HttpResultSerializationOptions.ProtocolVersion.V1),
+                new (HttpResultSerializationOptions.ProtocolFormat.HttpApi, HttpResultSerializationOptions.ProtocolVersion.V1),
+                new (HttpResultSerializationOptions.ProtocolFormat.HttpApi, HttpResultSerializationOptions.ProtocolVersion.V2)
+            };
+
+            foreach(var (format, version) in testScenarios)
+            {
+                var stream = result.Serialize(new HttpResultSerializationOptions { Format = format, Version = version });
+                var jsonDoc = JsonDocument.Parse(stream);
+                if (format == HttpResultSerializationOptions.ProtocolFormat.RestApi || (format == HttpResultSerializationOptions.ProtocolFormat.HttpApi && version == HttpResultSerializationOptions.ProtocolVersion.V1))
+                {
+                    Assert.Equal((int)statusCode, jsonDoc.RootElement.GetProperty("statusCode").GetInt32());
+
+                    if(body != null)
+                    {
+                        Assert.Equal(body, jsonDoc.RootElement.GetProperty("body").GetString());
+                        Assert.Equal(isBase64Encoded, jsonDoc.RootElement.GetProperty("isBase64Encoded").GetBoolean());
+                    }
+                    else
+                    {
+                        var bodyProperties = jsonDoc.RootElement.GetProperty("body");
+                        Assert.Equal(JsonValueKind.Null, bodyProperties.ValueKind);
+                    }
+
+                    if (headers != null)
+                    {
+                        var headerProperties = jsonDoc.RootElement.GetProperty("multiValueHeaders");
+                        Assert.Equal(headers.Count, headerProperties.EnumerateObject().Count());
+
+                        foreach(var kvp in headers)
+                        {
+                            if(!headerProperties.TryGetProperty(kvp.Key, out var values))
+                            {
+                                Assert.Fail($"Fail to find header {kvp.Key}");
+                            }
+
+                            Assert.Equal(JsonValueKind.Array, values.ValueKind);
+                            Assert.Equal(kvp.Value.Count, values.GetArrayLength());
+                            for(var i = 0; i < kvp.Value.Count; i++)
+                            {
+                                Assert.Equal(kvp.Value[i], values[i].GetString());
+                            }
+                        }
+                    }
+                    else
+                    {
+                        var headerProperties = jsonDoc.RootElement.GetProperty("multiValueHeaders");
+                        Assert.Equal(JsonValueKind.Null, headerProperties.ValueKind);
+                    }
+                }
+                else
+                {
+                    Assert.Equal((int)statusCode, jsonDoc.RootElement.GetProperty("statusCode").GetInt32());
+                    if (body != null)
+                    {
+                        Assert.Equal(body, jsonDoc.RootElement.GetProperty("body").GetString());
+                        Assert.Equal(isBase64Encoded, jsonDoc.RootElement.GetProperty("isBase64Encoded").GetBoolean());
+                    }
+                    else
+                    {
+                        var bodyProperties = jsonDoc.RootElement.GetProperty("body");
+                        Assert.Equal(JsonValueKind.Null, bodyProperties.ValueKind);
+                    }
+
+                    if (headers != null)
+                    {
+                        var headerProperties = jsonDoc.RootElement.GetProperty("headers");
+                        Assert.Equal(headers.Count, headerProperties.EnumerateObject().Count());
+
+                        foreach (var kvp in headers)
+                        {
+                            var commaDelimtedValues = string.Join(",", kvp.Value);
+                            if (!headerProperties.TryGetProperty(kvp.Key, out var values))
+                            {
+                                Assert.Fail($"Fail to find header {kvp.Key}");
+                            }
+                            Assert.Equal(commaDelimtedValues, values.GetString());                            
+                        }
+                    }
+                    else
+                    {
+                        var headerProperties = jsonDoc.RootElement.GetProperty("headers");
+                        Assert.Equal(JsonValueKind.Null, headerProperties.ValueKind);
+                    }
+                }
+            }
+        }
+
+        public class FakeBody
+        {
+            public int Id { get; set; } = 1;
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ComplexCalculator_Subtract_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ComplexCalculator_Subtract_Generated.g.cs
@@ -33,7 +33,7 @@ namespace TestServerlessApp
             // return 400 Bad Request if there exists a validation error
             if (validationErrors.Any())
             {
-                return new Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyResponse
+                var errorResult = new Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyResponse
                 {
                     Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
                     Headers = new Dictionary<string, string>
@@ -43,6 +43,7 @@ namespace TestServerlessApp
                     },
                     StatusCode = 400
                 };
+                return errorResult;
             }
 
             var response = complexCalculator.Subtract(complexNumbers);

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_NotFoundResponseWithHeaderV1Async_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_NotFoundResponseWithHeaderV1Async_Generated.g.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.Annotations.APIGateway;
+
+namespace TestServerlessApp
+{
+    public class CustomizeResponseExamples_NotFoundResponseWithHeaderV1Async_Generated
+    {
+        private readonly CustomizeResponseExamples customizeResponseExamples;
+
+        public CustomizeResponseExamples_NotFoundResponseWithHeaderV1Async_Generated()
+        {
+            SetExecutionEnvironment();
+            customizeResponseExamples = new CustomizeResponseExamples();
+        }
+
+        public async System.Threading.Tasks.Task<System.IO.Stream> NotFoundResponseWithHeaderV1Async(Amazon.Lambda.APIGatewayEvents.APIGatewayProxyRequest __request__, Amazon.Lambda.Core.ILambdaContext __context__)
+        {
+            var validationErrors = new List<string>();
+
+            var x = default(int);
+            if (__request__.PathParameters?.ContainsKey("x") == true)
+            {
+                try
+                {
+                    x = (int)Convert.ChangeType(__request__.PathParameters["x"], typeof(int));
+                }
+                catch (Exception e) when (e is InvalidCastException || e is FormatException || e is OverflowException || e is ArgumentException)
+                {
+                    validationErrors.Add($"Value {__request__.PathParameters["x"]} at 'x' failed to satisfy constraint: {e.Message}");
+                }
+            }
+
+            // return 400 Bad Request if there exists a validation error
+            if (validationErrors.Any())
+            {
+                var errorResult = new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
+                {
+                    Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
+                    Headers = new Dictionary<string, string>
+                    {
+                        {"Content-Type", "application/json"},
+                        {"x-amzn-ErrorType", "ValidationException"}
+                    },
+                    StatusCode = 400
+                };
+                var errorStream = new System.IO.MemoryStream();
+                System.Text.Json.JsonSerializer.Serialize(errorStream, errorResult);
+                return errorStream;
+            }
+
+            var httpResults = await customizeResponseExamples.NotFoundResponseWithHeaderV1Async(x, __context__);
+            HttpResultSerializationOptions.ProtocolFormat serializationFormat = HttpResultSerializationOptions.ProtocolFormat.HttpApi;
+            HttpResultSerializationOptions.ProtocolVersion serializationVersion = HttpResultSerializationOptions.ProtocolVersion.V1;
+            var serializationOptions = new HttpResultSerializationOptions { Format = serializationFormat, Version = serializationVersion };
+            var response = httpResults.Serialize(serializationOptions);
+            return response;
+        }
+
+        private static void SetExecutionEnvironment()
+        {
+            const string envName = "AWS_EXECUTION_ENV";
+
+            var envValue = new StringBuilder();
+
+            // If there is an existing execution environment variable add the annotations package as a suffix.
+            if(!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(envName)))
+            {
+                envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
+            }
+
+            envValue.Append("amazon-lambda-annotations_0.10.0.0");
+
+            Environment.SetEnvironmentVariable(envName, envValue.ToString());
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_NotFoundResponseWithHeaderV1_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_NotFoundResponseWithHeaderV1_Generated.g.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.Annotations.APIGateway;
+
+namespace TestServerlessApp
+{
+    public class CustomizeResponseExamples_NotFoundResponseWithHeaderV1_Generated
+    {
+        private readonly CustomizeResponseExamples customizeResponseExamples;
+
+        public CustomizeResponseExamples_NotFoundResponseWithHeaderV1_Generated()
+        {
+            SetExecutionEnvironment();
+            customizeResponseExamples = new CustomizeResponseExamples();
+        }
+
+        public System.IO.Stream NotFoundResponseWithHeaderV1(Amazon.Lambda.APIGatewayEvents.APIGatewayProxyRequest __request__, Amazon.Lambda.Core.ILambdaContext __context__)
+        {
+            var validationErrors = new List<string>();
+
+            var x = default(int);
+            if (__request__.PathParameters?.ContainsKey("x") == true)
+            {
+                try
+                {
+                    x = (int)Convert.ChangeType(__request__.PathParameters["x"], typeof(int));
+                }
+                catch (Exception e) when (e is InvalidCastException || e is FormatException || e is OverflowException || e is ArgumentException)
+                {
+                    validationErrors.Add($"Value {__request__.PathParameters["x"]} at 'x' failed to satisfy constraint: {e.Message}");
+                }
+            }
+
+            // return 400 Bad Request if there exists a validation error
+            if (validationErrors.Any())
+            {
+                var errorResult = new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
+                {
+                    Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
+                    Headers = new Dictionary<string, string>
+                    {
+                        {"Content-Type", "application/json"},
+                        {"x-amzn-ErrorType", "ValidationException"}
+                    },
+                    StatusCode = 400
+                };
+                var errorStream = new System.IO.MemoryStream();
+                System.Text.Json.JsonSerializer.Serialize(errorStream, errorResult);
+                return errorStream;
+            }
+
+            var httpResults = customizeResponseExamples.NotFoundResponseWithHeaderV1(x, __context__);
+            HttpResultSerializationOptions.ProtocolFormat serializationFormat = HttpResultSerializationOptions.ProtocolFormat.HttpApi;
+            HttpResultSerializationOptions.ProtocolVersion serializationVersion = HttpResultSerializationOptions.ProtocolVersion.V1;
+            var serializationOptions = new HttpResultSerializationOptions { Format = serializationFormat, Version = serializationVersion };
+            var response = httpResults.Serialize(serializationOptions);
+            return response;
+        }
+
+        private static void SetExecutionEnvironment()
+        {
+            const string envName = "AWS_EXECUTION_ENV";
+
+            var envValue = new StringBuilder();
+
+            // If there is an existing execution environment variable add the annotations package as a suffix.
+            if(!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(envName)))
+            {
+                envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
+            }
+
+            envValue.Append("amazon-lambda-annotations_0.10.0.0");
+
+            Environment.SetEnvironmentVariable(envName, envValue.ToString());
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_NotFoundResponseWithHeaderV2Async_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_NotFoundResponseWithHeaderV2Async_Generated.g.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.Annotations.APIGateway;
+
+namespace TestServerlessApp
+{
+    public class CustomizeResponseExamples_NotFoundResponseWithHeaderV2Async_Generated
+    {
+        private readonly CustomizeResponseExamples customizeResponseExamples;
+
+        public CustomizeResponseExamples_NotFoundResponseWithHeaderV2Async_Generated()
+        {
+            SetExecutionEnvironment();
+            customizeResponseExamples = new CustomizeResponseExamples();
+        }
+
+        public async System.Threading.Tasks.Task<System.IO.Stream> NotFoundResponseWithHeaderV2Async(Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyRequest __request__, Amazon.Lambda.Core.ILambdaContext __context__)
+        {
+            var validationErrors = new List<string>();
+
+            var x = default(int);
+            if (__request__.PathParameters?.ContainsKey("x") == true)
+            {
+                try
+                {
+                    x = (int)Convert.ChangeType(__request__.PathParameters["x"], typeof(int));
+                }
+                catch (Exception e) when (e is InvalidCastException || e is FormatException || e is OverflowException || e is ArgumentException)
+                {
+                    validationErrors.Add($"Value {__request__.PathParameters["x"]} at 'x' failed to satisfy constraint: {e.Message}");
+                }
+            }
+
+            // return 400 Bad Request if there exists a validation error
+            if (validationErrors.Any())
+            {
+                var errorResult = new Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyResponse
+                {
+                    Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
+                    Headers = new Dictionary<string, string>
+                    {
+                        {"Content-Type", "application/json"},
+                        {"x-amzn-ErrorType", "ValidationException"}
+                    },
+                    StatusCode = 400
+                };
+                var errorStream = new System.IO.MemoryStream();
+                System.Text.Json.JsonSerializer.Serialize(errorStream, errorResult);
+                return errorStream;
+            }
+
+            var httpResults = await customizeResponseExamples.NotFoundResponseWithHeaderV2Async(x, __context__);
+            HttpResultSerializationOptions.ProtocolFormat serializationFormat = HttpResultSerializationOptions.ProtocolFormat.HttpApi;
+            HttpResultSerializationOptions.ProtocolVersion serializationVersion = HttpResultSerializationOptions.ProtocolVersion.V2;
+            var serializationOptions = new HttpResultSerializationOptions { Format = serializationFormat, Version = serializationVersion };
+            var response = httpResults.Serialize(serializationOptions);
+            return response;
+        }
+
+        private static void SetExecutionEnvironment()
+        {
+            const string envName = "AWS_EXECUTION_ENV";
+
+            var envValue = new StringBuilder();
+
+            // If there is an existing execution environment variable add the annotations package as a suffix.
+            if(!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(envName)))
+            {
+                envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
+            }
+
+            envValue.Append("amazon-lambda-annotations_0.10.0.0");
+
+            Environment.SetEnvironmentVariable(envName, envValue.ToString());
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_NotFoundResponseWithHeaderV2_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_NotFoundResponseWithHeaderV2_Generated.g.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.Annotations.APIGateway;
+
+namespace TestServerlessApp
+{
+    public class CustomizeResponseExamples_NotFoundResponseWithHeaderV2_Generated
+    {
+        private readonly CustomizeResponseExamples customizeResponseExamples;
+
+        public CustomizeResponseExamples_NotFoundResponseWithHeaderV2_Generated()
+        {
+            SetExecutionEnvironment();
+            customizeResponseExamples = new CustomizeResponseExamples();
+        }
+
+        public System.IO.Stream NotFoundResponseWithHeaderV2(Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyRequest __request__, Amazon.Lambda.Core.ILambdaContext __context__)
+        {
+            var validationErrors = new List<string>();
+
+            var x = default(int);
+            if (__request__.PathParameters?.ContainsKey("x") == true)
+            {
+                try
+                {
+                    x = (int)Convert.ChangeType(__request__.PathParameters["x"], typeof(int));
+                }
+                catch (Exception e) when (e is InvalidCastException || e is FormatException || e is OverflowException || e is ArgumentException)
+                {
+                    validationErrors.Add($"Value {__request__.PathParameters["x"]} at 'x' failed to satisfy constraint: {e.Message}");
+                }
+            }
+
+            // return 400 Bad Request if there exists a validation error
+            if (validationErrors.Any())
+            {
+                var errorResult = new Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyResponse
+                {
+                    Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
+                    Headers = new Dictionary<string, string>
+                    {
+                        {"Content-Type", "application/json"},
+                        {"x-amzn-ErrorType", "ValidationException"}
+                    },
+                    StatusCode = 400
+                };
+                var errorStream = new System.IO.MemoryStream();
+                System.Text.Json.JsonSerializer.Serialize(errorStream, errorResult);
+                return errorStream;
+            }
+
+            var httpResults = customizeResponseExamples.NotFoundResponseWithHeaderV2(x, __context__);
+            HttpResultSerializationOptions.ProtocolFormat serializationFormat = HttpResultSerializationOptions.ProtocolFormat.HttpApi;
+            HttpResultSerializationOptions.ProtocolVersion serializationVersion = HttpResultSerializationOptions.ProtocolVersion.V2;
+            var serializationOptions = new HttpResultSerializationOptions { Format = serializationFormat, Version = serializationVersion };
+            var response = httpResults.Serialize(serializationOptions);
+            return response;
+        }
+
+        private static void SetExecutionEnvironment()
+        {
+            const string envName = "AWS_EXECUTION_ENV";
+
+            var envValue = new StringBuilder();
+
+            // If there is an existing execution environment variable add the annotations package as a suffix.
+            if(!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(envName)))
+            {
+                envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
+            }
+
+            envValue.Append("amazon-lambda-annotations_0.10.0.0");
+
+            Environment.SetEnvironmentVariable(envName, envValue.ToString());
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_OkResponseWithHeaderAsync_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_OkResponseWithHeaderAsync_Generated.g.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.Annotations.APIGateway;
+
+namespace TestServerlessApp
+{
+    public class CustomizeResponseExamples_OkResponseWithHeaderAsync_Generated
+    {
+        private readonly CustomizeResponseExamples customizeResponseExamples;
+
+        public CustomizeResponseExamples_OkResponseWithHeaderAsync_Generated()
+        {
+            SetExecutionEnvironment();
+            customizeResponseExamples = new CustomizeResponseExamples();
+        }
+
+        public async System.Threading.Tasks.Task<System.IO.Stream> OkResponseWithHeaderAsync(Amazon.Lambda.APIGatewayEvents.APIGatewayProxyRequest __request__, Amazon.Lambda.Core.ILambdaContext __context__)
+        {
+            var validationErrors = new List<string>();
+
+            var x = default(int);
+            if (__request__.PathParameters?.ContainsKey("x") == true)
+            {
+                try
+                {
+                    x = (int)Convert.ChangeType(__request__.PathParameters["x"], typeof(int));
+                }
+                catch (Exception e) when (e is InvalidCastException || e is FormatException || e is OverflowException || e is ArgumentException)
+                {
+                    validationErrors.Add($"Value {__request__.PathParameters["x"]} at 'x' failed to satisfy constraint: {e.Message}");
+                }
+            }
+
+            // return 400 Bad Request if there exists a validation error
+            if (validationErrors.Any())
+            {
+                var errorResult = new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
+                {
+                    Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
+                    Headers = new Dictionary<string, string>
+                    {
+                        {"Content-Type", "application/json"},
+                        {"x-amzn-ErrorType", "ValidationException"}
+                    },
+                    StatusCode = 400
+                };
+                var errorStream = new System.IO.MemoryStream();
+                System.Text.Json.JsonSerializer.Serialize(errorStream, errorResult);
+                return errorStream;
+            }
+
+            var httpResults = await customizeResponseExamples.OkResponseWithHeaderAsync(x, __context__);
+            HttpResultSerializationOptions.ProtocolFormat serializationFormat = HttpResultSerializationOptions.ProtocolFormat.RestApi;
+            HttpResultSerializationOptions.ProtocolVersion serializationVersion = HttpResultSerializationOptions.ProtocolVersion.V1;
+            var serializationOptions = new HttpResultSerializationOptions { Format = serializationFormat, Version = serializationVersion };
+            var response = httpResults.Serialize(serializationOptions);
+            return response;
+        }
+
+        private static void SetExecutionEnvironment()
+        {
+            const string envName = "AWS_EXECUTION_ENV";
+
+            var envValue = new StringBuilder();
+
+            // If there is an existing execution environment variable add the annotations package as a suffix.
+            if(!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(envName)))
+            {
+                envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
+            }
+
+            envValue.Append("amazon-lambda-annotations_0.10.0.0");
+
+            Environment.SetEnvironmentVariable(envName, envValue.ToString());
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_OkResponseWithHeader_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_OkResponseWithHeader_Generated.g.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.Annotations.APIGateway;
+
+namespace TestServerlessApp
+{
+    public class CustomizeResponseExamples_OkResponseWithHeader_Generated
+    {
+        private readonly CustomizeResponseExamples customizeResponseExamples;
+
+        public CustomizeResponseExamples_OkResponseWithHeader_Generated()
+        {
+            SetExecutionEnvironment();
+            customizeResponseExamples = new CustomizeResponseExamples();
+        }
+
+        public System.IO.Stream OkResponseWithHeader(Amazon.Lambda.APIGatewayEvents.APIGatewayProxyRequest __request__, Amazon.Lambda.Core.ILambdaContext __context__)
+        {
+            var validationErrors = new List<string>();
+
+            var x = default(int);
+            if (__request__.PathParameters?.ContainsKey("x") == true)
+            {
+                try
+                {
+                    x = (int)Convert.ChangeType(__request__.PathParameters["x"], typeof(int));
+                }
+                catch (Exception e) when (e is InvalidCastException || e is FormatException || e is OverflowException || e is ArgumentException)
+                {
+                    validationErrors.Add($"Value {__request__.PathParameters["x"]} at 'x' failed to satisfy constraint: {e.Message}");
+                }
+            }
+
+            // return 400 Bad Request if there exists a validation error
+            if (validationErrors.Any())
+            {
+                var errorResult = new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
+                {
+                    Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
+                    Headers = new Dictionary<string, string>
+                    {
+                        {"Content-Type", "application/json"},
+                        {"x-amzn-ErrorType", "ValidationException"}
+                    },
+                    StatusCode = 400
+                };
+                var errorStream = new System.IO.MemoryStream();
+                System.Text.Json.JsonSerializer.Serialize(errorStream, errorResult);
+                return errorStream;
+            }
+
+            var httpResults = customizeResponseExamples.OkResponseWithHeader(x, __context__);
+            HttpResultSerializationOptions.ProtocolFormat serializationFormat = HttpResultSerializationOptions.ProtocolFormat.RestApi;
+            HttpResultSerializationOptions.ProtocolVersion serializationVersion = HttpResultSerializationOptions.ProtocolVersion.V1;
+            var serializationOptions = new HttpResultSerializationOptions { Format = serializationFormat, Version = serializationVersion };
+            var response = httpResults.Serialize(serializationOptions);
+            return response;
+        }
+
+        private static void SetExecutionEnvironment()
+        {
+            const string envName = "AWS_EXECUTION_ENV";
+
+            var envValue = new StringBuilder();
+
+            // If there is an existing execution environment variable add the annotations package as a suffix.
+            if(!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(envName)))
+            {
+                envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
+            }
+
+            envValue.Append("amazon-lambda-annotations_0.10.0.0");
+
+            Environment.SetEnvironmentVariable(envName, envValue.ToString());
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Greeter_SayHelloAsync_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Greeter_SayHelloAsync_Generated.g.cs
@@ -42,7 +42,7 @@ namespace TestServerlessApp
             // return 400 Bad Request if there exists a validation error
             if (validationErrors.Any())
             {
-                return new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
+                var errorResult = new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
                 {
                     Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
                     Headers = new Dictionary<string, string>
@@ -52,6 +52,7 @@ namespace TestServerlessApp
                     },
                     StatusCode = 400
                 };
+                return errorResult;
             }
 
             await greeter.SayHelloAsync(firstNames);

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Greeter_SayHello_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Greeter_SayHello_Generated.g.cs
@@ -42,7 +42,7 @@ namespace TestServerlessApp
             // return 400 Bad Request if there exists a validation error
             if (validationErrors.Any())
             {
-                return new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
+                var errorResult = new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
                 {
                     Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
                     Headers = new Dictionary<string, string>
@@ -52,6 +52,7 @@ namespace TestServerlessApp
                     },
                     StatusCode = 400
                 };
+                return errorResult;
             }
 
             greeter.SayHello(firstNames, __request__, __context__);

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/customizeResponse.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/customizeResponse.template
@@ -1,0 +1,201 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Transform": "AWS::Serverless-2016-10-31",
+  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v0.10.0.0).",
+  "Resources": {
+    "TestServerlessAppCustomizeResponseExamplesOkResponseWithHeaderGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestProject::TestServerlessApp.CustomizeResponseExamples_OkResponseWithHeader_Generated::OkResponseWithHeader"
+          ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "Api",
+            "Properties": {
+              "Path": "/okresponsewithheader/{x}",
+              "Method": "GET"
+            }
+          }
+        }
+      }
+    },
+    "TestServerlessAppCustomizeResponseExamplesOkResponseWithHeaderAsyncGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestProject::TestServerlessApp.CustomizeResponseExamples_OkResponseWithHeaderAsync_Generated::OkResponseWithHeaderAsync"
+          ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "Api",
+            "Properties": {
+              "Path": "/okresponsewithheaderasync/{x}",
+              "Method": "GET"
+            }
+          }
+        }
+      }
+    },
+    "TestServerlessAppCustomizeResponseExamplesNotFoundResponseWithHeaderV2Generated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestProject::TestServerlessApp.CustomizeResponseExamples_NotFoundResponseWithHeaderV2_Generated::NotFoundResponseWithHeaderV2"
+          ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "HttpApi",
+            "Properties": {
+              "Path": "/notfoundwithheaderv2/{x}",
+              "Method": "GET"
+            }
+          }
+        }
+      }
+    },
+    "TestServerlessAppCustomizeResponseExamplesNotFoundResponseWithHeaderV2AsyncGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestProject::TestServerlessApp.CustomizeResponseExamples_NotFoundResponseWithHeaderV2Async_Generated::NotFoundResponseWithHeaderV2Async"
+          ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "HttpApi",
+            "Properties": {
+              "Path": "/notfoundwithheaderv2async/{x}",
+              "Method": "GET"
+            }
+          }
+        }
+      }
+    },
+    "TestServerlessAppCustomizeResponseExamplesNotFoundResponseWithHeaderV1Generated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestProject::TestServerlessApp.CustomizeResponseExamples_NotFoundResponseWithHeaderV1_Generated::NotFoundResponseWithHeaderV1"
+          ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "HttpApi",
+            "Properties": {
+              "Path": "/notfoundwithheaderv1/{x}",
+              "Method": "GET",
+              "PayloadFormatVersion": "1.0"
+            }
+          }
+        }
+      }
+    },
+    "TestServerlessAppCustomizeResponseExamplesNotFoundResponseWithHeaderV1AsyncGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestProject::TestServerlessApp.CustomizeResponseExamples_NotFoundResponseWithHeaderV1Async_Generated::NotFoundResponseWithHeaderV1Async"
+          ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "HttpApi",
+            "Properties": {
+              "Path": "/notfoundwithheaderv1async/{x}",
+              "Method": "GET",
+              "PayloadFormatVersion": "1.0"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Add_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Add_Generated.g.cs
@@ -63,7 +63,7 @@ namespace TestServerlessApp
             // return 400 Bad Request if there exists a validation error
             if (validationErrors.Any())
             {
-                return new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
+                var errorResult = new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
                 {
                     Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
                     Headers = new Dictionary<string, string>
@@ -73,6 +73,7 @@ namespace TestServerlessApp
                     },
                     StatusCode = 400
                 };
+                return errorResult;
             }
 
             var response = simpleCalculator.Add(x, y);

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_DivideAsync_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_DivideAsync_Generated.g.cs
@@ -63,7 +63,7 @@ namespace TestServerlessApp
             // return 400 Bad Request if there exists a validation error
             if (validationErrors.Any())
             {
-                return new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
+                var errorResult = new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
                 {
                     Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
                     Headers = new Dictionary<string, string>
@@ -73,6 +73,7 @@ namespace TestServerlessApp
                     },
                     StatusCode = 400
                 };
+                return errorResult;
             }
 
             var response = await simpleCalculator.DivideAsync(first, second);

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Multiply_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Multiply_Generated.g.cs
@@ -63,7 +63,7 @@ namespace TestServerlessApp
             // return 400 Bad Request if there exists a validation error
             if (validationErrors.Any())
             {
-                return new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
+                var errorResult = new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
                 {
                     Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
                     Headers = new Dictionary<string, string>
@@ -73,6 +73,7 @@ namespace TestServerlessApp
                     },
                     StatusCode = 400
                 };
+                return errorResult;
             }
 
             var response = simpleCalculator.Multiply(x, y);

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Subtract_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Subtract_Generated.g.cs
@@ -64,7 +64,7 @@ namespace TestServerlessApp
             // return 400 Bad Request if there exists a validation error
             if (validationErrors.Any())
             {
-                return new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
+                var errorResult = new Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse
                 {
                     Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
                     Headers = new Dictionary<string, string>
@@ -74,6 +74,7 @@ namespace TestServerlessApp
                     },
                     StatusCode = 400
                 };
+                return errorResult;
             }
 
             var response = simpleCalculator.Subtract(x, y, simpleCalculatorService);

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
@@ -48,7 +48,8 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                         new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("Greeter_SayHello_Generated.g.cs", expectedSayHelloGenerated),
                         new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("Greeter_SayHelloAsync_Generated.g.cs", expectedSayHelloAsyncGenerated),
                         new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments($"TestServerlessApp{Path.DirectorySeparatorChar}serverless.template", expectedTemplateContent)
-                    }
+                    },
+                    ReferenceAssemblies = ReferenceAssemblies.Net.Net60
                 }
             }.RunAsync();
 
@@ -82,7 +83,8 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                     {
                         // Now AWS Lambda Annotations INFO diagnostics were emited showing again the generator didn't run.
                         new DiagnosticResult("CS1513", DiagnosticSeverity.Error).WithSpan("NonCompilableCodeFile.cs", 22, 2, 22, 2)
-                    }
+                    },
+                    ReferenceAssemblies = ReferenceAssemblies.Net.Net60
                 }
             }.RunAsync();
         }
@@ -112,6 +114,8 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                         (Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "FromServicesAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "FromServicesAttribute.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "RestApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "RestApiAttribute.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"))),
                     },
                     GeneratedSources =
                     {
@@ -161,7 +165,8 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                         new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("SimpleCalculator_Random_Generated.g.cs", expectedRandomGenerated),
                         new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("SimpleCalculator_Randoms_Generated.g.cs", expectedRandomsGenerated),
                         new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments($"TestServerlessApp{Path.DirectorySeparatorChar}serverless.template", expectedTemplateContent)
-                    }
+                    },
+                    ReferenceAssemblies = ReferenceAssemblies.Net.Net60
                 }
             }.RunAsync();
 
@@ -204,7 +209,8 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                         new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("ComplexCalculator_Add_Generated.g.cs", expectedAddGenerated),
                         new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("ComplexCalculator_Subtract_Generated.g.cs", expectedSubtractGenerated),
                         new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments($"TestServerlessApp{Path.DirectorySeparatorChar}serverless.template", expectedTemplateContent)
-                    }
+                    },
+                    ReferenceAssemblies = ReferenceAssemblies.Net.Net60
                 }
             }.RunAsync();
 
@@ -240,7 +246,8 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                     {
                         new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("Functions_ToUpper_Generated.g.cs", expectedSubNamespaceGenerated),
                         new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments($"TestServerlessApp{Path.DirectorySeparatorChar}serverless.template", expectedTemplateContent)
-                    }
+                    },
+                    ReferenceAssemblies = ReferenceAssemblies.Net.Net60
                 }
             }.RunAsync();
 
@@ -276,7 +283,8 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                     {
                         new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("VoidExample_VoidReturn_Generated.g.cs", expectedSubNamespaceGenerated),
                         new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments($"TestServerlessApp{Path.DirectorySeparatorChar}serverless.template", expectedTemplateContent)
-                    }
+                    },
+                    ReferenceAssemblies = ReferenceAssemblies.Net.Net60
                 }
             }.RunAsync();
 
@@ -312,7 +320,8 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                     {
                         new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("TaskExample_TaskReturn_Generated.g.cs", expectedSubNamespaceGenerated),
                         new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments($"TestServerlessApp{Path.DirectorySeparatorChar}serverless.template", expectedTemplateContent)
-                    }
+                    },
+                    ReferenceAssemblies = ReferenceAssemblies.Net.Net60
                 }
             }.RunAsync();
 
@@ -355,12 +364,119 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                         new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("DynamicExample_DynamicReturn_Generated.g.cs", expectedSubNamespaceGenerated_DynamicReturn),
                         new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments($"TestServerlessApp{Path.DirectorySeparatorChar}serverless.template", expectedTemplateContent),
                         new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("DynamicExample_DynamicInput_Generated.g.cs", expectedSubNamespaceGenerated_DynamicInput)
-                    }
+                    },
+                    ReferenceAssemblies = ReferenceAssemblies.Net.Net60
                 }
             }.RunAsync();
 
             var actualTemplateContent = File.ReadAllText(Path.Combine("TestServerlessApp", "serverless.template"));
             Assert.Equal(expectedTemplateContent, actualTemplateContent);
+        }
+
+        [Fact]
+        public async Task CustomizeResponses()
+        {
+            var expectedTemplateContent = File.ReadAllText(Path.Combine("Snapshots", "ServerlessTemplates", "customizeResponse.template")).ToEnvironmentLineEndings();
+            var expectedOkResponseWithHeaderGenerated = File.ReadAllText(Path.Combine("Snapshots", "CustomizeResponseExamples_OkResponseWithHeader_Generated.g.cs")).ToEnvironmentLineEndings();
+            var expectedNotFoundResponseWithHeaderV2Generated = File.ReadAllText(Path.Combine("Snapshots", "CustomizeResponseExamples_NotFoundResponseWithHeaderV2_Generated.g.cs")).ToEnvironmentLineEndings();
+            var expectedNotFoundResponseWithHeaderV1Generated = File.ReadAllText(Path.Combine("Snapshots", "CustomizeResponseExamples_NotFoundResponseWithHeaderV1_Generated.g.cs")).ToEnvironmentLineEndings();
+
+            var expectedOkResponseWithHeaderAsyncGenerated = File.ReadAllText(Path.Combine("Snapshots", "CustomizeResponseExamples_OkResponseWithHeaderAsync_Generated.g.cs")).ToEnvironmentLineEndings();
+            var expectedNotFoundResponseWithHeaderV2AsyncGenerated = File.ReadAllText(Path.Combine("Snapshots", "CustomizeResponseExamples_NotFoundResponseWithHeaderV2Async_Generated.g.cs")).ToEnvironmentLineEndings();
+            var expectedNotFoundResponseWithHeaderV1AsyncGenerated = File.ReadAllText(Path.Combine("Snapshots", "CustomizeResponseExamples_NotFoundResponseWithHeaderV1Async_Generated.g.cs")).ToEnvironmentLineEndings();
+
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        (Path.Combine("TestServerlessApp", "CustomizeResponseExamples.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "CustomizeResponseExamples.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "RestApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "RestApiAttribute.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"))),
+                    },
+                    GeneratedSources =
+                    {
+                        (
+                            typeof(SourceGenerator.Generator),
+                            "CustomizeResponseExamples_OkResponseWithHeader_Generated.g.cs",
+                            SourceText.From(expectedOkResponseWithHeaderGenerated, Encoding.UTF8, SourceHashAlgorithm.Sha256)
+                        ),
+                        (
+                            typeof(SourceGenerator.Generator),
+                            "CustomizeResponseExamples_OkResponseWithHeaderAsync_Generated.g.cs",
+                            SourceText.From(expectedOkResponseWithHeaderAsyncGenerated, Encoding.UTF8, SourceHashAlgorithm.Sha256)
+                        ),
+                        (
+                            typeof(SourceGenerator.Generator),
+                            "CustomizeResponseExamples_NotFoundResponseWithHeaderV2_Generated.g.cs",
+                            SourceText.From(expectedNotFoundResponseWithHeaderV2Generated, Encoding.UTF8, SourceHashAlgorithm.Sha256)
+                        ),
+                        (
+                            typeof(SourceGenerator.Generator),
+                            "CustomizeResponseExamples_NotFoundResponseWithHeaderV2Async_Generated.g.cs",
+                            SourceText.From(expectedNotFoundResponseWithHeaderV2AsyncGenerated, Encoding.UTF8, SourceHashAlgorithm.Sha256)
+                        ),
+                        (
+                            typeof(SourceGenerator.Generator),
+                            "CustomizeResponseExamples_NotFoundResponseWithHeaderV1_Generated.g.cs",
+                            SourceText.From(expectedNotFoundResponseWithHeaderV1Generated, Encoding.UTF8, SourceHashAlgorithm.Sha256)
+                        ),
+                        (
+                            typeof(SourceGenerator.Generator),
+                            "CustomizeResponseExamples_NotFoundResponseWithHeaderV1Async_Generated.g.cs",
+                            SourceText.From(expectedNotFoundResponseWithHeaderV1AsyncGenerated, Encoding.UTF8, SourceHashAlgorithm.Sha256)
+                        )
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("CustomizeResponseExamples_OkResponseWithHeader_Generated.g.cs", expectedOkResponseWithHeaderGenerated),
+                        new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("CustomizeResponseExamples_OkResponseWithHeaderAsync_Generated.g.cs", expectedOkResponseWithHeaderAsyncGenerated),
+
+                        new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("CustomizeResponseExamples_NotFoundResponseWithHeaderV2_Generated.g.cs", expectedNotFoundResponseWithHeaderV2Generated),
+                        new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("CustomizeResponseExamples_NotFoundResponseWithHeaderV2Async_Generated.g.cs", expectedNotFoundResponseWithHeaderV2AsyncGenerated),
+                        
+                        new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("CustomizeResponseExamples_NotFoundResponseWithHeaderV1_Generated.g.cs", expectedNotFoundResponseWithHeaderV1Generated),
+                        new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("CustomizeResponseExamples_NotFoundResponseWithHeaderV1Async_Generated.g.cs", expectedNotFoundResponseWithHeaderV1AsyncGenerated),
+
+                        new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments($"TestServerlessApp{Path.DirectorySeparatorChar}serverless.template", expectedTemplateContent)
+                    },
+                    ReferenceAssemblies = ReferenceAssemblies.Net.Net60
+                }
+                
+            }.RunAsync();
+
+            var actualTemplateContent = File.ReadAllText(Path.Combine("TestServerlessApp", "serverless.template"));
+            Assert.Equal(expectedTemplateContent, actualTemplateContent);
+        }
+
+        [Fact]
+        public async Task InvalidReturnTypeIHttpResult()
+        {
+
+
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        (Path.Combine("TestServerlessApp", "CustomizeResponseWithErrors.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "CustomizeResponseWithErrors.cs.error"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "RestApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "RestApiAttribute.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"))),
+                    },
+                    ExpectedDiagnostics =
+                    {
+                         DiagnosticResult.CompilerError("AWSLambda0105").WithSpan($"TestServerlessApp{Path.DirectorySeparatorChar}CustomizeResponseWithErrors.cs", 14, 9, 21, 10).WithArguments("Error")
+                    },
+                    ReferenceAssemblies = ReferenceAssemblies.Net.Net60
+                }
+
+            }.RunAsync();
         }
     }
 }

--- a/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixture.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixture.cs
@@ -55,7 +55,7 @@ namespace TestServerlessApp.IntegrationTests
 
             Assert.Equal(StackStatus.CREATE_COMPLETE, await _cloudFormationHelper.GetStackStatusAsync(_stackName));
             Assert.True(await _s3Helper.BucketExistsAsync(_bucketName));
-            Assert.Equal(16, LambdaFunctions.Count);
+            Assert.Equal(22, LambdaFunctions.Count);
             Assert.False(string.IsNullOrEmpty(RestApiUrlPrefix));
             Assert.False(string.IsNullOrEmpty(RestApiUrlPrefix));
 

--- a/Libraries/test/TestServerlessApp/CustomizeResponseExamples.cs
+++ b/Libraries/test/TestServerlessApp/CustomizeResponseExamples.cs
@@ -1,0 +1,70 @@
+﻿using Amazon.Lambda.Annotations;
+using Amazon.Lambda.Annotations.APIGateway;
+using Amazon.Lambda.Core;
+using System.Threading.Tasks;
+
+namespace TestServerlessApp
+{
+    public class CustomizeResponseExamples
+    {
+        [LambdaFunction(PackageType = LambdaPackageType.Image)]
+        [RestApi(LambdaHttpMethod.Get, "/okresponsewithheader/{x}")]
+        public IHttpResult OkResponseWithHeader(int x, ILambdaContext context)
+        {
+            return HttpResults.Ok("All Good")
+                                .AddHeader("Single-Header", "Value")
+                                .AddHeader("Multi-Header", "Foo")
+                                .AddHeader("Multi-Header", "Bar");
+        }
+
+        [LambdaFunction(PackageType = LambdaPackageType.Image)]
+        [RestApi(LambdaHttpMethod.Get, "/okresponsewithheaderasync/{x}")]
+        public Task<IHttpResult> OkResponseWithHeaderAsync(int x, ILambdaContext context)
+        {
+            return Task.FromResult(HttpResults.Ok("All Good")
+                                .AddHeader("Single-Header", "Value")
+                                .AddHeader("Multi-Header", "Foo")
+                                .AddHeader("Multi-Header", "Bar"));
+        }
+
+        [LambdaFunction(PackageType = LambdaPackageType.Image)]
+        [HttpApi(LambdaHttpMethod.Get, "/notfoundwithheaderv2/{x}")]
+        public IHttpResult NotFoundResponseWithHeaderV2(int x, ILambdaContext context)
+        {
+            return HttpResults.NotFound("Not Found")
+                                .AddHeader("Single-Header", "Value")
+                                .AddHeader("Multi-Header", "Foo")
+                                .AddHeader("Multi-Header", "Bar");
+        }
+
+        [LambdaFunction(PackageType = LambdaPackageType.Image)]
+        [HttpApi(LambdaHttpMethod.Get, "/notfoundwithheaderv2async/{x}")]
+        public Task<IHttpResult> NotFoundResponseWithHeaderV2Async(int x, ILambdaContext context)
+        {
+            return Task.FromResult(HttpResults.NotFound("Not Found")
+                                .AddHeader("Single-Header", "Value")
+                                .AddHeader("Multi-Header", "Foo")
+                                .AddHeader("Multi-Header", "Bar"));
+        }
+
+        [LambdaFunction(PackageType = LambdaPackageType.Image)]
+        [HttpApi(LambdaHttpMethod.Get, "/notfoundwithheaderv1/{x}", Version = HttpApiVersion.V1)]
+        public IHttpResult NotFoundResponseWithHeaderV1(int x, ILambdaContext context)
+        {
+            return HttpResults.NotFound("Not Found")
+                                .AddHeader("Single-Header", "Value")
+                                .AddHeader("Multi-Header", "Foo")
+                                .AddHeader("Multi-Header", "Bar");
+        }
+
+        [LambdaFunction(PackageType = LambdaPackageType.Image)]
+        [HttpApi(LambdaHttpMethod.Get, "/notfoundwithheaderv1async/{x}", Version = HttpApiVersion.V1)]
+        public Task<IHttpResult> NotFoundResponseWithHeaderV1Async(int x, ILambdaContext context)
+        {
+            return Task.FromResult(HttpResults.NotFound("Not Found")
+                                .AddHeader("Single-Header", "Value")
+                                .AddHeader("Multi-Header", "Foo")
+                                .AddHeader("Multi-Header", "Bar"));
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp/CustomizeResponseWithErrors.cs.error
+++ b/Libraries/test/TestServerlessApp/CustomizeResponseWithErrors.cs.error
@@ -1,0 +1,23 @@
+﻿using Amazon.Lambda.Annotations;
+using Amazon.Lambda.Annotations.APIGateway;
+using Amazon.Lambda.Core;
+using System.Threading.Tasks;
+
+// This class has a "error" extension because it fails to compile. It is used to make in unit tests to make sure
+// we get expected diagnostic error messages.
+
+namespace TestServerlessApp
+{
+    public class CustomizeResponseWithErrors
+    {
+        // Can not return IHttpResult for non API Gateway based function
+        [LambdaFunction(PackageType = LambdaPackageType.Image)]
+        public IHttpResult InvalidReturnTypeExample(int x, ILambdaContext context)
+        {
+            return HttpResults.Ok("All Good")
+                                .AddHeader("Single-Header", "Value")
+                                .AddHeader("Multi-Header", "Foo")
+                                .AddHeader("Multi-Header", "Bar");
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp/TestServerlessApp.csproj
+++ b/Libraries/test/TestServerlessApp/TestServerlessApp.csproj
@@ -13,6 +13,9 @@
     <Content Include="Generated\**" />
   </ItemGroup>
   <ItemGroup>
+    <None Remove="CustomizeResponseWithErrors.cs.error" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Libraries/test/TestServerlessApp/serverless.template
+++ b/Libraries/test/TestServerlessApp/serverless.template
@@ -22,172 +22,6 @@
     }
   },
   "Resources": {
-    "GreeterSayHello": {
-      "Type": "AWS::Serverless::Function",
-      "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations",
-        "SyncedEvents": [
-          "RootGet"
-        ]
-      },
-      "Properties": {
-        "MemorySize": 1024,
-        "Timeout": 30,
-        "Role": null,
-        "Policies": [
-          "AWSLambdaBasicExecutionRole"
-        ],
-        "Events": {
-          "RootGet": {
-            "Type": "HttpApi",
-            "Properties": {
-              "Path": "/Greeter/SayHello",
-              "Method": "GET",
-              "PayloadFormatVersion": "1.0"
-            }
-          }
-        },
-        "PackageType": "Image",
-        "ImageUri": ".",
-        "ImageConfig": {
-          "Command": [
-            "TestServerlessApp::TestServerlessApp.Greeter_SayHello_Generated::SayHello"
-          ]
-        }
-      }
-    },
-    "SimpleCalculatorAdd": {
-      "Type": "AWS::Serverless::Function",
-      "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations",
-        "SyncedEvents": [
-          "RootGet"
-        ]
-      },
-      "Properties": {
-        "MemorySize": 256,
-        "Timeout": 30,
-        "Role": null,
-        "Policies": [
-          "AWSLambdaBasicExecutionRole"
-        ],
-        "Events": {
-          "RootGet": {
-            "Type": "Api",
-            "Properties": {
-              "Path": "/SimpleCalculator/Add",
-              "Method": "GET"
-            }
-          }
-        },
-        "PackageType": "Image",
-        "ImageUri": ".",
-        "ImageConfig": {
-          "Command": [
-            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Add_Generated::Add"
-          ]
-        }
-      }
-    },
-    "SimpleCalculatorSubtract": {
-      "Type": "AWS::Serverless::Function",
-      "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations",
-        "SyncedEvents": [
-          "RootGet"
-        ]
-      },
-      "Properties": {
-        "MemorySize": 256,
-        "Timeout": 30,
-        "Role": null,
-        "Policies": [
-          "AWSLambdaBasicExecutionRole"
-        ],
-        "Events": {
-          "RootGet": {
-            "Type": "Api",
-            "Properties": {
-              "Path": "/SimpleCalculator/Subtract",
-              "Method": "GET"
-            }
-          }
-        },
-        "PackageType": "Image",
-        "ImageUri": ".",
-        "ImageConfig": {
-          "Command": [
-            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Subtract_Generated::Subtract"
-          ]
-        }
-      }
-    },
-    "SimpleCalculatorMultiply": {
-      "Type": "AWS::Serverless::Function",
-      "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations",
-        "SyncedEvents": [
-          "RootGet"
-        ]
-      },
-      "Properties": {
-        "MemorySize": 256,
-        "Timeout": 30,
-        "Role": null,
-        "Policies": [
-          "AWSLambdaBasicExecutionRole"
-        ],
-        "Events": {
-          "RootGet": {
-            "Type": "Api",
-            "Properties": {
-              "Path": "/SimpleCalculator/Multiply/{x}/{y}",
-              "Method": "GET"
-            }
-          }
-        },
-        "PackageType": "Image",
-        "ImageUri": ".",
-        "ImageConfig": {
-          "Command": [
-            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Multiply_Generated::Multiply"
-          ]
-        }
-      }
-    },
-    "SimpleCalculatorDivideAsync": {
-      "Type": "AWS::Serverless::Function",
-      "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations",
-        "SyncedEvents": [
-          "RootGet"
-        ]
-      },
-      "Properties": {
-        "MemorySize": 256,
-        "Timeout": 30,
-        "Role": null,
-        "Policies": [
-          "AWSLambdaBasicExecutionRole"
-        ],
-        "Events": {
-          "RootGet": {
-            "Type": "Api",
-            "Properties": {
-              "Path": "/SimpleCalculator/DivideAsync/{x}/{y}",
-              "Method": "GET"
-            }
-          }
-        },
-        "PackageType": "Image",
-        "ImageUri": ".",
-        "ImageConfig": {
-          "Command": [
-            "TestServerlessApp::TestServerlessApp.SimpleCalculator_DivideAsync_Generated::DivideAsync"
-          ]
-        }
-      }
-    },
     "TestServerlessAppComplexCalculatorAddGenerated": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
@@ -199,10 +33,16 @@
       "Properties": {
         "MemorySize": 256,
         "Timeout": 30,
-        "Role": null,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.ComplexCalculator_Add_Generated::Add"
+          ]
+        },
         "Events": {
           "RootPost": {
             "Type": "HttpApi",
@@ -211,13 +51,6 @@
               "Method": "POST"
             }
           }
-        },
-        "PackageType": "Image",
-        "ImageUri": ".",
-        "ImageConfig": {
-          "Command": [
-            "TestServerlessApp::TestServerlessApp.ComplexCalculator_Add_Generated::Add"
-          ]
         }
       }
     },
@@ -235,6 +68,13 @@
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.ComplexCalculator_Subtract_Generated::Subtract"
+          ]
+        },
         "Events": {
           "RootPost": {
             "Type": "HttpApi",
@@ -243,13 +83,240 @@
               "Method": "POST"
             }
           }
-        },
+        }
+      }
+    },
+    "TestServerlessAppDynamicExampleDynamicReturnGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations"
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
         "PackageType": "Image",
         "ImageUri": ".",
         "ImageConfig": {
           "Command": [
-            "TestServerlessApp::TestServerlessApp.ComplexCalculator_Subtract_Generated::Subtract"
+            "TestServerlessApp::TestServerlessApp.DynamicExample_DynamicReturn_Generated::DynamicReturn"
           ]
+        }
+      }
+    },
+    "TestServerlessAppDynamicExampleDynamicInputGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations"
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.DynamicExample_DynamicInput_Generated::DynamicInput"
+          ]
+        }
+      }
+    },
+    "GreeterSayHello": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 1024,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.Greeter_SayHello_Generated::SayHello"
+          ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "HttpApi",
+            "Properties": {
+              "Path": "/Greeter/SayHello",
+              "Method": "GET",
+              "PayloadFormatVersion": "1.0"
+            }
+          }
+        }
+      }
+    },
+    "GreeterSayHelloAsync": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 50,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.Greeter_SayHelloAsync_Generated::SayHelloAsync"
+          ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "HttpApi",
+            "Properties": {
+              "Path": "/Greeter/SayHelloAsync",
+              "Method": "GET",
+              "PayloadFormatVersion": "1.0"
+            }
+          }
+        }
+      }
+    },
+    "SimpleCalculatorAdd": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Add_Generated::Add"
+          ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "Api",
+            "Properties": {
+              "Path": "/SimpleCalculator/Add",
+              "Method": "GET"
+            }
+          }
+        }
+      }
+    },
+    "SimpleCalculatorSubtract": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Subtract_Generated::Subtract"
+          ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "Api",
+            "Properties": {
+              "Path": "/SimpleCalculator/Subtract",
+              "Method": "GET"
+            }
+          }
+        }
+      }
+    },
+    "SimpleCalculatorMultiply": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.SimpleCalculator_Multiply_Generated::Multiply"
+          ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "Api",
+            "Properties": {
+              "Path": "/SimpleCalculator/Multiply/{x}/{y}",
+              "Method": "GET"
+            }
+          }
+        }
+      }
+    },
+    "SimpleCalculatorDivideAsync": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.SimpleCalculator_DivideAsync_Generated::DivideAsync"
+          ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "Api",
+            "Properties": {
+              "Path": "/SimpleCalculator/DivideAsync/{x}/{y}",
+              "Method": "GET"
+            }
+          }
         }
       }
     },
@@ -313,39 +380,6 @@
         }
       }
     },
-    "GreeterSayHelloAsync": {
-      "Type": "AWS::Serverless::Function",
-      "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations",
-        "SyncedEvents": [
-          "RootGet"
-        ]
-      },
-      "Properties": {
-        "MemorySize": 256,
-        "Timeout": 50,
-        "Policies": [
-          "AWSLambdaBasicExecutionRole"
-        ],
-        "PackageType": "Image",
-        "Events": {
-          "RootGet": {
-            "Type": "HttpApi",
-            "Properties": {
-              "Path": "/Greeter/SayHelloAsync",
-              "Method": "GET",
-              "PayloadFormatVersion": "1.0"
-            }
-          }
-        },
-        "ImageUri": ".",
-        "ImageConfig": {
-          "Command": [
-            "TestServerlessApp::TestServerlessApp.Greeter_SayHelloAsync_Generated::SayHelloAsync"
-          ]
-        }
-      }
-    },
     "ToUpper": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
@@ -362,26 +396,6 @@
         "ImageConfig": {
           "Command": [
             "TestServerlessApp::TestServerlessApp.Sub1.Functions_ToUpper_Generated::ToUpper"
-          ]
-        }
-      }
-    },
-    "TestServerlessAppVoidExampleVoidReturnGenerated": {
-      "Type": "AWS::Serverless::Function",
-      "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations"
-      },
-      "Properties": {
-        "MemorySize": 256,
-        "Timeout": 30,
-        "Policies": [
-          "AWSLambdaBasicExecutionRole"
-        ],
-        "PackageType": "Image",
-        "ImageUri": ".",
-        "ImageConfig": {
-          "Command": [
-            "TestServerlessApp::TestServerlessApp.VoidExample_VoidReturn_Generated::VoidReturn"
           ]
         }
       }
@@ -406,7 +420,7 @@
         }
       }
     },
-    "TestServerlessAppDynamicExampleDynamicReturnGenerated": {
+    "TestServerlessAppVoidExampleVoidReturnGenerated": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
         "Tool": "Amazon.Lambda.Annotations"
@@ -421,15 +435,18 @@
         "ImageUri": ".",
         "ImageConfig": {
           "Command": [
-            "TestServerlessApp::TestServerlessApp.DynamicExample_DynamicReturn_Generated::DynamicReturn"
+            "TestServerlessApp::TestServerlessApp.VoidExample_VoidReturn_Generated::VoidReturn"
           ]
         }
       }
     },
-    "TestServerlessAppDynamicExampleDynamicInputGenerated": {
+    "TestServerlessAppCustomizeResponseExamplesOkResponseWithHeaderGenerated": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations"
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
       },
       "Properties": {
         "MemorySize": 256,
@@ -441,8 +458,179 @@
         "ImageUri": ".",
         "ImageConfig": {
           "Command": [
-            "TestServerlessApp::TestServerlessApp.DynamicExample_DynamicInput_Generated::DynamicInput"
+            "TestServerlessApp::TestServerlessApp.CustomizeResponseExamples_OkResponseWithHeader_Generated::OkResponseWithHeader"
           ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "Api",
+            "Properties": {
+              "Path": "/okresponsewithheader/{x}",
+              "Method": "GET"
+            }
+          }
+        }
+      }
+    },
+    "TestServerlessAppCustomizeResponseExamplesOkResponseWithHeaderAsyncGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.CustomizeResponseExamples_OkResponseWithHeaderAsync_Generated::OkResponseWithHeaderAsync"
+          ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "Api",
+            "Properties": {
+              "Path": "/okresponsewithheaderasync/{x}",
+              "Method": "GET"
+            }
+          }
+        }
+      }
+    },
+    "TestServerlessAppCustomizeResponseExamplesNotFoundResponseWithHeaderV2Generated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.CustomizeResponseExamples_NotFoundResponseWithHeaderV2_Generated::NotFoundResponseWithHeaderV2"
+          ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "HttpApi",
+            "Properties": {
+              "Path": "/notfoundwithheaderv2/{x}",
+              "Method": "GET"
+            }
+          }
+        }
+      }
+    },
+    "TestServerlessAppCustomizeResponseExamplesNotFoundResponseWithHeaderV2AsyncGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.CustomizeResponseExamples_NotFoundResponseWithHeaderV2Async_Generated::NotFoundResponseWithHeaderV2Async"
+          ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "HttpApi",
+            "Properties": {
+              "Path": "/notfoundwithheaderv2async/{x}",
+              "Method": "GET"
+            }
+          }
+        }
+      }
+    },
+    "TestServerlessAppCustomizeResponseExamplesNotFoundResponseWithHeaderV1Generated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.CustomizeResponseExamples_NotFoundResponseWithHeaderV1_Generated::NotFoundResponseWithHeaderV1"
+          ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "HttpApi",
+            "Properties": {
+              "Path": "/notfoundwithheaderv1/{x}",
+              "Method": "GET",
+              "PayloadFormatVersion": "1.0"
+            }
+          }
+        }
+      }
+    },
+    "TestServerlessAppCustomizeResponseExamplesNotFoundResponseWithHeaderV1AsyncGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.CustomizeResponseExamples_NotFoundResponseWithHeaderV1Async_Generated::NotFoundResponseWithHeaderV1Async"
+          ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "HttpApi",
+            "Properties": {
+              "Path": "/notfoundwithheaderv1async/{x}",
+              "Method": "GET",
+              "PayloadFormatVersion": "1.0"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/979#issuecomment-1218455773
https://github.com/aws/aws-lambda-dotnet/discussions/1379

*Description of changes:*
ASP.NET Core has the [TypesResults](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.typedresults) class which is used to create an `IResult` for the desired HTTP response. Using that for inspiration this PR creates `HttpResults` and `IHttpResults` to allow users using the Annotations library to customize the HTTP response.

The default experience without using `IHttpResults` is users return back their own types like the following:
```
    [LambdaFunction()]
    [HttpApi(LambdaHttpMethod.Get, "/")]
    public IHttpResults SimpleExample()
    {
        return new OrderInfo();
    }
```
Annotations will treat the response as a 200 success and serialize the `OrderInfo` as JSON.

Using `HttpResults` you can do same thing and include headers.
```
    [LambdaFunction()]
    [HttpApi(LambdaHttpMethod.Get, "/")]
    public IHttpResults SimpleExample()
    {
        return HttpResults.Ok(new OrderInfo())
                                      .AddHeader("MyHeader", "Value");
    }
```
The `IHttpResults` has the `AddHeader` method that returns back the instance of `IHttpResults` to follow a fluent building pattern.

There are methods for on `HttpResults` for each of the typical status codes like `TypesResults`. Here is a not found example:

```
    [LambdaFunction()]
    [HttpApi(LambdaHttpMethod.Get, "/{orderId}")]
    public IHttpResults GetOrder(int orderId)
    {
        return HttpResults.NotFound($"Failed to find order for {orderId}");
    }
```

## Other refactoring changes
* Added .NET 6 target framework to `Amazon.Lambda.Annotations`. It still needs to target .NET Standard 2.0 when used inside the source generator. This causes some tricky snipping out of .NET 6 code.
* Found a bug when the Lambda function was returning a `Task` but not using the `async` keyword. I got rid of the logic based on the `IsAsync` property and created new `Task` properties to identify when a `Task` is used and when the task is returning void or a type.
* Updated source generator test project to target .NET 6.





By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
