### PR TITLE
Use the new .NET 8 APIs to configure max heap memory size

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
@@ -3,10 +3,9 @@
   <Import Project="..\..\..\buildtools\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net8.0</TargetFrameworks>
     <VersionPrefix>1.8.8</VersionPrefix>
     <Description>Provides a bootstrap and Lambda Runtime API Client to help you to develop custom .NET Core Lambda Runtimes.</Description>
-    <Description>Provides a bootstrap and Lambda Runtime API Client to help you  to develop custom .NET Core Lambda Runtimes.</Description>
     <AssemblyTitle>Amazon.Lambda.RuntimeSupport</AssemblyTitle>
     <AssemblyName>Amazon.Lambda.RuntimeSupport</AssemblyName>
     <PackageId>Amazon.Lambda.RuntimeSupport</PackageId>

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
@@ -114,7 +114,11 @@ namespace Amazon.Lambda.RuntimeSupport
         /// <returns>A Task that represents the operation.</returns>
         public async Task RunAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            if(UserCodeInit.IsCallPreJit())
+#if NET8_0_OR_GREATER
+            AdjustMemorySettings();
+#endif
+
+            if (UserCodeInit.IsCallPreJit())
             {
                 this._logger.LogInformation("PreJit: CultureInfo");
                 UserCodeInit.LoadStringCultureInfo();
@@ -247,6 +251,45 @@ namespace Amazon.Lambda.RuntimeSupport
             // will take care of writing to the function's log stream.
             Console.Error.WriteLine(exception);
         }
+
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// The .NET runtime does not recognize the memory limits placed by Lambda via Lambda's cgroups. This method is run during startup to inform the
+        /// .NET runtime the max memory configured for Lambda function. The max memory can be determined using the AWS_LAMBDA_FUNCTION_MEMORY_SIZE environment variable
+        /// which has the memory in MB.
+        /// 
+        /// For additional context on setting the heap size refer to this GitHub issue:
+        /// https://github.com/dotnet/runtime/issues/70601
+        /// </summary>
+        private void AdjustMemorySettings()
+        {
+            try
+            {
+                int lambdaMemoryInMb;
+                if (!int.TryParse(Environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_MEMORY_SIZE"), out lambdaMemoryInMb))
+                    return;
+
+                ulong memoryInBytes = (ulong)lambdaMemoryInMb * 1048576;
+
+                // If the user has already configured the hard heap limit to something lower then is available 
+                // then make no adjustments to honor the user's setting.
+                if ((ulong)GC.GetGCMemoryInfo().TotalAvailableMemoryBytes < memoryInBytes)
+                    return;
+
+                AppContext.SetData("GCHeapHardLimit", memoryInBytes);
+
+// The RefreshMemoryLimit API is currently marked as a preview feature. Disable the warning for now but this
+// feature can not be merged till the API is no longer marked as preview.
+#pragma warning disable CA2252
+                GC.RefreshMemoryLimit();
+#pragma warning disable CA2252
+            }
+            catch(Exception ex)
+            {
+                _logger.LogError(ex, "Failed to communicate to the .NET runtime the amount of memory configured for the Lambda function via the AWS_LAMBDA_FUNCTION_MEMORY_SIZE environment variable.");
+            }
+        }
+#endif
 
         #region IDisposable Support
         private bool disposedValue = false; // To detect redundant calls

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/Amazon.Lambda.RuntimeSupport.IntegrationTests.csproj
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/Amazon.Lambda.RuntimeSupport.IntegrationTests.csproj
@@ -43,16 +43,20 @@
     <Exec Command="dotnet tool install -g Amazon.Lambda.Tools" IgnoreExitCode="true" />
 
 	<Exec WorkingDirectory="..\CustomRuntimeFunctionTest" Command="dotnet restore" />
-    <Exec WorkingDirectory="..\CustomRuntimeFunctionTest" Condition="'$(Architecture)'=='' or '$(Architecture)'=='x86'" Command="dotnet lambda package -c Release" />
-    <Exec WorkingDirectory="..\CustomRuntimeFunctionTest" Condition="'$(Architecture)'=='arm64'" Command="dotnet lambda package -c Release --function-architecture arm64" />
+    <Exec WorkingDirectory="..\CustomRuntimeFunctionTest" Condition="'$(Architecture)'=='' or '$(Architecture)'=='x86'" Command="dotnet lambda package -c Release --framework net6.0" />
+    <Exec WorkingDirectory="..\CustomRuntimeFunctionTest" Condition="'$(Architecture)'=='arm64'" Command="dotnet lambda package -c Release --framework net6.0 --function-architecture arm64" />
+	  
+	<Exec WorkingDirectory="..\CustomRuntimeFunctionTest" Command="dotnet restore" />
+    <Exec WorkingDirectory="..\CustomRuntimeFunctionTest" Condition="'$(Architecture)'=='' or '$(Architecture)'=='x86'" Command="dotnet lambda package -c Release --framework net8.0" />
+    <Exec WorkingDirectory="..\CustomRuntimeFunctionTest" Condition="'$(Architecture)'=='arm64'" Command="dotnet lambda package -c Release --framework net8.0 --function-architecture arm64" />	  
 
 	<Exec WorkingDirectory="..\CustomRuntimeAspNetCoreMinimalApiTest" Command="dotnet restore" />
-	<Exec WorkingDirectory="..\CustomRuntimeAspNetCoreMinimalApiTest" Condition="'$(Architecture)'=='' or '$(Architecture)'=='x86'" Command="dotnet lambda package -c Release" />
-	<Exec WorkingDirectory="..\CustomRuntimeAspNetCoreMinimalApiTest" Condition="'$(Architecture)'=='arm64'" Command="dotnet lambda package -c Release --function-architecture arm64" />
+	<Exec WorkingDirectory="..\CustomRuntimeAspNetCoreMinimalApiTest" Condition="'$(Architecture)'=='' or '$(Architecture)'=='x86'" Command="dotnet lambda package -c Release --framework net6.0" />
+	<Exec WorkingDirectory="..\CustomRuntimeAspNetCoreMinimalApiTest" Condition="'$(Architecture)'=='arm64'" Command="dotnet lambda package -c Release --framework net6.0 --function-architecture arm64" />
 
 	<Exec WorkingDirectory="..\CustomRuntimeAspNetCoreMinimalApiCustomSerializerTest" Command="dotnet restore" />
-	<Exec WorkingDirectory="..\CustomRuntimeAspNetCoreMinimalApiCustomSerializerTest" Condition="'$(Architecture)'=='' or '$(Architecture)'=='x86'" Command="dotnet lambda package -c Release" />
-	<Exec WorkingDirectory="..\CustomRuntimeAspNetCoreMinimalApiCustomSerializerTest" Condition="'$(Architecture)'=='arm64'" Command="dotnet lambda package -c Release --function-architecture arm64" />	  
+	<Exec WorkingDirectory="..\CustomRuntimeAspNetCoreMinimalApiCustomSerializerTest" Condition="'$(Architecture)'=='' or '$(Architecture)'=='x86'" Command="dotnet lambda package -c Release --framework net6.0" />
+	<Exec WorkingDirectory="..\CustomRuntimeAspNetCoreMinimalApiCustomSerializerTest" Condition="'$(Architecture)'=='arm64'" Command="dotnet lambda package -c Release --framework net6.0 --function-architecture arm64" />	  
   </Target>
 
 </Project>

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/BaseCustomRuntimeTest.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/BaseCustomRuntimeTest.cs
@@ -15,6 +15,8 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
 {
     public class BaseCustomRuntimeTest
     {
+        public const int FUNCTION_MEMORY_MB = 512;
+
         protected static readonly RegionEndpoint TestRegion = RegionEndpoint.USWest2;
         protected static readonly string LAMBDA_ASSUME_ROLE_POLICY =
         @"
@@ -240,7 +242,7 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
                     S3Key = DeploymentZipKey
                 },
                 Handler = this.Handler,
-                MemorySize = 512,
+                MemorySize = FUNCTION_MEMORY_MB,
                 Timeout = 30,
                 Runtime = Runtime.Dotnet6,
                 Role = ExecutionRoleArn

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/CustomRuntimeFunctionTest/CustomRuntimeFunction.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/CustomRuntimeFunctionTest/CustomRuntimeFunction.cs
@@ -36,6 +36,9 @@ namespace CustomRuntimeFunctionTest
             {
                 switch (handler)
                 {
+                    case nameof(GetTotalAvailableMemoryBytes):
+                        bootstrap = new LambdaBootstrap(GetTotalAvailableMemoryBytes);
+                        break;
                     case nameof(ExceptionNonAsciiCharacterUnwrappedAsync):
                         bootstrap = new LambdaBootstrap(ExceptionNonAsciiCharacterUnwrappedAsync);
                         break;
@@ -424,6 +427,11 @@ namespace CustomRuntimeFunctionTest
         private static Task<InvocationResponse> GetTimezoneNameAsync(InvocationRequest invocation)
         {
             return Task.FromResult(GetInvocationResponse(nameof(GetTimezoneNameAsync), TimeZoneInfo.Local.Id));
+        }
+
+        private static async Task<InvocationResponse> GetTotalAvailableMemoryBytes(InvocationRequest invocation)
+        {
+            return GetInvocationResponse(nameof(GetTotalAvailableMemoryBytes), GC.GetGCMemoryInfo().TotalAvailableMemoryBytes.ToString());
         }
 
         #region Helpers

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/CustomRuntimeFunctionTest/CustomRuntimeFunctionTest.csproj
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/CustomRuntimeFunctionTest/CustomRuntimeFunctionTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The .NET runtime does recognize the memory limits that have been set by Lambda's cgroup configuration. As part of .NET 8 the .NET team added support for configuring the max heap memory size via the `AppContext.SetData("GCHeapHardLimit", memoryInBytes);` and `GC.RefreshMemoryLimit();` APIs. Refer to this GitHub issue for more information on these APIs. https://github.com/dotnet/runtime/issues/70601

**WARNING:** The new APIs are currently marked as preview in the .NET runtime. This PR should not be merged till the APIs are no longer marked as preview. Removing the preview attribute is being discussed here: https://github.com/dotnet/runtime/discussions/91567

The Lambda runtime client (Amazon.Lambda.RuntimeSupport) is now using these APIs for functions that target .NET 8 by taking the memory size configured for the Lambda function and communicating that size to the .NET runtime via the new APIs. This is done via the new `AdjustMemorySettings` method in `LambdaBootstrap` inside RuntimeSupport. The method is called once before any Lambda invocations are made. 

If the users set the memory max memory settings themselves, for example using the `DOTNET_GCHeapHardLimit`, to a value less than what Lambda function is configured for then the `AdjustMemorySettings` will return making no adjustments. Users might now they will run other processes in the background that will take away some of the memory and so tell .NET it has to use less then the full function's memory setting.

New integration tests were added to confirm the memory settings. The tests only work for .NET 8. If the test run for .NET 6 they will with the Lambda function thinking it has more memory then it really does have. These were the first .NET 8 integration tests added for RuntimeSupport and the integration tests need to be reworked a bit to support both .NET 6 and .NET 8 integration tests.