### PR TITLE
chore: Throw diagnostic errors for invalid parameter attribute names

### DIFF
--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/AnalyzerReleases.Shipped.md
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/AnalyzerReleases.Shipped.md
@@ -1,6 +1,11 @@
 ; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
+## Release 0.13.6.0
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+AWSLambda0110 | AWSLambdaCSharpGenerator | Error | Invalid Parameter Attribute Name
+
 ## Release 0.13.4.0
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/DiagnosticDescriptors.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/DiagnosticDescriptors.cs
@@ -80,5 +80,12 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Diagnostics
             category: "AWSLambdaCSharpGenerator",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor InvalidParameterAttributeName = new DiagnosticDescriptor(id: "AWSLambda0110",
+           title: "Invalid Parameter Attribute Name",
+           messageFormat: "Invalid parameter attribute name '{0}' for method parameter '{1}' encountered. Valid values can only contain uppercase and lowercase alphanumeric characters, periods (.), hyphens (-), underscores (_) and dollar signs ($).",
+           category: "AWSLambdaCSharpGenerator",
+           DiagnosticSeverity.Error,
+           isEnabledByDefault: true);
     }
 }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
@@ -686,6 +686,40 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
             }.RunAsync();
         }
 
+        [Fact]
+        public async Task InvalidParameterAttributeNames_ThrowsDiagnosticErrors()
+        {
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        (Path.Combine("TestServerlessApp", "PlaceholderClass.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "PlaceholderClass.cs"))),
+                        (Path.Combine("TestServerlessApp", "InvalidParameterAttributeNames.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "InvalidParameterAttributeNames.cs.error"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaFunctionAttribute.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "LambdaStartupAttribute.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "RestApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "RestApiAttribute.cs"))),
+                        (Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"), File.ReadAllText(Path.Combine("Amazon.Lambda.Annotations", "APIGateway", "HttpApiAttribute.cs"))),
+                        (Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"), File.ReadAllText(Path.Combine("TestServerlessApp", "AssemblyAttributes.cs"))),
+                    },
+                    ExpectedDiagnostics =
+                    {
+                         DiagnosticResult.CompilerError("AWSLambda0110").WithSpan($"TestServerlessApp{Path.DirectorySeparatorChar}InvalidParameterAttributeNames.cs", 10, 9, 15, 10)
+                                            .WithMessage("Invalid parameter attribute name 'This is a name' for method parameter 'name' encountered. Valid values can only contain uppercase and lowercase alphanumeric characters, periods (.), hyphens (-), underscores (_) and dollar signs ($)."),
+
+                          DiagnosticResult.CompilerError("AWSLambda0110").WithSpan($"TestServerlessApp{Path.DirectorySeparatorChar}InvalidParameterAttributeNames.cs", 18, 9, 23, 10)
+                                            .WithMessage("Invalid parameter attribute name 'System.Diagnostics.Process.Start(\"CMD.exe\",\"whoami\");' for method parameter 'test' encountered. Valid values can only contain uppercase and lowercase alphanumeric characters, periods (.), hyphens (-), underscores (_) and dollar signs ($)."),
+
+                          DiagnosticResult.CompilerError("AWSLambda0110").WithSpan($"TestServerlessApp{Path.DirectorySeparatorChar}InvalidParameterAttributeNames.cs", 26, 9, 31, 10)
+                                            .WithMessage("Invalid parameter attribute name 'first@name' for method parameter 'firstName' encountered. Valid values can only contain uppercase and lowercase alphanumeric characters, periods (.), hyphens (-), underscores (_) and dollar signs ($).")
+                    },
+                    ReferenceAssemblies = ReferenceAssemblies.Net.Net60
+                }
+
+            }.RunAsync();
+        }
+
         public void Dispose()
         {
             File.Delete(Path.Combine("TestServerlessApp", "serverless.template"));

--- a/Libraries/test/TestServerlessApp/InvalidParameterAttributeNames.cs.error
+++ b/Libraries/test/TestServerlessApp/InvalidParameterAttributeNames.cs.error
@@ -1,0 +1,33 @@
+﻿﻿using Amazon.Lambda.Annotations;
+using Amazon.Lambda.Annotations.APIGateway;
+using Amazon.Lambda.Core;
+
+namespace TestServerlessApp
+{
+    public class InvalidParameterAttributeNames
+    {
+        // This fails because the FromQuery attribute name contains whitespaces
+        [LambdaFunction()]
+        [HttpApi(LambdaHttpMethod.Get, "/SayHello", Version = HttpApiVersion.V1)]
+        public string SayHello([FromQuery(Name = "This is a name")] string name, ILambdaContext context)
+        {
+            return $"Hello, {name}!";
+        }
+
+        // This fails because the FromHeader attribute name contains escape characters and ';'
+        [LambdaFunction()]
+        [HttpApi(LambdaHttpMethod.Get, "/inject")]
+        public int Injection([FromHeader(Name = "System.Diagnostics.Process.Start(\"CMD.exe\",\"whoami\");")] int test, ILambdaContext context)
+        {
+            return 1;
+        }
+
+        // This fails because the FromRoute attribute name contains '@'
+        [LambdaFunction()]
+        [HttpApi(LambdaHttpMethod.Get, "/SayHello/{first@name}", Version = HttpApiVersion.V1)]
+        public string SayHelloFromRoute([FromRoute(Name = "first@name")] string firstName, ILambdaContext context)
+        {
+            return $"Hello, {firstName}!";
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp/TestServerlessApp.csproj
+++ b/Libraries/test/TestServerlessApp/TestServerlessApp.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <None Remove="ComplexQueryParameter.cs.error" />
     <None Remove="CustomizeResponseWithErrors.cs.error" />
+    <None Remove="InvalidParameterAttributeNames.cs.error" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7048

*Description of changes:*
This PR validates the _'Name'_ property of the `FromQuery`, `FromHeader`, `FromRoute` attributes against the following regex - `^[a-zA-Z0-9._$-]+$`

This regex is found on the official AWS docs for API Gateway request and response data mapping - https://docs.aws.amazon.com/apigateway/latest/developerguide/request-response-data-mappings.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
