### PR TITLE
Fixed issues with starting from an empty project to adding Annotations

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/AnalyzerReleases.Shipped.md
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/AnalyzerReleases.Shipped.md
@@ -1,6 +1,11 @@
 ; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
+## Release 0.13.3.0
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+AWSLambda0108 | AWSLambdaCSharpGenerator | Error | Assembly attribute Amazon.Lambda.Core.LambdaSerializerAttribute is missing
+
 ## Release 0.13.1.0
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/DiagnosticDescriptors.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/DiagnosticDescriptors.cs
@@ -40,7 +40,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Diagnostics
 
         public static readonly DiagnosticDescriptor MissingDependencies = new DiagnosticDescriptor(id: "AWSLambda0104",
             title: "Missing reference to a required dependency",
-            messageFormat: "Your project has a missing required package dependency. Please add a reference to the following package: {0}",
+            messageFormat: "Your project has a missing required package dependency. Please add a reference to the following package: {0}.",
             category: "AWSLambdaCSharpGenerator",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
@@ -62,6 +62,14 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Diagnostics
         public static readonly DiagnosticDescriptor CodeGenerationFailed = new DiagnosticDescriptor(id: "AWSLambda0107",
             title: "Failed Code Generation",
             messageFormat: "{0}",
+            category: "AWSLambdaCSharpGenerator",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor MissingLambdaSerializer = new DiagnosticDescriptor(id: "AWSLambda0108",
+            title: "Failed Code Generation",
+            messageFormat: "Assembly attribute Amazon.Lambda.Core.LambdaSerializerAttribute is missing. Add serialization package like " + 
+                "Amazon.Lambda.Serialization.SystemTextJson and add the assembly attribute to register the JSON serializer for Lambda events.",
             category: "AWSLambdaCSharpGenerator",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Generator.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Generator.cs
@@ -86,6 +86,15 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
                 {
                     var lambdaMethodModel = semanticModelProvider.GetMethodSemanticModel(lambdaMethod);
 
+                    if (!HasSerializerAttribute(context, lambdaMethodModel))
+                    {
+                        diagnosticReporter.Report(Diagnostic.Create(DiagnosticDescriptors.MissingLambdaSerializer,
+                            lambdaMethod.GetLocation()));
+
+                        foundFatalError = true;
+                        continue;
+                    }
+
                     // Check for necessary references
                     if (lambdaMethodModel.HasAttribute(context, TypeFullNames.RestApiAttribute)
                         || lambdaMethodModel.HasAttribute(context, TypeFullNames.HttpApiAttribute))
@@ -96,6 +105,9 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
                             diagnosticReporter.Report(Diagnostic.Create(DiagnosticDescriptors.MissingDependencies,
                                 lambdaMethod.GetLocation(),
                                 "Amazon.Lambda.APIGatewayEvents"));
+
+                            foundFatalError = true;
+                            continue;
                         }
                     }
 
@@ -187,6 +199,16 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
                 throw;
 #endif
             }
+        }
+
+        private bool HasSerializerAttribute(GeneratorExecutionContext context, IMethodSymbol methodModel)
+        {
+            if(methodModel.ContainingAssembly.HasAttribute(context, TypeFullNames.LambdaSerializerAttribute))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         public void Initialize(GeneratorInitializationContext context)

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/TypeFullNames.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/TypeFullNames.cs
@@ -32,6 +32,8 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
         public const string FromBodyAttribute = "Amazon.Lambda.Annotations.APIGateway.FromBodyAttribute";
         public const string FromRouteAttribute = "Amazon.Lambda.Annotations.APIGateway.FromRouteAttribute";
 
+        public const string LambdaSerializerAttribute = "Amazon.Lambda.Core.LambdaSerializerAttribute";
+
         public static HashSet<string> Requests = new HashSet<string>
         {
             APIGatewayProxyRequest,

--- a/Libraries/src/Amazon.Lambda.Annotations.nuspec
+++ b/Libraries/src/Amazon.Lambda.Annotations.nuspec
@@ -1,7 +1,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>Amazon.Lambda.Annotations</id>
-        <version>0.13.2</version>
+        <version>0.13.200</version>
         <authors>Amazon Web Services</authors>
         <tags>AWS Amazon Lambda</tags>
         <description>Annotations that can be added to Lambda projects to generate C# code and CloudFormation templates. This library is currently in dev preview.</description>
@@ -9,7 +9,9 @@
         <projectUrl>https://github.com/aws/aws-lambda-dotnet</projectUrl>
         <license type="expression">Apache-2.0</license>
         <dependencies>
-            <group targetFramework=".net6.0"/>
+            <group targetFramework=".net6.0">
+				<dependency id="Amazon.Lambda.Core" version="2.1.0" />
+			</group>
         </dependencies>
 		<icon>images\icon.png</icon>
 		<readme>docs\README.md</readme>

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/CSharpSourceGeneratorVerifier.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/CSharpSourceGeneratorVerifier.cs
@@ -20,17 +20,33 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
     {
         public class Test : CSharpSourceGeneratorTest<TSourceGenerator, XUnitVerifier>
         {
-            public Test()
+            public enum ReferencesMode {All, NoApiGatewayEvents}
+            public Test(ReferencesMode referencesMode = ReferencesMode.All)
             {
-                this.SolutionTransforms.Add((solution, projectId) =>
+                if(referencesMode == ReferencesMode.NoApiGatewayEvents)
                 {
-                    return solution.AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(ILambdaContext).Assembly.Location))
-                        .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(APIGatewayProxyRequest).Assembly.Location))
-                        .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(IServiceCollection).Assembly.Location))
-                        .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(ServiceProvider).Assembly.Location))
-                        .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(RestApiAttribute).Assembly.Location))
-                        .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(DefaultLambdaJsonSerializer).Assembly.Location));
-                });
+                    this.SolutionTransforms.Add((solution, projectId) =>
+                    {
+                        return solution.AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(ILambdaContext).Assembly.Location))
+                            .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(IServiceCollection).Assembly.Location))
+                            .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(ServiceProvider).Assembly.Location))
+                            .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(RestApiAttribute).Assembly.Location))
+                            .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(DefaultLambdaJsonSerializer).Assembly.Location));
+                    });
+
+                }
+                else
+                {
+                    this.SolutionTransforms.Add((solution, projectId) =>
+                    {
+                        return solution.AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(ILambdaContext).Assembly.Location))
+                            .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(APIGatewayProxyRequest).Assembly.Location))
+                            .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(IServiceCollection).Assembly.Location))
+                            .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(ServiceProvider).Assembly.Location))
+                            .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(RestApiAttribute).Assembly.Location))
+                            .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(DefaultLambdaJsonSerializer).Assembly.Location));
+                    });
+                }
             }
 
             protected override CompilationOptions CreateCompilationOptions()

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
@@ -29,6 +29,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                         (Path.Combine("TestServerlessApp", "Greeter.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "Greeter.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"))),
+                        (Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"))),
                     },
                     GeneratedSources =
                     {
@@ -74,6 +75,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                         ("NonCompilableCodeFile.cs", File.ReadAllText("NonCompilableCodeFile.cs")),
                         (Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"))),
+                        (Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"))),
                     },
                     GeneratedSources =
                     {
@@ -116,6 +118,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                         (Path.Combine("Amazon.Lambda.Annotations", "FromServicesAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "FromServicesAttribute.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "RestApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "RestApiAttribute.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"))),
+                        (Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"))),
                     },
                     GeneratedSources =
                     {
@@ -190,6 +193,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                         (Path.Combine("TestServerlessApp", "ComplexCalculator.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "ComplexCalculator.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"))),
+                        (Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"))),
                     },
                     GeneratedSources =
                     {
@@ -233,6 +237,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                         (Path.Combine("TestServerlessApp", "Sub1", "Functions.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "Sub1", "Functions.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"))),
+                        (Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"))),
                     },
                     GeneratedSources =
                     {
@@ -270,6 +275,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                         (Path.Combine("TestServerlessApp", "VoidExample.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "VoidExample.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"))),
+                        (Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"))),
                     },
                     GeneratedSources =
                     {
@@ -307,6 +313,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                         (Path.Combine("TestServerlessApp", "TaskExample.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "TaskExample.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"))),
+                        (Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"))),
                     },
                     GeneratedSources =
                     {
@@ -345,6 +352,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                         (Path.Combine("TestServerlessApp", "DynamicExample.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "DynamicExample.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"))),
+                        (Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"))),
                     },
                     GeneratedSources =
                     {
@@ -396,6 +404,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                         (Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "RestApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "RestApiAttribute.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"))),
+                        (Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"))),
                     },
                     GeneratedSources =
                     {
@@ -469,6 +478,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                         (Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "RestApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "RestApiAttribute.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"))),
+                        (Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"))),
                     },
                     ExpectedDiagnostics =
                     {
@@ -495,10 +505,11 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                         (Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "RestApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "RestApiAttribute.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"))),
+                        (Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"))),
                     },
                     ExpectedDiagnostics =
                     {
-                         DiagnosticResult.CompilerError("AWSLambda0107").WithSpan($"TestServerlessApp{Path.DirectorySeparatorChar}MissingResourePathMapping.cs", 18, 9, 23, 10)
+                         DiagnosticResult.CompilerError("AWSLambda0107").WithSpan($"TestServerlessApp{Path.DirectorySeparatorChar}MissingResourePathMapping.cs", 15, 9, 20, 10)
                                             .WithMessage("Route template /add/{x}/{y} is invalid. Missing x parameters in method definition.")
                     },
                     ReferenceAssemblies = ReferenceAssemblies.Net.Net60
@@ -524,6 +535,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                         (Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "RestApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "RestApiAttribute.cs"))),
                         (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"))),
+                        (Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"))),
                     },
                     GeneratedSources =
                     {
@@ -546,6 +558,65 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
 
             var actualTemplateContent = File.ReadAllText(Path.Combine("TestServerlessApp", "serverless.template"));
             Assert.Equal(expectedTemplateContent, actualTemplateContent);
+        }
+
+        [Fact]
+        public async Task VerifyNoApiGatewayEventsReference()
+        {
+            var test = new VerifyCS.Test(VerifyCS.Test.ReferencesMode.NoApiGatewayEvents)
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        (Path.Combine("TestServerlessApp", "FromScratch", "NoApiGatewayEventsReference.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "FromScratch", "NoApiGatewayEventsReference.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"))),
+                        (Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"))),
+                    },
+                    GeneratedSources =
+                    {
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        new DiagnosticResult("AWSLambda0104", DiagnosticSeverity.Error)
+                            .WithMessage("Your project has a missing required package dependency. Please add a reference to the following package: Amazon.Lambda.APIGatewayEvents")
+                            .WithSpan("TestServerlessApp\\FromScratch\\NoApiGatewayEventsReference.cs", 9, 9, 14, 10),
+                    },
+                    ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
+                },
+            };
+
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task VerifyNoSerializerAttributeReference()
+        {
+            var test = new VerifyCS.Test()
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        (Path.Combine("TestServerlessApp", "FromScratch", "NoSerializerAttributeReference.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "FromScratch", "NoSerializerAttributeReference.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"))),
+                    },
+                    GeneratedSources =
+                    {
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        new DiagnosticResult("AWSLambda0108", DiagnosticSeverity.Error)
+                            .WithSpan("TestServerlessApp\\FromScratch\\NoSerializerAttributeReference.cs", 9, 9, 13, 10),
+                    },
+                    ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
+                },
+            };
+
+            await test.RunAsync();
         }
     }
 }

--- a/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixture.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixture.cs
@@ -55,7 +55,7 @@ namespace TestServerlessApp.IntegrationTests
 
             Assert.Equal(StackStatus.CREATE_COMPLETE, await _cloudFormationHelper.GetStackStatusAsync(_stackName));
             Assert.True(await _s3Helper.BucketExistsAsync(_bucketName));
-            Assert.Equal(23, LambdaFunctions.Count);
+            Assert.Equal(25, LambdaFunctions.Count);
             Assert.False(string.IsNullOrEmpty(RestApiUrlPrefix));
             Assert.False(string.IsNullOrEmpty(RestApiUrlPrefix));
 

--- a/Libraries/test/TestServerlessApp/AssemblyAttributes.cs
+++ b/Libraries/test/TestServerlessApp/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+﻿using Amazon.Lambda.Core;
+
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]

--- a/Libraries/test/TestServerlessApp/FromScratch/NoApiGatewayEventsReference.cs
+++ b/Libraries/test/TestServerlessApp/FromScratch/NoApiGatewayEventsReference.cs
@@ -1,0 +1,16 @@
+﻿using Amazon.Lambda.Annotations;
+using Amazon.Lambda.Annotations.APIGateway;
+using Amazon.Lambda.Core;
+
+namespace TestServerlessApp.FromScratch
+{
+    public class NoApiGatewayEventsReference
+    {
+        [LambdaFunction(PackageType = LambdaPackageType.Image)]
+        [HttpApi(LambdaHttpMethod.Get, "/{text}")]
+        public string ToUpper(string text)
+        {
+            return text.ToUpper();
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp/FromScratch/NoSerializerAttributeReference.cs
+++ b/Libraries/test/TestServerlessApp/FromScratch/NoSerializerAttributeReference.cs
@@ -1,0 +1,15 @@
+﻿using Amazon.Lambda.Annotations;
+using Amazon.Lambda.Annotations.APIGateway;
+using Amazon.Lambda.Core;
+
+namespace TestServerlessApp.FromScratch
+{
+    public class NoSerializerAttributeReference
+    {
+        [LambdaFunction(PackageType = LambdaPackageType.Image)]
+        public string ToUpper(string text)
+        {
+            return text.ToUpper();
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp/MissingResourePathMapping.cs.error
+++ b/Libraries/test/TestServerlessApp/MissingResourePathMapping.cs.error
@@ -7,9 +7,6 @@ using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.Annotations;
 using Amazon.Lambda.Annotations.APIGateway;
 
-// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
-
 namespace TestServerlessApp
 {
     public class MissingResourcePathMapping

--- a/Libraries/test/TestServerlessApp/SimpleCalculator.cs
+++ b/Libraries/test/TestServerlessApp/SimpleCalculator.cs
@@ -8,9 +8,6 @@ using Amazon.Lambda.Annotations;
 using Amazon.Lambda.Annotations.APIGateway;
 using TestServerlessApp.Services;
 
-// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
-
 namespace TestServerlessApp
 {
     public class SimpleCalculator

--- a/Libraries/test/TestServerlessApp/serverless.template
+++ b/Libraries/test/TestServerlessApp/serverless.template
@@ -665,6 +665,59 @@
           }
         }
       }
+    },
+    "TestServerlessAppFromScratchNoApiGatewayEventsReferenceToUpperGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "Events": {
+          "RootGet": {
+            "Type": "HttpApi",
+            "Properties": {
+              "Path": "/{text}",
+              "Method": "GET"
+            }
+          }
+        },
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.FromScratch.NoApiGatewayEventsReference_ToUpper_Generated::ToUpper"
+          ]
+        }
+      }
+    },
+    "TestServerlessAppFromScratchNoSerializerAttributeReferenceToUpperGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations"
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "Events": {},
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.FromScratch.NoSerializerAttributeReference_ToUpper_Generated::ToUpper"
+          ]
+        }
+      }
     }
   },
   "Outputs": {


### PR DESCRIPTION
*Description of changes:*
Starting from a class library with just a method with no Lambda stuff in it I ran into the following issues turning a function into a Lambda function using Annotations.

* After adding the Amazon.Lambda.Annotations package and marking a function with the `LambdaFunction` attribute. I got a compilation error missing "Core". This happened because there was no reference to `Amazon.Lambda.Core` which is referenced for the `ILambdaContext`. **Fixed:** Added Amazon.Lambda.Core as a dependency for Amazon.Lambda.Annotations since you are always going to need it.

* After adding `Amazon.Lambda.Core` I was able to deploy but it failed because there was no registered `ILambdaSerializer`. **Fixed:** By adding a new diagnostics error informing the user during compilation that there is no assembly `LambdaSerializerAttribute`. Also discovered we don't support method level `LambdaSerializerAttribute` but that should be fixed in a separate PR.

* Added the `HttpApi` attribute to expose the function through API Gateway. I got the expected diagnostic error about missing reference to `Amazon.Lambda.APIGatewayEvents` but also "This is a bug" with a sub null reference exception diagnostic error from source generator. **Fixed:** The source generator wasn't treating the  missing `Amazon.Lambda.APIGatewayEvents` as a fatal error and kept running and eventually ran into a NPE because it couldn't find the `HttpApiAttribute` type. The error is now treated as fatal to stop processing right away.


**Note:** I never got the original reported issue about the source generator failing if there was no `aws-lambda-tools-defaults.json` file in the project. Since that report is old I suspect it has been fixed by some other previous change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
