### PR TITLE
chore: rename Lambda Powertools to Powertools for AWS Lambda (.NET)

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": "Lambda Powertools",
+  "display-name": "Powertools for AWS Lambda",
   "system-name": "FunctionPowertools",
-  "description": "Setup the project and test project to create a Lambda function with Powertools from scratch.",
+  "description": "Setup the project and test project to create a Lambda function with Powertools for AWS Lambda from scratch.",
   "sort-order": 124,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/.template.config/template.json
@@ -6,7 +6,7 @@
     "Function",
     "Powertools"
   ],
-  "name": "Lambda Function with Powertools",
+  "name": "Lambda Function with Powertools for AWS Lambda (.NET)",
   "identity": "AWS.Lambda.Function.Powertools.CSharp",
   "groupIdentity": "AWS.Lambda.Function.Powertools",
   "shortName": "lambda.Powertools",

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/Function.cs
@@ -9,10 +9,10 @@ using AWS.Lambda.Powertools.Tracing;
 namespace BlueprintBaseName._1;
 
 /// <summary>
-/// Learn more about Lambda Powertools at https://awslabs.github.io/aws-lambda-powertools-dotnet/
-/// Lambda Powertools Logging: https://awslabs.github.io/aws-lambda-powertools-dotnet/core/logging/
-/// Lambda Powertools Tracing: https://awslabs.github.io/aws-lambda-powertools-dotnet/core/tracing/
-/// Lambda Powertools Metrics: https://awslabs.github.io/aws-lambda-powertools-dotnet/core/metrics/
+/// Learn more about Powertools for AWS Lambda (.NET) at https://awslabs.github.io/aws-lambda-powertools-dotnet/
+/// Powertools for AWS Lambda (.NET) Logging: https://awslabs.github.io/aws-lambda-powertools-dotnet/core/logging/
+/// Powertools for AWS Lambda (.NET) Tracing: https://awslabs.github.io/aws-lambda-powertools-dotnet/core/tracing/
+/// Powertools for AWS Lambda (.NET) Metrics: https://awslabs.github.io/aws-lambda-powertools-dotnet/core/metrics/
 /// Metrics Namespace and Service can be defined through Environment Variables https://awslabs.github.io/aws-lambda-powertools-dotnet/core/metrics/#getting-started
 /// </summary>
 public class Function

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/Readme.md
@@ -1,4 +1,4 @@
-# AWS Lambda Function Project with Lambda Powertools
+# AWS Lambda Function Project with Powertools for AWS Lambda (.NET)
 
 This starter project consists of:
 
@@ -9,9 +9,9 @@ You may also have a test project depending on the options selected.
 
 The generated function handler is a simple method accepting a string argument that returns the uppercase equivalent of the input string. Replace the body of this method, and parameters, to suit your needs.
 
-## AWS Lambda Powertools for .NET
+## Powertools for AWS Lambda (.NET)
 
-[AWS Lambda Powertools for .NET](https://awslabs.github.io/aws-lambda-powertools-dotnet/) is a developer toolkit to implement Serverless best practices and increase developer velocity.
+[Powertools for AWS Lambda (.NET)](https://awslabs.github.io/aws-lambda-powertools-dotnet/) is a developer toolkit to implement Serverless best practices and increase developer velocity.
 
 This starter project comes with Powertools Loging, Metrics and Tracing configured through environment variables defined in the `aws-lambda-tools-defaults.json` file and annotations on methods in `Function.cs`
 

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": "Lambda Powertools",
+  "display-name": "Powertools for AWS Lambda (.NET)",
   "system-name": "ServerlessPowertools",
-  "description": "Setup the project and test project to create a Serverless application with Powertools from scratch.",
+  "description": "Setup the project and test project to create a Serverless application with Powertools for AWS Lambda (.NET) from scratch.",
   "sort-order": 124,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/.template.config/template.json
@@ -6,7 +6,7 @@
     "Serverless",
     "Powertools"
   ],
-  "name": "Lambda Serverless with Powertools",
+  "name": "Lambda Serverless with Powertools for AWS Lambda (.NET)",
   "identity": "AWS.Lambda.Serverless.Powertools.CSharp",
   "groupIdentity": "AWS.Lambda.Serverless.Powertools",
   "shortName": "serverless.Powertools",

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/Functions.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/Functions.cs
@@ -11,10 +11,10 @@ using AWS.Lambda.Powertools.Tracing;
 namespace BlueprintBaseName._1;
 
 /// <summary>
-/// Learn more about Lambda Powertools at https://awslabs.github.io/aws-lambda-powertools-dotnet/
-/// Lambda Powertools Logging: https://awslabs.github.io/aws-lambda-powertools-dotnet/core/logging/
-/// Lambda Powertools Tracing: https://awslabs.github.io/aws-lambda-powertools-dotnet/core/tracing/
-/// Lambda Powertools Metrics: https://awslabs.github.io/aws-lambda-powertools-dotnet/core/metrics/
+/// Learn more about Powertools for AWS Lambda (.NET) at https://awslabs.github.io/aws-lambda-powertools-dotnet/
+/// Powertools for AWS Lambda (.NET) Logging: https://awslabs.github.io/aws-lambda-powertools-dotnet/core/logging/
+/// Powertools for AWS Lambda (.NET) Tracing: https://awslabs.github.io/aws-lambda-powertools-dotnet/core/tracing/
+/// Powertools for AWS Lambda (.NET) Metrics: https://awslabs.github.io/aws-lambda-powertools-dotnet/core/metrics/
 /// </summary>
 public class Functions
 {
@@ -47,6 +47,6 @@ public class Functions
     {
         Metrics.AddMetric("GetGreeting_Invocations", 1, MetricUnit.Count);
 
-        return "Hello Lambda Powertools";
+        return "Hello Powertools for AWS Lambda (.NET)";
     }
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/Readme.md
@@ -1,4 +1,4 @@
-# AWS Serverless Application Project with Lambda Powertools
+# AWS Serverless Application Project with Powertools for AWS Lambda (.NET)
 
 This starter project consists of:
 
@@ -10,9 +10,9 @@ You may also have a test project depending on the options selected.
 
 The generated project contains a Serverless template declaration for a single AWS Lambda function that will be exposed through Amazon API Gateway as a HTTP *Get* operation. Edit the template to customize the function or add more functions and other resources needed by your application, and edit the function code in Function.cs. You can then deploy your Serverless application.
 
-## AWS Lambda Powertools for .NET
+## Powertools for AWS Lambda (.NET)
 
-[AWS Lambda Powertools for .NET](https://awslabs.github.io/aws-lambda-powertools-dotnet/) is a developer toolkit to implement Serverless best practices and increase developer velocity.
+[Powertools for AWS Lambda (.NET)](https://awslabs.github.io/aws-lambda-powertools-dotnet/) is a developer toolkit to implement Serverless best practices and increase developer velocity.
 
 This starter project comes with Powertools Loging, Metrics and Tracing configured through environment variables defined in the `serverless.template` file and annotations on methods in `Function.cs`
 

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/test/BlueprintBaseName.1.Tests/FunctionsTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/test/BlueprintBaseName.1.Tests/FunctionsTest.cs
@@ -27,6 +27,6 @@ public class FunctionTest
         context = new TestLambdaContext();
         response = functions.Get(request, context);
         Assert.Equal(200, response.StatusCode);
-        Assert.Equal("Hello Lambda Powertools", response.Body);
+        Assert.Equal("Hello Powertools for AWS Lambda (.NET)", response.Body);
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Finds and replaces references of Lambda Powertools to Powertools for AWS Lambda (.NET) as per the rename effort happening in the Powertools for AWS Lambda (.NET) project

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
