### PR TITLE
Add support for named Executable Assembly functions

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Runtime.razor
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Runtime.razor
@@ -45,8 +45,10 @@
                 }
             }
         </select>
-        <label class="col-xs-3 control-label" for="function-payload">Function Input:</label>
+        <label class="col-xs-3 control-label" for="function-name">Function Name:</label>
+        <input typ="text" class="form-control" style="margin: 5px" @bind="FunctionName" placeholder="Optionally the name of the Lambda Function to execute."/>
         <textarea class="form-control" style="margin: 5px" rows="20" @bind="FunctionInput" placeholder="JSON document as input to Lambda Function. Plain strings must be wrapped in quotes."></textarea>
+        <label class="col-xs-3 control-label" for="function-payload">Function Input:</label>
         <div class="col-sm form-group">
             <button class="btn btn-primary btn-sm" @onclick="OnAddEventClick">Queue Event</button>
         </div>
@@ -66,6 +68,10 @@
                       <p><b>Request ID:</b> @RuntimeApiModel.ActiveEvent.AwsRequestId</p>
                       <p><b>Status:</b> <span style="@GetStatusStyle(RuntimeApiModel.ActiveEvent.EventStatus)">@RuntimeApiModel.ActiveEvent.EventStatus</span></p>
                       <p><b>Last Updated:</b> @RuntimeApiModel.ActiveEvent.LastUpdated</p>
+                      @if (RuntimeApiModel.ActiveEvent.FunctionName != null)
+                      {
+                          <p><b>Function Name:</b> @RuntimeApiModel.ActiveEvent.FunctionName</p>
+                      }
                       <p><b>Event JSON:</b><span class="event-value"><span class="fake-link" @onclick="() => ShowEventJson(RuntimeApiModel.ActiveEvent)">@CreateSnippet(RuntimeApiModel.ActiveEvent.EventJson)</span></span></p>
                       @if (RuntimeApiModel.ActiveEvent.EventStatus == IEventContainer.Status.Failure)
                       {
@@ -104,6 +110,12 @@
                             @((MarkupString)CLOSE_ICON)
                         </div>
                     </div>
+                    @if (evnt.FunctionName != null)
+                    {
+                        <div class="row" style="padding: 2px">
+                            <div class="event-label">Function Name:</div><div class="event-value">@evnt.FunctionName</div>
+                        </div>
+                    }
                     <div class="row" style="padding: 2px">
                         <div class="event-label">Event JSON:</div><div class="event-value"><span class="fake-link" @onclick="() => ShowEventJson(evnt)">@CreateSnippet(evnt.EventJson)</span></div>
                     </div>
@@ -130,6 +142,12 @@
                             @((MarkupString)CLOSE_ICON)
                         </div>
                     </div>
+                    @if (evnt.FunctionName != null)
+                    {
+                        <div class="row" style="padding: 2px">
+                            <div class="event-label">Function Name:</div><div class="event-value">@evnt.FunctionName</div>
+                        </div>
+                    }
                     <div class="row" style="padding: 2px">
                         <div class="event-label">Event JSON:</div><div class="event-value"><span class="fake-link" @onclick="() => ShowEventJson(evnt)">@CreateSnippet(evnt.EventJson)</span></div>
                     </div>
@@ -173,6 +191,7 @@
     private const string NO_SAMPLE_SELECTED_ID = "void-select-request";
 
     private string FunctionInput { get; set; }
+    private string FunctionName { get; set; }
 
     private IDictionary<string, IList<LambdaRequest>> SampleRequests { get; set; }
 
@@ -207,7 +226,7 @@
 
     void OnAddEventClick()
     {
-        RuntimeApiModel.QueueEvent(this.FunctionInput);
+        RuntimeApiModel.QueueEvent(FunctionName, this.FunctionInput);
         this.FunctionInput = "";
         this.SelectedSampleRequestName = NO_SAMPLE_SELECTED_ID;
         this.StateHasChanged();
@@ -240,7 +259,7 @@
         if (evnt == null)
             return;
 
-        this.RuntimeApiModel.QueueEvent(evnt.EventJson);
+        this.RuntimeApiModel.QueueEvent(evnt.FunctionName, evnt.EventJson);
         this.StateHasChanged();
     }
 

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.BlazorTester.Tests/RuntimeApiDataStoreNamedTests.cs
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.BlazorTester.Tests/RuntimeApiDataStoreNamedTests.cs
@@ -5,22 +5,24 @@ using Xunit;
 
 namespace Amazon.Lambda.TestTool.BlazorTester.Tests
 {
-    public class RuntimeApiDataStoreTests
+    public class RuntimeApiDataStoreNamedTests
     {
+        const string FunctionName = "TestFunction";
+
         [Fact]
         public void ActivateEvents()
         {
             var dataStore = new RuntimeApiDataStore();
 
             IEventContainer evnt;
-            Assert.False(dataStore.TryActivateEvent(null, out evnt));
+            Assert.False(dataStore.TryActivateEvent(FunctionName, out evnt));
             Assert.Empty(dataStore.QueuedEvents);
 
-            dataStore.QueueEvent(null, "{}");
+            dataStore.QueueEvent(FunctionName, "{}");
             Assert.Single(dataStore.QueuedEvents);
             Assert.Equal(IEventContainer.Status.Queued, dataStore.QueuedEvents[0].EventStatus);
 
-            Assert.True(dataStore.TryActivateEvent(null, out evnt));
+            Assert.True(dataStore.TryActivateEvent(FunctionName, out evnt));
             Assert.Equal("{}", evnt.EventJson);
             Assert.Equal(evnt, dataStore.ActiveEvent);
             Assert.Equal(IEventContainer.Status.Executing, dataStore.ActiveEvent.EventStatus);
@@ -33,14 +35,14 @@ namespace Amazon.Lambda.TestTool.BlazorTester.Tests
             var dataStore = new RuntimeApiDataStore();
             for(int i = 0; i< 10; i++)
             {
-                dataStore.QueueEvent(null, "{}");
+                dataStore.QueueEvent(FunctionName, "{}");
             }
             Assert.Equal(10, dataStore.QueuedEvents.Count);
 
             var requestIds = new HashSet<string>();
             for(int i = 0;i < 10;i++)
             {
-                Assert.True(dataStore.TryActivateEvent(null, out var evnt));
+                Assert.True(dataStore.TryActivateEvent(FunctionName, out var evnt));
                 Assert.DoesNotContain(evnt.AwsRequestId, requestIds);
                 requestIds.Add(evnt.AwsRequestId);
             }
@@ -53,10 +55,10 @@ namespace Amazon.Lambda.TestTool.BlazorTester.Tests
         public void ReportSuccess()
         {
             var dataStore = new RuntimeApiDataStore();
-            dataStore.QueueEvent(null, "{}");
+            dataStore.QueueEvent(FunctionName, "{}");
             Assert.Equal(IEventContainer.Status.Queued, dataStore.QueuedEvents[0].EventStatus);
 
-            Assert.True(dataStore.TryActivateEvent(null, out var evnt));
+            Assert.True(dataStore.TryActivateEvent(FunctionName, out var evnt));
 
             dataStore.ReportSuccess(evnt.AwsRequestId, "\"Success\"");
 
@@ -68,10 +70,10 @@ namespace Amazon.Lambda.TestTool.BlazorTester.Tests
         public void ReportError()
         {
             var dataStore = new RuntimeApiDataStore();
-            dataStore.QueueEvent(null, "{}");
+            dataStore.QueueEvent(FunctionName, "{}");
             Assert.Equal(IEventContainer.Status.Queued, dataStore.QueuedEvents[0].EventStatus);
 
-            Assert.True(dataStore.TryActivateEvent(null, out var evnt));
+            Assert.True(dataStore.TryActivateEvent(FunctionName, out var evnt));
 
             dataStore.ReportError(evnt.AwsRequestId, "BadError", "\"YouFail\"");
 
@@ -86,7 +88,7 @@ namespace Amazon.Lambda.TestTool.BlazorTester.Tests
             var dataStore = new RuntimeApiDataStore();
             for (int i = 0; i < 10; i++)
             {
-                dataStore.QueueEvent(null, "{}");
+                dataStore.QueueEvent(FunctionName, "{}");
             }
             Assert.Equal(10, dataStore.QueuedEvents.Count);
 
@@ -100,13 +102,13 @@ namespace Amazon.Lambda.TestTool.BlazorTester.Tests
             var dataStore = new RuntimeApiDataStore();
             for (int i = 0; i < 10; i++)
             {
-                dataStore.QueueEvent(null, "{}");
+                dataStore.QueueEvent(FunctionName, "{}");
             }
             Assert.Equal(10, dataStore.QueuedEvents.Count);
 
             for (int i = 0; i < 10; i++)
             {
-                Assert.True(dataStore.TryActivateEvent(null, out _));
+                Assert.True(dataStore.TryActivateEvent(FunctionName, out _));
             }
 
             // This is 9 because the 10th event is the active event.
@@ -121,12 +123,12 @@ namespace Amazon.Lambda.TestTool.BlazorTester.Tests
             var dataStore = new RuntimeApiDataStore();
             for (int i = 0; i < 10; i++)
             {
-                dataStore.QueueEvent(null, "{}");
+                dataStore.QueueEvent(FunctionName, "{}");
             }
 
             for (int i = 0; i < 5; i++)
             {
-                Assert.True(dataStore.TryActivateEvent(null, out _));
+                Assert.True(dataStore.TryActivateEvent(FunctionName, out _));
             }
 
             Assert.Equal(5, dataStore.QueuedEvents.Count);


### PR DESCRIPTION
At the moment it's difficult to debug a Visual Studio solution with multiple lambda projects at the same time as they all require a separate test tool instance. The complication arises when trying to invoke those lambda's through the `IAmazonLambda` client, you would need to dynamically switch the Endpoint URL.

By setting the `AWS_LAMBDA_RUNTIME_API` to the URL + the name of the function the API can access each function separately:
```
{
  "profiles": {
    "Lambda1": {
      "commandName": "Project",
      "environmentVariables": {
        "AWS_LAMBDA_RUNTIME_API": "localhost:5050/Lambda1"
      }
    }
  }
}

{
  "profiles": {
    "Lambda2": {
      "commandName": "Project",
      "environmentVariables": {
        "AWS_LAMBDA_RUNTIME_API": "localhost:5050/Lambda2"
      }
    }
  }
}
```

Can be invoked as:
```
var builder = WebApplication.CreateBuilder(args);

builder.Services.AddDefaultAWSOptions(new AWSOptions
{
    Profile = "test-profile",
    Credentials = new AnonymousAWSCredentials(),
    DefaultClientConfig =
    {
        EndpointProvider = new StaticEndpointProvider("http://localhost:5050/")
    }
});

builder.Services.AddAWSService<IAmazonLambda>();

var app = builder.Build();

app.UseHttpsRedirection();

app.MapGet("/", async (IAmazonLambda amazonLambda) =>
{
    await amazonLambda.InvokeAsync(new InvokeRequest
    {
        FunctionName = "Lambda1"
    });
    await amazonLambda.InvokeAsync(new InvokeRequest
    {
        FunctionName = "Lambda2"
    });
});

app.Run();
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
