### PR TITLE
Fix Annotation bugs handling header names being case insensitive and parameters with nullable annotations

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/TypeModel.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/TypeModel.cs
@@ -35,6 +35,25 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
         /// </summary>
         public IList<TypeModel> TypeArguments { get; set; }
 
+        /// <summary>
+        /// True if the type has the "?" annotation for nullable.
+        /// </summary>
+        public bool HasNullableAnnotations { get; set; }
+
+
+        public string FullNameWithoutAnnotations
+        {
+            get
+            {
+                if(!HasNullableAnnotations)
+                {
+                    return this.FullName;
+                }
+
+                return this.FullName.Substring(0, this.FullName.Length - 1);
+            }
+        }
+
 
         /// <summary>
         /// Gets type argument of the <see cref="Task{TResult}"/> type.

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/TypeModelBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/TypeModelBuilder.cs
@@ -38,7 +38,8 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
                 IsValueType = symbol.IsValueType,
                 IsGenericType = isGenericType,
                 TypeArguments = typeArguments,
-                IsEnumerable = isEnumerable
+                IsEnumerable = isEnumerable,
+                HasNullableAnnotations = symbol.NullableAnnotation == NullableAnnotation.Annotated
             };
 
             return model;

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/APIGatewaySetupParameters.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/APIGatewaySetupParameters.cs
@@ -226,7 +226,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             this.Write(")Convert.ChangeType(q, typeof(");
             
             #line 111 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\APIGatewaySetupParameters.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(typeArgument.FullName));
+            this.Write(this.ToStringHelper.ToStringWithCulture(typeArgument.FullNameWithoutAnnotations));
             
             #line default
             #line hidden
@@ -301,7 +301,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             this.Write("\"], typeof(");
             
             #line 132 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\APIGatewaySetupParameters.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(parameter.Type.FullName));
+            this.Write(this.ToStringHelper.ToStringWithCulture(parameter.Type.FullNameWithoutAnnotations));
             
             #line default
             #line hidden
@@ -407,14 +407,15 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             
             #line default
             #line hidden
-            this.Write("?.ContainsKey(\"");
+            this.Write("?.Any(x => string.Equals(x.Key, \"");
             
             #line 185 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\APIGatewaySetupParameters.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(headerKey));
             
             #line default
             #line hidden
-            this.Write("\") == true)\r\n            {\r\n                ");
+            this.Write("\", StringComparison.OrdinalIgnoreCase)) == true)\r\n            {\r\n                " +
+                    "");
             
             #line 187 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\APIGatewaySetupParameters.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(parameter.Name));
@@ -428,14 +429,14 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             
             #line default
             #line hidden
-            this.Write("[\"");
+            this.Write(".First(x => string.Equals(x.Key, \"");
             
             #line 187 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\APIGatewaySetupParameters.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(headerKey));
             
             #line default
             #line hidden
-            this.Write("\"]");
+            this.Write("\", StringComparison.OrdinalIgnoreCase)).Value");
             
             #line 187 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\APIGatewaySetupParameters.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(commaSplit));
@@ -453,7 +454,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             this.Write(")Convert.ChangeType(q, typeof(");
             
             #line 192 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\APIGatewaySetupParameters.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(typeArgument.FullName));
+            this.Write(this.ToStringHelper.ToStringWithCulture(typeArgument.FullNameWithoutAnnotations));
             
             #line default
             #line hidden
@@ -489,15 +490,15 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             
             #line default
             #line hidden
-            this.Write("?.ContainsKey(\"");
+            this.Write("?.Any(x => string.Equals(x.Key, \"");
             
             #line 209 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\APIGatewaySetupParameters.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(headerKey));
             
             #line default
             #line hidden
-            this.Write("\") == true)\r\n            {\r\n                try\r\n                {\r\n             " +
-                    "       ");
+            this.Write("\", StringComparison.OrdinalIgnoreCase)) == true)\r\n            {\r\n                " +
+                    "try\r\n                {\r\n                    ");
             
             #line 213 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\APIGatewaySetupParameters.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(parameter.Name));
@@ -518,17 +519,17 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             
             #line default
             #line hidden
-            this.Write("[\"");
+            this.Write(".First(x => string.Equals(x.Key, \"");
             
             #line 213 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\APIGatewaySetupParameters.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(headerKey));
             
             #line default
             #line hidden
-            this.Write("\"], typeof(");
+            this.Write("\", StringComparison.OrdinalIgnoreCase)).Value, typeof(");
             
             #line 213 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\APIGatewaySetupParameters.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(parameter.Type.FullName));
+            this.Write(this.ToStringHelper.ToStringWithCulture(parameter.Type.FullNameWithoutAnnotations));
             
             #line default
             #line hidden
@@ -542,14 +543,14 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             
             #line default
             #line hidden
-            this.Write("[\"");
+            this.Write(".First(x => string.Equals(x.Key, \"");
             
             #line 217 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\APIGatewaySetupParameters.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(headerKey));
             
             #line default
             #line hidden
-            this.Write("\"]} at \'");
+            this.Write("\", StringComparison.OrdinalIgnoreCase)).Value} at \'");
             
             #line 217 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\APIGatewaySetupParameters.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(headerKey));
@@ -689,7 +690,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Templates
             this.Write("\"], typeof(");
             
             #line 262 "C:\codebase\aws-lambda-dotnet\Libraries\src\Amazon.Lambda.Annotations.SourceGenerator\Templates\APIGatewaySetupParameters.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(parameter.Type.FullName));
+            this.Write(this.ToStringHelper.ToStringWithCulture(parameter.Type.FullNameWithoutAnnotations));
             
             #line default
             #line hidden

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/APIGatewaySetupParameters.tt
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Templates/APIGatewaySetupParameters.tt
@@ -108,7 +108,7 @@
                     {
                         try
                         {
-                            return (<#= typeArgument.FullName #>)Convert.ChangeType(q, typeof(<#= typeArgument.FullName #>));
+                            return (<#= typeArgument.FullName #>)Convert.ChangeType(q, typeof(<#= typeArgument.FullNameWithoutAnnotations #>));
                         }
                         catch (Exception e) when (e is InvalidCastException || e is FormatException || e is OverflowException || e is ArgumentException)
                         {
@@ -129,7 +129,7 @@
             {
                 try
                 {
-                    <#= parameter.Name #> = (<#= parameter.Type.FullName #>)Convert.ChangeType(__request__.<#= queryStringParameters #>["<#= parameterKey #>"], typeof(<#= parameter.Type.FullName #>));
+                    <#= parameter.Name #> = (<#= parameter.Type.FullName #>)Convert.ChangeType(__request__.<#= queryStringParameters #>["<#= parameterKey #>"], typeof(<#= parameter.Type.FullNameWithoutAnnotations #>));
                 }
                 catch (Exception e) when (e is InvalidCastException || e is FormatException || e is OverflowException || e is ArgumentException)
                 {
@@ -182,14 +182,14 @@
                     // Generic types are mapped using Select statement to the target parameter type argument.
                     var typeArgument = parameter.Type.TypeArguments.First();
 #>
-            if (__request__.<#= headers #>?.ContainsKey("<#= headerKey #>") == true)
+            if (__request__.<#= headers #>?.Any(x => string.Equals(x.Key, "<#= headerKey #>", StringComparison.OrdinalIgnoreCase)) == true)
             {
-                <#= parameter.Name #> = __request__.<#= headers #>["<#= headerKey #>"]<#= commaSplit #>
+                <#= parameter.Name #> = __request__.<#= headers #>.First(x => string.Equals(x.Key, "<#= headerKey #>", StringComparison.OrdinalIgnoreCase)).Value<#= commaSplit #>
                     .Select(q =>
                     {
                         try
                         {
-                            return (<#= typeArgument.FullName #>)Convert.ChangeType(q, typeof(<#= typeArgument.FullName #>));
+                            return (<#= typeArgument.FullName #>)Convert.ChangeType(q, typeof(<#= typeArgument.FullNameWithoutAnnotations #>));
                         }
                         catch (Exception e) when (e is InvalidCastException || e is FormatException || e is OverflowException || e is ArgumentException)
                         {
@@ -206,15 +206,15 @@
                 {
                     // Non-generic types are mapped directly to the target parameter.
 #>
-            if (__request__.<#= headers #>?.ContainsKey("<#= headerKey #>") == true)
+            if (__request__.<#= headers #>?.Any(x => string.Equals(x.Key, "<#= headerKey #>", StringComparison.OrdinalIgnoreCase)) == true)
             {
                 try
                 {
-                    <#= parameter.Name #> = (<#= parameter.Type.FullName #>)Convert.ChangeType(__request__.<#= headers #>["<#= headerKey #>"], typeof(<#= parameter.Type.FullName #>));
+                    <#= parameter.Name #> = (<#= parameter.Type.FullName #>)Convert.ChangeType(__request__.<#= headers #>.First(x => string.Equals(x.Key, "<#= headerKey #>", StringComparison.OrdinalIgnoreCase)).Value, typeof(<#= parameter.Type.FullNameWithoutAnnotations #>));
                 }
                 catch (Exception e) when (e is InvalidCastException || e is FormatException || e is OverflowException || e is ArgumentException)
                 {
-                    validationErrors.Add($"Value {__request__.<#= headers #>["<#= headerKey #>"]} at '<#= headerKey #>' failed to satisfy constraint: {e.Message}");
+                    validationErrors.Add($"Value {__request__.<#= headers #>.First(x => string.Equals(x.Key, "<#= headerKey #>", StringComparison.OrdinalIgnoreCase)).Value} at '<#= headerKey #>' failed to satisfy constraint: {e.Message}");
                 }
             }
 
@@ -259,7 +259,7 @@
             {
                 try
                 {
-                    <#= parameter.Name #> = (<#= parameter.Type.FullName #>)Convert.ChangeType(__request__.PathParameters["<#= routeKey #>"], typeof(<#= parameter.Type.FullName #>));
+                    <#= parameter.Name #> = (<#= parameter.Type.FullName #>)Convert.ChangeType(__request__.PathParameters["<#= routeKey #>"], typeof(<#= parameter.Type.FullNameWithoutAnnotations #>));
                 }
                 catch (Exception e) when (e is InvalidCastException || e is FormatException || e is OverflowException || e is ArgumentException)
                 {

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
@@ -60,6 +60,7 @@
     <ItemGroup>
       <None Remove="Snapshots\ServerlessTemplates\customizeResponse.template" />
       <None Remove="Snapshots\ServerlessTemplates\dynamicexample.template" />
+      <None Remove="Snapshots\ServerlessTemplates\nullreferenceexample.template" />
       <None Remove="Snapshots\ServerlessTemplates\subnamespace.template" />
       <None Remove="Snapshots\ServerlessTemplates\taskexample.template" />
       <None Remove="Snapshots\ServerlessTemplates\voidexample.template" />

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/CSharpSourceGeneratorVerifier.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/CSharpSourceGeneratorVerifier.cs
@@ -36,8 +36,10 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
             protected override CompilationOptions CreateCompilationOptions()
             {
                 var compilationOptions = base.CreateCompilationOptions();
-                return compilationOptions.WithSpecificDiagnosticOptions(
-                    compilationOptions.SpecificDiagnosticOptions.SetItems(GetNullableWarningsFromCompiler()));
+
+                return compilationOptions
+                    .WithSpecificDiagnosticOptions(compilationOptions.SpecificDiagnosticOptions.SetItems(GetNullableWarningsFromCompiler()))
+                    .WithSpecificDiagnosticOptions(compilationOptions.SpecificDiagnosticOptions.SetItems(EnableNullability()));
             }
 
             public LanguageVersion LanguageVersion { get; set; } = LanguageVersion.Default;
@@ -45,6 +47,15 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
             private static ImmutableDictionary<string, ReportDiagnostic> GetNullableWarningsFromCompiler()
             {
                 string[] args = { "/warnaserror:nullable" };
+                var commandLineArguments = CSharpCommandLineParser.Default.Parse(args, baseDirectory: Environment.CurrentDirectory, sdkDirectory: Environment.CurrentDirectory);
+                var nullableWarnings = commandLineArguments.CompilationOptions.SpecificDiagnosticOptions;
+
+                return nullableWarnings;
+            }
+
+            private static ImmutableDictionary<string, ReportDiagnostic> EnableNullability()
+            {
+                string[] args = { "/p:Nullable=enable" };
                 var commandLineArguments = CSharpCommandLineParser.Default.Parse(args, baseDirectory: Environment.CurrentDirectory, sdkDirectory: Environment.CurrentDirectory);
                 var nullableWarnings = commandLineArguments.CompilationOptions.SpecificDiagnosticOptions;
 

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Greeter_SayHelloAsync_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/Greeter_SayHelloAsync_Generated.g.cs
@@ -21,9 +21,9 @@ namespace TestServerlessApp
             var validationErrors = new List<string>();
 
             var firstNames = default(System.Collections.Generic.IEnumerable<string>);
-            if (__request__.MultiValueHeaders?.ContainsKey("names") == true)
+            if (__request__.MultiValueHeaders?.Any(x => string.Equals(x.Key, "names", StringComparison.OrdinalIgnoreCase)) == true)
             {
-                firstNames = __request__.MultiValueHeaders["names"]
+                firstNames = __request__.MultiValueHeaders.First(x => string.Equals(x.Key, "names", StringComparison.OrdinalIgnoreCase)).Value
                     .Select(q =>
                     {
                         try

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/NullableReferenceTypeExample_NullableHeaderHttpApi_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/NullableReferenceTypeExample_NullableHeaderHttpApi_Generated.g.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text;
+using Amazon.Lambda.Core;
+
+namespace TestServerlessApp
+{
+    public class NullableReferenceTypeExample_NullableHeaderHttpApi_Generated
+    {
+        private readonly NullableReferenceTypeExample nullableReferenceTypeExample;
+
+        public NullableReferenceTypeExample_NullableHeaderHttpApi_Generated()
+        {
+            SetExecutionEnvironment();
+            nullableReferenceTypeExample = new NullableReferenceTypeExample();
+        }
+
+        public Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyResponse NullableHeaderHttpApi(Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyRequest __request__, Amazon.Lambda.Core.ILambdaContext __context__)
+        {
+            var validationErrors = new List<string>();
+
+            var text = default(string?);
+            if (__request__.Headers?.Any(x => string.Equals(x.Key, "MyHeader", StringComparison.OrdinalIgnoreCase)) == true)
+            {
+                try
+                {
+                    text = (string?)Convert.ChangeType(__request__.Headers.First(x => string.Equals(x.Key, "MyHeader", StringComparison.OrdinalIgnoreCase)).Value, typeof(string));
+                }
+                catch (Exception e) when (e is InvalidCastException || e is FormatException || e is OverflowException || e is ArgumentException)
+                {
+                    validationErrors.Add($"Value {__request__.Headers.First(x => string.Equals(x.Key, "MyHeader", StringComparison.OrdinalIgnoreCase)).Value} at 'MyHeader' failed to satisfy constraint: {e.Message}");
+                }
+            }
+
+            // return 400 Bad Request if there exists a validation error
+            if (validationErrors.Any())
+            {
+                var errorResult = new Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyResponse
+                {
+                    Body = @$"{{""message"": ""{validationErrors.Count} validation error(s) detected: {string.Join(",", validationErrors)}""}}",
+                    Headers = new Dictionary<string, string>
+                    {
+                        {"Content-Type", "application/json"},
+                        {"x-amzn-ErrorType", "ValidationException"}
+                    },
+                    StatusCode = 400
+                };
+                return errorResult;
+            }
+
+            nullableReferenceTypeExample.NullableHeaderHttpApi(text, __context__);
+
+            return new Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyResponse
+            {
+                StatusCode = 200
+            };
+        }
+
+        private static void SetExecutionEnvironment()
+        {
+            const string envName = "AWS_EXECUTION_ENV";
+
+            var envValue = new StringBuilder();
+
+            // If there is an existing execution environment variable add the annotations package as a suffix.
+            if(!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(envName)))
+            {
+                envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
+            }
+
+            envValue.Append("amazon-lambda-annotations_0.13.2.0");
+
+            Environment.SetEnvironmentVariable(envName, envValue.ToString());
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/nullreferenceexample.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/nullreferenceexample.template
@@ -1,0 +1,39 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Transform": "AWS::Serverless-2016-10-31",
+  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v0.13.2.0).",
+  "Resources": {
+    "TestServerlessAppNullableReferenceTypeExampleNullableHeaderHttpApiGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestProject::TestServerlessApp.NullableReferenceTypeExample_NullableHeaderHttpApi_Generated::NullableHeaderHttpApi"
+          ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "HttpApi",
+            "Properties": {
+              "Path": "/nullableheaderhttpapi",
+              "Method": "GET"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Subtract_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/SimpleCalculator_Subtract_Generated.g.cs
@@ -35,28 +35,28 @@ namespace TestServerlessApp
             var validationErrors = new List<string>();
 
             var x = default(int);
-            if (__request__.Headers?.ContainsKey("x") == true)
+            if (__request__.Headers?.Any(x => string.Equals(x.Key, "x", StringComparison.OrdinalIgnoreCase)) == true)
             {
                 try
                 {
-                    x = (int)Convert.ChangeType(__request__.Headers["x"], typeof(int));
+                    x = (int)Convert.ChangeType(__request__.Headers.First(x => string.Equals(x.Key, "x", StringComparison.OrdinalIgnoreCase)).Value, typeof(int));
                 }
                 catch (Exception e) when (e is InvalidCastException || e is FormatException || e is OverflowException || e is ArgumentException)
                 {
-                    validationErrors.Add($"Value {__request__.Headers["x"]} at 'x' failed to satisfy constraint: {e.Message}");
+                    validationErrors.Add($"Value {__request__.Headers.First(x => string.Equals(x.Key, "x", StringComparison.OrdinalIgnoreCase)).Value} at 'x' failed to satisfy constraint: {e.Message}");
                 }
             }
 
             var y = default(int);
-            if (__request__.Headers?.ContainsKey("y") == true)
+            if (__request__.Headers?.Any(x => string.Equals(x.Key, "y", StringComparison.OrdinalIgnoreCase)) == true)
             {
                 try
                 {
-                    y = (int)Convert.ChangeType(__request__.Headers["y"], typeof(int));
+                    y = (int)Convert.ChangeType(__request__.Headers.First(x => string.Equals(x.Key, "y", StringComparison.OrdinalIgnoreCase)).Value, typeof(int));
                 }
                 catch (Exception e) when (e is InvalidCastException || e is FormatException || e is OverflowException || e is ArgumentException)
                 {
-                    validationErrors.Add($"Value {__request__.Headers["y"]} at 'y' failed to satisfy constraint: {e.Message}");
+                    validationErrors.Add($"Value {__request__.Headers.First(x => string.Equals(x.Key, "y", StringComparison.OrdinalIgnoreCase)).Value} at 'y' failed to satisfy constraint: {e.Message}");
                 }
             }
 

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
@@ -506,5 +506,46 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
 
             }.RunAsync();
         }
+
+        [Fact]
+        public async Task VerifyApiFunctionUsingNullableParameters()
+        {
+            var expectedTemplateContent = File.ReadAllText(Path.Combine("Snapshots", "ServerlessTemplates", "nullreferenceexample.template")).ToEnvironmentLineEndings();
+            var expectedCSharpContent = File.ReadAllText(Path.Combine("Snapshots", "NullableReferenceTypeExample_NullableHeaderHttpApi_Generated.g.cs")).ToEnvironmentLineEndings();
+
+            var test = new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        (Path.Combine("TestServerlessApp", "NullableReferenceTypeExample.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "NullableReferenceTypeExample.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "RestApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "RestApiAttribute.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"))),
+                    },
+                    GeneratedSources =
+                    {
+                        (
+                            typeof(SourceGenerator.Generator),
+                            "NullableReferenceTypeExample_NullableHeaderHttpApi_Generated.g.cs",
+                            SourceText.From(expectedCSharpContent, Encoding.UTF8, SourceHashAlgorithm.Sha256)
+                        )
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments("NullableReferenceTypeExample_NullableHeaderHttpApi_Generated.g.cs", expectedCSharpContent),
+                        new DiagnosticResult("AWSLambda0103", DiagnosticSeverity.Info).WithArguments($"TestServerlessApp{Path.DirectorySeparatorChar}serverless.template", expectedTemplateContent)
+                    },
+                    ReferenceAssemblies = ReferenceAssemblies.Net.Net60,                    
+                },                
+            };
+
+            await test.RunAsync();
+
+            var actualTemplateContent = File.ReadAllText(Path.Combine("TestServerlessApp", "serverless.template"));
+            Assert.Equal(expectedTemplateContent, actualTemplateContent);
+        }
     }
 }

--- a/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixture.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixture.cs
@@ -55,7 +55,7 @@ namespace TestServerlessApp.IntegrationTests
 
             Assert.Equal(StackStatus.CREATE_COMPLETE, await _cloudFormationHelper.GetStackStatusAsync(_stackName));
             Assert.True(await _s3Helper.BucketExistsAsync(_bucketName));
-            Assert.Equal(22, LambdaFunctions.Count);
+            Assert.Equal(23, LambdaFunctions.Count);
             Assert.False(string.IsNullOrEmpty(RestApiUrlPrefix));
             Assert.False(string.IsNullOrEmpty(RestApiUrlPrefix));
 

--- a/Libraries/test/TestServerlessApp/NullableReferenceTypeExample.cs
+++ b/Libraries/test/TestServerlessApp/NullableReferenceTypeExample.cs
@@ -1,0 +1,16 @@
+﻿using Amazon.Lambda.Annotations;
+using Amazon.Lambda.Annotations.APIGateway;
+using Amazon.Lambda.Core;
+
+namespace TestServerlessApp
+{
+    public class NullableReferenceTypeExample
+    {
+        [LambdaFunction(PackageType = LambdaPackageType.Image)]
+        [HttpApi(LambdaHttpMethod.Get, "/nullableheaderhttpapi")]
+        public void NullableHeaderHttpApi([FromHeader(Name = "MyHeader")] string? text, ILambdaContext context)
+        {
+            context.Logger.LogLine(text);
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp/serverless.template
+++ b/Libraries/test/TestServerlessApp/serverless.template
@@ -633,6 +633,38 @@
           ]
         }
       }
+    },
+    "TestServerlessAppNullableReferenceTypeExampleNullableHeaderHttpApiGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.NullableReferenceTypeExample_NullableHeaderHttpApi_Generated::NullableHeaderHttpApi"
+          ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "HttpApi",
+            "Properties": {
+              "Path": "/nullableheaderhttpapi",
+              "Method": "GET"
+            }
+          }
+        }
+      }
     }
   },
   "Outputs": {


### PR DESCRIPTION
*Description of changes:*

The PR fixes 2 bugs with Lambda annotations. 

* If the `FromHeader` attribute is used support the name must support name being case insensitive. Unfortunately the dictionary for headers coming from `Amazon.Lambda.APIGateways` is not case insensitive. The generated code instead uses some Linq commands to check for existence and pull the value from it.
* If a parameter from the Lambda function is using the `?` nullability operator there was a bug where the `?` annotation was being included into the `typeof` operator. That is a compile error with something like `string?`. To test this I had to update the verifier base class to enable nullablility.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
