### PR TITLE
fix: update dockerfiles workflow did not include net7 arm in description

### DIFF
--- a/.github/workflows/update-Dockerfiles.yml
+++ b/.github/workflows/update-Dockerfiles.yml
@@ -97,7 +97,7 @@ jobs:
             \n\n*Description of changes:*
             \n${{ format
                 (
-                  '{0}\n{1}\n{2}',
+                  '{0}\n{1}\n{2}\n{3}',
                   join(steps.update-net6-amd64.outputs.*, '\n'),
                   join(steps.update-net6-arm64.outputs.*, '\n'),
                   join(steps.update-net7-amd64.outputs.*, '\n'),


### PR DESCRIPTION
*Description of changes:*
This PR fixes an issue that causes the .NET7 ARM image to not be included in the description of the generated PR when running the "Update Dockerfiles" workflow.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
