### PR TITLE
adjust dotnet target framework for template AspNetCoreWebAPI-Image

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": "ASP.NET Core 6 (Container Image)",
+  "display-name": "ASP.NET Core 7 (Container Image)",
   "system-name": "AspNetCoreWebAPIImage",
-  "description": "Serverless ASP.NET Core 6 Web API packaged as a container image.",
+  "description": "Serverless ASP.NET Core 7 Web API packaged as a container image.",
   "sort-order": 250,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EnableDefaultContentItems>False</EnableDefaultContentItems>


### PR DESCRIPTION
adjust target framework to match dockerfile (7_0)

*Issue #, if available:*
when creating app from template i found out that csproj target v6 but dockerfile v7 
after deploying lambda oviously is not working screeming that it requires v6 but docker image has v7

look like forgoten in https://github.com/aws/aws-lambda-dotnet/pull/1367

*Description of changes:*
adjusted csproj to target 7

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
