### PR TITLE
Typo in lambda annotations README.md

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations/README.md
+++ b/Libraries/src/Amazon.Lambda.Annotations/README.md
@@ -716,7 +716,7 @@ List of .NET attributes currently supported.
 
 ### Event Attributes    
 
-Event attributes configuring the source generator for the type of event to expect and setup the event source in the CloudFormation temlate. If an event attribute is not set the
+Event attributes configuring the source generator for the type of event to expect and setup the event source in the CloudFormation template. If an event attribute is not set the
 parameter to the `LambdaFunction` must be the event object and the event source must be configured outside of the code.
 
 * RestApi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There was typo in readme for lambda annotations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
