### PR TITLE
fix: Add Null Conditional on Find Parent Directory

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/LocalLambdaOptions.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/LocalLambdaOptions.cs
@@ -63,7 +63,7 @@ namespace Amazon.Lambda.TestTool
             var currentDirectory = this.LambdaRuntime.LambdaAssemblyDirectory;
             while (currentDirectory != null && !Utils.IsProjectDirectory(currentDirectory))
             {
-                currentDirectory = Directory.GetParent(currentDirectory).FullName;
+                currentDirectory = Directory.GetParent(currentDirectory)?.FullName;
             }
 
             if (currentDirectory == null)


### PR DESCRIPTION


Issue #1555

*Description of changes:*

- Add operator to prevent null exception if no directory is found


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
