### PR TITLE
chore: Update Powertools definitions 1.7.0

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -14,8 +14,8 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
-    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.1.0" />
-    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.2.0" />
-    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.1.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.3.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.4.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.3.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.6.0" />
-    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.1.0" />
-    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.2.0" />
-    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.1.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.3.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.4.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.3.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update Powertools defenitions to reflect latest 1.7.0 release

AWS.Lambda.Powertools.Logging - 1.3.0
AWS.Lambda.Powertools.Metrics - 1.4.0
AWS.Lambda.Powertools.Tracing - 1.3.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
