### PR TITLE
Update Powertools definitions 1.2.0

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -14,8 +14,8 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
-    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.0.1" />
-    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.0.1" />
-    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.0.1" />
+    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.1.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.2.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.1.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.6.0" />
-    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.0.1" />
-    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.0.1" />
-    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.0.1" />
+    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.1.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.2.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
issue Update Powertools definitions 1.2.0

*Description of changes:*

Logging and tracing to version 1.1.0
Metrics to version 1.2.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
