### PR TITLE
fix: Lambda test tool debugs the correct assembly when the Lambda project depends on other executable projects

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LocalLambdaRuntime.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LocalLambdaRuntime.cs
@@ -53,20 +53,15 @@ namespace Amazon.Lambda.TestTool.Runtime
                 throw new DirectoryNotFoundException($"Directory containing built Lambda project does not exist {directory}");
             }
 
-            var depsFile = Directory.GetFiles(directory, "*.deps.json").FirstOrDefault();
-            if (depsFile == null)
-            {
-                throw new Exception($"Failed to find a deps.json file in the specified directory ({directory})");
-            }
+            var lambdaAssemblyPath = Utils.FindLambdaAssemblyPath(directory);
 
-            var fileName = depsFile.Substring(0, depsFile.Length - ".deps.json".Length) + ".dll";
-            if (!File.Exists(fileName))
+            if (string.IsNullOrEmpty(lambdaAssemblyPath) || !File.Exists(lambdaAssemblyPath))
             {
                 throw new Exception($"Failed to find Lambda project entry assembly in the specified directory ({directory})");
             }
 
             // The resolver provides the ability to load the assemblies containing the select Lambda function.
-            var resolver = new LambdaAssemblyLoadContext(fileName);
+            var resolver = new LambdaAssemblyLoadContext(lambdaAssemblyPath);
 
             var runtime = new LocalLambdaRuntime(resolver, directory, awsService);
             return runtime;

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/Amazon.Lambda.TestTool.Tests.NET6.csproj
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/Amazon.Lambda.TestTool.Tests.NET6.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -24,6 +24,12 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Amazon.Lambda.TestTool\Amazon.Lambda.TestTool.csproj" />
     <ProjectReference Include="..\LambdaFunctions\net6\SourceGeneratorExample\SourceGeneratorExample.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="TestFiles\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/LambdaAssemblyPathTests.cs
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/LambdaAssemblyPathTests.cs
@@ -1,0 +1,20 @@
+﻿namespace Amazon.Lambda.TestTool.Tests.NET6
+{
+    public class LambdaAssemblyPathTests
+    {
+
+        [Fact]
+        public void SingleDepsJsonFile()
+        {
+            var lambdaAssemblyPath =  Utils.FindLambdaAssemblyPath(Path.Combine("TestFiles", "SingleDepsJsonFile"));
+            Assert.Equal(Path.Combine("TestFiles", "SingleDepsJsonFile", "LambdaDemo.dll"), lambdaAssemblyPath);
+        }
+
+        [Fact]
+        public void MultipleDepsJsonFile()
+        {
+            var lambdaAssemblyPath = Utils.FindLambdaAssemblyPath(Path.Combine("TestFiles", "MultipleDepsJsonFile"));
+            Assert.Equal(Path.Combine("TestFiles", "MultipleDepsJsonFile", "LambdaDemo.dll"), lambdaAssemblyPath);
+        }
+    }
+}

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/TestFiles/MultipleDepsJsonFile/Dependency.txt
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/TestFiles/MultipleDepsJsonFile/Dependency.txt
@@ -1,0 +1,3 @@
+The dependency graph is as follows:
+	1. LambdaDemo depends on LambdaDemo.Api1 and LambdaDemo.Api2
+	2. LambdaDemo.Api1 depends on LambdaDemo.Api2

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/TestFiles/MultipleDepsJsonFile/LambdaDemo.Api1.deps.json
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/TestFiles/MultipleDepsJsonFile/LambdaDemo.Api1.deps.json
@@ -1,0 +1,129 @@
+{
+    "runtimeTarget": {
+      "name": ".NETCoreApp,Version=v6.0",
+      "signature": ""
+    },
+    "compilationOptions": {},
+    "targets": {
+      ".NETCoreApp,Version=v6.0": {
+        "LambdaDemo.Api1/1.0.0": {
+          "dependencies": {
+            "LambdaDemo.Api2": "1.0.0",
+            "Swashbuckle.AspNetCore": "6.5.0"
+          },
+          "runtime": {
+            "LambdaDemo.Api1.dll": {}
+          }
+        },
+        "LambdaDemo.Api2/1.0.0": {
+            "dependencies": {
+              "Swashbuckle.AspNetCore": "6.5.0"
+            },
+            "runtime": {
+              "LambdaDemo.Api2.dll": {}
+            }
+          },
+        "Microsoft.Extensions.ApiDescription.Server/6.0.5": {},
+        "Microsoft.OpenApi/1.2.3": {
+          "runtime": {
+            "lib/netstandard2.0/Microsoft.OpenApi.dll": {
+              "assemblyVersion": "1.2.3.0",
+              "fileVersion": "1.2.3.0"
+            }
+          }
+        },
+        "Swashbuckle.AspNetCore/6.5.0": {
+          "dependencies": {
+            "Microsoft.Extensions.ApiDescription.Server": "6.0.5",
+            "Swashbuckle.AspNetCore.Swagger": "6.5.0",
+            "Swashbuckle.AspNetCore.SwaggerGen": "6.5.0",
+            "Swashbuckle.AspNetCore.SwaggerUI": "6.5.0"
+          }
+        },
+        "Swashbuckle.AspNetCore.Swagger/6.5.0": {
+          "dependencies": {
+            "Microsoft.OpenApi": "1.2.3"
+          },
+          "runtime": {
+            "lib/net6.0/Swashbuckle.AspNetCore.Swagger.dll": {
+              "assemblyVersion": "6.5.0.0",
+              "fileVersion": "6.5.0.0"
+            }
+          }
+        },
+        "Swashbuckle.AspNetCore.SwaggerGen/6.5.0": {
+          "dependencies": {
+            "Swashbuckle.AspNetCore.Swagger": "6.5.0"
+          },
+          "runtime": {
+            "lib/net6.0/Swashbuckle.AspNetCore.SwaggerGen.dll": {
+              "assemblyVersion": "6.5.0.0",
+              "fileVersion": "6.5.0.0"
+            }
+          }
+        },
+        "Swashbuckle.AspNetCore.SwaggerUI/6.5.0": {
+          "runtime": {
+            "lib/net6.0/Swashbuckle.AspNetCore.SwaggerUI.dll": {
+              "assemblyVersion": "6.5.0.0",
+              "fileVersion": "6.5.0.0"
+            }
+          }
+        }
+      }
+    },
+    "libraries": {
+      "LambdaDemo.Api1/1.0.0": {
+        "type": "project",
+        "serviceable": false,
+        "sha512": ""
+      },
+      "LambdaDemo.Api2/1.0.0": {
+        "type": "project",
+        "serviceable": false,
+        "sha512": ""
+      },
+      "Microsoft.Extensions.ApiDescription.Server/6.0.5": {
+        "type": "package",
+        "serviceable": true,
+        "sha512": "sha512-Ckb5EDBUNJdFWyajfXzUIMRkhf52fHZOQuuZg/oiu8y7zDCVwD0iHhew6MnThjHmevanpxL3f5ci2TtHQEN6bw==",
+        "path": "microsoft.extensions.apidescription.server/6.0.5",
+        "hashPath": "microsoft.extensions.apidescription.server.6.0.5.nupkg.sha512"
+      },
+      "Microsoft.OpenApi/1.2.3": {
+        "type": "package",
+        "serviceable": true,
+        "sha512": "sha512-Nug3rO+7Kl5/SBAadzSMAVgqDlfGjJZ0GenQrLywJ84XGKO0uRqkunz5Wyl0SDwcR71bAATXvSdbdzPrYRYKGw==",
+        "path": "microsoft.openapi/1.2.3",
+        "hashPath": "microsoft.openapi.1.2.3.nupkg.sha512"
+      },
+      "Swashbuckle.AspNetCore/6.5.0": {
+        "type": "package",
+        "serviceable": true,
+        "sha512": "sha512-FK05XokgjgwlCI6wCT+D4/abtQkL1X1/B9Oas6uIwHFmYrIO9WUD5aLC9IzMs9GnHfUXOtXZ2S43gN1mhs5+aA==",
+        "path": "swashbuckle.aspnetcore/6.5.0",
+        "hashPath": "swashbuckle.aspnetcore.6.5.0.nupkg.sha512"
+      },
+      "Swashbuckle.AspNetCore.Swagger/6.5.0": {
+        "type": "package",
+        "serviceable": true,
+        "sha512": "sha512-XWmCmqyFmoItXKFsQSwQbEAsjDKcxlNf1l+/Ki42hcb6LjKL8m5Db69OTvz5vLonMSRntYO1XLqz0OP+n3vKnA==",
+        "path": "swashbuckle.aspnetcore.swagger/6.5.0",
+        "hashPath": "swashbuckle.aspnetcore.swagger.6.5.0.nupkg.sha512"
+      },
+      "Swashbuckle.AspNetCore.SwaggerGen/6.5.0": {
+        "type": "package",
+        "serviceable": true,
+        "sha512": "sha512-Y/qW8Qdg9OEs7V013tt+94OdPxbRdbhcEbw4NiwGvf4YBcfhL/y7qp/Mjv/cENsQ2L3NqJ2AOu94weBy/h4KvA==",
+        "path": "swashbuckle.aspnetcore.swaggergen/6.5.0",
+        "hashPath": "swashbuckle.aspnetcore.swaggergen.6.5.0.nupkg.sha512"
+      },
+      "Swashbuckle.AspNetCore.SwaggerUI/6.5.0": {
+        "type": "package",
+        "serviceable": true,
+        "sha512": "sha512-OvbvxX+wL8skxTBttcBsVxdh73Fag4xwqEU2edh4JMn7Ws/xJHnY/JB1e9RoCb6XpDxUF3hD9A0Z1lEUx40Pfw==",
+        "path": "swashbuckle.aspnetcore.swaggerui/6.5.0",
+        "hashPath": "swashbuckle.aspnetcore.swaggerui.6.5.0.nupkg.sha512"
+      }
+    }
+  }

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/TestFiles/MultipleDepsJsonFile/LambdaDemo.Api2.deps.json
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/TestFiles/MultipleDepsJsonFile/LambdaDemo.Api2.deps.json
@@ -1,0 +1,115 @@
+{
+    "runtimeTarget": {
+      "name": ".NETCoreApp,Version=v6.0",
+      "signature": ""
+    },
+    "compilationOptions": {},
+    "targets": {
+      ".NETCoreApp,Version=v6.0": {
+        "LambdaDemo.Api2/1.0.0": {
+          "dependencies": {
+            "Swashbuckle.AspNetCore": "6.5.0"
+          },
+          "runtime": {
+            "LambdaDemo.Api2.dll": {}
+          }
+        },
+        "Microsoft.Extensions.ApiDescription.Server/6.0.5": {},
+        "Microsoft.OpenApi/1.2.3": {
+          "runtime": {
+            "lib/netstandard2.0/Microsoft.OpenApi.dll": {
+              "assemblyVersion": "1.2.3.0",
+              "fileVersion": "1.2.3.0"
+            }
+          }
+        },
+        "Swashbuckle.AspNetCore/6.5.0": {
+          "dependencies": {
+            "Microsoft.Extensions.ApiDescription.Server": "6.0.5",
+            "Swashbuckle.AspNetCore.Swagger": "6.5.0",
+            "Swashbuckle.AspNetCore.SwaggerGen": "6.5.0",
+            "Swashbuckle.AspNetCore.SwaggerUI": "6.5.0"
+          }
+        },
+        "Swashbuckle.AspNetCore.Swagger/6.5.0": {
+          "dependencies": {
+            "Microsoft.OpenApi": "1.2.3"
+          },
+          "runtime": {
+            "lib/net6.0/Swashbuckle.AspNetCore.Swagger.dll": {
+              "assemblyVersion": "6.5.0.0",
+              "fileVersion": "6.5.0.0"
+            }
+          }
+        },
+        "Swashbuckle.AspNetCore.SwaggerGen/6.5.0": {
+          "dependencies": {
+            "Swashbuckle.AspNetCore.Swagger": "6.5.0"
+          },
+          "runtime": {
+            "lib/net6.0/Swashbuckle.AspNetCore.SwaggerGen.dll": {
+              "assemblyVersion": "6.5.0.0",
+              "fileVersion": "6.5.0.0"
+            }
+          }
+        },
+        "Swashbuckle.AspNetCore.SwaggerUI/6.5.0": {
+          "runtime": {
+            "lib/net6.0/Swashbuckle.AspNetCore.SwaggerUI.dll": {
+              "assemblyVersion": "6.5.0.0",
+              "fileVersion": "6.5.0.0"
+            }
+          }
+        }
+      }
+    },
+    "libraries": {
+      "LambdaDemo.Api2/1.0.0": {
+        "type": "project",
+        "serviceable": false,
+        "sha512": ""
+      },
+      "Microsoft.Extensions.ApiDescription.Server/6.0.5": {
+        "type": "package",
+        "serviceable": true,
+        "sha512": "sha512-Ckb5EDBUNJdFWyajfXzUIMRkhf52fHZOQuuZg/oiu8y7zDCVwD0iHhew6MnThjHmevanpxL3f5ci2TtHQEN6bw==",
+        "path": "microsoft.extensions.apidescription.server/6.0.5",
+        "hashPath": "microsoft.extensions.apidescription.server.6.0.5.nupkg.sha512"
+      },
+      "Microsoft.OpenApi/1.2.3": {
+        "type": "package",
+        "serviceable": true,
+        "sha512": "sha512-Nug3rO+7Kl5/SBAadzSMAVgqDlfGjJZ0GenQrLywJ84XGKO0uRqkunz5Wyl0SDwcR71bAATXvSdbdzPrYRYKGw==",
+        "path": "microsoft.openapi/1.2.3",
+        "hashPath": "microsoft.openapi.1.2.3.nupkg.sha512"
+      },
+      "Swashbuckle.AspNetCore/6.5.0": {
+        "type": "package",
+        "serviceable": true,
+        "sha512": "sha512-FK05XokgjgwlCI6wCT+D4/abtQkL1X1/B9Oas6uIwHFmYrIO9WUD5aLC9IzMs9GnHfUXOtXZ2S43gN1mhs5+aA==",
+        "path": "swashbuckle.aspnetcore/6.5.0",
+        "hashPath": "swashbuckle.aspnetcore.6.5.0.nupkg.sha512"
+      },
+      "Swashbuckle.AspNetCore.Swagger/6.5.0": {
+        "type": "package",
+        "serviceable": true,
+        "sha512": "sha512-XWmCmqyFmoItXKFsQSwQbEAsjDKcxlNf1l+/Ki42hcb6LjKL8m5Db69OTvz5vLonMSRntYO1XLqz0OP+n3vKnA==",
+        "path": "swashbuckle.aspnetcore.swagger/6.5.0",
+        "hashPath": "swashbuckle.aspnetcore.swagger.6.5.0.nupkg.sha512"
+      },
+      "Swashbuckle.AspNetCore.SwaggerGen/6.5.0": {
+        "type": "package",
+        "serviceable": true,
+        "sha512": "sha512-Y/qW8Qdg9OEs7V013tt+94OdPxbRdbhcEbw4NiwGvf4YBcfhL/y7qp/Mjv/cENsQ2L3NqJ2AOu94weBy/h4KvA==",
+        "path": "swashbuckle.aspnetcore.swaggergen/6.5.0",
+        "hashPath": "swashbuckle.aspnetcore.swaggergen.6.5.0.nupkg.sha512"
+      },
+      "Swashbuckle.AspNetCore.SwaggerUI/6.5.0": {
+        "type": "package",
+        "serviceable": true,
+        "sha512": "sha512-OvbvxX+wL8skxTBttcBsVxdh73Fag4xwqEU2edh4JMn7Ws/xJHnY/JB1e9RoCb6XpDxUF3hD9A0Z1lEUx40Pfw==",
+        "path": "swashbuckle.aspnetcore.swaggerui/6.5.0",
+        "hashPath": "swashbuckle.aspnetcore.swaggerui.6.5.0.nupkg.sha512"
+      }
+    }
+  }

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/TestFiles/MultipleDepsJsonFile/LambdaDemo.deps.json
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/TestFiles/MultipleDepsJsonFile/LambdaDemo.deps.json
@@ -1,0 +1,89 @@
+{
+    "runtimeTarget": {
+      "name": ".NETCoreApp,Version=v6.0",
+      "signature": ""
+    },
+    "compilationOptions": {},
+    "targets": {
+      ".NETCoreApp,Version=v6.0": {
+        "LambdaDemo/1.0.0": {
+          "dependencies": {
+            "Amazon.Lambda.Core": "2.1.0",
+            "Amazon.Lambda.Serialization.SystemTextJson": "2.3.1",
+            "LambdaDemo.Api1": "1.0.0",
+            "LambdaDemo.Api2": "1.0.0"
+          },
+          "runtime": {
+            "LambdaDemo.dll": {}
+          }
+        },
+        "LambdaDemo.Api1/1.0.0": {
+          "dependencies": {
+            "LambdaDemo.Api2": "1.0.0",
+            "Swashbuckle.AspNetCore": "6.5.0"
+          },
+          "runtime": {
+            "LambdaDemo.Api1.dll": {}
+          }
+        },
+        "LambdaDemo.Api2/1.0.0": {
+          "dependencies": {
+            "Swashbuckle.AspNetCore": "6.5.0"
+          },
+          "runtime": {
+            "LambdaDemo.Api2.dll": {}
+          }
+        },
+        "Amazon.Lambda.Core/2.1.0": {
+          "runtime": {
+            "lib/net6.0/Amazon.Lambda.Core.dll": {
+              "assemblyVersion": "1.0.0.0",
+              "fileVersion": "1.0.0.0"
+            }
+          }
+        },
+        "Amazon.Lambda.Serialization.SystemTextJson/2.3.1": {
+          "dependencies": {
+            "Amazon.Lambda.Core": "2.1.0"
+          },
+          "runtime": {
+            "lib/net6.0/Amazon.Lambda.Serialization.SystemTextJson.dll": {
+              "assemblyVersion": "0.0.0.0",
+              "fileVersion": "0.0.0.0"
+            }
+          }
+        }
+      }
+    },
+    "libraries": {
+      "LambdaDemo/1.0.0": {
+        "type": "project",
+        "serviceable": false,
+        "sha512": ""
+      },
+      "LambdaDemo.Api1/1.0.0": {
+        "type": "project",
+        "serviceable": false,
+        "sha512": ""
+      },
+      "LambdaDemo.Api2/1.0.0": {
+        "type": "project",
+        "serviceable": false,
+        "sha512": ""
+      },
+      "Amazon.Lambda.Core/2.1.0": {
+        "type": "package",
+        "serviceable": true,
+        "sha512": "sha512-ok06UhfBZw6j6+PhiJR9C0EOMuJvnq8rMCHVkaFmPFrlI/q447ukwGZQKaAKqodV+MNTfpb/iPxjgUPVbSlVVw==",
+        "path": "amazon.lambda.core/2.1.0",
+        "hashPath": "amazon.lambda.core.2.1.0.nupkg.sha512"
+      },
+      "Amazon.Lambda.Serialization.SystemTextJson/2.3.1": {
+        "type": "package",
+        "serviceable": true,
+        "sha512": "sha512-7dGGgikMlEz72rGqeDwQEIxq+O8RDEdR4GH2S7hfZ8uzv5lyWVDuP2urV6MyD6APJ2WVHRwJlV74bB+XJncQpw==",
+        "path": "amazon.lambda.serialization.systemtextjson/2.3.1",
+        "hashPath": "amazon.lambda.serialization.systemtextjson.2.3.1.nupkg.sha512"
+      }
+    }
+  }

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/TestFiles/SingleDepsJsonFile/LambdaDemo.deps.json
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.NET6/TestFiles/SingleDepsJsonFile/LambdaDemo.deps.json
@@ -1,0 +1,60 @@
+{
+    "runtimeTarget": {
+      "name": ".NETCoreApp,Version=v6.0",
+      "signature": ""
+    },
+    "compilationOptions": {},
+    "targets": {
+      ".NETCoreApp,Version=v6.0": {
+        "LambdaDemo/1.0.0": {
+          "dependencies": {
+            "Amazon.Lambda.Core": "2.1.0",
+            "Amazon.Lambda.Serialization.SystemTextJson": "2.3.1"
+          },
+          "runtime": {
+            "LambdaDemo.dll": {}
+          }
+        },
+        "Amazon.Lambda.Core/2.1.0": {
+          "runtime": {
+            "lib/net6.0/Amazon.Lambda.Core.dll": {
+              "assemblyVersion": "1.0.0.0",
+              "fileVersion": "1.0.0.0"
+            }
+          }
+        },
+        "Amazon.Lambda.Serialization.SystemTextJson/2.3.1": {
+          "dependencies": {
+            "Amazon.Lambda.Core": "2.1.0"
+          },
+          "runtime": {
+            "lib/net6.0/Amazon.Lambda.Serialization.SystemTextJson.dll": {
+              "assemblyVersion": "0.0.0.0",
+              "fileVersion": "0.0.0.0"
+            }
+          }
+        }
+      }
+    },
+    "libraries": {
+      "LambdaDemo/1.0.0": {
+        "type": "project",
+        "serviceable": false,
+        "sha512": ""
+      },
+      "Amazon.Lambda.Core/2.1.0": {
+        "type": "package",
+        "serviceable": true,
+        "sha512": "sha512-ok06UhfBZw6j6+PhiJR9C0EOMuJvnq8rMCHVkaFmPFrlI/q447ukwGZQKaAKqodV+MNTfpb/iPxjgUPVbSlVVw==",
+        "path": "amazon.lambda.core/2.1.0",
+        "hashPath": "amazon.lambda.core.2.1.0.nupkg.sha512"
+      },
+      "Amazon.Lambda.Serialization.SystemTextJson/2.3.1": {
+        "type": "package",
+        "serviceable": true,
+        "sha512": "sha512-7dGGgikMlEz72rGqeDwQEIxq+O8RDEdR4GH2S7hfZ8uzv5lyWVDuP2urV6MyD6APJ2WVHRwJlV74bB+XJncQpw==",
+        "path": "amazon.lambda.serialization.systemtextjson/2.3.1",
+        "hashPath": "amazon.lambda.serialization.systemtextjson.2.3.1.nupkg.sha512"
+      }
+    }
+  }


### PR DESCRIPTION
*Issue #, if available:*
* DOTNET-6421
* https://github.com/aws/aws-lambda-dotnet/issues/1235
* https://github.com/aws/aws-lambda-dotnet/issues/1398

*Description of changes:*
When the Lambda project references other executable projects (such as an ASP.NET Core Web API project) the `./bin/{CONFIGURATION}/{TARGET_FRAMEWORK}` will contain multiple `*deps.json` file. The Lambda test tool currently selects the first `deps.json` file it finds and will try to load the assembly context from the corresponsing `.dll` file.

This PR ensures that the right assembly is selected via the following algorithm
* Loop through all `*deps.json` files and extract all the keys in the `dependencies` JSON blob.
* Loop through all `*deps.json` files again:
  * Extract the project name by removing `.deps.json` suffix
  * Check if the project name is part of the `dependencies` collection.
  * If it isn't then this is the root project. Resolve the assembly path for this project and return it


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
