### PR TITLE
Fix diagnostic message format to have correct number of arguments.

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Amazon.Lambda.Annotations.SourceGenerator.csproj
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Amazon.Lambda.Annotations.SourceGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyVersion>0.13.1.0</AssemblyVersion>
+    <AssemblyVersion>0.13.2.0</AssemblyVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
 
     <!-- This is required to allow copying all the dependencies to bin directory which can be copied after to nuget package based on nuspec -->

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/DiagnosticDescriptors.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/DiagnosticDescriptors.cs
@@ -61,7 +61,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Diagnostics
 
         public static readonly DiagnosticDescriptor CodeGenerationFailed = new DiagnosticDescriptor(id: "AWSLambda0107",
             title: "Failed Code Generation",
-            messageFormat: $"{{0}}{Environment.NewLine}{{1}}",
+            messageFormat: "{0}",
             category: "AWSLambdaCSharpGenerator",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);

--- a/Libraries/src/Amazon.Lambda.Annotations.nuspec
+++ b/Libraries/src/Amazon.Lambda.Annotations.nuspec
@@ -1,7 +1,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>Amazon.Lambda.Annotations</id>
-        <version>0.13.1</version>
+        <version>0.13.2</version>
         <authors>Amazon Web Services</authors>
         <tags>AWS Amazon Lambda</tags>
         <description>Annotations that can be added to Lambda projects to generate C# code and CloudFormation templates. This library is currently in dev preview.</description>

--- a/Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj
+++ b/Libraries/src/Amazon.Lambda.Annotations/Amazon.Lambda.Annotations.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyVersion>0.13.1.0</AssemblyVersion>
+    <AssemblyVersion>0.13.2.0</AssemblyVersion>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ComplexCalculator_Add_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ComplexCalculator_Add_Generated.g.cs
@@ -47,7 +47,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ComplexCalculator_Subtract_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ComplexCalculator_Subtract_Generated.g.cs
@@ -73,7 +73,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_NotFoundResponseWithHeaderV1Async_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_NotFoundResponseWithHeaderV1Async_Generated.g.cs
@@ -72,7 +72,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_NotFoundResponseWithHeaderV1_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_NotFoundResponseWithHeaderV1_Generated.g.cs
@@ -72,7 +72,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_NotFoundResponseWithHeaderV2Async_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_NotFoundResponseWithHeaderV2Async_Generated.g.cs
@@ -72,7 +72,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_NotFoundResponseWithHeaderV2_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_NotFoundResponseWithHeaderV2_Generated.g.cs
@@ -72,7 +72,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_OkResponseWithHeaderAsync_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_OkResponseWithHeaderAsync_Generated.g.cs
@@ -72,7 +72,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_OkResponseWithHeader_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/CustomizeResponseExamples_OkResponseWithHeader_Generated.g.cs
@@ -72,7 +72,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/DynamicExample_DynamicInput_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/DynamicExample_DynamicInput_Generated.g.cs
@@ -33,7 +33,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/DynamicExample_DynamicReturn_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/DynamicExample_DynamicReturn_Generated.g.cs
@@ -33,7 +33,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Functions_ToUpper_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Functions_ToUpper_Generated.g.cs
@@ -33,7 +33,7 @@ namespace TestServerlessApp.Sub1
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Greeter_SayHelloAsync_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Greeter_SayHelloAsync_Generated.g.cs
@@ -75,7 +75,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Greeter_SayHello_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Greeter_SayHello_Generated.g.cs
@@ -75,7 +75,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/complexCalculator.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/complexCalculator.template
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v0.13.1.0).",
+  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v0.13.2.0).",
   "Resources": {
     "TestServerlessAppComplexCalculatorAddGenerated": {
       "Type": "AWS::Serverless::Function",

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/customizeResponse.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/customizeResponse.template
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v0.13.1.0).",
+  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v0.13.2.0).",
   "Resources": {
     "TestServerlessAppCustomizeResponseExamplesOkResponseWithHeaderGenerated": {
       "Type": "AWS::Serverless::Function",

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/dynamicexample.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/dynamicexample.template
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v0.13.1.0).",
+  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v0.13.2.0).",
   "Resources": {
     "TestServerlessAppDynamicExampleDynamicReturnGenerated": {
       "Type": "AWS::Serverless::Function",

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/greeter.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/greeter.template
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v0.13.1.0).",
+  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v0.13.2.0).",
   "Resources": {
     "GreeterSayHello": {
       "Type": "AWS::Serverless::Function",

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/simpleCalculator.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/simpleCalculator.template
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v0.13.1.0).",
+  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v0.13.2.0).",
   "Resources": {
     "SimpleCalculatorAdd": {
       "Type": "AWS::Serverless::Function",

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/subnamespace.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/subnamespace.template
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v0.13.1.0).",
+  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v0.13.2.0).",
   "Resources": {
     "ToUpper": {
       "Type": "AWS::Serverless::Function",

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/taskexample.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/taskexample.template
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v0.13.1.0).",
+  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v0.13.2.0).",
   "Resources": {
     "TestServerlessAppTaskExampleTaskReturnGenerated": {
       "Type": "AWS::Serverless::Function",

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/voidexample.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/voidexample.template
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v0.13.1.0).",
+  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v0.13.2.0).",
   "Resources": {
     "TestServerlessAppVoidExampleVoidReturnGenerated": {
       "Type": "AWS::Serverless::Function",

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Add_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Add_Generated.g.cs
@@ -103,7 +103,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_DivideAsync_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_DivideAsync_Generated.g.cs
@@ -103,7 +103,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Multiply_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Multiply_Generated.g.cs
@@ -101,7 +101,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Pi_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Pi_Generated.g.cs
@@ -48,7 +48,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Random_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Random_Generated.g.cs
@@ -47,7 +47,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Randoms_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Randoms_Generated.g.cs
@@ -47,7 +47,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Subtract_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Subtract_Generated.g.cs
@@ -93,7 +93,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/TaskExample_TaskReturn_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/TaskExample_TaskReturn_Generated.g.cs
@@ -33,7 +33,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/VoidExample_VoidReturn_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/VoidExample_VoidReturn_Generated.g.cs
@@ -33,7 +33,7 @@ namespace TestServerlessApp
                 envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
             }
 
-            envValue.Append("amazon-lambda-annotations_0.13.1.0");
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
 
             Environment.SetEnvironmentVariable(envName, envValue.ToString());
         }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
@@ -499,7 +499,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                     ExpectedDiagnostics =
                     {
                          DiagnosticResult.CompilerError("AWSLambda0107").WithSpan($"TestServerlessApp{Path.DirectorySeparatorChar}MissingResourePathMapping.cs", 18, 9, 23, 10)
-                                            .WithArguments("Route template /add/{x}/{y} is invalid. Missing x parameters in method definition.")
+                                            .WithMessage("Route template /add/{x}/{y} is invalid. Missing x parameters in method definition.")
                     },
                     ReferenceAssemblies = ReferenceAssemblies.Net.Net60
                 }

--- a/Libraries/test/TestServerlessApp/serverless.template
+++ b/Libraries/test/TestServerlessApp/serverless.template
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "An AWS Serverless Application. This template is partially managed by Amazon.Lambda.Annotations (v0.13.1.0).",
+  "Description": "An AWS Serverless Application. This template is partially managed by Amazon.Lambda.Annotations (v0.13.2.0).",
   "Parameters": {
     "ArchitectureTypeParameter": {
       "Type": "String",


### PR DESCRIPTION
*Description of changes:*
The failed to code generate diagnostics message format was defined with 2 arguments but in reality we only use one. Since there was a mess match of number arguments the argument was not applied giving user terrible error reporting experience.

![image](https://user-images.githubusercontent.com/1653751/233869626-c0c45c0a-ab77-43f9-983d-429ff386a715.png)

This wasn't caught before because our unit tests were using the `WithArguments` method which was just checking for the existence of the argument. I change the test to use `WithMessage` to check the actual reported error message.

PR also contains the version bump to 0.13.2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
