### PR TITLE
Corrected the date type of RabbitMQMessage.BasicProperties.Priority to Nullable int in RabbitMQEvent class.

### DIFF
--- a/Libraries/src/Amazon.Lambda.MQEvents/Amazon.Lambda.MQEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.MQEvents/Amazon.Lambda.MQEvents.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <Description>Amazon Lambda .NET Core support - MQEvents package.</Description>
     <AssemblyTitle>Amazon.Lambda.MQEvents</AssemblyTitle>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.MQEvents</AssemblyName>
     <PackageId>Amazon.Lambda.MQEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda;Amazon MQ;Rabbit MQ;Apache Active MQ</PackageTags>

--- a/Libraries/src/Amazon.Lambda.MQEvents/RabbitMQEvent.cs
+++ b/Libraries/src/Amazon.Lambda.MQEvents/RabbitMQEvent.cs
@@ -74,7 +74,7 @@
             /// <summary>
             /// Priority
             /// </summary>
-            public int Priority { get; set; }
+            public int? Priority { get; set; }
 
             /// <summary>
             /// Correlation ID

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -2823,26 +2823,47 @@ namespace Amazon.Lambda.Tests
                 Assert.Equal("arn:aws:mq:us-west-2:112556298976:broker:pizzaBroker:b-9bcfa592-423a-4942-879d-eb284b418fc8", rabbitmqEvent.EventSourceArn);
 
                 Assert.Equal(1, rabbitmqEvent.RmqMessagesByQueue.Count);
-                Assert.Equal(1, rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"].Count);
-                Assert.NotNull(rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"][0].BasicProperties);
-                Assert.Equal("text/plain", rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"][0].BasicProperties.ContentType);
-                Assert.Null(rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"][0].BasicProperties.ContentEncoding);
-                Assert.Equal(3, rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"][0].BasicProperties.Headers.Count);
-                Assert.Equal(1, rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"][0].BasicProperties.DeliveryMode);
-                Assert.Equal(34, rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"][0].BasicProperties.Priority);
-                Assert.Null(rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"][0].BasicProperties.CorrelationId);
-                Assert.Null(rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"][0].BasicProperties.ReplyTo);
-                Assert.Equal("60000", rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"][0].BasicProperties.Expiration);
-                Assert.Null(rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"][0].BasicProperties.MessageId);
-                Assert.NotNull(rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"][0].BasicProperties.Timestamp);
-                Assert.Null(rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"][0].BasicProperties.Type);
-                Assert.Equal("AIDACKCEVSQ6C2EXAMPLE", rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"][0].BasicProperties.UserId);
-                Assert.Null(rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"][0].BasicProperties.AppId);
-                Assert.Null(rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"][0].BasicProperties.ClusterId);
-                Assert.Equal(80, rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"][0].BasicProperties.BodySize);
+                Assert.Equal(2, rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"].Count);
 
-                Assert.False(rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"][0].Redelivered);
-                Assert.Equal("{\"timeout\":0,\"data\":\"CZrmf0Gw8Ov4bqLQxD4E\"}", Encoding.UTF8.GetString(Convert.FromBase64String(rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"][0].Data)));
+                var firstMessage = rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"][0];
+                Assert.NotNull(firstMessage.BasicProperties);
+                Assert.Equal("text/plain", firstMessage.BasicProperties.ContentType);
+                Assert.Null(firstMessage.BasicProperties.ContentEncoding);
+                Assert.Equal(3, firstMessage.BasicProperties.Headers.Count);
+                Assert.Equal(1, firstMessage.BasicProperties.DeliveryMode);
+                Assert.Equal(34, firstMessage.BasicProperties.Priority);
+                Assert.Null(firstMessage.BasicProperties.CorrelationId);
+                Assert.Null(firstMessage.BasicProperties.ReplyTo);
+                Assert.Equal("60000", firstMessage.BasicProperties.Expiration);
+                Assert.Null(firstMessage.BasicProperties.MessageId);
+                Assert.NotNull(firstMessage.BasicProperties.Timestamp);
+                Assert.Null(firstMessage.BasicProperties.Type);
+                Assert.Equal("AIDACKCEVSQ6C2EXAMPLE", firstMessage.BasicProperties.UserId);
+                Assert.Null(firstMessage.BasicProperties.AppId);
+                Assert.Null(firstMessage.BasicProperties.ClusterId);
+                Assert.Equal(80, firstMessage.BasicProperties.BodySize);
+                Assert.False(firstMessage.Redelivered);
+                Assert.Equal("{\"timeout\":0,\"data\":\"CZrmf0Gw8Ov4bqLQxD4E\"}", Encoding.UTF8.GetString(Convert.FromBase64String(firstMessage.Data)));
+
+                var secondMessage = rabbitmqEvent.RmqMessagesByQueue["pizzaQueue::/"][1];
+                Assert.NotNull(secondMessage.BasicProperties);
+                Assert.Null(secondMessage.BasicProperties.ContentType);
+                Assert.Null(secondMessage.BasicProperties.ContentEncoding);
+                Assert.Equal(0, secondMessage.BasicProperties.Headers.Count);
+                Assert.Equal(1, secondMessage.BasicProperties.DeliveryMode);
+                Assert.Null(secondMessage.BasicProperties.Priority);
+                Assert.Null(secondMessage.BasicProperties.CorrelationId);
+                Assert.Null(secondMessage.BasicProperties.ReplyTo);
+                Assert.Null(secondMessage.BasicProperties.Expiration);
+                Assert.Null(secondMessage.BasicProperties.MessageId);
+                Assert.Null(secondMessage.BasicProperties.Timestamp);
+                Assert.Null(secondMessage.BasicProperties.Type);
+                Assert.Null(secondMessage.BasicProperties.UserId);
+                Assert.Null(secondMessage.BasicProperties.AppId);
+                Assert.Null(secondMessage.BasicProperties.ClusterId);
+                Assert.Equal(11, secondMessage.BasicProperties.BodySize);
+                Assert.True(secondMessage.Redelivered);
+                Assert.Equal("Hello World", Encoding.UTF8.GetString(Convert.FromBase64String(secondMessage.Data)));
             }
         }
 

--- a/Libraries/test/EventsTests.Shared/amazonmq-rabbitmq.json
+++ b/Libraries/test/EventsTests.Shared/amazonmq-rabbitmq.json
@@ -45,6 +45,27 @@
         },
         "redelivered": false,
         "data": "eyJ0aW1lb3V0IjowLCJkYXRhIjoiQ1pybWYwR3c4T3Y0YnFMUXhENEUifQ=="
+      },
+      {
+        "basicProperties": {
+          "contentType": null,
+          "contentEncoding": null,
+          "headers": {},
+          "deliveryMode": 1,
+          "priority": null,
+          "correlationId": null,
+          "replyTo": null,
+          "expiration": null,
+          "messageId": null,
+          "timestamp": null,
+          "type": null,
+          "userId": null,
+          "appId": null,
+          "clusterId": null,
+          "bodySize": 11
+        },
+        "redelivered": true,
+        "data": "SGVsbG8gV29ybGQ="
       }
     ]
   }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-lambda-dotnet/issues/1562

*Description of changes:*
Corrected the date type of `RabbitMQMessage.BasicProperties.Priority` to Nullable `int` in `RabbitMQEvent` class.

Based on testing, the priority  value could be `null` as an example below:
```JSON
{
    "eventSourceArn": "arn:aws:mq:us-east-2:<<REDACTED>>:broker:testrabbitmqbroker:<<REDACTED>>",
    "rmqMessagesByQueue": {
        "TestQueue::/": [
            {
                "basicProperties": {
                    "contentType": null,
                    "contentEncoding": null,
                    "headers": {},
                    "deliveryMode": 1,
                    "priority": null,
                    "correlationId": null,
                    "replyTo": null,
                    "expiration": null,
                    "messageId": null,
                    "timestamp": null,
                    "type": null,
                    "userId": null,
                    "appId": null,
                    "clusterId": null,
                    "bodySize": 11
                },
                "redelivered": true,
                "data": "SGVsbG8gV29ybGQ="
            }
        ]
    },
    "eventSource": "aws:rmq"
}
```

___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
