### PR TITLE
Version bump Amazon.Lambda.Serialization.Json to 2.1.1

### DIFF
--- a/Libraries/src/Amazon.Lambda.Serialization.Json/Amazon.Lambda.Serialization.Json.csproj
+++ b/Libraries/src/Amazon.Lambda.Serialization.Json/Amazon.Lambda.Serialization.Json.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>Amazon.Lambda.Serialization.Json</AssemblyName>
     <PackageId>Amazon.Lambda.Serialization.Json</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionPrefix>2.1.1</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Description of changes:*
Version bump Amazon.Lambda.Serialization.Json to 2.1.1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
