### PR TITLE
ci: add ability to specify next .NET version for update-dockerfiles workflow

### DIFF
--- a/.github/workflows/update-Dockerfiles.yml
+++ b/.github/workflows/update-Dockerfiles.yml
@@ -1,4 +1,4 @@
-name: Update Dockerfiles
+name: Update Lambda Dockerfiles
 
 on:
   # Allows to run this workflow manually from the Actions tab
@@ -14,6 +14,10 @@ on:
         type: boolean
         required: true
         default: "true"
+      NET_6_NEXT_VERSION:
+        description: ".NET 6 Next Version"
+        type: string
+        required: true
       NET_7_AMD64:
         description: ".NET 7 AMD64"
         type: boolean
@@ -24,6 +28,10 @@ on:
         type: boolean
         required: true
         default: "true"
+      NET_7_NEXT_VERSION:
+        description: ".NET 7 Next Version"
+        type: string
+        required: true
 
 jobs:
   build:
@@ -43,28 +51,28 @@ jobs:
         id: update-net6-amd64
         shell: pwsh
         run: |
-          .\LambdaRuntimeDockerfiles/update-dockerfile.ps1 -Dockerfile ${{ env.NET_6_AMD64_Dockerfile }}
+          .\LambdaRuntimeDockerfiles/update-dockerfile.ps1 -DockerfilePath ${{ env.NET_6_AMD64_Dockerfile }} -NextVersion ${{ github.event.inputs.NET_6_NEXT_VERSION }}
         if: ${{ github.event.inputs.NET_6_AMD64 == 'true' }}
 
       - name: Update .NET 6 ARM64
         id: update-net6-arm64
         shell: pwsh
         run: |
-          .\LambdaRuntimeDockerfiles/update-dockerfile.ps1 -Dockerfile ${{ env.NET_6_ARM64_Dockerfile }}
+          .\LambdaRuntimeDockerfiles/update-dockerfile.ps1 -DockerfilePath ${{ env.NET_6_ARM64_Dockerfile }} -NextVersion ${{ github.event.inputs.NET_6_NEXT_VERSION }}
         if: ${{ github.event.inputs.NET_6_ARM64 == 'true' }}
 
       - name: Update .NET 7 AMD64
         id: update-net7-amd64
         shell: pwsh
         run: |
-          .\LambdaRuntimeDockerfiles/update-dockerfile.ps1 -Dockerfile ${{ env.NET_7_AMD64_Dockerfile }}
+          .\LambdaRuntimeDockerfiles/update-dockerfile.ps1 -DockerfilePath ${{ env.NET_7_AMD64_Dockerfile }} -NextVersion ${{ github.event.inputs.NET_7_NEXT_VERSION }}
         if: ${{ github.event.inputs.NET_7_AMD64 == 'true' }}
 
       - name: Update .NET 7 ARM64
         id: update-net7-arm64
         shell: pwsh
         run: |
-          .\LambdaRuntimeDockerfiles/update-dockerfile.ps1 -Dockerfile ${{ env.NET_7_ARM64_Dockerfile }}
+          .\LambdaRuntimeDockerfiles/update-dockerfile.ps1 -DockerfilePath ${{ env.NET_7_ARM64_Dockerfile }} -NextVersion ${{ github.event.inputs.NET_7_NEXT_VERSION }}
         if: ${{ github.event.inputs.NET_7_ARM64 == 'true' }}
 
       # Update Dockerfiles if newer version of ASP.NET Core is available

--- a/LambdaRuntimeDockerfiles/update-dockerfile.ps1
+++ b/LambdaRuntimeDockerfiles/update-dockerfile.ps1
@@ -1,36 +1,32 @@
-# This script allows to update Dockerfiles with next ASP.NET Core patch version.
-# It greps the current version from Dockerfile, increment the patch version and fetches checksum file from Microsoft server.
+# This script allows to update Dockerfiles to the next ASP.NET Core version.
+# It fetches the checksum file of the next .NET version from Microsoft server.
 # If checksum file is available, it will update the Dockerfile next version and its checksum.
-# NOTE: This scripts only updates patch version by incrementing the next patch version.
-# If Microsoft ever releases a minor version, this needs to updated accordingly to include minor version.
 
-param ([Parameter(Mandatory)]$DockerfilePath)
+param ([Parameter(Mandatory)]$DockerfilePath, [Parameter(Mandatory)]$NextVersion)
 
 # Updates the Dockerfile with next ASP.NET Core version and checksum512 hash if available
-function Update-Dockerfile ([string]$DockerfilePath) {
+function Update-Dockerfile ([string]$DockerfilePath, [string]$NextVersion) {
     Write-Host "Updating $DockerfilePath with next ASP.NET Core version"
 
-    $nextVersion = Get-NextASPNETVersion -DockerfilePath $DockerfilePath
+    $checksumFilePath = "${NextVersion}-checksum.txt"
 
-    $checksumFilePath = "${nextVersion}-checksum.txt"
-
-    $checksumUri = "https://dotnetcli.blob.core.windows.net/dotnet/checksums/${nextVersion}-sha.txt"
+    $checksumUri = "https://dotnetcli.blob.core.windows.net/dotnet/checksums/${NextVersion}-sha.txt"
     Write-Host "Downloading checksums from $checksumUri"
 
     Invoke-WebRequest -Uri $checksumUri -OutFile $checksumFilePath
 
     $arch = Get-Architecture -DockerfilePath $DockerfilePath
 
-    $artifact = "aspnetcore-runtime-${nextVersion}-linux-${arch}.tar.gz"
+    $artifact = "aspnetcore-runtime-${NextVersion}-linux-${arch}.tar.gz"
     $checksum = Get-Checksum -Artifact $artifact -DockerfilePath $checksumFilePath
 
-    (Get-Content $DockerfilePath) -replace 'ARG ASPNET_VERSION=.*', "ARG ASPNET_VERSION=${nextVersion}" -replace 'ARG ASPNET_SHA512=.*', "ARG ASPNET_SHA512=${checksum}" | Out-File $DockerfilePath
+    (Get-Content $DockerfilePath) -replace 'ARG ASPNET_VERSION=.*', "ARG ASPNET_VERSION=${NextVersion}" -replace 'ARG ASPNET_SHA512=.*', "ARG ASPNET_SHA512=${checksum}" | Out-File $DockerfilePath
 
-    Write-Host "Updated ${DockerfilePath} to ${nextVersion}."
+    Write-Host "Updated ${DockerfilePath} to ${NextVersion}."
 
     # This allows checksumring the $DockerfilePath variable between steps
     # which is needed to update the description of the PR
-    Write-Host "::set-output name=${DockerfilePath}::- Updated ${DockerfilePath} to ${nextVersion}<br> - Artifact: ${artifact}<br> - Checksum Source: ${checksumUri}"
+    Write-Host "::set-output name=${DockerfilePath}::- Updated ${DockerfilePath} to ${NextVersion}<br> - Artifact: ${artifact}<br> - Checksum Source: ${checksumUri}"
 }
 
 # Returns Checksum of given ASP.NET Core version from the give Checksum file
@@ -53,27 +49,4 @@ function Get-Architecture ([string]$DockerfilePath) {
     }
 }
 
-# Returns the next ASP.NET version to be updated in the Dockerfile
-function Get-NextASPNETVersion ([string]$DockerfilePath) {
-    $line = Select-String -Path $DockerfilePath -Pattern "ARG ASPNET_VERSION=" | Select-Object -Property Line -ExpandProperty Line
-    $currentVersion = $line.Split("=")[1]
-    Write-Host "Current ASPNET version: ${currentVersion}"
-
-    $nextVersion = Update-PatchVersion -Version $currentVersion
-    Write-Host "Next ASPNET version: ${nextVersion}"
-
-    return $nextVersion
-}
-
-# Returns the next patch version of the given version
-function Update-PatchVersion ([string]$version) {
-    $components = $version.Split(".");
-    $major = $components[0];
-    $minor = $components[1];
-    $patch = $components[2];
-    $patch = [int]$patch + 1;
-    $newVersion = $major + "." + $minor + "." + $patch;
-    return $newVersion;
-}
-
-Update-Dockerfile $DockerfilePath
+Update-Dockerfile $DockerfilePath $NextVersion


### PR DESCRIPTION
*Description of changes:*
Update workflow to allow specifying the next .NET version to update to. The current approach of always incrementing the patch version does not always work. This change was prompted by Microsoft updating .NET 6 from 6.0.16 to 6.0.18 which broke our current workflow.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
