### PR TITLE
fix: Correctly handle null values while deserializing JSON to MemoryStream in Amazon.Lambda.Serialization.Json

### DIFF
--- a/Libraries/src/Amazon.Lambda.Serialization.Json/JsonToMemoryStreamDataConverter.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.Json/JsonToMemoryStreamDataConverter.cs
@@ -24,6 +24,9 @@ namespace Amazon.Lambda.Serialization.Json
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, NewtonsoftJsonSerializer serializer)
         {
             var dataBase64 = reader.Value as string;
+            if (dataBase64 is null)
+                return null;
+
             return Common.Base64ToMemoryStream(dataBase64);
         }
 

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -1302,6 +1302,7 @@ namespace Amazon.Lambda.Tests
                     Assert.Equal("b2", attribute2.StringListValues[1]);
 
                     Assert.Equal("String", attribute2.DataType);
+                    Assert.Null(attribute2.BinaryValue);
                 }
 
                 Handle(sqsEvent);

--- a/Libraries/test/EventsTests.Shared/sqs-event.json
+++ b/Libraries/test/EventsTests.Shared/sqs-event.json
@@ -26,8 +26,9 @@
         "Attribute2": {
           "stringValue": "AttributeValue2",
           "stringListValues": [ "b1", "b2" ],
-          "binaryListValues": [  ],
-          "dataType": "String"
+          "binaryListValues": [],
+          "dataType": "String",
+          "binaryValue": null
         }
       }
     }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1339

*Description of changes:*
SQS messages can contain message attributes which is a map of `string` as keys and [`MessageAttributeValue`](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_MessageAttributeValue.html) as values.
`MessageAttributeValue` has a nested property called `BinaryValue` which is [deserialized](https://github.com/aws/aws-lambda-dotnet/blob/cacb32a081aeb04ebc556884eae9a34769b4cf30/Libraries/src/Amazon.Lambda.SQSEvents/SQSEvent.cs#L31) as a `MemoryStream` while creating an [SQSMessage](https://github.com/aws/aws-lambda-dotnet/blob/cacb32a081aeb04ebc556884eae9a34769b4cf30/Libraries/src/Amazon.Lambda.SQSEvents/SQSEvent.cs#LL52C22-L52C32) object . 


 The `Amazon.Lambda.Serialization.Json` package can incorrectly attempt to deserialize a null `BinaryValue` which results in a runtime exception. This PR adds a null check before performing the deserialization.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
