### PR TITLE
Tag user-agent string with aot when applicable

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
@@ -215,7 +215,6 @@ namespace Amazon.Lambda.RuntimeSupport
         {
             var dotnetRuntimeVersion = new DirectoryInfo(System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory()).Name;
             var amazonLambdaRuntimeSupport = typeof(LambdaBootstrap).Assembly.GetName().Version;
-            var userAgentString = $"aws-lambda-dotnet/{dotnetRuntimeVersion}-{amazonLambdaRuntimeSupport}";
 
 #if NET6_0_OR_GREATER
             // Create the SocketsHttpHandler directly to avoid spending cold start time creating the wrapper HttpClientHandler
@@ -223,8 +222,14 @@ namespace Amazon.Lambda.RuntimeSupport
             {
 
             };
+
+            // If we are running in an AOT environment, mark it as such.
+            var userAgentString = NativeAotHelper.IsRunningNativeAot() ? $"aws-lambda-dotnet/{dotnetRuntimeVersion}-{amazonLambdaRuntimeSupport}-aot"
+                : $"aws-lambda-dotnet/{dotnetRuntimeVersion}-{amazonLambdaRuntimeSupport}";
+
             var client = new HttpClient(handler);
 #else
+            var userAgentString = $"aws-lambda-dotnet/{dotnetRuntimeVersion}-{amazonLambdaRuntimeSupport}";
             var client = new HttpClient();
 #endif
             client.DefaultRequestHeaders.Add("User-Agent", userAgentString);

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeInit.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeInit.cs
@@ -32,10 +32,9 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
         public static bool IsCallPreJit()
         {
 #if NET6_0_OR_GREATER
-            // If dynamic code is not supported we are most likely running in an AOT environment. In that
-            // case there is no point in doing any prejit optmization and will most likely cause errors
-            // using APIs that are not supported in AOT.
-            if(!RuntimeFeature.IsDynamicCodeSupported)
+            // If we are running in an AOT environment, there is no point in doing any prejit optmization
+            // and will most likely cause errors using APIs that are not supported in AOT.
+            if(NativeAotHelper.IsRunningNativeAot())
             {
                 return false;
             }    

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/NativeAotHelper.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/NativeAotHelper.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System.Runtime.CompilerServices;
+
+namespace Amazon.Lambda.RuntimeSupport.Helpers
+{
+    internal static class NativeAotHelper
+    {
+        public static bool IsRunningNativeAot()
+        {
+            // If dynamic code is not supported we are most likely running in an AOT environment. 
+#if NET6_0_OR_GREATER
+            return !RuntimeFeature.IsDynamicCodeSupported;
+#else
+            return false;
+#endif
+        }
+    }
+}


### PR DESCRIPTION
*Description of changes:*
Add "aot" to the end of the user agent string to differentiate between non-aot and aot. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
