### PR TITLE
Fix blueprint packaging not include the .vs directory if it exists.

### DIFF
--- a/Blueprints/BlueprintPackager/Utilities.cs
+++ b/Blueprints/BlueprintPackager/Utilities.cs
@@ -29,7 +29,9 @@ namespace Packager
                     if (relativePath.StartsWith("bin/") ||
                         relativePath.Contains("/bin/") ||
                         relativePath.StartsWith("obj/") ||
-                        relativePath.Contains("/obj/"))
+                        relativePath.Contains("/obj/") ||
+                        relativePath.StartsWith(".vs/") ||
+                        relativePath.Contains("/.vs/"))
                         continue;
 
                     var entry = archive.CreateEntry(relativePath);


### PR DESCRIPTION
*Description of changes:*
Fix the code that creates the zip files of the blueprints for Visual Studio to make sure it does not include any `.vs` directories that might happen to exist locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
