### PR TITLE
Added support for --disable-logs command line option in Lambda Test Tool in --no-ui mode.

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj
@@ -6,7 +6,7 @@
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET Core AWS Lambda functions locally.</Description>
     <LangVersion>Latest</LangVersion>
-    <VersionPrefix>0.13.1</VersionPrefix>
+    <VersionPrefix>0.14.0</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester31-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester31-pack.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET Core 3.1 AWS Lambda functions locally.</Description>
-    <VersionPrefix>0.13.1</VersionPrefix>
+    <VersionPrefix>0.14.0</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester50-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester50-pack.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET 5.0 AWS Lambda functions locally.</Description>
-    <VersionPrefix>0.13.1</VersionPrefix>
+    <VersionPrefix>0.14.0</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester60-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester60-pack.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET 6.0 AWS Lambda functions locally.</Description>
-    <VersionPrefix>0.13.1</VersionPrefix>
+    <VersionPrefix>0.14.0</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester70-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester70-pack.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET 7.0 AWS Lambda functions locally.</Description>
-    <VersionPrefix>0.13.1</VersionPrefix>
+    <VersionPrefix>0.14.0</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/CommandLineOptions.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/CommandLineOptions.cs
@@ -28,6 +28,8 @@ namespace Amazon.Lambda.TestTool
 
         public bool PauseExit { get; set; } = true;
 
+        public bool DisableLogs { get; set; } = false;
+
         public static CommandLineOptions Parse(string[] args)
         {
             var options = new CommandLineOptions();
@@ -92,6 +94,13 @@ namespace Amazon.Lambda.TestTool
                         break;
                     case "--pause-exit":
                         options.PauseExit = GetNextBoolValue(i, out skipAhead);
+                        if (skipAhead)
+                        {
+                            i++;
+                        }
+                        break;
+                    case "--disable-logs":
+                        options.DisableLogs = GetNextBoolValue(i, out skipAhead);
                         if (skipAhead)
                         {
                             i++;
@@ -172,6 +181,7 @@ namespace Amazon.Lambda.TestTool
             Console.WriteLine("\t--pause-exit <true or false>          If set to true the test tool will pause waiting for a key input before exiting. The is useful");
             Console.WriteLine("\t                                      when executing from an IDE so you can avoid having the output window immediately disappear after");
             Console.WriteLine("\t                                      executing the Lambda code. The default value is true.");
+            Console.WriteLine("\t--disable-logs                        Logs response only or any exceptions (switch is valid when using --no-ui).");
         }
     }
 

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Utils.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Utils.cs
@@ -123,7 +123,7 @@ namespace Amazon.Lambda.TestTool
             return FindLambdaProjectDirectory(Directory.GetParent(lambdaAssemblyDirectory)?.FullName);
         }
 
-        public static IList<string> SearchForConfigFiles(string lambdaFunctionDirectory)
+        public static IList<string> SearchForConfigFiles(string lambdaFunctionDirectory, bool disableLogging = false)
         {
             var configFiles = new List<string>();
 
@@ -143,7 +143,7 @@ namespace Amazon.Lambda.TestTool
 
                         if (!string.IsNullOrEmpty(configFile.DetermineHandler()))
                         {
-                            Console.WriteLine($"Found Lambda config file {file}");
+                            if (!disableLogging) Console.WriteLine($"Found Lambda config file {file}");
                             configFiles.Add(file);
                         }
                         else if (!string.IsNullOrEmpty(configFile.Template) && File.Exists(Path.Combine(lambdaFunctionDirectory, configFile.Template)))
@@ -151,14 +151,14 @@ namespace Amazon.Lambda.TestTool
                             var config = LambdaDefaultsConfigFileParser.LoadFromFile(configFile);
                             if (config.FunctionInfos?.Count > 0)
                             {
-                                Console.WriteLine($"Found Lambda config file {file}");
+                                if (!disableLogging) Console.WriteLine($"Found Lambda config file {file}");
                                 configFiles.Add(file);
                             }
                         }
                     }
                     catch
                     {
-                        Console.WriteLine($"Error parsing JSON file: {file}");
+                        if (!disableLogging) Console.WriteLine($"Error parsing JSON file: {file}");
                     }
                 }
 
@@ -240,7 +240,12 @@ namespace Amazon.Lambda.TestTool
             if (depsFile.Count == 0)
                 return debugDirectory;
 
-            return depsFile[0].Directory.FullName;            
+            return depsFile[0].Directory.FullName;
+        }
+
+        public static bool ShouldDisableLogs(CommandLineOptions commandOptions)
+        {
+            return commandOptions != null && commandOptions.DisableLogs && commandOptions.NoUI;
         }
 
         /// <summary>

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/CommandLineParserTests.cs
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/CommandLineParserTests.cs
@@ -9,7 +9,7 @@ namespace Amazon.Lambda.TestTool.Tests
         {
             var options = CommandLineOptions.Parse(new string[] {"--help", "--host", "example.com", "--port", "1111", "--no-launch-window",
                                                                 "--path", "./foo", "--profile", "test", "--region", "special-region",
-                                                                "--no-ui", "--config-file", "test-config.json", "--payload", "myfile.json", "--pause-exit", "false" });
+                                                                "--no-ui", "--config-file", "test-config.json", "--payload", "myfile.json", "--pause-exit", "false", "--disable-logs" });
 
             Assert.True(options.ShowHelp);
             Assert.Equal("example.com", options.Host);
@@ -22,6 +22,7 @@ namespace Amazon.Lambda.TestTool.Tests
             Assert.Equal("test-config.json", options.ConfigFile);
             Assert.Equal("myfile.json", options.Payload);
             Assert.False(options.PauseExit);
+            Assert.True(options.DisableLogs);
         }
 
 

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/NoUiStartupTests.cs
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests.Shared/NoUiStartupTests.cs
@@ -96,13 +96,23 @@ namespace Amazon.Lambda.TestTool.Tests
             Assert.Contains("No default AWS region configured. The --region switch can be used to configure an AWS Region.", runConfiguration.OutputWriter.ToString());
         }
 
+        [Fact]
+        public void DirectFunctionCallFromConfigWithDisableLogs()
+        {
+            var runConfiguration = CreateRunConfiguration();
+            var buildPath = TestUtils.GetLambdaFunctionBuildPath("ToUpperFunc");
+
+            TestToolStartup.Startup("Unit Tests", null, new string[] { "--path", buildPath, "--no-ui", "--payload", "\"hello WORLD\"", "--disable-logs" }, runConfiguration);
+            Assert.Equal("\"HELLO WORLD\"", runConfiguration.OutputWriter.ToString());
+        }
+
         private TestToolStartup.RunConfiguration CreateRunConfiguration()
         {
             return new TestToolStartup.RunConfiguration
             {
                 Mode = TestToolStartup.RunConfiguration.RunMode.Test,
                 OutputWriter = new StringWriter()
-            };            
+            };
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:* #757

*Description of changes:*
Added support for `--disable-logs` command line option in Lambda Test Tool in `--no-ui` mode.

**NOTE:**
- The `--disable-logs` per my understanding should only be supported when `--no-ui` option is `true` (present) since in UI mode, we would like to capture all the logging information to be displayed in test tool page controls. Also the `--disable-logs` was requested by Amplify team, perhaps when they are executing tool in `--no-ui` mode.

___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
