### PR TITLE
Fix invalid user agent string for native aot executables running in root directory

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
@@ -214,6 +214,10 @@ namespace Amazon.Lambda.RuntimeSupport
         public static HttpClient ConstructHttpClient()
         {
             var dotnetRuntimeVersion = new DirectoryInfo(System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory()).Name;
+            if (dotnetRuntimeVersion == "/")
+            {
+                dotnetRuntimeVersion = "unknown";
+            }
             var amazonLambdaRuntimeSupport = typeof(LambdaBootstrap).Assembly.GetName().Version;
 
 #if NET6_0_OR_GREATER


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1490

*Description of changes:*
Check if the returned version is a slash and modify string.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
