### PR TITLE
Marshall IHttpRequestFeature.RawTarget

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction.cs
@@ -108,12 +108,15 @@ namespace Amazon.Lambda.AspNetCoreServer
                     _logger.LogWarning($"Request does not contain domain name information but is derived from {nameof(APIGatewayProxyFunction)}.");
                 }
 
+                string rawQueryString = Utilities.CreateQueryStringParametersFromHttpApiV2(apiGatewayRequest.RawQueryString);
+                requestFeatures.RawTarget = apiGatewayRequest.RawPath + rawQueryString;
+                requestFeatures.QueryString = rawQueryString;
+
                 requestFeatures.Path = Utilities.DecodeResourcePath(httpInfo.Path);
                 if (!requestFeatures.Path.StartsWith("/"))
                 {
                     requestFeatures.Path = "/" + requestFeatures.Path;
                 }
-
 
                 // If there is a stage name in the resource path strip it out and set the stage name as the base path.
                 // This is required so that ASP.NET Core will route request based on the resource path without the stage name.
@@ -126,8 +129,6 @@ namespace Amazon.Lambda.AspNetCoreServer
                         requestFeatures.PathBase = $"/{stageName}";
                     }
                 }
-
-                requestFeatures.QueryString = Utilities.CreateQueryStringParametersFromHttpApiV2(apiGatewayRequest.RawQueryString);
 
                 // API Gateway HTTP API V2 format supports multiple values for headers by comma separating the values.
                 if (apiGatewayRequest.Headers != null)

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction.cs
@@ -108,7 +108,7 @@ namespace Amazon.Lambda.AspNetCoreServer
                     _logger.LogWarning($"Request does not contain domain name information but is derived from {nameof(APIGatewayProxyFunction)}.");
                 }
 
-                string rawQueryString = Utilities.CreateQueryStringParametersFromHttpApiV2(apiGatewayRequest.RawQueryString);
+                var rawQueryString = Utilities.CreateQueryStringParametersFromHttpApiV2(apiGatewayRequest.RawQueryString);
                 requestFeatures.RawTarget = apiGatewayRequest.RawPath + rawQueryString;
                 requestFeatures.QueryString = rawQueryString;
 

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -179,6 +179,11 @@ namespace Amazon.Lambda.AspNetCoreServer
                     path = "/" + path;
                 }
 
+                var rawQueryString = Utilities.CreateQueryStringParameters(
+                    apiGatewayRequest.QueryStringParameters, apiGatewayRequest.MultiValueQueryStringParameters, true);
+
+                requestFeatures.RawTarget = apiGatewayRequest.Path + rawQueryString;
+                requestFeatures.QueryString = rawQueryString;
                 requestFeatures.Path = path;
 
                 requestFeatures.PathBase = string.Empty;
@@ -206,9 +211,6 @@ namespace Amazon.Lambda.AspNetCoreServer
                 }
 
                 requestFeatures.Path = Utilities.DecodeResourcePath(requestFeatures.Path);
-
-                requestFeatures.QueryString = Utilities.CreateQueryStringParameters(
-                    apiGatewayRequest.QueryStringParameters, apiGatewayRequest.MultiValueQueryStringParameters, true);
 
                 Utilities.SetHeadersCollection(requestFeatures.Headers, apiGatewayRequest.Headers, apiGatewayRequest.MultiValueHeaders);
 

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/ApplicationLoadBalancerFunction.cs
@@ -82,10 +82,14 @@ namespace Amazon.Lambda.AspNetCoreServer
                 var requestFeatures = (IHttpRequestFeature)features;
                 requestFeatures.Scheme = GetSingleHeaderValue(lambdaRequest, "x-forwarded-proto");
                 requestFeatures.Method = lambdaRequest.HttpMethod;
-                requestFeatures.Path = Utilities.DecodeResourcePath(lambdaRequest.Path);
 
-                requestFeatures.QueryString = Utilities.CreateQueryStringParameters(
+                var rawPath = lambdaRequest.Path;
+                var rawQueryString = Utilities.CreateQueryStringParameters(
                     lambdaRequest.QueryStringParameters, lambdaRequest.MultiValueQueryStringParameters, false);
+
+                requestFeatures.RawTarget = rawPath + rawQueryString;
+                requestFeatures.QueryString = rawQueryString;
+                requestFeatures.Path = Utilities.DecodeResourcePath(rawPath);
 
                 Utilities.SetHeadersCollection(requestFeatures.Headers, lambdaRequest.Headers, lambdaRequest.MultiValueHeaders);
 

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/Amazon.Lambda.AspNetCoreServer.Test.csproj
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/Amazon.Lambda.AspNetCoreServer.Test.csproj
@@ -23,6 +23,18 @@
     <None Remove="additional-path-parameters-in-proxy-path.json" />
     <None Remove="authtest-access-request.json" />
     <None Remove="missing-resource-request.json" />
+    <None Remove="rawtarget-escaped-percent-in-path-alb.json" />
+    <None Remove="rawtarget-escaped-percent-in-path-httpapi-v2.json" />
+    <None Remove="rawtarget-escaped-percent-in-path.json" />
+    <None Remove="rawtarget-escaped-percent-slash-in-path-alb.json" />
+    <None Remove="rawtarget-escaped-percent-slash-in-path-httpapi-v2.json" />
+    <None Remove="rawtarget-escaped-percent-slash-in-path.json" />
+    <None Remove="rawtarget-escaped-reserved-in-query-alb.json" />
+    <None Remove="rawtarget-escaped-reserved-in-query-httpapi-v2.json" />
+    <None Remove="rawtarget-escaped-reserved-in-query.json" />
+    <None Remove="rawtarget-escaped-slash-in-path-alb.json" />
+    <None Remove="rawtarget-escaped-slash-in-path-httpapi-v2.json" />
+    <None Remove="rawtarget-escaped-slash-in-path.json" />
     <None Remove="values-get-all-httpapi-request.json" />
   </ItemGroup>
 

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestApiGatewayHttpApiV2Calls.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestApiGatewayHttpApiV2Calls.cs
@@ -184,6 +184,21 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
             Assert.Equal("/foo/", root["Path"]?.ToString());
         }
 
+        [Theory]
+        [InlineData("rawtarget-escaped-percent-in-path-httpapi-v2.json", "/foo%25bar")]
+        [InlineData("rawtarget-escaped-percent-slash-in-path-httpapi-v2.json", "/foo%25%2Fbar")]
+        [InlineData("rawtarget-escaped-reserved-in-query-httpapi-v2.json", "/foo/bar?foo=b%40r")]
+        [InlineData("rawtarget-escaped-slash-in-path-httpapi-v2.json", "/foo%2Fbar")]
+        public async Task TestRawTarget(string requestFileName, string expectedRawTarget)
+        {
+            var response = await this.InvokeAPIGatewayRequest(requestFileName);
+
+            Assert.Equal(200, response.StatusCode);
+
+            var root = JObject.Parse(response.Body);
+            Assert.Equal(expectedRawTarget, root["RawTarget"]?.ToString());
+        }
+
         [Fact]
         public async Task TestAuthTestAccess()
         {

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
@@ -325,6 +325,21 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
             Assert.Equal("/foo/", root?["Path"]?.ToString());
         }
 
+        [Theory]
+        [InlineData("rawtarget-escaped-percent-in-path.json", "/foo%25bar")]
+        [InlineData("rawtarget-escaped-percent-slash-in-path.json", "/foo%25%2Fbar")]
+        [InlineData("rawtarget-escaped-reserved-in-query.json", "/foo/bar?foo=b%2540r")]
+        [InlineData("rawtarget-escaped-slash-in-path.json", "/foo%2Fbar")]
+        public async Task TestRawTarget(string requestFileName, string expectedRawTarget)
+        {
+            var response = await this.InvokeAPIGatewayRequest(requestFileName);
+
+            Assert.Equal(200, response.StatusCode);
+
+            var root = JsonSerializer.Deserialize<JsonObject>(response.Body);
+            Assert.Equal(expectedRawTarget, root["RawTarget"]?.ToString());
+        }
+
         [Fact]
         public async Task TestAuthTestAccess()
         {

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-percent-in-path-alb.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-percent-in-path-alb.json
@@ -1,0 +1,15 @@
+{
+  "requestContext": {
+    "elb": {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09"
+    }
+  },
+  "httpMethod": "GET",
+  "path": "/foo%25bar",
+  "queryStringParameters": {},
+  "headers": {
+    "user-agent": "ELB-HealthChecker/2.0"
+  },
+  "body": "",
+  "isBase64Encoded": false
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-percent-in-path-httpapi-v2.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-percent-in-path-httpapi-v2.json
@@ -1,0 +1,44 @@
+{
+  "version": "2.0",
+  "routeKey": "ANY /{proxy+}",
+  "rawPath": "/foo%25bar",
+  "rawQueryString": "",
+  "headers": {
+    "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+    "accept-encoding": "gzip, deflate, br",
+    "accept-language": "en-US,en;q=0.9",
+    "content-length": "0",
+    "host": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "sec-fetch-dest": "document",
+    "sec-fetch-mode": "navigate",
+    "sec-fetch-site": "none",
+    "upgrade-insecure-requests": "1",
+    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36",
+    "x-amzn-trace-id": "Root=1-5e7a9b35-de6483466ec0ab54b18a9b09",
+    "x-forwarded-for": "192.182.149.40",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "requestContext": {
+    "accountId": "626492997873",
+    "apiId": "uo9pe23ec6",
+    "domainName": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "uo9pe23ec6",
+    "http": {
+      "method": "GET",
+      "path": "/foo%25bar",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "192.182.149.40",
+      "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
+    },
+    "requestId": "J60wWgQVoAMEPEA=",
+    "routeKey": "ANY /{proxy+}",
+    "stage": "$default",
+    "time": "24/Mar/2020:23:43:49 +0000",
+    "timeEpoch": 1585093429356
+  },
+  "pathParameters": {
+    "proxy": "foo%25bar"
+  },
+  "isBase64Encoded": false
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-percent-in-path.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-percent-in-path.json
@@ -1,0 +1,66 @@
+{
+  "resource": "/{proxy+}",
+  "path": "/foo%25bar",
+  "httpMethod": "GET",
+  "headers": {
+    "Authorization": "eyJraWQiOiJLdXprWCtcL0E4MWlVZGU5QSt2SFBMdzZCTUFmQzVqUGJ1NTZiT0VGNXdkaz0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiI4ZWYzZTQ1NS0zODY5LTQwMmUtYWM5ZS1mODhlODZjMzIwYjMiLCJjb2duaXRvOmdyb3VwcyI6WyJBZG1pbiJdLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiaXNzIjoiaHR0cHM6XC9cL2NvZ25pdG8taWRwLnVzLXdlc3QtMi5hbWF6b25hd3MuY29tXC91cy13ZXN0LTJfUExpM2NmMHUwIiwicGhvbmVfbnVtYmVyX3ZlcmlmaWVkIjp0cnVlLCJjb2duaXRvOnVzZXJuYW1lIjoibm9ybWoiLCJhdWQiOiIzbXVzaGZjOHNnbTh1b2FjdmlmNXZoa3Q0OSIsImV2ZW50X2lkIjoiNzU3NjBmNTgtZjk4NC0xMWU3LThkNGEtMjM4OWVmYzUwZDY4IiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1MTU5NzMyOTYsInBob25lX251bWJlciI6IisxNDI1NzM2NzM0OSIsImV4cCI6MTUxNTk3Njg5NiwiaWF0IjoxNTE1OTczMjk2LCJlbWFpbCI6ImpvaGFuc28yQGdtYWlsLmNvbSJ9.v1zIeTutUMzgXGoQy5dpOXUW6km9Ye-X-iLehgn1fO4HeJPZ9rOY9jDRMyRjyF5I57sAsN1v9uB3f98gEdStzO4qpASlYK7F7CtcenJ2lZYNU4gJPDQqEDdoMvE5Nir89RL09PYFceKaZw2Qr53VTLBfwaNGJYeSYeiZN09RL6fXwciH5h15rGwgNpl3kvzZOTLCqHNv3J7Y5POr8BjT2DvqUVJv7X1M5pOzHxWIqtBfAfyhEzZftIDqNKsI_aKZolkRd_UI77dSMNuZokJSAKlEuXc6fNJ556R3xSAhEli5DeZUIMdQLQVB7pIQzRlXvt2M0MMK-uC2d7_kUWAkVg",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "zzqupfvhrk.execute-api.us-west-2.amazonaws.com",
+    "Via": "1.1 ca79756ec49e2babf1b916300304b2fb.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "3OhHlF5fim8xxjG1-RZEFK4nos0t-JtPu6vvpNkUg9NOcl-Os53gBg==",
+    "X-Amzn-Trace-Id": "Root=1-5a5beab2-7cd6a52c614f43910ab9be30",
+    "X-Forwarded-For": "50.35.77.7, 52.46.17.45",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "queryStringParameters": null,
+  "pathParameters": {
+    "proxy": "foo%25bar"
+  },
+  "stageVariables": null,
+  "requestContext": {
+    "resourceId": "8gffya",
+    "authorizer": {
+      "claims": {
+        "cognito:groups": "Admin",
+        "phone_number_verified": "true",
+        "cognito:username": "normj",
+        "aud": "3mushfc8sgm8uoacvif5vhkt49",
+        "event_id": "75760f58-f984-11e7-8d4a-2389efc50d68",
+        "token_use": "id",
+        "auth_time": "1515973296",
+        "you_are_special": "true"
+      }
+    },
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "requestTime": "14/Jan/2018:23:41:38 +0000",
+    "path": "/Prod/foo%25bar/",
+    "accountId": "626492997873",
+    "protocol": "HTTP/1.1",
+    "stage": "Prod",
+    "requestTimeEpoch": 1515973298687,
+    "requestId": "7713b963-f984-11e7-b02a-f346964d4540",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "sourceIp": "50.35.77.7",
+      "accessKey": null,
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": null,
+      "user": null
+    },
+    "apiId": "zzqupfvhrk"
+  },
+  "body": null,
+  "isBase64Encoded": false
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-percent-slash-in-path-alb.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-percent-slash-in-path-alb.json
@@ -1,0 +1,15 @@
+{
+  "requestContext": {
+    "elb": {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09"
+    }
+  },
+  "httpMethod": "GET",
+  "path": "/foo%25%2Fbar",
+  "queryStringParameters": {},
+  "headers": {
+    "user-agent": "ELB-HealthChecker/2.0"
+  },
+  "body": "",
+  "isBase64Encoded": false
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-percent-slash-in-path-httpapi-v2.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-percent-slash-in-path-httpapi-v2.json
@@ -1,0 +1,44 @@
+{
+  "version": "2.0",
+  "routeKey": "ANY /{proxy+}",
+  "rawPath": "/foo%25%2Fbar",
+  "rawQueryString": "",
+  "headers": {
+    "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+    "accept-encoding": "gzip, deflate, br",
+    "accept-language": "en-US,en;q=0.9",
+    "content-length": "0",
+    "host": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "sec-fetch-dest": "document",
+    "sec-fetch-mode": "navigate",
+    "sec-fetch-site": "none",
+    "upgrade-insecure-requests": "1",
+    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36",
+    "x-amzn-trace-id": "Root=1-5e7a9b35-de6483466ec0ab54b18a9b09",
+    "x-forwarded-for": "192.182.149.40",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "requestContext": {
+    "accountId": "626492997873",
+    "apiId": "uo9pe23ec6",
+    "domainName": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "uo9pe23ec6",
+    "http": {
+      "method": "GET",
+      "path": "/foo%25%2Fbar",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "192.182.149.40",
+      "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
+    },
+    "requestId": "J60wWgQVoAMEPEA=",
+    "routeKey": "ANY /{proxy+}",
+    "stage": "$default",
+    "time": "24/Mar/2020:23:43:49 +0000",
+    "timeEpoch": 1585093429356
+  },
+  "pathParameters": {
+    "proxy": "foo%25%2Fbar"
+  },
+  "isBase64Encoded": false
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-percent-slash-in-path.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-percent-slash-in-path.json
@@ -1,0 +1,66 @@
+{
+  "resource": "/{proxy+}",
+  "path": "/foo%25%2Fbar",
+  "httpMethod": "GET",
+  "headers": {
+    "Authorization": "eyJraWQiOiJLdXprWCtcL0E4MWlVZGU5QSt2SFBMdzZCTUFmQzVqUGJ1NTZiT0VGNXdkaz0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiI4ZWYzZTQ1NS0zODY5LTQwMmUtYWM5ZS1mODhlODZjMzIwYjMiLCJjb2duaXRvOmdyb3VwcyI6WyJBZG1pbiJdLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiaXNzIjoiaHR0cHM6XC9cL2NvZ25pdG8taWRwLnVzLXdlc3QtMi5hbWF6b25hd3MuY29tXC91cy13ZXN0LTJfUExpM2NmMHUwIiwicGhvbmVfbnVtYmVyX3ZlcmlmaWVkIjp0cnVlLCJjb2duaXRvOnVzZXJuYW1lIjoibm9ybWoiLCJhdWQiOiIzbXVzaGZjOHNnbTh1b2FjdmlmNXZoa3Q0OSIsImV2ZW50X2lkIjoiNzU3NjBmNTgtZjk4NC0xMWU3LThkNGEtMjM4OWVmYzUwZDY4IiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1MTU5NzMyOTYsInBob25lX251bWJlciI6IisxNDI1NzM2NzM0OSIsImV4cCI6MTUxNTk3Njg5NiwiaWF0IjoxNTE1OTczMjk2LCJlbWFpbCI6ImpvaGFuc28yQGdtYWlsLmNvbSJ9.v1zIeTutUMzgXGoQy5dpOXUW6km9Ye-X-iLehgn1fO4HeJPZ9rOY9jDRMyRjyF5I57sAsN1v9uB3f98gEdStzO4qpASlYK7F7CtcenJ2lZYNU4gJPDQqEDdoMvE5Nir89RL09PYFceKaZw2Qr53VTLBfwaNGJYeSYeiZN09RL6fXwciH5h15rGwgNpl3kvzZOTLCqHNv3J7Y5POr8BjT2DvqUVJv7X1M5pOzHxWIqtBfAfyhEzZftIDqNKsI_aKZolkRd_UI77dSMNuZokJSAKlEuXc6fNJ556R3xSAhEli5DeZUIMdQLQVB7pIQzRlXvt2M0MMK-uC2d7_kUWAkVg",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "zzqupfvhrk.execute-api.us-west-2.amazonaws.com",
+    "Via": "1.1 ca79756ec49e2babf1b916300304b2fb.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "3OhHlF5fim8xxjG1-RZEFK4nos0t-JtPu6vvpNkUg9NOcl-Os53gBg==",
+    "X-Amzn-Trace-Id": "Root=1-5a5beab2-7cd6a52c614f43910ab9be30",
+    "X-Forwarded-For": "50.35.77.7, 52.46.17.45",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "queryStringParameters": null,
+  "pathParameters": {
+    "proxy": "foo%25%2Fbar"
+  },
+  "stageVariables": null,
+  "requestContext": {
+    "resourceId": "8gffya",
+    "authorizer": {
+      "claims": {
+        "cognito:groups": "Admin",
+        "phone_number_verified": "true",
+        "cognito:username": "normj",
+        "aud": "3mushfc8sgm8uoacvif5vhkt49",
+        "event_id": "75760f58-f984-11e7-8d4a-2389efc50d68",
+        "token_use": "id",
+        "auth_time": "1515973296",
+        "you_are_special": "true"
+      }
+    },
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "requestTime": "14/Jan/2018:23:41:38 +0000",
+    "path": "/Prod/foo%25%2Fbar/",
+    "accountId": "626492997873",
+    "protocol": "HTTP/1.1",
+    "stage": "Prod",
+    "requestTimeEpoch": 1515973298687,
+    "requestId": "7713b963-f984-11e7-b02a-f346964d4540",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "sourceIp": "50.35.77.7",
+      "accessKey": null,
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": null,
+      "user": null
+    },
+    "apiId": "zzqupfvhrk"
+  },
+  "body": null,
+  "isBase64Encoded": false
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-reserved-in-query-alb.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-reserved-in-query-alb.json
@@ -1,0 +1,17 @@
+{
+  "requestContext": {
+    "elb": {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09"
+    }
+  },
+  "httpMethod": "GET",
+  "path": "/foo/bar",
+  "queryStringParameters": {
+    "foo": "b%40r"
+  },
+  "headers": {
+    "user-agent": "ELB-HealthChecker/2.0"
+  },
+  "body": "",
+  "isBase64Encoded": false
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-reserved-in-query-httpapi-v2.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-reserved-in-query-httpapi-v2.json
@@ -1,0 +1,44 @@
+{
+  "version": "2.0",
+  "routeKey": "ANY /{proxy+}",
+  "rawPath": "/foo/bar",
+  "rawQueryString": "foo=b%40r",
+  "headers": {
+    "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+    "accept-encoding": "gzip, deflate, br",
+    "accept-language": "en-US,en;q=0.9",
+    "content-length": "0",
+    "host": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "sec-fetch-dest": "document",
+    "sec-fetch-mode": "navigate",
+    "sec-fetch-site": "none",
+    "upgrade-insecure-requests": "1",
+    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36",
+    "x-amzn-trace-id": "Root=1-5e7a9b35-de6483466ec0ab54b18a9b09",
+    "x-forwarded-for": "192.182.149.40",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "requestContext": {
+    "accountId": "626492997873",
+    "apiId": "uo9pe23ec6",
+    "domainName": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "uo9pe23ec6",
+    "http": {
+      "method": "GET",
+      "path": "/foo/bar",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "192.182.149.40",
+      "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
+    },
+    "requestId": "J60wWgQVoAMEPEA=",
+    "routeKey": "ANY /{proxy+}",
+    "stage": "$default",
+    "time": "24/Mar/2020:23:43:49 +0000",
+    "timeEpoch": 1585093429356
+  },
+  "pathParameters": {
+    "proxy": "foo/bar"
+  },
+  "isBase64Encoded": false
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-reserved-in-query.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-reserved-in-query.json
@@ -1,0 +1,68 @@
+{
+  "resource": "/{proxy+}",
+  "path": "/foo/bar",
+  "httpMethod": "GET",
+  "headers": {
+    "Authorization": "eyJraWQiOiJLdXprWCtcL0E4MWlVZGU5QSt2SFBMdzZCTUFmQzVqUGJ1NTZiT0VGNXdkaz0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiI4ZWYzZTQ1NS0zODY5LTQwMmUtYWM5ZS1mODhlODZjMzIwYjMiLCJjb2duaXRvOmdyb3VwcyI6WyJBZG1pbiJdLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiaXNzIjoiaHR0cHM6XC9cL2NvZ25pdG8taWRwLnVzLXdlc3QtMi5hbWF6b25hd3MuY29tXC91cy13ZXN0LTJfUExpM2NmMHUwIiwicGhvbmVfbnVtYmVyX3ZlcmlmaWVkIjp0cnVlLCJjb2duaXRvOnVzZXJuYW1lIjoibm9ybWoiLCJhdWQiOiIzbXVzaGZjOHNnbTh1b2FjdmlmNXZoa3Q0OSIsImV2ZW50X2lkIjoiNzU3NjBmNTgtZjk4NC0xMWU3LThkNGEtMjM4OWVmYzUwZDY4IiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1MTU5NzMyOTYsInBob25lX251bWJlciI6IisxNDI1NzM2NzM0OSIsImV4cCI6MTUxNTk3Njg5NiwiaWF0IjoxNTE1OTczMjk2LCJlbWFpbCI6ImpvaGFuc28yQGdtYWlsLmNvbSJ9.v1zIeTutUMzgXGoQy5dpOXUW6km9Ye-X-iLehgn1fO4HeJPZ9rOY9jDRMyRjyF5I57sAsN1v9uB3f98gEdStzO4qpASlYK7F7CtcenJ2lZYNU4gJPDQqEDdoMvE5Nir89RL09PYFceKaZw2Qr53VTLBfwaNGJYeSYeiZN09RL6fXwciH5h15rGwgNpl3kvzZOTLCqHNv3J7Y5POr8BjT2DvqUVJv7X1M5pOzHxWIqtBfAfyhEzZftIDqNKsI_aKZolkRd_UI77dSMNuZokJSAKlEuXc6fNJ556R3xSAhEli5DeZUIMdQLQVB7pIQzRlXvt2M0MMK-uC2d7_kUWAkVg",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "zzqupfvhrk.execute-api.us-west-2.amazonaws.com",
+    "Via": "1.1 ca79756ec49e2babf1b916300304b2fb.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "3OhHlF5fim8xxjG1-RZEFK4nos0t-JtPu6vvpNkUg9NOcl-Os53gBg==",
+    "X-Amzn-Trace-Id": "Root=1-5a5beab2-7cd6a52c614f43910ab9be30",
+    "X-Forwarded-For": "50.35.77.7, 52.46.17.45",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "queryStringParameters": {
+    "foo": "b%40r"
+  },
+  "pathParameters": {
+    "proxy": "foo/bar"
+  },
+  "stageVariables": null,
+  "requestContext": {
+    "resourceId": "8gffya",
+    "authorizer": {
+      "claims": {
+        "cognito:groups": "Admin",
+        "phone_number_verified": "true",
+        "cognito:username": "normj",
+        "aud": "3mushfc8sgm8uoacvif5vhkt49",
+        "event_id": "75760f58-f984-11e7-8d4a-2389efc50d68",
+        "token_use": "id",
+        "auth_time": "1515973296",
+        "you_are_special": "true"
+      }
+    },
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "requestTime": "14/Jan/2018:23:41:38 +0000",
+    "path": "/Prod/foo/bar/",
+    "accountId": "626492997873",
+    "protocol": "HTTP/1.1",
+    "stage": "Prod",
+    "requestTimeEpoch": 1515973298687,
+    "requestId": "7713b963-f984-11e7-b02a-f346964d4540",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "sourceIp": "50.35.77.7",
+      "accessKey": null,
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": null,
+      "user": null
+    },
+    "apiId": "zzqupfvhrk"
+  },
+  "body": null,
+  "isBase64Encoded": false
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-slash-in-path-alb.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-slash-in-path-alb.json
@@ -1,0 +1,15 @@
+{
+  "requestContext": {
+    "elb": {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09"
+    }
+  },
+  "httpMethod": "GET",
+  "path": "/foo%2Fbar",
+  "queryStringParameters": {},
+  "headers": {
+    "user-agent": "ELB-HealthChecker/2.0"
+  },
+  "body": "",
+  "isBase64Encoded": false
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-slash-in-path-httpapi-v2.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-slash-in-path-httpapi-v2.json
@@ -1,0 +1,44 @@
+{
+  "version": "2.0",
+  "routeKey": "ANY /{proxy+}",
+  "rawPath": "/foo%2Fbar",
+  "rawQueryString": "",
+  "headers": {
+    "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+    "accept-encoding": "gzip, deflate, br",
+    "accept-language": "en-US,en;q=0.9",
+    "content-length": "0",
+    "host": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "sec-fetch-dest": "document",
+    "sec-fetch-mode": "navigate",
+    "sec-fetch-site": "none",
+    "upgrade-insecure-requests": "1",
+    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36",
+    "x-amzn-trace-id": "Root=1-5e7a9b35-de6483466ec0ab54b18a9b09",
+    "x-forwarded-for": "192.182.149.40",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "requestContext": {
+    "accountId": "626492997873",
+    "apiId": "uo9pe23ec6",
+    "domainName": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "uo9pe23ec6",
+    "http": {
+      "method": "GET",
+      "path": "/foo%2Fbar",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "192.182.149.40",
+      "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
+    },
+    "requestId": "J60wWgQVoAMEPEA=",
+    "routeKey": "ANY /{proxy+}",
+    "stage": "$default",
+    "time": "24/Mar/2020:23:43:49 +0000",
+    "timeEpoch": 1585093429356
+  },
+  "pathParameters": {
+    "proxy": "foo%2Fbar"
+  },
+  "isBase64Encoded": false
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-slash-in-path.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/rawtarget-escaped-slash-in-path.json
@@ -1,0 +1,66 @@
+{
+  "resource": "/{proxy+}",
+  "path": "/foo%2Fbar",
+  "httpMethod": "GET",
+  "headers": {
+    "Authorization": "eyJraWQiOiJLdXprWCtcL0E4MWlVZGU5QSt2SFBMdzZCTUFmQzVqUGJ1NTZiT0VGNXdkaz0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiI4ZWYzZTQ1NS0zODY5LTQwMmUtYWM5ZS1mODhlODZjMzIwYjMiLCJjb2duaXRvOmdyb3VwcyI6WyJBZG1pbiJdLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiaXNzIjoiaHR0cHM6XC9cL2NvZ25pdG8taWRwLnVzLXdlc3QtMi5hbWF6b25hd3MuY29tXC91cy13ZXN0LTJfUExpM2NmMHUwIiwicGhvbmVfbnVtYmVyX3ZlcmlmaWVkIjp0cnVlLCJjb2duaXRvOnVzZXJuYW1lIjoibm9ybWoiLCJhdWQiOiIzbXVzaGZjOHNnbTh1b2FjdmlmNXZoa3Q0OSIsImV2ZW50X2lkIjoiNzU3NjBmNTgtZjk4NC0xMWU3LThkNGEtMjM4OWVmYzUwZDY4IiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1MTU5NzMyOTYsInBob25lX251bWJlciI6IisxNDI1NzM2NzM0OSIsImV4cCI6MTUxNTk3Njg5NiwiaWF0IjoxNTE1OTczMjk2LCJlbWFpbCI6ImpvaGFuc28yQGdtYWlsLmNvbSJ9.v1zIeTutUMzgXGoQy5dpOXUW6km9Ye-X-iLehgn1fO4HeJPZ9rOY9jDRMyRjyF5I57sAsN1v9uB3f98gEdStzO4qpASlYK7F7CtcenJ2lZYNU4gJPDQqEDdoMvE5Nir89RL09PYFceKaZw2Qr53VTLBfwaNGJYeSYeiZN09RL6fXwciH5h15rGwgNpl3kvzZOTLCqHNv3J7Y5POr8BjT2DvqUVJv7X1M5pOzHxWIqtBfAfyhEzZftIDqNKsI_aKZolkRd_UI77dSMNuZokJSAKlEuXc6fNJ556R3xSAhEli5DeZUIMdQLQVB7pIQzRlXvt2M0MMK-uC2d7_kUWAkVg",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "zzqupfvhrk.execute-api.us-west-2.amazonaws.com",
+    "Via": "1.1 ca79756ec49e2babf1b916300304b2fb.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "3OhHlF5fim8xxjG1-RZEFK4nos0t-JtPu6vvpNkUg9NOcl-Os53gBg==",
+    "X-Amzn-Trace-Id": "Root=1-5a5beab2-7cd6a52c614f43910ab9be30",
+    "X-Forwarded-For": "50.35.77.7, 52.46.17.45",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "queryStringParameters": null,
+  "pathParameters": {
+    "proxy": "foo%2Fbar"
+  },
+  "stageVariables": null,
+  "requestContext": {
+    "resourceId": "8gffya",
+    "authorizer": {
+      "claims": {
+        "cognito:groups": "Admin",
+        "phone_number_verified": "true",
+        "cognito:username": "normj",
+        "aud": "3mushfc8sgm8uoacvif5vhkt49",
+        "event_id": "75760f58-f984-11e7-8d4a-2389efc50d68",
+        "token_use": "id",
+        "auth_time": "1515973296",
+        "you_are_special" : "true"
+      }
+    },
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "requestTime": "14/Jan/2018:23:41:38 +0000",
+    "path": "/Prod/foo%2Fbar/",
+    "accountId": "626492997873",
+    "protocol": "HTTP/1.1",
+    "stage": "Prod",
+    "requestTimeEpoch": 1515973298687,
+    "requestId": "7713b963-f984-11e7-b02a-f346964d4540",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "sourceIp": "50.35.77.7",
+      "accessKey": null,
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": null,
+      "user": null
+    },
+    "apiId": "zzqupfvhrk"
+  },
+  "body": null,
+  "isBase64Encoded": false
+}

--- a/Libraries/test/TestWebApp/Startup.cs
+++ b/Libraries/test/TestWebApp/Startup.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.Runtime.Serialization.Json;
 using System.IO;
+using Microsoft.AspNetCore.Http.Features;
 
 #if NETCOREAPP_2_1
 using Newtonsoft.Json.Linq;
@@ -88,10 +89,13 @@ namespace TestWebApp
 #endif
             app.Run(async (context) =>
             {
+                var rawTarget = context.Features.Get<IHttpRequestFeature>()?.RawTarget;
+
 #if NETCOREAPP_2_1
                 var root = new JObject();
                 root["Path"] = new JValue(context.Request.Path);
                 root["PathBase"] = new JValue(context.Request.PathBase);
+                root["RawTarget"] = new JValue(rawTarget);
 
                 var query = new JObject();
                 foreach(var queryKey in context.Request.Query.Keys)
@@ -112,6 +116,7 @@ namespace TestWebApp
                 writer.WriteStartObject();
                 writer.WriteString("Path", context.Request.Path);
                 writer.WriteString("PathBase", context.Request.PathBase);
+                writer.WriteString("RawTarget", rawTarget);
                 writer.WriteStartObject("QueryVariables");
                 foreach (var queryKey in context.Request.Query.Keys)
                 {


### PR DESCRIPTION
*Description of changes:*
The `HttpRequest.Path` and `HttpRequest.PathBase` properties contain unescaped representations of the request path; however, it is sometimes useful to have access to the raw (escaped) request path as supplied exactly by the caller. Due to inconsistencies in URL escaping rules (that is, which characters are considered necessary to escape) and to the fact that the `PathString` type contains a _partial_ unescaping, it is not possible to reconstruct the original, raw request path from the `Path` and `PathBase` properties.

The `RawTarget` property exists on the `IHttpRequestFeature` interface to address the above issue; however, that property is currently not set during request marshalling. This PR updates the `MarshallRequest` implementations to set the `IHttpRequestFeature.RawTarget` property.

All existing unit tests pass and new unit tests have been added to verify new functionality.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
