### PR TITLE
feat: add lambda powertools templates

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/blueprint-manifest.json
@@ -1,0 +1,8 @@
+{
+  "display-name": "Function with Powertools",
+  "system-name": "FunctionPowertools",
+  "description": "Setup the project and test project to create a Lambda function with Powertools from scratch.",
+  "sort-order": 100,
+  "hidden-tags": ["C#", "LambdaProject"],
+  "tags": ["Powertools", "Custom"]
+}

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/blueprint-manifest.json
@@ -2,7 +2,7 @@
   "display-name": "Function with Powertools",
   "system-name": "FunctionPowertools",
   "description": "Setup the project and test project to create a Lambda function with Powertools from scratch.",
-  "sort-order": 100,
+  "sort-order": 160,
   "hidden-tags": ["C#", "LambdaProject"],
   "tags": ["Powertools", "Custom"]
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/.template.config/template.json
@@ -4,7 +4,7 @@
   "name": "Lambda Function with Powertools",
   "identity": "AWS.Lambda.Function.Powertools.CSharp",
   "groupIdentity": "AWS.Lambda.Function.Powertools",
-  "shortName": "lambda.Function.Powertools",
+  "shortName": "lambda.Powertools",
   "tags": {
     "language": "C#",
     "type": "project"

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/.template.config/template.json
@@ -1,0 +1,35 @@
+{
+  "author": "AWS",
+  "classifications": ["AWS", "Lambda", "Function", "Powertools"],
+  "name": "Lambda Function with Powertools",
+  "identity": "AWS.Lambda.Function.Powertools.CSharp",
+  "groupIdentity": "AWS.Lambda.Function.Powertools",
+  "shortName": "lambda.Function.Powertools",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "BlueprintBaseName.1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "profile": {
+      "type": "parameter",
+      "description": "The AWS credentials profile set in aws-lambda-tools-defaults.json and used as the default profile when interacting with AWS.",
+      "datatype": "string",
+      "replaces": "DefaultProfile",
+      "defaultValue": ""
+    },
+    "region": {
+      "type": "parameter",
+      "description": "The AWS region set in aws-lambda-tools-defaults.json and used as the default region when interacting with AWS.",
+      "datatype": "string",
+      "replaces": "DefaultRegion",
+      "defaultValue": ""
+    }
+  },
+  "primaryOutputs": [
+    {
+      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+    }
+  ]
+}

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -14,8 +14,8 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
-    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="0.0.2-preview" />
-    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="0.0.2-preview" />
-    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="0.0.2-preview" />
+    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.0.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.0.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AWSProjectType>Lambda</AWSProjectType>
+    <!-- This property makes the build directory similar to a publish directory and helps the AWS
+    .NET Lambda Mock Test Tool find project dependencies. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!-- Generate ready to run images during publishing to improve cold start time. -->
+    <PublishReadyToRun>true</PublishReadyToRun>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="0.0.2-preview" />
+    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="0.0.2-preview" />
+    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="0.0.2-preview" />
+  </ItemGroup>
+</Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
     <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="0.0.2-preview" />
     <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="0.0.2-preview" />
     <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="0.0.2-preview" />

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/Function.cs
@@ -24,8 +24,8 @@ public class Function
     /// <param name="input"></param>
     /// <param name="context"></param>
     /// <returns></returns>
-    [Logging(LogEvent = true, Service = "To_Upper_Function")]
-    [Tracing(CaptureMode = TracingCaptureMode.ResponseAndError)]
+    [Logging(LogEvent = true)]
+    [Tracing]
     public string FunctionHandler(string input, ILambdaContext context)
     {
         var upperCaseString = UpperCaseString(input);
@@ -35,7 +35,7 @@ public class Function
         return upperCaseString;
     }
 
-    [Metrics(Namespace = "PowertoolsNamespace", CaptureColdStart = true, Service = "To_Upper_Function")]
+    [Metrics(CaptureColdStart = true)]
     [Tracing(SegmentName = "UpperCaseString Method")]
     private static string UpperCaseString(string input)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/Function.cs
@@ -1,0 +1,54 @@
+using Amazon.Lambda.Core;
+using AWS.Lambda.Powertools.Logging;
+using AWS.Lambda.Powertools.Metrics;
+using AWS.Lambda.Powertools.Tracing;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace BlueprintBaseName._1;
+
+/// <summary>
+/// Learn more about Lambda Powertools at https://awslabs.github.io/aws-lambda-powertools-dotnet/
+/// Lambda Powertools Logging: https://awslabs.github.io/aws-lambda-powertools-dotnet/core/logging/
+/// Lambda Powertools Tracing: https://awslabs.github.io/aws-lambda-powertools-dotnet/core/tracing/
+/// Lambda Powertools Metrics: https://awslabs.github.io/aws-lambda-powertools-dotnet/core/metrics/
+/// Metrics Namespace and Service can be defined through Environment Variables https://awslabs.github.io/aws-lambda-powertools-dotnet/core/metrics/#getting-started
+/// </summary>
+public class Function
+{
+
+    /// <summary>
+    /// A simple function that takes a string and does a ToUpper
+    /// </summary>
+    /// <param name="input"></param>
+    /// <param name="context"></param>
+    /// <returns></returns>
+    [Logging(LogEvent = true, Service = "To_Upper_Function")]
+    [Tracing(CaptureMode = TracingCaptureMode.ResponseAndError)]
+    public string FunctionHandler(string input, ILambdaContext context)
+    {
+        var upperCaseString = UpperCaseString(input);
+
+        Logger.LogInformation($"Uppercase of '{input}' is {upperCaseString}");
+
+        return upperCaseString;
+    }
+
+    [Metrics(Namespace = "PowertoolsNamespace", CaptureColdStart = true, Service = "To_Upper_Function")]
+    [Tracing(SegmentName = "UpperCaseString Method")]
+    private static string UpperCaseString(string input)
+    {
+        try
+        {
+            Metrics.AddMetric("UpperCaseString_Invocations", 1, MetricUnit.Count);
+
+            return input.ToUpper();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex);
+            throw;
+        }
+    }
+}

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/Readme.md
@@ -8,11 +8,11 @@ You may also have a test project depending on the options selected.
 
 The generated function handler is a simple method accepting a string argument that returns the uppercase equivalent of the input string. Replace the body of this method, and parameters, to suit your needs. 
 
-## Lambda Powertools
+## AWS Lambda Powertools for .NET
 
-[AWS Lambda Powertools for .NET](https://awslabs.github.io/aws-lambda-powertools-dotnet/) is a suite of utilities for AWS Lambda functions to ease adopting best practices such as tracing, structured logging, custom metrics, and more.
+[AWS Lambda Powertools for .NET](https://awslabs.github.io/aws-lambda-powertools-dotnet/) is a developer toolkit to implement Serverless best practices and increase developer velocity.
 
-This starter project comes with Powertools Loging, Metrics and Tracing configured in Function.cs. 
+This starter project comes with Powertools Loging, Metrics and Tracing configured through environment variables and annotations on methods in Function.cs
 
 Included NuGet Packages:
 * [AWS.Lambda.Powertools.Logging](https://awslabs.github.io/aws-lambda-powertools-dotnet/core/logging/)

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/Readme.md
@@ -1,0 +1,61 @@
+# AWS Lambda Function Project with Lambda Powertools
+
+This starter project consists of:
+* Function.cs - class file containing a class with a single function handler method
+* aws-lambda-tools-defaults.json - default argument settings for use with Visual Studio and command line deployment tools for AWS
+
+You may also have a test project depending on the options selected.
+
+The generated function handler is a simple method accepting a string argument that returns the uppercase equivalent of the input string. Replace the body of this method, and parameters, to suit your needs. 
+
+## Lambda Powertools
+
+[AWS Lambda Powertools for .NET](https://awslabs.github.io/aws-lambda-powertools-dotnet/) is a suite of utilities for AWS Lambda functions to ease adopting best practices such as tracing, structured logging, custom metrics, and more.
+
+This starter project comes with Powertools Loging, Metrics and Tracing configured in Function.cs. 
+
+Included NuGet Packages:
+* [AWS.Lambda.Powertools.Logging](https://awslabs.github.io/aws-lambda-powertools-dotnet/core/logging/)
+* [AWS.Lambda.Powertools.Metrics](https://awslabs.github.io/aws-lambda-powertools-dotnet/core/metrics/)
+* [AWS.Lambda.Powertools.Tracing](https://awslabs.github.io/aws-lambda-powertools-dotnet/core/tracing/)
+
+
+## Here are some steps to follow from Visual Studio:
+
+To deploy your function to AWS Lambda, right click the project in Solution Explorer and select *Publish to AWS Lambda*.
+
+To view your deployed function open its Function View window by double-clicking the function name shown beneath the AWS Lambda node in the AWS Explorer tree.
+
+To perform testing against your deployed function use the Test Invoke tab in the opened Function View window.
+
+To configure event sources for your deployed function, for example to have your function invoked when an object is created in an Amazon S3 bucket, use the Event Sources tab in the opened Function View window.
+
+To update the runtime configuration of your deployed function use the Configuration tab in the opened Function View window.
+
+To view execution logs of invocations of your function use the Logs tab in the opened Function View window.
+
+## Here are some steps to follow to get started from the command line:
+
+Once you have edited your template and code you can deploy your application using the [Amazon.Lambda.Tools Global Tool](https://github.com/aws/aws-extensions-for-dotnet-cli#aws-lambda-amazonlambdatools) from the command line.
+
+Install Amazon.Lambda.Tools Global Tools if not already installed.
+```
+    dotnet tool install -g Amazon.Lambda.Tools
+```
+
+If already installed check if new version is available.
+```
+    dotnet tool update -g Amazon.Lambda.Tools
+```
+
+Execute unit tests
+```
+    cd "BlueprintBaseName.1/test/BlueprintBaseName.1.Tests"
+    dotnet test
+```
+
+Deploy function to AWS Lambda
+```
+    cd "BlueprintBaseName.1/src/BlueprintBaseName.1"
+    dotnet lambda deploy-function
+```

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/Readme.md
@@ -1,26 +1,38 @@
 # AWS Lambda Function Project with Lambda Powertools
 
 This starter project consists of:
+
 * Function.cs - class file containing a class with a single function handler method
 * aws-lambda-tools-defaults.json - default argument settings for use with Visual Studio and command line deployment tools for AWS
 
 You may also have a test project depending on the options selected.
 
-The generated function handler is a simple method accepting a string argument that returns the uppercase equivalent of the input string. Replace the body of this method, and parameters, to suit your needs. 
+The generated function handler is a simple method accepting a string argument that returns the uppercase equivalent of the input string. Replace the body of this method, and parameters, to suit your needs.
 
 ## AWS Lambda Powertools for .NET
 
 [AWS Lambda Powertools for .NET](https://awslabs.github.io/aws-lambda-powertools-dotnet/) is a developer toolkit to implement Serverless best practices and increase developer velocity.
 
-This starter project comes with Powertools Loging, Metrics and Tracing configured through environment variables and annotations on methods in Function.cs
+This starter project comes with Powertools Loging, Metrics and Tracing configured through environment variables defined in the `aws-lambda-tools-defaults.json` file and annotations on methods in `Function.cs`
 
-Included NuGet Packages:
+**Environment variables:**
+
+* POWERTOOLS_SERVICE_NAME=PowertoolsFunction
+* POWERTOOLS_LOG_LEVEL=Info
+* POWERTOOLS_LOGGER_CASE=PascalCase
+* POWERTOOLS_TRACER_CAPTURE_RESPONSE=true
+* POWERTOOLS_TRACER_CAPTURE_ERROR=true
+* POWERTOOLS_METRICS_NAMESPACE=powertools_function
+
+References to the environment variables can be found [here]([https://](https://awslabs.github.io/aws-lambda-powertools-dotnet/references/))
+
+**Included NuGet Packages:**
+
 * [AWS.Lambda.Powertools.Logging](https://awslabs.github.io/aws-lambda-powertools-dotnet/core/logging/)
 * [AWS.Lambda.Powertools.Metrics](https://awslabs.github.io/aws-lambda-powertools-dotnet/core/metrics/)
 * [AWS.Lambda.Powertools.Tracing](https://awslabs.github.io/aws-lambda-powertools-dotnet/core/tracing/)
 
-
-## Here are some steps to follow from Visual Studio:
+## Here are some steps to follow from Visual Studio
 
 To deploy your function to AWS Lambda, right click the project in Solution Explorer and select *Publish to AWS Lambda*.
 
@@ -34,27 +46,31 @@ To update the runtime configuration of your deployed function use the Configurat
 
 To view execution logs of invocations of your function use the Logs tab in the opened Function View window.
 
-## Here are some steps to follow to get started from the command line:
+## Here are some steps to follow to get started from the command line
 
 Once you have edited your template and code you can deploy your application using the [Amazon.Lambda.Tools Global Tool](https://github.com/aws/aws-extensions-for-dotnet-cli#aws-lambda-amazonlambdatools) from the command line.
 
 Install Amazon.Lambda.Tools Global Tools if not already installed.
+
 ```
     dotnet tool install -g Amazon.Lambda.Tools
 ```
 
 If already installed check if new version is available.
+
 ```
     dotnet tool update -g Amazon.Lambda.Tools
 ```
 
 Execute unit tests
+
 ```
     cd "BlueprintBaseName.1/test/BlueprintBaseName.1.Tests"
     dotnet test
 ```
 
 Deploy function to AWS Lambda
+
 ```
     cd "BlueprintBaseName.1/src/BlueprintBaseName.1"
     dotnet lambda deploy-function

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -12,5 +12,6 @@
   "function-runtime": "dotnet6",
   "function-memory-size": 256,
   "function-timeout": 30,
-  "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler"
+  "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler",
+  "environment-variables": "POWERTOOLS_SERVICE_NAME=PowertoolsFunction;POWERTOOLS_LOG_LEVEL=Info;POWERTOOLS_LOGGER_CASE=PascalCase;POWERTOOLS_TRACER_CAPTURE_RESPONSE=true;POWERTOOLS_TRACER_CAPTURE_ERROR=true;POWERTOOLS_METRICS_NAMESPACE=powertools_function"
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -1,0 +1,16 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+    "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+    "dotnet lambda help",
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+  "profile": "DefaultProfile",
+  "region": "DefaultRegion",
+  "configuration": "Release",
+  "function-architecture": "x86_64",
+  "function-runtime": "dotnet6",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler"
+}

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>    
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\BlueprintBaseName.1\BlueprintBaseName.1.csproj" />
+  </ItemGroup>
+</Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
@@ -1,0 +1,20 @@
+using Xunit;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.TestUtilities;
+
+namespace BlueprintBaseName._1.Tests;
+
+public class FunctionTest
+{
+    [Fact]
+    public void TestToUpperFunction()
+    {
+
+        // Invoke the lambda function and confirm the string was upper cased.
+        var function = new Function();
+        var context = new TestLambdaContext();
+        var upperCase = function.FunctionHandler("hello world", context);
+
+        Assert.Equal("HELLO WORLD", upperCase);
+    }
+}

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
@@ -10,6 +10,7 @@ public class FunctionTest
     public void TestToUpperFunction()
     {
 
+        Environment.SetEnvironmentVariable("POWERTOOLS_METRICS_NAMESPACE", "AWSLambdaPowertools");
         // Invoke the lambda function and confirm the string was upper cased.
         var function = new Function();
         var context = new TestLambdaContext();

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/blueprint-manifest.json
@@ -2,7 +2,7 @@
   "display-name": "Serverless Application with Powertools",
   "system-name": "ServerlessPowertools",
   "description": "Setup the project and test project to create a Serverless application with Powertools from scratch.",
-  "sort-order": 100,
+  "sort-order": 160,
   "hidden-tags": ["C#", "ServerlessProject"],
   "tags": ["Powertools"]
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/blueprint-manifest.json
@@ -1,0 +1,8 @@
+{
+  "display-name": "Serverless Application with Powertools",
+  "system-name": "ServerlessPowertools",
+  "description": "Setup the project and test project to create a Serverless application with Powertools from scratch.",
+  "sort-order": 100,
+  "hidden-tags": ["C#", "ServerlessProject"],
+  "tags": ["Powertools"]
+}

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/.template.config/template.json
@@ -1,0 +1,35 @@
+{
+  "author": "AWS",
+  "classifications": ["AWS", "Lambda", "Serverless", "Powertools"],
+  "name": "Lambda Serverless with Powertools",
+  "identity": "AWS.Lambda.Serverless.Powertools.CSharp",
+  "groupIdentity": "AWS.Lambda.Serverless.Powertools",
+  "shortName": "serverless.Powertools",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "BlueprintBaseName.1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "profile": {
+      "type": "parameter",
+      "description": "The AWS credentials profile set in aws-lambda-tools-defaults.json and used as the default profile when interacting with AWS.",
+      "datatype": "string",
+      "replaces": "DefaultProfile",
+      "defaultValue": ""
+    },
+    "region": {
+      "type": "parameter",
+      "description": "The AWS region set in aws-lambda-tools-defaults.json and used as the default region when interacting with AWS.",
+      "datatype": "string",
+      "replaces": "DefaultRegion",
+      "defaultValue": ""
+    }
+  },
+  "primaryOutputs": [
+    {
+      "path": "./src/BlueprintBaseName.1/BlueprintBaseName.1.csproj"
+    }
+  ]
+}

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.6.0" />
     <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="0.0.2-preview" />
     <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="0.0.2-preview" />
     <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="0.0.2-preview" />

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AWSProjectType>Lambda</AWSProjectType>
+    <!-- This property makes the build directory similar to a publish directory and helps the AWS
+    .NET Lambda Mock Test Tool find project dependencies. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!-- Generate ready to run images during publishing to improve cold start time. -->
+    <PublishReadyToRun>true</PublishReadyToRun>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="0.0.2-preview" />
+    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="0.0.2-preview" />
+    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="0.0.2-preview" />
+  </ItemGroup>
+</Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.6.0" />
-    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="0.0.2-preview" />
-    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="0.0.2-preview" />
-    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="0.0.2-preview" />
+    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.0.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.0.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/Functions.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/Functions.cs
@@ -1,0 +1,52 @@
+using System.Net;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+using AWS.Lambda.Powertools.Logging;
+using AWS.Lambda.Powertools.Metrics;
+using AWS.Lambda.Powertools.Tracing;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace BlueprintBaseName._1;
+
+/// <summary>
+/// Learn more about Lambda Powertools at https://awslabs.github.io/aws-lambda-powertools-dotnet/
+/// Lambda Powertools Logging: https://awslabs.github.io/aws-lambda-powertools-dotnet/core/logging/
+/// Lambda Powertools Tracing: https://awslabs.github.io/aws-lambda-powertools-dotnet/core/tracing/
+/// Lambda Powertools Metrics: https://awslabs.github.io/aws-lambda-powertools-dotnet/core/metrics/
+/// </summary>
+public class Functions
+{
+    /// <summary>
+    /// A Lambda function to respond to HTTP Get methods from API Gateway
+    /// </summary>
+    /// <param name="request"></param>
+    /// <returns>The API Gateway response.</returns>
+    [Logging(LogEvent = true, CorrelationIdPath = CorrelationIdPaths.ApiGatewayRest)]
+    [Metrics(CaptureColdStart = true)]
+    [Tracing(CaptureMode = TracingCaptureMode.ResponseAndError)]
+    public APIGatewayProxyResponse Get(APIGatewayProxyRequest request, ILambdaContext context)
+    {
+        Logger.LogInformation("Get Request\n");
+
+        var greeting = GetGreeting();
+
+        var response = new APIGatewayProxyResponse
+        {
+            StatusCode = (int)HttpStatusCode.OK,
+            Body = greeting,
+            Headers = new Dictionary<string, string> { { "Content-Type", "text/plain" } }
+        };
+
+        return response;
+    }
+
+    [Tracing(SegmentName = "GetGreeting Method")]
+    private static string GetGreeting()
+    {
+        Metrics.AddMetric("GetGreeting_Invocations", 1, MetricUnit.Count);
+
+        return "Hello Lambda Powertools";
+    }
+}

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/Functions.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/Functions.cs
@@ -28,7 +28,7 @@ public class Functions
     [Tracing(CaptureMode = TracingCaptureMode.ResponseAndError)]
     public APIGatewayProxyResponse Get(APIGatewayProxyRequest request, ILambdaContext context)
     {
-        Logger.LogInformation("Get Request\n");
+        Logger.LogInformation("Get Request");
 
         var greeting = GetGreeting();
 

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/Readme.md
@@ -9,11 +9,11 @@ You may also have a test project depending on the options selected.
 
 The generated project contains a Serverless template declaration for a single AWS Lambda function that will be exposed through Amazon API Gateway as a HTTP *Get* operation. Edit the template to customize the function or add more functions and other resources needed by your application, and edit the function code in Function.cs. You can then deploy your Serverless application.
 
-## Lambda Powertools
+## AWS Lambda Powertools for .NET
 
-[AWS Lambda Powertools for .NET](https://awslabs.github.io/aws-lambda-powertools-dotnet/) is a suite of utilities for AWS Lambda functions to ease adopting best practices such as tracing, structured logging, custom metrics, and more.
+[AWS Lambda Powertools for .NET](https://awslabs.github.io/aws-lambda-powertools-dotnet/) is a developer toolkit to implement Serverless best practices and increase developer velocity.
 
-This starter project comes with Powertools Loging, Metrics and Tracing configured in Function.cs.
+This starter project comes with Powertools Loging, Metrics and Tracing configured through environment variables and annotations on methods in Function.cs
 
 Included NuGet Packages:
 

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/Readme.md
@@ -1,6 +1,7 @@
 # AWS Serverless Application Project with Lambda Powertools
 
 This starter project consists of:
+
 * serverless.template - an AWS CloudFormation Serverless Application Model template file for declaring your Serverless functions and other AWS resources
 * Function.cs - class file containing the C# method mapped to the single function declared in the template file
 * aws-lambda-tools-defaults.json - default argument settings for use with Visual Studio and command line deployment tools for AWS
@@ -13,47 +14,63 @@ The generated project contains a Serverless template declaration for a single AW
 
 [AWS Lambda Powertools for .NET](https://awslabs.github.io/aws-lambda-powertools-dotnet/) is a developer toolkit to implement Serverless best practices and increase developer velocity.
 
-This starter project comes with Powertools Loging, Metrics and Tracing configured through environment variables and annotations on methods in Function.cs
+This starter project comes with Powertools Loging, Metrics and Tracing configured through environment variables defined in the `serverless.template` file and annotations on methods in `Function.cs`
 
-Included NuGet Packages:
+**Environment variables:**
+
+* POWERTOOLS_SERVICE_NAME=ServerlessGreeting
+* POWERTOOLS_LOG_LEVEL=Info
+* POWERTOOLS_LOGGER_CASE=PascalCase
+* POWERTOOLS_TRACER_CAPTURE_RESPONSE=true
+* POWERTOOLS_TRACER_CAPTURE_ERROR=true
+* POWERTOOLS_METRICS_NAMESPACE=ServerlessGreeting
+
+References to the environment variables can be found [here]([https://](https://awslabs.github.io/aws-lambda-powertools-dotnet/references/))
+
+**Included NuGet Packages:**
 
 * [AWS.Lambda.Powertools.Logging](https://awslabs.github.io/aws-lambda-powertools-dotnet/core/logging/)
 * [AWS.Lambda.Powertools.Metrics](https://awslabs.github.io/aws-lambda-powertools-dotnet/core/metrics/)
 * [AWS.Lambda.Powertools.Tracing](https://awslabs.github.io/aws-lambda-powertools-dotnet/core/tracing/)
 
-## Here are some steps to follow from Visual Studio:
+## Here are some steps to follow from Visual Studio
 
 To deploy your Serverless application, right click the project in Solution Explorer and select *Publish to AWS Lambda*.
 
 To view your deployed application open the Stack View window by double-clicking the stack name shown beneath the AWS CloudFormation node in the AWS Explorer tree. The Stack View also displays the root URL to your published application.
 
-## Here are some steps to follow to get started from the command line:
+## Here are some steps to follow to get started from the command line
 
 Once you have edited your template and code you can deploy your application using the [Amazon.Lambda.Tools Global Tool](https://github.com/aws/aws-extensions-for-dotnet-cli#aws-lambda-amazonlambdatools) from the command line.
 
 Install Amazon.Lambda.Tools Global Tools if not already installed.
+
 ```
     dotnet tool install -g Amazon.Lambda.Tools
 ```
 
 If already installed check if new version is available.
+
 ```
     dotnet tool update -g Amazon.Lambda.Tools
 ```
 
 Execute unit tests
+
 ```
     cd "BlueprintBaseName.1/test/BlueprintBaseName.1.Tests"
     dotnet test
 ```
 
 Deploy application
+
 ```
     cd "BlueprintBaseName.1/src/BlueprintBaseName.1"
     dotnet lambda deploy-serverless
 ```
+
 ## Arm64
 
 Arm64 support is provided by the AWS Graviton2 processor. For many Lambda workloads Graviton2 provides the best price performance.
 
-If you want to run your Lambda on a Graviton2 Arm64 processor, all you need to do is replace `x86_64` with `arm64` under `"Architectures": ` in the `serverless.template` file. Then deploy as described above. 
+If you want to run your Lambda on a Graviton2 Arm64 processor, all you need to do is replace `x86_64` with `arm64` under `"Architectures":` in the `serverless.template` file. Then deploy as described above.

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/Readme.md
@@ -1,0 +1,59 @@
+# AWS Serverless Application Project with Lambda Powertools
+
+This starter project consists of:
+* serverless.template - an AWS CloudFormation Serverless Application Model template file for declaring your Serverless functions and other AWS resources
+* Function.cs - class file containing the C# method mapped to the single function declared in the template file
+* aws-lambda-tools-defaults.json - default argument settings for use with Visual Studio and command line deployment tools for AWS
+
+You may also have a test project depending on the options selected.
+
+The generated project contains a Serverless template declaration for a single AWS Lambda function that will be exposed through Amazon API Gateway as a HTTP *Get* operation. Edit the template to customize the function or add more functions and other resources needed by your application, and edit the function code in Function.cs. You can then deploy your Serverless application.
+
+## Lambda Powertools
+
+[AWS Lambda Powertools for .NET](https://awslabs.github.io/aws-lambda-powertools-dotnet/) is a suite of utilities for AWS Lambda functions to ease adopting best practices such as tracing, structured logging, custom metrics, and more.
+
+This starter project comes with Powertools Loging, Metrics and Tracing configured in Function.cs.
+
+Included NuGet Packages:
+
+* [AWS.Lambda.Powertools.Logging](https://awslabs.github.io/aws-lambda-powertools-dotnet/core/logging/)
+* [AWS.Lambda.Powertools.Metrics](https://awslabs.github.io/aws-lambda-powertools-dotnet/core/metrics/)
+* [AWS.Lambda.Powertools.Tracing](https://awslabs.github.io/aws-lambda-powertools-dotnet/core/tracing/)
+
+## Here are some steps to follow from Visual Studio:
+
+To deploy your Serverless application, right click the project in Solution Explorer and select *Publish to AWS Lambda*.
+
+To view your deployed application open the Stack View window by double-clicking the stack name shown beneath the AWS CloudFormation node in the AWS Explorer tree. The Stack View also displays the root URL to your published application.
+
+## Here are some steps to follow to get started from the command line:
+
+Once you have edited your template and code you can deploy your application using the [Amazon.Lambda.Tools Global Tool](https://github.com/aws/aws-extensions-for-dotnet-cli#aws-lambda-amazonlambdatools) from the command line.
+
+Install Amazon.Lambda.Tools Global Tools if not already installed.
+```
+    dotnet tool install -g Amazon.Lambda.Tools
+```
+
+If already installed check if new version is available.
+```
+    dotnet tool update -g Amazon.Lambda.Tools
+```
+
+Execute unit tests
+```
+    cd "BlueprintBaseName.1/test/BlueprintBaseName.1.Tests"
+    dotnet test
+```
+
+Deploy application
+```
+    cd "BlueprintBaseName.1/src/BlueprintBaseName.1"
+    dotnet lambda deploy-serverless
+```
+## Arm64
+
+Arm64 support is provided by the AWS Graviton2 processor. For many Lambda workloads Graviton2 provides the best price performance.
+
+If you want to run your Lambda on a Graviton2 Arm64 processor, all you need to do is replace `x86_64` with `arm64` under `"Architectures": ` in the `serverless.template` file. Then deploy as described above. 

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -10,10 +10,5 @@
   "configuration": "Release",
   "s3-prefix": "BlueprintBaseName.1/",
   "template": "serverless.template",
-  "function-architecture": "x86_64",
-  "function-runtime": "dotnet6",
-  "function-memory-size": 256,
-  "function-timeout": 30,
-  "template-parameters": "",
-  "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Functions::Get"
+  "template-parameters": ""
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -1,0 +1,19 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+    "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+    "dotnet lambda help",
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+  "profile": "DefaultProfile",
+  "region": "DefaultRegion",
+  "configuration": "Release",
+  "s3-prefix": "BlueprintBaseName.1/",
+  "template": "serverless.template",
+  "function-architecture": "x86_64",
+  "function-runtime": "dotnet6",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "template-parameters": "",
+  "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Functions::Get"
+}

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/serverless.template
@@ -20,8 +20,12 @@
         ],
         "Environment": {
           "Variables": {
-            "POWERTOOLS_METRICS_NAMESPACE": "ServerlessGreeting",
-            "POWERTOOLS_SERVICE_NAME": "ServerlessGreeting"
+            "POWERTOOLS_SERVICE_NAME": "ServerlessGreeting",
+            "POWERTOOLS_LOG_LEVEL": "Info",
+            "POWERTOOLS_LOGGER_CASE": "PascalCase",
+            "POWERTOOLS_TRACER_CAPTURE_RESPONSE": true,
+            "POWERTOOLS_TRACER_CAPTURE_ERROR": true,
+            "POWERTOOLS_METRICS_NAMESPACE": "ServerlessGreeting"
           }
         },
         "Events": {

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/serverless.template
@@ -1,0 +1,47 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Transform": "AWS::Serverless-2016-10-31",
+  "Description": "An AWS Serverless Application.",
+  "Resources": {
+    "Get": {
+      "Type": "AWS::Serverless::Function",
+      "Properties": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Functions::Get",
+        "Runtime": "dotnet6",
+        "CodeUri": "",
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Role": null,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "Environment": {
+          "Variables": {
+            "POWERTOOLS_METRICS_NAMESPACE": "ServerlessGreeting",
+            "POWERTOOLS_SERVICE_NAME": "ServerlessGreeting"
+          }
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "Api",
+            "Properties": {
+              "Path": "/",
+              "Method": "GET"
+            }
+          }
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "ApiURL": {
+      "Description": "API endpoint URL for Prod environment",
+      "Value": {
+        "Fn::Sub": "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+      }
+    }
+  }
+}

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\BlueprintBaseName.1\BlueprintBaseName.1.csproj" />
+  </ItemGroup>
+</Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/test/BlueprintBaseName.1.Tests/FunctionsTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/test/BlueprintBaseName.1.Tests/FunctionsTest.cs
@@ -1,0 +1,32 @@
+using Xunit;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.TestUtilities;
+using Amazon.Lambda.APIGatewayEvents;
+
+
+namespace BlueprintBaseName._1.Tests;
+
+public class FunctionTest
+{
+    public FunctionTest()
+    {
+    }
+
+    [Fact]
+    public void TestGetMethod()
+    {
+        Environment.SetEnvironmentVariable("POWERTOOLS_METRICS_NAMESPACE", "AWSLambdaPowertools");
+
+        TestLambdaContext context;
+        APIGatewayProxyRequest request;
+        APIGatewayProxyResponse response;
+
+        Functions functions = new Functions();
+
+        request = new APIGatewayProxyRequest();
+        context = new TestLambdaContext();
+        response = functions.Get(request, context);
+        Assert.Equal(200, response.StatusCode);
+        Assert.Equal("Hello Lambda Powertools", response.Body);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/198

*Description of changes:*

Creating new templates for dotnet6 runtime. These two templates are based on Empty Function and Empty Serverless templates but include AWS Lambda Powertools Tracing, Logging and Metrics utilities.
AWS Lambda Powertools is a developer toolkit to implement Serverless best practices and increase developer velocity.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
