### PR TITLE
Add --print-tool-path CLI arguments to simplify IDE debug configuration

### DIFF
--- a/Tools/LambdaTestTool/README.md
+++ b/Tools/LambdaTestTool/README.md
@@ -83,6 +83,7 @@ using the commandline switches as described below. To switch to the no web inter
 These options are valid for either mode the Lambda test tool is running in.
 
         --path &lt;directory&gt;                    The path to the lambda project to execute. If not set then the current directory will be used.
+        --print-tool-path &lt;vs|vscode|other&gt;   Printing the .NET Lambda Test Tool location path to be inserted in the IDE."
 
 These options are valid when using the web interface to select and execute the Lambda code.
 
@@ -157,6 +158,12 @@ Before using Visual Studio Code you must follow the instructions above on instal
 
 To debug with Visual Studio Code and the .NET Mock Lambda Test Tool edit the [launch.json](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations) configuration file and have the `program` property point to `dotnet-lambda-test-tool-3.1.exe` and make sure `cwd` is pointing the .NET Core Lambda project. Note that on a non-windows environment the executable will be called `dotnet-lambda-test-tool-3.1` without the ".exe" at the end. The `dotnet-lambda-test-tool-3.1.exe` executable can be found in the `.dotnet/tools` directory under your home directory. Depending on your file system settings, the `.dotnet` directory can appear hidden.
 
+**Note:** to make it easier to find the location of a tool, you can call it with the arguments `--print-tool-path` and copy the resulting path into the IDE.
+
+```
+dotnet lambda-test-tool-3.1 --print-tool-path vscode
+```
+
 ```json
 {
     "version": "0.2.0",
@@ -195,6 +202,12 @@ The path to the .NET Core 3.1 entry assembly is:
 <home-directory>/.dotnet/tools/.store/amazon.lambda.testtool-3.1/<nuget-version>/amazon.lambda.testtool-3.1/<nuget-version>/tools/netcoreapp3.1/any/Amazon.Lambda.TestTool.WebTester31.dll
 ```
 
+**Note:** to make it easier to find the location of a tool, you can call it with the arguments `--print-tool-path` and
+copy the resulting path into the IDE.
+
+```
+dotnet lambda-test-tool-3.1 --print-tool-path other
+```
 
 Remember when you update your version of the .NET Mock Lambda Test Tool to update the nuget versions numbers in this path string for your IDE's configuration.
 
@@ -221,6 +234,13 @@ The path to the .NET Core 3.1 entry assembly is:
 
 ```
 <home-directory>/.dotnet/tools/.store/amazon.lambda.testtool-3.1/<nuget-version>/amazon.lambda.testtool-3.1/<nuget-version>/tools/netcoreapp3.1/any/Amazon.Lambda.TestTool.WebTester31.dll
+```
+
+**Note:** to make it easier to find the location of a tool, you can call it with the arguments `--print-tool-path` and
+copy the resulting path into the IDE.
+
+```
+dotnet lambda-test-tool-3.1 --print-tool-path other
 ```
 
 Remember when you update your version of the .NET Mock Lambda Test Tool to update the nuget versions numbers in this path string for your IDE's configuration.

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/CommandLineOptions.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/CommandLineOptions.cs
@@ -26,6 +26,8 @@ namespace Amazon.Lambda.TestTool
 
         public bool ShowHelp { get; set; }
 
+        public string PrintToolPathIde { get; set; }
+
         public bool PauseExit { get; set; } = true;
 
         public static CommandLineOptions Parse(string[] args)
@@ -43,6 +45,11 @@ namespace Amazon.Lambda.TestTool
                         {
                             i++;
                         }
+                        break;
+                    case "--print-tool-path":
+                        options.PrintToolPathIde = GetNextStringValue(i);
+                        i++;
+
                         break;
                     case "--host":
                         options.Host = GetNextStringValue(i);
@@ -145,6 +152,7 @@ namespace Amazon.Lambda.TestTool
             Console.WriteLine("These options are valid for either mode the Lambda test tool is running in.");
             Console.WriteLine();
             Console.WriteLine("\t--path <directory>                    The path to the lambda project to execute. If not set then the current directory will be used.");
+            Console.WriteLine("\t--print-tool-path <vs|vscode|other>   Printing the .NET Lambda Test Tool location path to be inserted in the IDE.");
             Console.WriteLine();
 
             Console.WriteLine("These options are valid when using the web interface to select and execute the Lambda code.");

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/TestToolStartup.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/TestToolStartup.cs
@@ -42,6 +42,12 @@ namespace Amazon.Lambda.TestTool
                     return;
                 }
 
+                if (!string.IsNullOrEmpty(commandOptions.PrintToolPathIde))
+                {
+                    Console.WriteLine(Utils.GetToolPath(commandOptions.PrintToolPathIde));
+                    return;
+                }
+
                 var localLambdaOptions = new LocalLambdaOptions()
                 {
                     Host = commandOptions.Host,

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Utils.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Utils.cs
@@ -241,5 +241,21 @@ namespace Amazon.Lambda.TestTool
 
             return depsFile[0].Directory.FullName;            
         }
+
+        /// <summary>
+        /// Return tool path compatible with specific IDE for debug purposes
+        /// </summary>
+        /// <param name="ideName"></param>
+        /// <returns></returns>
+        public static string GetToolPath(string ideName)
+        {
+            ideName = ideName.Trim().ToLower();
+            if (ideName == "vs" || ideName == "vscode")
+            {
+                return Process.GetCurrentProcess().MainModule!.FileName;
+            }
+
+            return Assembly.GetEntryAssembly()!.Location;
+        }
     }
 }


### PR DESCRIPTION
The main purpose of this argument is to print to the console the path to the executable file that is used when configuring the debug inside IDE.
It respects IDE requirements, so for Visual Studio and Visual Studio Code it return path to `.exe` file for other path to `.dll` file.

For example on MacOS it return for VSCode:

```sh
% dotnet-lambda-test-tool-6.0 --print-tool-path vscode
AWS .NET Core 6.0 Mock Lambda Test Tool (0.12.3)
/Users/someuser/.dotnet/tools/dotnet-lambda-test-tool-6.0
```

and for Rider
```sh
% dotnet-lambda-test-tool-6.0 --print-tool-path other 
AWS .NET Core 6.0 Mock Lambda Test Tool (0.12.3)
/Users/someuser/.dotnet/tools/.store/amazon.lambda.testtool-6.0/0.12.3/amazon.lambda.testtool-6.0/0.12.3/tools/net6.0/any/Amazon.Lambda.TestTool.BlazorTester.dll
```

Also tested on Windows.

*Changes:*

1. Added new cli argument `--print-tool-path`;
2. Added a method to use `GetToolPath`, which returns the path to the executable file, taking into account the requirements of the IDE

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
