### PR TITLE
Add support for setting environment variables with test tool

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/LambdaConfigFile.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/LambdaConfigFile.cs
@@ -19,6 +19,9 @@ namespace Amazon.Lambda.TestTool
         [JsonPropertyName("image-command")]
         public string ImageCommand { get; set; }
 
+        [JsonPropertyName("environment-variables")]
+        public string EnvironmentVariables { get; set; }
+
         public string ConfigFileLocation { get; set; }
 
         public string DetermineHandler()

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaFunctionInfo.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaFunctionInfo.cs
@@ -1,4 +1,6 @@
-﻿namespace Amazon.Lambda.TestTool.Runtime
+﻿using System.Collections.Generic;
+
+namespace Amazon.Lambda.TestTool.Runtime
 {
     public class LambdaFunctionInfo
     {
@@ -11,5 +13,7 @@
         /// The Lambda function handler string.
         /// </summary>
         public string Handler { get; set; }
+
+        public IDictionary<string, string> EnvironmentVariables { get; }  = new Dictionary<string, string>();
     }
 }

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/DefaultsFileParseTests.cs
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/DefaultsFileParseTests.cs
@@ -41,6 +41,28 @@ namespace Amazon.Lambda.TestTool.Tests
                 File.Delete(jsonFile);
             }
         }
+
+        [Fact]
+        public void LambdaFunctionWithEnvironmentVariables()
+        {
+            var jsonFile = WriteTempConfigFile("{\"function-handler\" : \"Assembly::Type::Method\", \"environment-variables\" : \"key1=value1;key2=value2\"}");
+            try
+            {
+                var configInfo = LambdaDefaultsConfigFileParser.LoadFromFile(jsonFile);
+                Assert.Single(configInfo.FunctionInfos);
+                Assert.Equal("Assembly::Type::Method", configInfo.FunctionInfos[0].Handler);
+                Assert.Equal("TheFunc", configInfo.FunctionInfos[0].Name);
+
+                Assert.Equal(2, configInfo.FunctionInfos[0].EnvironmentVariables.Count);
+                Assert.Equal("value1", configInfo.FunctionInfos[0].EnvironmentVariables["key1"]);
+                Assert.Equal("value2", configInfo.FunctionInfos[0].EnvironmentVariables["key2"]);
+            }
+            finally
+            {
+                File.Delete(jsonFile);
+            }
+        }
+
         [Fact]
         public void LambdaFunctionWithImageCommand()
         {


### PR DESCRIPTION
*Description of changes:*
Before executing the Lambda function's code look to see if there are environment variables have been configured in the deployment config file or the CloudFormation template. If they have been defined set them in the process so the function's code will see them and then clear them out once the function is done being executed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
