### PR TITLE
fix: fix error thrown when template includes intrinsic function

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Writers/CloudFormationWriter.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Writers/CloudFormationWriter.cs
@@ -284,7 +284,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Writers
             }
 
             var toRemove = new List<string>();
-            foreach (var resourceName in _templateWriter.GetToken<Dictionary<string, object>>("Resources").Keys)
+            foreach (var resourceName in _templateWriter.GetKeys("Resources"))
             {
                 var resourcePath = $"Resources.{resourceName}";
                 var type = _templateWriter.GetToken<string>($"{resourcePath}.Type", string.Empty);

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Writers/ITemplateWriter.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Writers/ITemplateWriter.cs
@@ -1,4 +1,7 @@
-﻿namespace Amazon.Lambda.Annotations.SourceGenerator.Writers
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Amazon.Lambda.Annotations.SourceGenerator.Writers
 {
     /// <summary>
     /// This interface contains utility methods to manipulate a YAML or JSON blob
@@ -56,5 +59,11 @@
         /// If a string value starts with '@' then a reference node is created and returned.
         /// </summary>
         object GetValueOrRef(string value);
+
+        /// <summary>
+        /// Retrieves a list of keys for a specified template path.
+        /// </summary>
+        /// <param name="path">dot(.) seperated path. Example "Person.Name.FirstName"</param>
+        IList<string> GetKeys(string path);
     }
 }

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Writers/JsonWriter.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Writers/JsonWriter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
@@ -224,6 +225,18 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Writers
                 return deserializedToken;
             }
             return JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(token));
+        }
+
+        public IList<string> GetKeys(string path)
+        {
+            try
+            {
+                return GetToken<Dictionary<string, object>>(path).Keys.ToList();
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Unable to retrieve keys for the specified JSON path '{path}'.", ex);
+            }
         }
     }
 }

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Writers/YamlWriter.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Writers/YamlWriter.cs
@@ -271,5 +271,17 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Writers
 
             return _deserializer.Deserialize<T>(_serializer.Serialize(token));
         }
+
+        public IList<string> GetKeys(string path)
+        {
+            try
+            {
+                return GetToken<Dictionary<string, YamlMappingNode>>(path).Keys.ToList();
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Unable to retrieve keys for the specified YAML path '{path}'.", ex);
+            }
+        }
     }
 }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
@@ -60,6 +60,7 @@
     <ItemGroup>
       <None Remove="Snapshots\ServerlessTemplates\customizeResponse.template" />
       <None Remove="Snapshots\ServerlessTemplates\dynamicexample.template" />
+      <None Remove="Snapshots\ServerlessTemplates\intrinsicexample.template" />
       <None Remove="Snapshots\ServerlessTemplates\nullreferenceexample.template" />
       <None Remove="Snapshots\ServerlessTemplates\subnamespace.template" />
       <None Remove="Snapshots\ServerlessTemplates\taskexample.template" />

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/IntrinsicExample_HasIntrinsic_Generated.g.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/IntrinsicExample_HasIntrinsic_Generated.g.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text;
+using Amazon.Lambda.Core;
+
+namespace TestServerlessApp
+{
+    public class IntrinsicExample_HasIntrinsic_Generated
+    {
+        private readonly IntrinsicExample intrinsicExample;
+
+        public IntrinsicExample_HasIntrinsic_Generated()
+        {
+            SetExecutionEnvironment();
+            intrinsicExample = new IntrinsicExample();
+        }
+
+        public void HasIntrinsic(string text, Amazon.Lambda.Core.ILambdaContext __context__)
+        {
+            intrinsicExample.HasIntrinsic(text, __context__);
+        }
+
+        private static void SetExecutionEnvironment()
+        {
+            const string envName = "AWS_EXECUTION_ENV";
+
+            var envValue = new StringBuilder();
+
+            // If there is an existing execution environment variable add the annotations package as a suffix.
+            if(!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(envName)))
+            {
+                envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
+            }
+
+            envValue.Append("amazon-lambda-annotations_0.13.4.0");
+
+            Environment.SetEnvironmentVariable(envName, envValue.ToString());
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/intrinsicexample.template
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Snapshots/ServerlessTemplates/intrinsicexample.template
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: 'AWS::Serverless-2016-10-31'
+Description: This template is partially managed by Amazon.Lambda.Annotations (v0.13.4.0).
+Resources:
+  TestServerlessAppIntrinsicExampleHasIntrinsicGenerated:
+    Type: AWS::Serverless::Function
+    Metadata:
+      Tool: Amazon.Lambda.Annotations
+    Properties:
+      Description: !Sub 'This is deployed in region ${AWS::Region}'
+      MemorySize: 256
+      Timeout: 30
+      Policies:
+        - AWSLambdaBasicExecutionRole
+      PackageType: Image
+      ImageUri: .
+      ImageConfig:
+        Command:
+          - TestProject::TestServerlessApp.IntrinsicExample_HasIntrinsic_Generated::HasIntrinsic

--- a/Libraries/test/TestServerlessApp/IntrinsicExample.cs
+++ b/Libraries/test/TestServerlessApp/IntrinsicExample.cs
@@ -1,0 +1,14 @@
+﻿using Amazon.Lambda.Annotations;
+using Amazon.Lambda.Core;
+
+namespace TestServerlessApp
+{
+    public class IntrinsicExample
+    {
+        [LambdaFunction(PackageType = LambdaPackageType.Image)]
+        public void HasIntrinsic(string text, ILambdaContext context)
+        {
+            context.Logger.LogLine(text);
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-4300, #1340

*Description of changes:*
An error was thrown when a short form intrinsic function appears in a CloudFormation template. This error was due to an invalid casting to `Dictionary<string, object>`. Modifying this to a `Dictionary<string, YamlMappingNode>` for YAML templates fixed the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
