### PR TITLE
Fixed an issue where unhandled exceptions containing non-ASCII characters in the exception message cause Runtime.ExitError.

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
-    <VersionPrefix>1.8.7</VersionPrefix>
+    <VersionPrefix>1.8.8</VersionPrefix>
     <Description>Provides a bootstrap and Lambda Runtime API Client to help you to develop custom .NET Core Lambda Runtimes.</Description>
     <Description>Provides a bootstrap and Lambda Runtime API Client to help you  to develop custom .NET Core Lambda Runtimes.</Description>
     <AssemblyTitle>Amazon.Lambda.RuntimeSupport</AssemblyTitle>

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
@@ -224,7 +224,8 @@ namespace Amazon.Lambda.RuntimeSupport
             // Create the SocketsHttpHandler directly to avoid spending cold start time creating the wrapper HttpClientHandler
             var handler = new SocketsHttpHandler
             {
-
+                // Fix for https://github.com/aws/aws-lambda-dotnet/issues/1231. HttpClient by default supports only ASCII characters in headers. Changing it to allow UTF8 characters.
+                RequestHeaderEncodingSelector = delegate { return System.Text.Encoding.UTF8; }
             };
 
             // If we are running in an AOT environment, mark it as such.

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/CustomRuntimeTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/CustomRuntimeTests.cs
@@ -54,6 +54,7 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
                 {
                     roleAlreadyExisted = await PrepareTestResources(s3Client, lambdaClient, iamClient);
 
+                    await RunTestExceptionAsync(lambdaClient, "ExceptionNonAsciiCharacterUnwrappedAsync", "", "Exception", "Unhandled exception with non ASCII character: ♂");
                     await RunTestSuccessAsync(lambdaClient, "UnintendedDisposeTest", "not-used", "UnintendedDisposeTest-SUCCESS");
                     await RunTestSuccessAsync(lambdaClient, "LoggingStressTest", "not-used", "LoggingStressTest-success");
                     await RunLoggingTestAsync(lambdaClient, "LoggingTest", null);

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/CustomRuntimeFunctionTest/CustomRuntimeFunction.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/CustomRuntimeFunctionTest/CustomRuntimeFunction.cs
@@ -36,6 +36,9 @@ namespace CustomRuntimeFunctionTest
             {
                 switch (handler)
                 {
+                    case nameof(ExceptionNonAsciiCharacterUnwrappedAsync):
+                        bootstrap = new LambdaBootstrap(ExceptionNonAsciiCharacterUnwrappedAsync);
+                        break;
                     case nameof(UnintendedDisposeTest):
                         bootstrap = new LambdaBootstrap(UnintendedDisposeTest);
                         break;
@@ -342,6 +345,13 @@ namespace CustomRuntimeFunctionTest
             // do something async so this function is compiled as async
             var dummy = await Task.FromResult("xyz");
             throw new Exception("Exception thrown from an async handler.");
+        }
+
+        private static async Task<InvocationResponse> ExceptionNonAsciiCharacterUnwrappedAsync(InvocationRequest invocation)
+        {
+            // do something async so this function is compiled as async
+            var dummy = await Task.FromResult("xyz");
+            throw new Exception("Unhandled exception with non ASCII character: ♂");
         }
 
         private static void AggregateExceptionUnwrapped()


### PR DESCRIPTION
*Issue #, if available:* #1231

*Description of changes:*
Fixed an issue where unhandled exceptions containing non-ASCII characters in the exception message cause Runtime.ExitError.

`HttpClient` by default supports only ASCII characters in headers. Changing it to allow UTF8 characters. The fix is only applicable for .NET 5 or later.
**References:**
- https://github.com/dotnet/runtime/issues/38711
- https://github.com/dotnet/docs/pull/21197

Discussed with @normj, we only need to support fix for .NET 6 runtime or later since earlier runtimes are now deprecated.

___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
