### PR TITLE
Add common 5xx status codes to HttpResults for Annotations framework

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations/APIGateway/HttpResults.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/APIGateway/HttpResults.cs
@@ -304,7 +304,11 @@ namespace Amazon.Lambda.Annotations.APIGateway
         public static IHttpResult ServiceUnavailable(int? delaySeconds = null)
         {
             var result = new HttpResults(HttpStatusCode.ServiceUnavailable);
-            if (delaySeconds != null && delaySeconds > 0) result.AddHeader("Retry-After", delaySeconds.ToString());
+            if (delaySeconds != null && delaySeconds > 0)
+            {
+                result.AddHeader("Retry-After", delaySeconds.ToString());
+            }
+            
             return result;
         }
 

--- a/Libraries/src/Amazon.Lambda.Annotations/APIGateway/HttpResults.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/APIGateway/HttpResults.cs
@@ -168,6 +168,15 @@ namespace Amazon.Lambda.Annotations.APIGateway
         {
             return new HttpResults(HttpStatusCode.Accepted, body);
         }
+        
+        /// <summary>
+        /// Creates an IHttpResult for a Bad Gateway (502) status code.
+        /// </summary>
+        /// <returns></returns>
+        public static IHttpResult BadGateway()
+        {
+            return new HttpResults(HttpStatusCode.BadGateway);
+        }
 
         /// <summary>
         /// Creates an IHttpResult for a BadRequest (400) status code.
@@ -214,6 +223,16 @@ namespace Amazon.Lambda.Annotations.APIGateway
         public static IHttpResult Forbid(object body = null)
         {
             return new HttpResults(HttpStatusCode.Forbidden, body);
+        }
+        
+        /// <summary>
+        /// Creates an IHttpResult for an Internal Server Error (500) status code.
+        /// </summary>
+        /// <param name="body">Optional response body</param>
+        /// <returns></returns>
+        public static IHttpResult InternalServerError(object body = null)
+        {
+            return new HttpResults(HttpStatusCode.InternalServerError, body);
         }
 
         /// <summary>
@@ -274,6 +293,18 @@ namespace Amazon.Lambda.Annotations.APIGateway
                 result.AddHeader("location", uri);
             }
 
+            return result;
+        }
+        
+        /// <summary>
+        /// Creates an IHttpResult for a Service Unavailable (503) status code.
+        /// </summary>
+        /// <param name="delaySeconds">Optional number of seconds to return in a Retry-After header</param>
+        /// <returns></returns>
+        public static IHttpResult ServiceUnavailable(int? delaySeconds = null)
+        {
+            var result = new HttpResults(HttpStatusCode.ServiceUnavailable);
+            if (delaySeconds != null && delaySeconds > 0) result.AddHeader("Retry-After", delaySeconds.ToString());
             return result;
         }
 

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/HttpResultsTest.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/HttpResultsTest.cs
@@ -264,10 +264,12 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
             ValidateResult(result, HttpStatusCode.BadGateway);
         }
         
-        [Fact]
-        public void ServiceUnavailable_WithoutRetryAfter()
+        [Theory]
+        [InlineData(null)]
+        [InlineData(0)]
+        public void ServiceUnavailable_WithoutRetryAfter(int? delay)
         {
-            var result = HttpResults.ServiceUnavailable();
+            var result = HttpResults.ServiceUnavailable(delay);
             ValidateResult(result, HttpStatusCode.ServiceUnavailable);
         }
         

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/HttpResultsTest.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/HttpResultsTest.cs
@@ -249,6 +249,37 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                 {"key", new List<string> {"value1", "value2", "VALUE3"} }
             });
         }
+        
+        [Fact]
+        public void InternalServerError()
+        {
+            var result = HttpResults.InternalServerError();
+            ValidateResult(result, HttpStatusCode.InternalServerError);
+        }
+        
+        [Fact]
+        public void BadGateway()
+        {
+            var result = HttpResults.BadGateway();
+            ValidateResult(result, HttpStatusCode.BadGateway);
+        }
+        
+        [Fact]
+        public void ServiceUnavailable_WithoutRetryAfter()
+        {
+            var result = HttpResults.ServiceUnavailable();
+            ValidateResult(result, HttpStatusCode.ServiceUnavailable);
+        }
+        
+        [Fact]
+        public void ServiceUnavailable_WithRetryAfter()
+        {
+            var result = HttpResults.ServiceUnavailable(100);
+            ValidateResult(result, HttpStatusCode.ServiceUnavailable, headers: new Dictionary<string, IList<string>>
+            {
+                {"retry-after", new List<string> {"100"} }
+            });
+        }
 
 
         private void ValidateResult(IHttpResult result, HttpStatusCode statusCode, string body = null, bool isBase64Encoded = false, IDictionary<string, IList<string>> headers = null)


### PR DESCRIPTION
Fixes: https://github.com/aws/aws-lambda-dotnet/issues/1431

*Description of changes:*
Added return types for HttpResults described in issue. This change adds 500, 502 and 503 errors

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
