### PR TITLE
Added support to populate some ILambdaContext properties to dummy values when executing under test tool.

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaExecutor.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaExecutor.cs
@@ -53,7 +53,10 @@ namespace Amazon.Lambda.TestTool.Runtime
 
                 var context = new LocalLambdaContext()
                 {
-                    Logger = logger
+                    Logger = logger,
+                    AwsRequestId = Guid.NewGuid().ToString(),
+                    FunctionName = request.Function.FunctionInfo.Name,
+                    InvokedFunctionArn = string.Format("arn:aws:lambda:{0}::function:{1}", request.AWSRegion, request.Function.FunctionInfo.Name)
                 };
 
                 object instance = null;


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-lambda-dotnet/issues/802

*Description of changes:*
Added support to populate some ILambdaContext properties to dummy values when executing under test tool.
___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
