### PR TITLE
fix: Report diagnostic error for invalid CloudFormation resource names

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/AnalyzerReleases.Shipped.md
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/AnalyzerReleases.Shipped.md
@@ -1,6 +1,13 @@
 ; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
+## Release 0.13.0.0
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+AWSLambda0106 | AWSLambdaCSharpGenerator | Error | Invalid CloudFormation resource name
+
+
 ## Release 0.11.0.0
 
 Rule ID | Category | Severity | Notes

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/DiagnosticDescriptors.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/DiagnosticDescriptors.cs
@@ -37,7 +37,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Diagnostics
             category: "AWSLambdaCSharpGenerator",
             DiagnosticSeverity.Info,
             isEnabledByDefault: true);
-        
+
         public static readonly DiagnosticDescriptor MissingDependencies = new DiagnosticDescriptor(id: "AWSLambda0104",
             title: "Missing reference to a required dependency",
             messageFormat: "Your project has a missing required package dependency. Please add a reference to the following package: {0}",
@@ -48,6 +48,13 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Diagnostics
         public static readonly DiagnosticDescriptor HttpResultsOnNonApiFunction = new DiagnosticDescriptor(id: "AWSLambda0105",
             title: $"Invalid return type {nameof(IHttpResult)}",
             messageFormat: $"{nameof(IHttpResult)} is not a valid return type for LambdaFunctions without {nameof(HttpApiAttribute)} or {nameof(RestApiAttribute)} attributes",
+            category: "AWSLambdaCSharpGenerator",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+        public static readonly  DiagnosticDescriptor InvalidResourceName = new DiagnosticDescriptor(id: "AWSLambda0106",
+            title: $"Invalid CloudFormation resource name",
+            messageFormat: "The specified CloudFormation resource name is not valid. It must only contain alphanumeric characters.",
             category: "AWSLambdaCSharpGenerator",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/LambdaFunctionAttributeDataBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/LambdaFunctionAttributeDataBuilder.cs
@@ -13,9 +13,9 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes
 
             foreach (var pair in att.NamedArguments)
             {
-                if (pair.Key == nameof(data.Name) && pair.Value.Value is string value)
+                if (pair.Key == nameof(data.ResourceName) && pair.Value.Value is string value)
                 {
-                    data.Name = value;
+                    data.ResourceName = value;
                 }
 
                 if (pair.Key == nameof(data.Policies) && pair.Value.Value is string policies)

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/ILambdaFunctionSerializable.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/ILambdaFunctionSerializable.cs
@@ -16,9 +16,9 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
         string Handler { get; }
 
         /// <summary>
-        /// The name of the Lambda function which is used to uniquely identify the function within an AWS region.
+        /// The name of the CloudFormation resource that is associated with the Lambda function.
         /// </summary>
-        string Name { get; }
+        string ResourceName { get; }
 
         /// <summary>
         /// The amount of time in seconds that Lambda allows a function to run before stopping it.

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/LambdaFunctionModel.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/LambdaFunctionModel.cs
@@ -35,7 +35,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
         public string Handler => $"{LambdaMethod.ContainingAssembly}::{GeneratedMethod.ContainingType.FullName}::{LambdaMethod.Name}";
 
         /// <inheritdoc />
-        public string Name => LambdaMethod.LambdaFunctionAttribute.Data.Name ??
+        public string ResourceName => LambdaMethod.LambdaFunctionAttribute.Data.ResourceName ??
                               string.Join(string.Empty, GeneratedMethod.ContainingType.FullName.Where(char.IsLetterOrDigit));
 
         /// <inheritdoc />

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Writers/CloudFormationWriter.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Writers/CloudFormationWriter.cs
@@ -66,7 +66,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Writers
                 if (!ShouldProcessLambdaFunction(lambdaFunction))
                     continue;
                 ProcessLambdaFunction(lambdaFunction, relativeProjectUri);
-                processedLambdaFunctions.Add(lambdaFunction.Name);
+                processedLambdaFunctions.Add(lambdaFunction.ResourceName);
             }
 
             RemoveOrphanedLambdaFunctions(processedLambdaFunctions);
@@ -84,7 +84,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Writers
         /// </summary>
         private bool ShouldProcessLambdaFunction(ILambdaFunctionSerializable lambdaFunction)
         {
-            var lambdaFunctionPath = $"Resources.{lambdaFunction.Name}";
+            var lambdaFunctionPath = $"Resources.{lambdaFunction.ResourceName}";
 
             if (!_templateWriter.Exists(lambdaFunctionPath))
                 return true;
@@ -100,7 +100,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Writers
         /// </summary>
         private void ProcessLambdaFunction(ILambdaFunctionSerializable lambdaFunction, string relativeProjectUri)
         {
-            var lambdaFunctionPath = $"Resources.{lambdaFunction.Name}";
+            var lambdaFunctionPath = $"Resources.{lambdaFunction.ResourceName}";
             var propertiesPath = $"{lambdaFunctionPath}.Properties";
 
             if (!_templateWriter.Exists(lambdaFunctionPath))
@@ -194,8 +194,8 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Writers
                 }
             }
 
-            var eventsPath = $"Resources.{lambdaFunction.Name}.Properties.Events";
-            var syncedEventsMetadataPath = $"Resources.{lambdaFunction.Name}.Metadata.SyncedEvents";
+            var eventsPath = $"Resources.{lambdaFunction.ResourceName}.Properties.Events";
+            var syncedEventsMetadataPath = $"Resources.{lambdaFunction.ResourceName}.Metadata.SyncedEvents";
             var previousSyncedEvents = _templateWriter.GetToken<List<string>>(syncedEventsMetadataPath, new List<string>());
 
             // Remove all events that exist in the serverless template but were not encountered during the current source generation pass.
@@ -216,7 +216,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Writers
         /// </summary>
         private string ProcessRestApiAttribute(ILambdaFunctionSerializable lambdaFunction, RestApiAttribute restApiAttribute)
         {
-            var eventPath = $"Resources.{lambdaFunction.Name}.Properties.Events";
+            var eventPath = $"Resources.{lambdaFunction.ResourceName}.Properties.Events";
             var methodName = restApiAttribute.Method.ToString();
             var methodPath = $"{eventPath}.Root{methodName}";
 
@@ -232,7 +232,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Writers
         /// </summary>
         private string ProcessHttpApiAttribute(ILambdaFunctionSerializable lambdaFunction, HttpApiAttribute httpApiAttribute)
         {
-            var eventPath = $"Resources.{lambdaFunction.Name}.Properties.Events";
+            var eventPath = $"Resources.{lambdaFunction.ResourceName}.Properties.Events";
             var methodName = httpApiAttribute.Method.ToString();
             var methodPath = $"{eventPath}.Root{methodName}";
 

--- a/Libraries/src/Amazon.Lambda.Annotations/LambdaFunctionAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/LambdaFunctionAttribute.cs
@@ -9,9 +9,9 @@ namespace Amazon.Lambda.Annotations
     public class LambdaFunctionAttribute : Attribute
     {
         /// <summary>
-        /// The name of the Lambda function which is used to uniquely identify the function within an AWS region.
+        /// The name of the CloudFormation resource that is associated with the Lambda function.
         /// </summary>
-        public string Name { get; set; }
+        public string ResourceName { get; set; }
 
         /// <summary>
         /// The amount of time in seconds that Lambda allows a function to run before stopping it.

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/CloudFormationWriterTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/CloudFormationWriterTests.cs
@@ -213,7 +213,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
             Assert.Equal("MyAssembly::MyNamespace.MyType::Handler", templateWriter.GetToken<string>("Resources.OldName.Properties.Handler"));
 
             // ACT - CHANGE NAME
-            lambdaFunctionModel.Name = "NewName";
+            lambdaFunctionModel.ResourceName = "NewName";
             cloudFormationWriter.ApplyReport(report);
 
             // ASSERT
@@ -654,7 +654,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
                     false, $"Existing description before {CloudFormationWriter.CurrentDescriptionSuffix}" },
 
                 // An existing description with our version in the front should be replaced
-                new object[] { "This template is partially managed by Amazon.Lambda.Annotations (v0.1). Existing description.", 
+                new object[] { "This template is partially managed by Amazon.Lambda.Annotations (v0.1). Existing description.",
                      false, $"{CloudFormationWriter.CurrentDescriptionSuffix} Existing description." },
 
                 // An existing description with our version in the front should be replaced
@@ -664,10 +664,10 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
                 // This would exceed CloudFormation's current limit on the description field, so should not be modified
                 new object[] { new string('-', 1000), false, new string('-', 1000)},
 
-                /* 
+                /*
                  * The remaining cases are with the opt-out flag set to true, which should remove any version descriptions
                  */
-                
+
                 // A blank description should be left alone
                 new object[] { "", true, "" },
 
@@ -783,13 +783,13 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
             mockFileManager.WriteAllText(ServerlessTemplateFilePath, originalContent);
             return mockFileManager;
         }
-        private LambdaFunctionModelTest GetLambdaFunctionModel(string handler, string name, uint? timeout,
+        private LambdaFunctionModelTest GetLambdaFunctionModel(string handler, string resourceName, uint? timeout,
             uint? memorySize, string role, string policies)
         {
             return new LambdaFunctionModelTest
             {
                 Handler = handler,
-                Name = name,
+                ResourceName = resourceName,
                 MemorySize = memorySize,
                 Timeout = timeout,
                 Policies = policies,
@@ -823,7 +823,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
         public class LambdaFunctionModelTest : ILambdaFunctionSerializable
         {
             public string Handler { get; set; }
-            public string Name { get; set; }
+            public string ResourceName { get; set; }
             public uint? Timeout { get; set; }
             public uint? MemorySize { get; set; }
             public string Role { get; set; }

--- a/Libraries/test/TestServerlessApp/Greeter.cs
+++ b/Libraries/test/TestServerlessApp/Greeter.cs
@@ -11,7 +11,7 @@ namespace TestServerlessApp
 {
     public class Greeter
     {
-        [LambdaFunction(Name = "GreeterSayHello", MemorySize = 1024, PackageType = LambdaPackageType.Image)]
+        [LambdaFunction(ResourceName = "GreeterSayHello", MemorySize = 1024, PackageType = LambdaPackageType.Image)]
         [HttpApi(LambdaHttpMethod.Get, "/Greeter/SayHello", Version = HttpApiVersion.V1)]
         public void SayHello([FromQuery(Name = "names")]IEnumerable<string> firstNames, APIGatewayProxyRequest request, ILambdaContext context)
         {
@@ -28,7 +28,7 @@ namespace TestServerlessApp
             }
         }
 
-        [LambdaFunction(Name = "GreeterSayHelloAsync", Timeout = 50, PackageType = LambdaPackageType.Image)]
+        [LambdaFunction(ResourceName = "GreeterSayHelloAsync", Timeout = 50, PackageType = LambdaPackageType.Image)]
         [HttpApi(LambdaHttpMethod.Get, "/Greeter/SayHelloAsync", Version = HttpApiVersion.V1)]
         public async Task SayHelloAsync([FromHeader(Name = "names")]IEnumerable<string> firstNames)
         {

--- a/Libraries/test/TestServerlessApp/SimpleCalculator.cs
+++ b/Libraries/test/TestServerlessApp/SimpleCalculator.cs
@@ -25,14 +25,14 @@ namespace TestServerlessApp
             this._simpleCalculatorService = simpleCalculatorService;
         }
 
-        [LambdaFunction(Name = "SimpleCalculatorAdd", PackageType = LambdaPackageType.Image)]
+        [LambdaFunction(ResourceName = "SimpleCalculatorAdd", PackageType = LambdaPackageType.Image)]
         [RestApi(LambdaHttpMethod.Get, "/SimpleCalculator/Add")]
         public int Add([FromQuery]int x, [FromQuery]int y)
         {
             return _simpleCalculatorService.Add(x, y);
         }
 
-        [LambdaFunction(Name = "SimpleCalculatorSubtract", PackageType = LambdaPackageType.Image)]
+        [LambdaFunction(ResourceName = "SimpleCalculatorSubtract", PackageType = LambdaPackageType.Image)]
         [RestApi(LambdaHttpMethod.Get, "/SimpleCalculator/Subtract")]
         public APIGatewayProxyResponse Subtract([FromHeader]int x, [FromHeader]int y, [FromServices]ISimpleCalculatorService simpleCalculatorService)
         {
@@ -43,27 +43,27 @@ namespace TestServerlessApp
             };
         }
 
-        [LambdaFunction(Name = "SimpleCalculatorMultiply", PackageType = LambdaPackageType.Image)]
+        [LambdaFunction(ResourceName = "SimpleCalculatorMultiply", PackageType = LambdaPackageType.Image)]
         [RestApi(LambdaHttpMethod.Get, "/SimpleCalculator/Multiply/{x}/{y}")]
         public string Multiply(int x, int y)
         {
             return _simpleCalculatorService.Multiply(x, y).ToString();
         }
 
-        [LambdaFunction(Name = "SimpleCalculatorDivideAsync", PackageType = LambdaPackageType.Image)]
+        [LambdaFunction(ResourceName = "SimpleCalculatorDivideAsync", PackageType = LambdaPackageType.Image)]
         [RestApi(template: "/SimpleCalculator/DivideAsync/{x}/{y}", method: LambdaHttpMethod.Get)]
         public async Task<int> DivideAsync([FromRoute(Name = "x")]int first, [FromRoute(Name = "y")]int second)
         {
             return await Task.FromResult(_simpleCalculatorService.Divide(first, second));
         }
 
-        [LambdaFunction(Name = "PI", PackageType = LambdaPackageType.Image)]
+        [LambdaFunction(ResourceName = "PI", PackageType = LambdaPackageType.Image)]
         public double Pi([FromServices]ISimpleCalculatorService simpleCalculatorService)
         {
             return simpleCalculatorService.PI();
         }
 
-        [LambdaFunction(Name = "Random", PackageType = LambdaPackageType.Image)]
+        [LambdaFunction(ResourceName = "Random", PackageType = LambdaPackageType.Image)]
         public async Task<int> Random(int maxValue, ILambdaContext context)
         {
             context.Logger.Log($"Max value: {maxValue}");
@@ -71,7 +71,7 @@ namespace TestServerlessApp
             return await Task.FromResult(value);
         }
 
-        [LambdaFunction(Name = "Randoms", PackageType = LambdaPackageType.Image)]
+        [LambdaFunction(ResourceName = "Randoms", PackageType = LambdaPackageType.Image)]
         public IList<int> Randoms(RandomsInput input, ILambdaContext context)
         {
             context.Logger.Log($"Count: {input.Count}");

--- a/Libraries/test/TestServerlessApp/Sub1/Functions.cs
+++ b/Libraries/test/TestServerlessApp/Sub1/Functions.cs
@@ -5,7 +5,7 @@ namespace TestServerlessApp.Sub1
 {
     public class Functions
     {
-        [LambdaFunction(Name = "ToUpper", PackageType = LambdaPackageType.Image)]
+        [LambdaFunction(ResourceName = "ToUpper", PackageType = LambdaPackageType.Image)]
         public string ToUpper(string text)
         {
             return text.ToUpper();

--- a/Libraries/test/TestServerlessApp/serverless.template
+++ b/Libraries/test/TestServerlessApp/serverless.template
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "An AWS Serverless Application. This template is partially managed by Amazon.Lambda.Annotations (v0.11.0.0).",
+  "Description": "An AWS Serverless Application. This template is partially managed by Amazon.Lambda.Annotations (v0.12.0.0).",
   "Parameters": {
     "ArchitectureTypeParameter": {
       "Type": "String",


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6738

*Description of changes:*
* Renames the `Name` property of `ILambdaFunctionSerializable` and `LambdaFunctionAttribute` to `ResourceName` so that it is better aligned with its use-case.
* Report diagnostic errrors when customers specify an invalid `ResourceName` as part of the `LambdaFunctionAttribute`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
