### PR TITLE
fix incorrect type

### DIFF
--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoVerifyAuthChallengeRequest.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoVerifyAuthChallengeRequest.cs
@@ -24,7 +24,7 @@ namespace Amazon.Lambda.CognitoEvents
 #if NETCOREAPP3_1
         [System.Text.Json.Serialization.JsonPropertyName("challengeAnswer")]
 # endif
-        public Dictionary<string, string> ChallengeAnswer { get; set; } = new Dictionary<string, string>();
+        public string ChallengeAnswer { get; set; } = string.Empty;
 
         /// <summary>
         /// One or more key-value pairs that you can provide as custom input to the Lambda function that you specify for the pre sign-up trigger. You can pass this data to your Lambda function by using the ClientMetadata parameter in the following API actions: AdminVerifyUser, AdminRespondToAuthChallenge, ForgotPassword, and SignUp.

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -728,11 +728,7 @@ namespace Amazon.Lambda.Tests
 
                 AssertBaseClass(cognitoVerifyAuthChallengeEvent);
 
-                Assert.Equal(2, cognitoVerifyAuthChallengeEvent.Request.ChallengeAnswer.Count);
-                Assert.Equal("answer_1", cognitoVerifyAuthChallengeEvent.Request.ChallengeAnswer.ToArray()[0].Key);
-                Assert.Equal("answer_value_1", cognitoVerifyAuthChallengeEvent.Request.ChallengeAnswer.ToArray()[0].Value);
-                Assert.Equal("answer_2", cognitoVerifyAuthChallengeEvent.Request.ChallengeAnswer.ToArray()[1].Key);
-                Assert.Equal("answer_value_2", cognitoVerifyAuthChallengeEvent.Request.ChallengeAnswer.ToArray()[1].Value);
+                Assert.Equal("answer_value", cognitoVerifyAuthChallengeEvent.Request.ChallengeAnswer);
 
                 Assert.Equal(2, cognitoVerifyAuthChallengeEvent.Request.ClientMetadata.Count);
                 Assert.Equal("metadata_1", cognitoVerifyAuthChallengeEvent.Request.ClientMetadata.ToArray()[0].Key);

--- a/Libraries/test/EventsTests.Shared/cognito-verifyauthchallenge-event.json
+++ b/Libraries/test/EventsTests.Shared/cognito-verifyauthchallenge-event.json
@@ -17,10 +17,7 @@
       "private_1": "private_value_1",
       "private_2": "private_value_2"
     },
-    "challengeAnswer": {
-      "answer_1": "answer_value_1",
-      "answer_2": "answer_value_2"
-    },
+    "challengeAnswer": "answer_value",
     "clientMetadata": {
       "metadata_1": "metadata_value_1",
       "metadata_2": "metadata_value_2"


### PR DESCRIPTION
Based on the documentation at https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-verify-auth-challenge-response.html#cognito-user-pools-lambda-trigger-syntax-verify-auth-challenge, the current type is incorrect. This fixes and local testing confirms resolution.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
