### PR TITLE
feat: Add configurable Lambda Context object

### DIFF
--- a/Tools/LambdaTestTool/README.md
+++ b/Tools/LambdaTestTool/README.md
@@ -105,6 +105,8 @@ These options are valid in the no web interface mode.
                                               from the config file will be used. This is the format of &lt;assembly::type-name::method-name&gt;.
         --payload &lt;file-name&gt;                 The JSON payload to send to the Lambda function. This can be either an inline string or a
                                               file path to a JSON file.
+        --lambdaContext <file-name>           The JSON Context object to send to the Lambda function. This can be either an inline string or a
+                                              file path to a JSON file.
         --pause-exit &lt;true or false&gt;          If set to true the test tool will pause waiting for a key input before exiting. The is useful
                                               when executing from an IDE so you can avoid having the output window immediately disappear after
                                               executing the Lambda code. The default value is true.

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Index.razor
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Index.razor
@@ -3,6 +3,7 @@
 @using System.Threading; 
 @using Amazon.Lambda.TestTool.Runtime;
 @using Amazon.Lambda.TestTool.SampleRequests;
+@using System.Text.Json
 @inject LocalLambdaOptions LambdaOptions
 @inject IModalService Modal
 
@@ -62,6 +63,13 @@
     </div>
 </div>
 
+<div class="row">
+    <div class="col-sm form-group">
+        <label class="col-xs-3 control-label" for="function-context">Lambda Context Input:</label>
+        <button type="button" class="btn btn-secondary btn-sm" @onclick="GenerateLocalLambdaContext">Generate Sample Context</button>
+        <textarea class="form-control" rows="10" id="function-context" @bind="LambdaContextInput" placeholder="JSON document to pass a custom Lambda Context object. If nothing is passed, only the logger will be set. Plain strings must be wrapped in quotes."></textarea>
+    </div>
+</div>
 
 <div class="row mt-3">
     <div class="col-sm form-group">
@@ -100,6 +108,8 @@
     public string FunctionResponse { get; set; }
 
     public string FunctionLogs { get; set; }
+    
+    public string LambdaContextInput { get; set; }
 
     string _selectedSampleRequestName;
     string SelectedSampleRequestName
@@ -114,11 +124,21 @@
     }
 
     SampleRequestManager SampleRequestManager { get; set; }
+    SampleLambdaContextManager SampleLambdaContextManager { get; set; }
 
     protected override void OnInitialized()
     {
         this.SampleRequestManager = new SampleRequestManager(LambdaOptions.GetPreferenceDirectory(false));
         this.SampleRequests = SampleRequestManager.GetSampleRequests();
+        this.SampleLambdaContextManager = new SampleLambdaContextManager();
+    }
+    
+    void GenerateLocalLambdaContext()
+    {
+        var context = SampleLambdaContextManager.GetSampleContextRequest();
+
+        this.LambdaContextInput = JsonSerializer.Serialize(context, new JsonSerializerOptions {WriteIndented = true});
+        this.StateHasChanged();
     }
 
     void OnSaveRequestClick()
@@ -166,7 +186,8 @@
                 Function = function,
                 AWSProfile = FunctionPicker.AWSProfile,
                 AWSRegion = FunctionPicker.AWSRegion,
-                Payload = this.FunctionInput
+                Payload = this.FunctionInput,
+                LambdaContext = this.LambdaContextInput
             };
 
             response = this.LambdaOptions.LambdaRuntime.ExecuteLambdaFunctionAsync(request).GetAwaiter().GetResult();

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/CommandLineOptions.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/CommandLineOptions.cs
@@ -25,7 +25,8 @@ namespace Amazon.Lambda.TestTool
         public string AWSRegion { get; set; }
 
         public bool ShowHelp { get; set; }
-
+        
+        public string LambdaContext { get; set; }
         public bool PauseExit { get; set; } = true;
 
         public static CommandLineOptions Parse(string[] args)
@@ -88,6 +89,10 @@ namespace Amazon.Lambda.TestTool
                         break;
                     case "--payload":
                         options.Payload = GetNextStringValue(i);
+                        i++;
+                        break;
+                    case "--lambdaContext":
+                        options.LambdaContext = GetNextStringValue(i);
                         i++;
                         break;
                     case "--pause-exit":
@@ -168,6 +173,8 @@ namespace Amazon.Lambda.TestTool
             Console.WriteLine("\t--function-handler <handler-string>   The Lambda function handler to identify the code to run. If not set then the function handler");
             Console.WriteLine("\t                                      from the config file will be used. This is the format of <assembly::type-name::method-name>.");
             Console.WriteLine("\t--payload <file-name>                 The JSON payload to send to the Lambda function. This can be either an inline string or a");
+            Console.WriteLine("\t                                      file path to a JSON file.");
+            Console.WriteLine("\t--lambdaContext <file-name>           The JSON Context object to send to the Lambda function. This can be either an inline string or a");
             Console.WriteLine("\t                                      file path to a JSON file.");
             Console.WriteLine("\t--pause-exit <true or false>          If set to true the test tool will pause waiting for a key input before exiting. The is useful");
             Console.WriteLine("\t                                      when executing from an IDE so you can avoid having the output window immediately disappear after");

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/InvokeParameters.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/InvokeParameters.cs
@@ -6,5 +6,6 @@ namespace Amazon.Lambda.TestTool
         public string Profile { get; set; }
         public string Region { get; set; }
         public string Payload { get; set; }
+        public string LambdaContext { get; set; }
     }
 }

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/ExecutionRequest.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/ExecutionRequest.cs
@@ -25,5 +25,9 @@
         /// </summary>
         public string Payload { get; set; }
         
+        /// <summary>
+        /// The JSON payload that will be the Lambda Context input of the Lambda function.
+        /// </summary>
+        public string LambdaContext { get; set; }
     }
 }

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaMocks/LocalLambdaContext.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaMocks/LocalLambdaContext.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Amazon.Lambda.Core;
 
 namespace Amazon.Lambda.TestTool.Runtime.LambdaMocks
@@ -6,15 +9,54 @@ namespace Amazon.Lambda.TestTool.Runtime.LambdaMocks
     public class LocalLambdaContext : ILambdaContext
     {
         public string AwsRequestId { get; set; }
+        
+        [JsonConverter(typeof(InterfaceConverter<LocalClientContext, IClientContext>))]
         public IClientContext ClientContext { get; set; }
         public string FunctionName { get; set; }
         public string FunctionVersion { get; set; }
+        [JsonConverter(typeof(InterfaceConverter<LocalCognitoIdentity, ICognitoIdentity>))]
         public ICognitoIdentity Identity { get; set; }
         public string InvokedFunctionArn { get; set; }
+        [JsonIgnore]
         public ILambdaLogger Logger { get; set; }
         public string LogGroupName { get; set; }
         public string LogStreamName { get; set; }
         public int MemoryLimitInMB { get; set; }
         public TimeSpan RemainingTime { get; set; }
+        
+        public class LocalCognitoIdentity : ICognitoIdentity
+        {
+            public string IdentityId { get; set; }
+            public string IdentityPoolId { get; set; }
+        }
+    
+        public class LocalClientContext : IClientContext
+        {
+            [JsonConverter(typeof(InterfaceConverter<Dictionary<string, string>, IDictionary<string, string>>))]
+            public IDictionary<string, string> Environment { get; set; }
+            [JsonConverter(typeof(InterfaceConverter<LocalClientApplication, IClientApplication>))]
+            public IClientApplication Client { get; set; }
+            [JsonConverter(typeof(InterfaceConverter<Dictionary<string, string>, IDictionary<string, string>>))]
+            public IDictionary<string, string> Custom { get; set; }
+        
+            public class LocalClientApplication : IClientApplication
+            {
+                public string AppPackageName { get; set; }
+                public string AppTitle { get; set; }
+                public string AppVersionCode { get; set; }
+                public string AppVersionName { get; set; }
+                public string InstallationId { get; set; }
+            }
+        }
+    
+        public class InterfaceConverter<T, I> : JsonConverter<I> where T : class, I
+        {
+            public override I Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                return JsonSerializer.Deserialize<T>(ref reader, options);
+            }
+
+            public override void Write(Utf8JsonWriter writer, I value, JsonSerializerOptions options) { }
+        }
     }
 }

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/SampleRequests/SampleLambdaContextManager.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/SampleRequests/SampleLambdaContextManager.cs
@@ -1,0 +1,30 @@
+using System;
+using Amazon.Lambda.TestTool.Runtime.LambdaMocks;
+
+namespace Amazon.Lambda.TestTool.SampleRequests
+{
+    /// <summary>
+    /// This class manages the sample Lambda Context input requests. This includes a default request and saved requests.
+    /// </summary>
+    public class SampleLambdaContextManager
+    {
+        public LocalLambdaContext GetSampleContextRequest()
+        {
+            const string functionName = "testfunction";
+            const string functionVersion = "1";
+            var arn = $"arn:aws:lambda:us-east-1:accountid:{functionName}:{functionVersion}";
+            var defaultContext = new LocalLambdaContext()
+            {
+                FunctionName = functionName,
+                FunctionVersion = functionVersion,
+                MemoryLimitInMB = 256,
+                AwsRequestId = Guid.NewGuid().ToString().Replace("-", ""),
+                InvokedFunctionArn = arn,
+                //3 seconds is the default timeout for Lambda functions
+                RemainingTime = TimeSpan.FromSeconds(3)
+            };
+
+            return defaultContext;
+        }
+    }
+}

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/TestToolStartup.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/TestToolStartup.cs
@@ -75,7 +75,6 @@ namespace Amazon.Lambda.TestTool
                 {
                     lambdaAssemblyDirectory = Path.Combine(lambdaAssemblyDirectory, $"bin/Debug/{targetFramework}");
                 }
-
                 lambdaAssemblyDirectory = Utils.SearchLatestCompilationDirectory(lambdaAssemblyDirectory);
 
                 localLambdaOptions.LambdaRuntime = LocalLambdaRuntime.Initialize(lambdaAssemblyDirectory);
@@ -134,8 +133,9 @@ namespace Amazon.Lambda.TestTool
             LambdaConfigInfo configInfo = LoadLambdaConfigInfo(configFile, commandOptions, lambdaAssemblyDirectory: lambdaAssemblyDirectory, lambdaProjectDirectory: lambdaProjectDirectory, runConfiguration);
             LambdaFunction lambdaFunction = LoadLambdaFunction(configInfo, localLambdaOptions, commandOptions, lambdaAssemblyDirectory: lambdaAssemblyDirectory, lambdaProjectDirectory: lambdaProjectDirectory, runConfiguration);
 
-            string payload = DeterminePayload(localLambdaOptions, commandOptions, lambdaAssemblyDirectory: lambdaAssemblyDirectory, lambdaProjectDirectory: lambdaProjectDirectory, runConfiguration);
-
+            string payload = DetermineInputValue(localLambdaOptions, commandOptions.Payload, lambdaAssemblyDirectory: lambdaAssemblyDirectory, lambdaProjectDirectory: lambdaProjectDirectory, runConfiguration);
+            string lambdaContext = DetermineInputValue(localLambdaOptions, commandOptions.LambdaContext, lambdaAssemblyDirectory: lambdaAssemblyDirectory, lambdaProjectDirectory: lambdaProjectDirectory, runConfiguration);
+            
             var awsProfile = commandOptions.AWSProfile ?? configInfo.AWSProfile;
             if (!string.IsNullOrEmpty(awsProfile))
             {
@@ -170,7 +170,8 @@ namespace Amazon.Lambda.TestTool
                 AWSProfile = awsProfile,
                 AWSRegion = awsRegion,
                 Payload = payload,
-                Function = lambdaFunction
+                Function = lambdaFunction,
+                LambdaContext = lambdaContext
             };
 
             ExecuteRequest(request, localLambdaOptions, runConfiguration);
@@ -271,59 +272,57 @@ namespace Amazon.Lambda.TestTool
             return lambdaFunction;
         }
 
-        private static string DeterminePayload(LocalLambdaOptions localLambdaOptions, CommandLineOptions commandOptions, string lambdaAssemblyDirectory, string lambdaProjectDirectory, RunConfiguration runConfiguration)
+        private static string DetermineInputValue(LocalLambdaOptions localLambdaOptions, string input, string lambdaAssemblyDirectory, string lambdaProjectDirectory, RunConfiguration runConfiguration)
         {
-            var payload = commandOptions.Payload;
-
-            bool payloadFileFound = false;
-            if (!string.IsNullOrEmpty(payload))
+            bool inputFileFound = false;
+            if (!string.IsNullOrEmpty(input))
             {
-                if (Path.IsPathFullyQualified(payload) && File.Exists(payload))
+                if (Path.IsPathFullyQualified(input) && File.Exists(input))
                 {
-                    runConfiguration.OutputWriter.WriteLine($"... Using payload with from the file {payload}");
-                    payload = File.ReadAllText(payload);
-                    payloadFileFound = true;
+                    runConfiguration.OutputWriter.WriteLine($"... Using input with from the file {input}");
+                    input = File.ReadAllText(input);
+                    inputFileFound = true;
                 }
                 else
                 {
-                    // Look to see if the payload value is a file in
+                    // Look to see if the context value is a file in
                     // * Directory with user Lambda assemblies.
                     // * Lambda project directory
                     // * Properties directory under the project directory. This is to make it easy to reconcile from the launchSettings.json file.
                     // * Is a saved sample request from the web interface
                     var possiblePaths = new[]
                     {
-                        Path.Combine(lambdaAssemblyDirectory, payload),
-                        Path.Combine(lambdaProjectDirectory, payload),
-                        Path.Combine(lambdaProjectDirectory, "Properties", payload),
-                        Path.Combine(localLambdaOptions.GetPreferenceDirectory(false), new SampleRequestManager(localLambdaOptions.GetPreferenceDirectory(false)).GetSaveRequestRelativePath(payload))
+                        Path.Combine(lambdaAssemblyDirectory, input),
+                        Path.Combine(lambdaProjectDirectory, input),
+                        Path.Combine(lambdaProjectDirectory, "Properties", input),
+                        Path.Combine(localLambdaOptions.GetPreferenceDirectory(false), new SampleRequestManager(localLambdaOptions.GetPreferenceDirectory(false)).GetSaveRequestRelativePath(input))
                     };
                     foreach (var possiblePath in possiblePaths)
                     {
                         if (File.Exists(possiblePath))
                         {
                             runConfiguration.OutputWriter.WriteLine($"... Using payload with from the file {Path.GetFullPath(possiblePath)}");
-                            payload = File.ReadAllText(possiblePath);
-                            payloadFileFound = true;
+                            input = File.ReadAllText(possiblePath);
+                            inputFileFound = true;
                             break;
                         }
                     }
                 }
             }
 
-            if (!payloadFileFound)
+            if (!inputFileFound)
             {
-                if (!string.IsNullOrEmpty(payload))
+                if (!string.IsNullOrEmpty(input))
                 {
-                    runConfiguration.OutputWriter.WriteLine($"... Using payload with the value {payload}");
+                    runConfiguration.OutputWriter.WriteLine($"... Using input with the value {input}");
                 }
                 else
                 {
-                    runConfiguration.OutputWriter.WriteLine("... No payload configured. If a payload is required set the --payload switch to a file path or a JSON document.");
+                    runConfiguration.OutputWriter.WriteLine("... No input configured. If an input is required set the input parameter, --lambdaContext or --payload, to switch to a file path or a JSON document.");
                 }
             }
 
-            return payload;
+            return input;
         }
 
         private static void ExecuteRequest(ExecutionRequest request, LocalLambdaOptions localLambdaOptions, RunConfiguration runConfiguration)

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/LambdaExecutorTests.cs
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/LambdaExecutorTests.cs
@@ -1,0 +1,173 @@
+using Amazon.Lambda.TestTool.Runtime;
+using Amazon.Lambda.TestTool.Runtime.LambdaMocks;
+
+namespace Amazon.Lambda.TestTool.Tests.NET6
+{
+    public class LambdaExecutorTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void NoPassedInContextShouldReturnOnlyLogger(string? noContext)
+        {
+            var executor = new LambdaExecutor();
+            var defaultLogger = new LocalLambdaLogger();
+
+            var result = executor.GetLambdaContextForRequest(noContext, defaultLogger);
+
+            Assert.Null(result.AwsRequestId);
+            Assert.Null(result.FunctionName);
+            Assert.Null(result.FunctionVersion);
+            Assert.Null(result.LogGroupName);
+            Assert.Null(result.ClientContext);
+            Assert.Null(result.Identity);
+            Assert.Null(result.InvokedFunctionArn);
+            Assert.Null(result.LogStreamName);
+
+            Assert.NotNull(result.Logger);
+
+            Assert.Same(defaultLogger, result.Logger);
+        }
+
+        [Fact]
+        public void PassedInAwsRequestIdShouldPopulateContextObject()
+        {
+            var executor = new LambdaExecutor();
+            var defaultLogger = new LocalLambdaLogger();
+
+            var awsRequstIdContext = "{\"AwsRequestId\":\"abc123\"}";
+
+            var result = executor.GetLambdaContextForRequest(awsRequstIdContext, defaultLogger);
+
+            Assert.NotNull(result.AwsRequestId);
+            Assert.Equal("abc123", result.AwsRequestId);
+            Assert.Null(result.FunctionName);
+            Assert.Null(result.FunctionVersion);
+            Assert.Null(result.LogGroupName);
+            Assert.Null(result.ClientContext);
+            Assert.Null(result.Identity);
+            Assert.Null(result.InvokedFunctionArn);
+            Assert.Null(result.LogStreamName);
+
+            Assert.NotNull(result.Logger);
+
+            Assert.Same(defaultLogger, result.Logger);
+        }
+        
+        [Fact]
+        public void PassedInRemainingTimeShouldDeserialiseAsTimeSpan()
+        {
+            var executor = new LambdaExecutor();
+            var defaultLogger = new LocalLambdaLogger();
+
+            var remainingTimeContext = "{\"RemainingTime\":\"00:00:22\"}";
+
+            var result = executor.GetLambdaContextForRequest(remainingTimeContext, defaultLogger);
+
+            Assert.Equal(TimeSpan.FromSeconds(22), result.RemainingTime);
+            Assert.Equal(22, result.RemainingTime.TotalSeconds);
+            Assert.Null(result.FunctionName);
+            Assert.Null(result.FunctionVersion);
+            Assert.Null(result.LogGroupName);
+            Assert.Null(result.ClientContext);
+            Assert.Null(result.Identity);
+            Assert.Null(result.InvokedFunctionArn);
+            Assert.Null(result.LogStreamName);
+
+            Assert.NotNull(result.Logger);
+
+            Assert.Same(defaultLogger, result.Logger);
+        }
+
+        [Fact]
+        public void PassedInFunctionNameShouldPopulateContextObject()
+        {
+            var executor = new LambdaExecutor();
+            var defaultLogger = new LocalLambdaLogger();
+
+            var functionNameContext = "{\"FunctionName\":\"testname\", \"FunctionVersion\":\"99\"}";
+
+            var result = executor.GetLambdaContextForRequest(functionNameContext, defaultLogger);
+
+            Assert.Null(result.AwsRequestId);
+            Assert.Equal("testname", result.FunctionName);
+            Assert.NotNull(result.FunctionName);
+            Assert.Equal("99", result.FunctionVersion);
+            Assert.NotNull(result.FunctionVersion);
+            Assert.Null(result.LogGroupName);
+            Assert.Null(result.ClientContext);
+            Assert.Null(result.Identity);
+            Assert.Null(result.InvokedFunctionArn);
+            Assert.Null(result.LogStreamName);
+
+            Assert.NotNull(result.Logger);
+
+            Assert.Same(defaultLogger, result.Logger);
+        }
+
+        [Fact]
+        public void PassedInObjectShouldPopulateContextObject()
+        {
+            var executor = new LambdaExecutor();
+            var defaultLogger = new LocalLambdaLogger();
+
+            var requestContext = "{\"AwsRequestId\":\"abc123\",\"FunctionName\":\"testname\",\"FunctionVersion\":\"99\",\"LogGroupName\":\"aLogGroup\",\"LogStreamName\":\"aLogStream\",\"InvokedFunctionArn\":\"someArn\"}";
+
+            var result = executor.GetLambdaContextForRequest(requestContext, defaultLogger);
+
+            Assert.Equal("abc123", result.AwsRequestId);
+            Assert.Equal("testname",result.FunctionName);
+            Assert.Equal("99", result.FunctionVersion);
+            Assert.Equal("aLogGroup", result.LogGroupName);
+            Assert.Equal("someArn", result.InvokedFunctionArn);
+            Assert.Equal("aLogStream", result.LogStreamName);
+
+            Assert.Null(result.ClientContext);
+            Assert.Null(result.Identity);
+            Assert.NotNull(result.Logger);
+
+            Assert.Same(defaultLogger, result.Logger);
+        }
+
+        [Fact]
+        public void PassedInComplexIdentityObjectShouldPopulateContextObject()
+        {
+            var executor = new LambdaExecutor();
+            var defaultLogger = new LocalLambdaLogger();
+
+            var identityObject = "{\"Identity\": {\"IdentityId\":\"someId\", \"IdentityPoolId\":\"somePoolId\"}}";
+
+            var result = executor.GetLambdaContextForRequest(identityObject, defaultLogger);
+
+            Assert.Null(result.ClientContext);
+            Assert.NotNull(result.Identity);
+            Assert.NotNull(result.Logger);
+
+            Assert.Equal("someId", result.Identity.IdentityId);
+            Assert.Equal("somePoolId", result.Identity.IdentityPoolId);
+
+            Assert.Same(defaultLogger, result.Logger);
+        }
+
+        [Fact]
+        public void PassedInComplexClientContextObjectShouldPopulateContextObject()
+        {
+            var executor = new LambdaExecutor();
+            var defaultLogger = new LocalLambdaLogger();
+
+            var identityObject = "{\"ClientContext\": {\"Client\":{\"AppPackageName\":\"some App Name\"}, \"Environment\": {\"customEnv\":\"dictValue\"}, \"Custom\": {\"userSetProperty\":\"userSetValue\"}}}";
+
+            var result = executor.GetLambdaContextForRequest(identityObject, defaultLogger);
+
+            Assert.NotNull(result.ClientContext);
+            Assert.Null(result.Identity);
+            Assert.NotNull(result.Logger);
+
+            Assert.Equal("some App Name", result.ClientContext.Client.AppPackageName);
+            Assert.Equal("dictValue", result.ClientContext.Environment["customEnv"]);
+            Assert.Equal("userSetValue", result.ClientContext.Custom["userSetProperty"]);
+
+            Assert.Same(defaultLogger, result.Logger);
+        }
+    }
+}


### PR DESCRIPTION
- Add code to support passing in a custom Lambda Context object from the CLI or Web UI
- Add a way to build a default context object through the UI tool

This supersedes https://github.com/aws/aws-lambda-dotnet/pull/742

*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/665

*Description of changes:*

This PR adds the ability to manually set properties on the LambdaContext object that gets passed to the invoked function.
It's possible to pass in via the CLI via a switch/arg or from the Web UI. The Web UI has a new section to populate the object and can generate a default value.

The Web UI has been updated:
![image](https://user-images.githubusercontent.com/1962883/228221454-a6d79d6b-bff9-4817-8faf-67b0bb1ce4d2.png)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

