### PR TITLE
Remove rd.xml from aot blueprints

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -11,13 +11,15 @@
     <!-- StripSymbols tells the compiler to strip debugging symbols from the final executable if we're on Linux and put them into their own file. 
     This will greatly reduce the final executable's size.-->
     <StripSymbols>true</StripSymbols>
+    <!-- TrimMode partial will only trim assemblies marked as trimmable. To reduce package size make all assemblies trimmable and set TrimMode to full.
+    If there are trim warnings during build, you can hit errors at runtime.-->
+    <TrimMode>partial</TrimMode>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="aws-lambda-tools-defaults.json" />
-    <Content Include="rd.xml" />
   </ItemGroup>
   <!-- 
   When publishing Lambda functions for ARM64 to the provided.al2 runtime a newer version of libicu needs to be included
@@ -35,9 +37,5 @@
   <ItemGroup>
     <Content Include="aws-lambda-tools-defaults.json" />
     <None Include="Readme.md" />
-  </ItemGroup>
-  <ItemGroup>
-    <!--The runtime directives file allows the compiler to know what types and assemblies to not trim out of the final binary, even if they don't appear to be used.-->
-    <RdXmlFile Include="rd.xml" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -16,11 +16,12 @@ module Function =
     /// https://github.com/aws/aws-lambda-dotnet#events
     /// and change the string input parameter to the desired event type.
     ///
-    /// When using Native AOT, libraries used with your Lambda function might not be compatible with trimming that
-    /// happens as part of the Native AOT compilation. If you find when testing your Native AOT Lambda function that 
-    /// you get runtime errors about missing types, methods or constructors then add the assembly that contains the
-    /// types into the rd.xml file. This will tell the Native AOT compiler to not trim those assemblies. Currently the 
-    /// AWS SDK for .NET does not support trimming and when used should be added to the rd.xml file.    
+    // When using Native AOT extra testing with the deployed Lambda functions is required to ensure
+    // the libraries used in the Lambda function work correctly with Native AOT. If a runtime 
+    // error occurs about missing types or methods the most likely solution will be to remove references to trim-unsafe 
+    // code or configure trimming options. This sample defaults to partial TrimMode because currently the AWS 
+    // SDK for .NET does not support trimming. This will result in a larger executable size, and still does not 
+    // guarantee runtime trimming errors won't be hit. 
     /// </summary>
     /// <param name="input"></param>
     /// <param name="context"></param>
@@ -34,11 +35,7 @@ module Function =
     /// <summary>
     /// The main entry point for the Lambda function. The main function is called once during the Lambda init phase. It
     /// initializes the .NET Lambda runtime client passing in the function handler to invoke for each Lambda event and
-    /// the JSON serializer to use for converting Lambda JSON format to the .NET types. 
-    ///
-    /// F# uses the DefaultLambdaJsonSerializer which uses reflection to convert the JSON events 
-    /// and responses to .NET types. The Assembly name that contains the .NET types to serialize with must be added
-    /// to the rd.xml file to avoid the Native AOT compiler from trimming out the types used by reflection. 
+    /// the JSON serializer to use for converting Lambda JSON format to the .NET types.
     /// </summary>
     /// <param name="args"></param>
     [<EntryPoint>]

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -3,7 +3,6 @@
 This starter project consists of:
 * Function.fs - contains a main function that starts the bootstrap and a single function handler.
 * aws-lambda-tools-defaults.json - default argument settings for use with Visual Studio and command line deployment tools for AWS.
-* rd.xml - Runtime directives configuration file used to tell the Native AOT compiler what code to not trim out of .NET assemblies.
 
 You may also have a test project depending on the options selected.
 
@@ -26,34 +25,16 @@ platform is Amazon Linux 2. The AWS tooling for Lambda like the AWS Toolkit for 
 perform a container build using a .NET 7 Amazon Linux 2 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
 when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2 build environments. To install docker go to https://www.docker.com/.
 
-Due to an incompatibility with Amazon Linux 2 and .NET 7 ARM support it is not possible to build and deploy ARM based Native AOT Lambda functions.
-Since the architectures need to match between the build and target environments for .NET Native AOT Lambda functions it is not currently possible
-to deploy Native AOT Lambda functions from an M based Mac.
-
 ### Trimming
 
 As part of the Native AOT compilation, .NET assemblies will be trimmed removing types and methods that the compiler does not find a reference to. This is important
-to keep the native executable size small. When types are used through reflection this can go undetected by the compiler causing necessary types and methods to 
-be removed. The `rd.xml` file in the project is used to provide additional configuration to the compiler about what types are used to prevent them from 
-being trimmed. When testing Native AOT Lambda functions in Lambda if a runtime error occurs about missing types or methods the most likely solution will
-be to update the `rd.xml` to not trim the type. 
+to keep the native executable size small. When types are used through reflection this can go undetected by the compiler causing necessary types and methods to
+be removed. When testing Native AOT Lambda functions in Lambda if a runtime error occurs about missing types or methods the most likely solution will
+be to remove references to trim-unsafe code or configure [trimming options](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options?pivots=dotnet-7-0).
+This sample defaults to partial TrimMode because currently the AWS SDK for .NET does not support trimming. This will result in a larger executable size, and still does not
+guarantee runtime trimming errors won't be hit.
 
-Currently the AWS SDK for .NET does not support trimming and when used should be added to the rd.xml file. For example here is a `rd.xml` file that excludes
-the AWS SDK's core and AWS DynamoDB package.
-```xml
-<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
-	<Application>
-		<Assembly Name="AWSSDK.Core" Dynamic="Required All">
-		</Assembly>
-		<Assembly Name="AWSSDK.DynamoDBv2" Dynamic="Required All">
-		</Assembly>
-		<Assembly Name="bootstrap" Dynamic="Required All">
-		</Assembly>
-	</Application>
-</Directives>
-```
-
-For informaton about the `rd.xml` checkout the runtime directives configuration file reference: https://learn.microsoft.com/en-us/windows/uwp/dotnet-native/runtime-directives-rd-xml-configuration-file-reference
+For information about trimming see the documentation: <https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-self-contained>
 
 ## Docker requirement
 

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/rd.xml
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/rd.xml
@@ -1,6 +1,0 @@
-<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
-  <Application>
-    <Assembly Name="bootstrap" Dynamic="Required All">
-    </Assembly>
-  </Application>
-</Directives>

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -13,6 +13,9 @@
     <!-- StripSymbols tells the compiler to strip debugging symbols from the final executable if we're on Linux and put them into their own file. 
     This will greatly reduce the final executable's size.-->
     <StripSymbols>true</StripSymbols>
+    <!-- TrimMode partial will only trim assemblies marked as trimmable. To reduce package size make all assemblies trimmable and set TrimMode to full.
+    If there are trim warnings during build, you can hit errors at runtime.-->
+    <TrimMode>partial</TrimMode>
   </PropertyGroup>
   <!-- 
   When publishing Lambda functions for ARM64 to the provided.al2 runtime a newer version of libicu needs to be included
@@ -26,9 +29,5 @@
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.8.5" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
-  </ItemGroup>
-  <ItemGroup>
-    <!--The runtime directives file allows the compiler to know what types and assemblies to not trim out of the final binary, even if they don't appear to be used.-->
-    <RdXmlFile Include="rd.xml" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/src/BlueprintBaseName.1/Function.cs
@@ -30,11 +30,12 @@ public class Function
     /// defined below will need the JsonSerializable updated. If the return type and event type are different then the 
     /// LambdaFunctionJsonSerializerContext must have two JsonSerializable attributes, one for each type.
     ///
-    /// When using Native AOT, libraries used with your Lambda function might not be compatible with trimming that
-    /// happens as part of the Native AOT compilation. If you find when testing your Native AOT Lambda function that 
-    /// you get runtime errors about missing types, methods or constructors then add the assembly that contains the
-    /// types into the rd.xml file. This will tell the Native AOT compiler to not trim those assemblies. Currently the 
-    /// AWS SDK for .NET does not support trimming and when used should be added to the rd.xml file.
+    // When using Native AOT extra testing with the deployed Lambda functions is required to ensure
+    // the libraries used in the Lambda function work correctly with Native AOT. If a runtime 
+    // error occurs about missing types or methods the most likely solution will be to remove references to trim-unsafe 
+    // code or configure trimming options. This sample defaults to partial TrimMode because currently the AWS 
+    // SDK for .NET does not support trimming. This will result in a larger executable size, and still does not 
+    // guarantee runtime trimming errors won't be hit. 
     /// </summary>
     /// <param name="input"></param>
     /// <param name="context"></param>

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/src/BlueprintBaseName.1/Readme.md
@@ -26,34 +26,16 @@ platform is Amazon Linux 2. The AWS tooling for Lambda like the AWS Toolkit for 
 perform a container build using a .NET 7 Amazon Linux 2 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
 when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2 build environments. To install docker go to https://www.docker.com/.
 
-Due to an incompatibility with Amazon Linux 2 and .NET 7 ARM support it is not possible to build and deploy ARM based Native AOT Lambda functions.
-Since the architectures need to match between the build and target environments for .NET Native AOT Lambda functions it is not currently possible
-to deploy Native AOT Lambda functions from an M based Mac.
-
 ### Trimming
 
 As part of the Native AOT compilation, .NET assemblies will be trimmed removing types and methods that the compiler does not find a reference to. This is important
-to keep the native executable size small. When types are used through reflection this can go undetected by the compiler causing necessary types and methods to 
-be removed. The `rd.xml` file in the project is used to provide additional configuration to the compiler about what types are used to prevent them from 
-being trimmed. When testing Native AOT Lambda functions in Lambda if a runtime error occurs about missing types or methods the most likely solution will
-be to update the `rd.xml` to not trim the type. 
+to keep the native executable size small. When types are used through reflection this can go undetected by the compiler causing necessary types and methods to
+be removed. When testing Native AOT Lambda functions in Lambda if a runtime error occurs about missing types or methods the most likely solution will
+be to remove references to trim-unsafe code or configure [trimming options](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options?pivots=dotnet-7-0).
+This sample defaults to partial TrimMode because currently the AWS SDK for .NET does not support trimming. This will result in a larger executable size, and still does not
+guarantee runtime trimming errors won't be hit.
 
-Currently the AWS SDK for .NET does not support trimming and when used should be added to the rd.xml file. For example here is a `rd.xml` file that excludes
-the AWS SDK's core and AWS DynamoDB package.
-```xml
-<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
-	<Application>
-		<Assembly Name="AWSSDK.Core" Dynamic="Required All">
-		</Assembly>
-		<Assembly Name="AWSSDK.DynamoDBv2" Dynamic="Required All">
-		</Assembly>
-		<Assembly Name="bootstrap" Dynamic="Required All">
-		</Assembly>
-	</Application>
-</Directives>
-```
-
-For informaton about the `rd.xml` checkout the runtime directives configuration file reference: https://learn.microsoft.com/en-us/windows/uwp/dotnet-native/runtime-directives-rd-xml-configuration-file-reference
+For information about trimming see the documentation: <https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-self-contained>
 
 ## Docker requirement
 

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/src/BlueprintBaseName.1/rd.xml
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/src/BlueprintBaseName.1/rd.xml
@@ -1,6 +1,0 @@
-<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
-  <Application>
-    <Assembly Name="bootstrap" Dynamic="Required All">
-    </Assembly>
-  </Application>
-</Directives>

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -11,13 +11,15 @@
     <!-- StripSymbols tells the compiler to strip debugging symbols from the final executable if we're on Linux and put them into their own file. 
     This will greatly reduce the final executable's size.-->
     <StripSymbols>true</StripSymbols>
+    <!-- TrimMode partial will only trim assemblies marked as trimmable. To reduce package size make all assemblies trimmable and set TrimMode to full.
+    If there are trim warnings during build, you can hit errors at runtime.-->
+    <TrimMode>partial</TrimMode>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="aws-lambda-tools-defaults.json" />
-    <Content Include="rd.xml" />
   </ItemGroup>
   <!-- 
   When publishing Lambda functions for ARM64 to the provided.al2 runtime a newer version of libicu needs to be included
@@ -36,9 +38,5 @@
   <ItemGroup>
     <Content Include="aws-lambda-tools-defaults.json" />
     <None Include="Readme.md" />
-  </ItemGroup>
-  <ItemGroup>
-    <!--The runtime directives file allows the compiler to know what types and assemblies to not trim out of the final binary, even if they don't appear to be used.-->
-    <RdXmlFile Include="rd.xml" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -18,11 +18,13 @@ module Function =
     /// https://github.com/aws/aws-lambda-dotnet#events
     /// and change the string input parameter to the desired event type.
     ///
-    /// When using Native AOT, libraries used with your Lambda function might not be compatible with trimming that
-    /// happens as part of the Native AOT compilation. If you find when testing your Native AOT Lambda function that 
-    /// you get runtime errors about missing types, methods or constructors then add the assembly that contains the
-    /// types into the rd.xml file. This will tell the Native AOT compiler to not trim those assemblies. Currently the 
-    /// AWS SDK for .NET does not support trimming and when used should be added to the rd.xml file.    
+    // When using Native AOT extra testing with the deployed Lambda functions is required to ensure
+    // the libraries used in the Lambda function work correctly with Native AOT. If a runtime 
+    // error occurs about missing types or methods the most likely solution will be to remove references to trim-unsafe 
+    // code or configure trimming options. This sample defaults to partial TrimMode because currently the AWS 
+    // SDK for .NET does not support trimming. This will result in a larger executable size, and still does not 
+    // guarantee runtime trimming errors won't be hit. 
+
     /// </summary>
     /// <param name="input"></param>
     /// <param name="context"></param>
@@ -43,11 +45,6 @@ module Function =
     /// initializes the .NET Lambda runtime client passing in the function handler to invoke for each Lambda event and
     /// the JSON serializer to use for converting Lambda JSON format to the .NET types. 
     ///
-    /// F# uses the DefaultLambdaJsonSerializer which uses reflection to convert the JSON events 
-    /// and responses to .NET types. The Assembly name that contains the .NET types to serialize with must be added
-    /// to the rd.xml file to avoid the Native AOT compiler from trimming out the types used by reflection. For
-    /// example in the starting code the Amazon.Lambda.APIGatewayEvents assembly which defined the APIGatewayProxyRequest
-    /// and APIGatewayProxyResponse types is added to the rd.xml file.
     /// </summary>
     /// <param name="args"></param>
     [<EntryPoint>]

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -4,7 +4,6 @@ This starter project consists of:
 * serverless.template - an AWS CloudFormation Serverless Application Model template file for declaring your Serverless functions and other AWS resources
 * Function.fs - contains a main function that starts the bootstrap and a single function handler.
 * aws-lambda-tools-defaults.json - default argument settings for use with Visual Studio and command line deployment tools for AWS.
-* rd.xml - Runtime directives configuration file used to tell the Native AOT compiler what code to not trim out of .NET assemblies.
 
 You may also have a test project depending on the options selected.
 
@@ -28,34 +27,16 @@ platform is Amazon Linux 2. The AWS tooling for Lambda like the AWS Toolkit for 
 perform a container build using a .NET 7 Amazon Linux 2 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
 when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2 build environments. To install docker go to https://www.docker.com/.
 
-Due to an incompatibility with Amazon Linux 2 and .NET 7 ARM support it is not possible to build and deploy ARM based Native AOT Lambda functions.
-Since the architectures need to match between the build and target environments for .NET Native AOT Lambda functions it is not currently possible
-to deploy Native AOT Lambda functions from an M based Mac.
-
 ### Trimming
 
 As part of the Native AOT compilation, .NET assemblies will be trimmed removing types and methods that the compiler does not find a reference to. This is important
-to keep the native executable size small. When types are used through reflection this can go undetected by the compiler causing necessary types and methods to 
-be removed. The `rd.xml` file in the project is used to provide additional configuration to the compiler about what types are used to prevent them from 
-being trimmed. When testing Native AOT Lambda functions in Lambda if a runtime error occurs about missing types or methods the most likely solution will
-be to update the `rd.xml` to not trim the type. 
+to keep the native executable size small. When types are used through reflection this can go undetected by the compiler causing necessary types and methods to
+be removed. When testing Native AOT Lambda functions in Lambda if a runtime error occurs about missing types or methods the most likely solution will
+be to remove references to trim-unsafe code or configure [trimming options](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options?pivots=dotnet-7-0).
+This sample defaults to partial TrimMode because currently the AWS SDK for .NET does not support trimming. This will result in a larger executable size, and still does not
+guarantee runtime trimming errors won't be hit.
 
-Currently the AWS SDK for .NET does not support trimming and when used should be added to the rd.xml file. For example here is a `rd.xml` file that excludes
-the AWS SDK's core and AWS DynamoDB package.
-```xml
-<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
-	<Application>
-		<Assembly Name="AWSSDK.Core" Dynamic="Required All">
-		</Assembly>
-		<Assembly Name="AWSSDK.DynamoDBv2" Dynamic="Required All">
-		</Assembly>
-		<Assembly Name="bootstrap" Dynamic="Required All">
-		</Assembly>
-	</Application>
-</Directives>
-```
-
-For informaton about the `rd.xml` checkout the runtime directives configuration file reference: https://learn.microsoft.com/en-us/windows/uwp/dotnet-native/runtime-directives-rd-xml-configuration-file-reference
+For information about trimming see the documentation: <https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-self-contained>
 
 ## Docker requirement
 

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/rd.xml
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/rd.xml
@@ -1,8 +1,0 @@
-<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
-  <Application>
-    <Assembly Name="Amazon.Lambda.APIGatewayEvents" Dynamic="Required All">
-    </Assembly>	  	      
-    <Assembly Name="bootstrap" Dynamic="Required All">
-    </Assembly>
-  </Application>
-</Directives>

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -13,6 +13,9 @@
     <!-- StripSymbols tells the compiler to strip debugging symbols from the final executable if we're on Linux and put them into their own file. 
     This will greatly reduce the final executable's size.-->
     <StripSymbols>true</StripSymbols>
+    <!-- TrimMode partial will only trim assemblies marked as trimmable. To reduce package size make all assemblies trimmable and set TrimMode to full.
+    If there are trim warnings during build, you can hit errors at runtime.-->
+    <TrimMode>partial</TrimMode>
   </PropertyGroup>
   <!-- 
   When publishing Lambda functions for ARM64 to the provided.al2 runtime a newer version of libicu needs to be included
@@ -27,9 +30,5 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.6.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <!--The runtime directives file allows the compiler to know what types and assemblies to not trim out of the final binary, even if they don't appear to be used.-->
-    <RdXmlFile Include="rd.xml" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/Functions.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/Functions.cs
@@ -49,11 +49,12 @@ public class Functions
     /// defined below will need the JsonSerializable updated. If the return type and event type are different then the 
     /// LambdaFunctionJsonSerializerContext must have two JsonSerializable attributes, one for each type.
     ///
-    /// When using Native AOT, libraries used with your Lambda function might not be compatible with trimming that
-    /// happens as part of the Native AOT compilation. If you find when testing your Native AOT Lambda function that 
-    /// you get runtime errors about missing types, methods or constructors then add the assembly that contains the
-    /// types into the rd.xml file. This will tell the Native AOT compiler to not trim those assemblies. Currently the 
-    /// AWS SDK for .NET does not support trimming and when used should be added to the rd.xml file.    
+    // When using Native AOT extra testing with the deployed Lambda functions is required to ensure
+    // the libraries used in the Lambda function work correctly with Native AOT. If a runtime 
+    // error occurs about missing types or methods the most likely solution will be to remove references to trim-unsafe 
+    // code or configure trimming options. This sample defaults to partial TrimMode because currently the AWS 
+    // SDK for .NET does not support trimming. This will result in a larger executable size, and still does not 
+    // guarantee runtime trimming errors won't be hit. 
     /// </summary>
     /// <param name="request"></param>
     /// <param name="context"></param>
@@ -82,11 +83,12 @@ public class Functions
     /// defined below will need the JsonSerializable updated. If the return type and event type are different then the 
     /// LambdaFunctionJsonSerializerContext must have two JsonSerializable attributes, one for each type.
     ///
-    /// When using Native AOT, libraries used with your Lambda function might not be compatible with trimming that
-    /// happens as part of the Native AOT compilation. If you find when testing your Native AOT Lambda function that 
-    /// you get runtime errors about missing types, methods or constructors then add the assembly that contains the
-    /// types into the rd.xml file. This will tell the Native AOT compiler to not trim those assemblies. Currently the 
-    /// AWS SDK for .NET does not support trimming and when used should be added to the rd.xml file.    
+    // When using Native AOT extra testing with the deployed Lambda functions is required to ensure
+    // the libraries used in the Lambda function work correctly with Native AOT. If a runtime 
+    // error occurs about missing types or methods the most likely solution will be to remove references to trim-unsafe 
+    // code or configure trimming options. This sample defaults to partial TrimMode because currently the AWS 
+    // SDK for .NET does not support trimming. This will result in a larger executable size, and still does not 
+    // guarantee runtime trimming errors won't be hit. 
     /// </summary>
     /// <param name="request"></param>
     /// <param name="context"></param>

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/Readme.md
@@ -4,7 +4,6 @@ This starter project consists of:
 * serverless.template - an AWS CloudFormation Serverless Application Model template file for declaring your Serverless functions and other AWS resources.
 * Function.cs - contains a class with a `Main` method that starts the bootstrap and a single function handler method.
 * aws-lambda-tools-defaults.json - default argument settings for use with Visual Studio and command line deployment tools for AWS.
-* rd.xml - Runtime directives configuration file used to tell the Native AOT compiler what code to not trim out of .NET assemblies.
 
 You may also have a test project depending on the options selected.
 
@@ -28,34 +27,16 @@ platform is Amazon Linux 2. The AWS tooling for Lambda like the AWS Toolkit for 
 perform a container build using a .NET 7 Amazon Linux 2 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
 when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2 build environments. To install docker go to https://www.docker.com/.
 
-Due to an incompatibility with Amazon Linux 2 and .NET 7 ARM support it is not possible to build and deploy ARM based Native AOT Lambda functions.
-Since the architectures need to match between the build and target environments for .NET Native AOT Lambda functions it is not currently possible
-to deploy Native AOT Lambda functions from an M based Mac.
-
 ### Trimming
 
 As part of the Native AOT compilation, .NET assemblies will be trimmed removing types and methods that the compiler does not find a reference to. This is important
-to keep the native executable size small. When types are used through reflection this can go undetected by the compiler causing necessary types and methods to 
-be removed. The `rd.xml` file in the project is used to provide additional configuration to the compiler about what types are used to prevent them from 
-being trimmed. When testing Native AOT Lambda functions in Lambda if a runtime error occurs about missing types or methods the most likely solution will
-be to update the `rd.xml` to not trim the type. 
+to keep the native executable size small. When types are used through reflection this can go undetected by the compiler causing necessary types and methods to
+be removed. When testing Native AOT Lambda functions in Lambda if a runtime error occurs about missing types or methods the most likely solution will
+be to remove references to trim-unsafe code or configure [trimming options](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options?pivots=dotnet-7-0).
+This sample defaults to partial TrimMode because currently the AWS SDK for .NET does not support trimming. This will result in a larger executable size, and still does not
+guarantee runtime trimming errors won't be hit.
 
-Currently the AWS SDK for .NET does not support trimming and when used should be added to the rd.xml file. For example here is a `rd.xml` file that excludes
-the AWS SDK's core and AWS DynamoDB package.
-```xml
-<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
-	<Application>
-		<Assembly Name="AWSSDK.Core" Dynamic="Required All">
-		</Assembly>
-		<Assembly Name="AWSSDK.DynamoDBv2" Dynamic="Required All">
-		</Assembly>
-		<Assembly Name="bootstrap" Dynamic="Required All">
-		</Assembly>
-	</Application>
-</Directives>
-```
-
-For informaton about the `rd.xml` checkout the runtime directives configuration file reference: https://learn.microsoft.com/en-us/windows/uwp/dotnet-native/runtime-directives-rd-xml-configuration-file-reference
+For information about trimming see the documentation: <https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-self-contained>
 
 ## Docker requirement
 

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/rd.xml
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/rd.xml
@@ -1,6 +1,0 @@
-<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
-  <Application>
-    <Assembly Name="bootstrap" Dynamic="Required All">
-    </Assembly>
-  </Application>
-</Directives>


### PR DESCRIPTION
*Description of changes:*
Removes rd.xml, which is being deprecated in favor of defaulting to trim mode partial for now.
Also updates some wording to make it clear of the dangers of trim warnings.

Tested by manually deploying the fSharp serverless and c# function and making sure they returned successfully when invoked in the AWS console.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
