### PR TITLE
Fix issue using .NET AOT and provisioned concurrency.

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
@@ -4,9 +4,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
-    <VersionPrefix>1.8.3</VersionPrefix>
+    <VersionPrefix>1.8.4</VersionPrefix>
     <Description>Provides a bootstrap and Lambda Runtime API Client to help you to develop custom .NET Core Lambda Runtimes.</Description>
-    <VersionPrefix>1.8.3</VersionPrefix>
     <Description>Provides a bootstrap and Lambda Runtime API Client to help you  to develop custom .NET Core Lambda Runtimes.</Description>
     <AssemblyTitle>Amazon.Lambda.RuntimeSupport</AssemblyTitle>
     <AssemblyName>Amazon.Lambda.RuntimeSupport</AssemblyName>

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeInit.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeInit.cs
@@ -31,6 +31,16 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
     {
         public static bool IsCallPreJit()
         {
+#if NET6_0_OR_GREATER
+            // If dynamic code is not supported we are most likely running in an AOT environment. In that
+            // case there is no point in doing any prejit optmization and will most likely cause errors
+            // using APIs that are not supported in AOT.
+            if(!RuntimeFeature.IsDynamicCodeSupported)
+            {
+                return false;
+            }    
+#endif
+
             string awsLambdaDotNetPreJitStr = Environment.GetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_DOTNET_PREJIT);
             string awsLambdaInitTypeStr = Environment.GetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_LAMBDA_INITIALIZATION_TYPE);
             AwsLambdaDotNetPreJit awsLambdaDotNetPreJit;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1441

*Description of changes:*
The .NET Lambda runtime client has code in it to detect if startup is part of a provision concurrency. If so then try to load up as many assemblies as possible to get jitting .NET as part of the provisioned concurrency startup. This logic is not valid in an AOT environment where the is just a single executable and so throws an exception.

The fix is to check if running in AOT mode and if so skip the prejitting logic.

I have tested this by first creating a AOT provisioned function and reproduced the failure. Then created a special build with this change deployed again as an AOT provisioned function and start ran correctly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
