### PR TITLE
Initial PR for structured logging support

### DIFF
--- a/Libraries/src/Amazon.Lambda.Core/ILambdaLogger.cs
+++ b/Libraries/src/Amazon.Lambda.Core/ILambdaLogger.cs
@@ -65,7 +65,7 @@ namespace Amazon.Lambda.Core
 #if NET6_0_OR_GREATER
 
         /// <summary>
-        /// Log message catagorized by the given log level
+        /// Log message categorized by the given log level
         /// <para>
         /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
         /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
@@ -76,7 +76,7 @@ namespace Amazon.Lambda.Core
         void Log(string level, string message) => LogLine(message);
 
         /// <summary>
-        /// Log message catagorized by the given log level
+        /// Log message categorized by the given log level
         /// <para>
         /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
         /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
@@ -154,7 +154,7 @@ namespace Amazon.Lambda.Core
             "project file to \"true\"";
 
         /// <summary>
-        /// Log message catagorized by the given log level
+        /// Log message categorized by the given log level
         /// <para>
         /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
         /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
@@ -167,7 +167,7 @@ namespace Amazon.Lambda.Core
         void Log(string level, string message, params object[] args) => Log(level, message, args);
 
         /// <summary>
-        /// Log message catagorized by the given log level
+        /// Log message categorized by the given log level
         /// <para>
         /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
         /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
@@ -185,7 +185,7 @@ namespace Amazon.Lambda.Core
         }
 
         /// <summary>
-        /// Log message catagorized by the given log level
+        /// Log message categorized by the given log level
         /// <para>
         /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
         /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
@@ -198,7 +198,7 @@ namespace Amazon.Lambda.Core
         void Log(LogLevel level, string message, params object[] args) => Log(level.ToString(), message, args);
 
         /// <summary>
-        /// Log message catagorized by the given log level
+        /// Log message categorized by the given log level
         /// <para>
         /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
         /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".

--- a/Libraries/src/Amazon.Lambda.Core/ILambdaLogger.cs
+++ b/Libraries/src/Amazon.Lambda.Core/ILambdaLogger.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Runtime.Versioning;
+
 namespace Amazon.Lambda.Core
 {
 #if NET6_0_OR_GREATER
@@ -142,6 +145,222 @@ namespace Amazon.Lambda.Core
         /// </summary>
         /// <param name="message"></param>
         void LogCritical(string message) => Log(LogLevel.Critical.ToString(), message);
+
+
+        private const string ParameterizedPreviewMessage =
+            "Parameterized logging is in preview till a new version of .NET Lambda runtime client that supports parameterized logging " +
+            "has been deployed to the .NET Lambda managed runtime. Till deployment has been made the feature can be used by deploying as an " +
+            "executable including the latest version of Amazon.Lambda.RuntimeSupport and setting the \"LangVersion\" in the Lambda " +
+            "project file to \"preview\"";
+
+        /// <summary>
+        /// Log message catagorized by the given log level
+        /// <para>
+        /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
+        /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
+        /// </para>
+        /// </summary>
+        /// <param name="level">Log level of the message.</param>
+        /// <param name="message">Message to log.</param>
+        /// <param name="args">Values to be replaced in log messages that are parameterized.</param>
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        void Log(string level, string message, params object[] args) => Log(level, message);
+
+        /// <summary>
+        /// Log message catagorized by the given log level
+        /// <para>
+        /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
+        /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
+        /// </para>
+        /// </summary>
+        /// <param name="level">Log level of the message.</param>
+        /// <param name="exception">Exception to include with the logging.</param>
+        /// <param name="message">Message to log.</param>
+        /// <param name="args">Values to be replaced in log messages that are parameterized.</param>
+        [RequiresPreviewFeatures("Parameterized logging is in preview till new version of .NET Lambda runtime client is deployed to the .NET Lambda managed runtime.")]
+        void Log(string level, Exception exception, string message, params object[] args)
+        {
+            Log(level, message);
+            Log(level, exception.ToString());
+        }
+
+        /// <summary>
+        /// Log message catagorized by the given log level
+        /// <para>
+        /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
+        /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
+        /// </para>
+        /// </summary>
+        /// <param name="level">Log level of the message.</param>
+        /// <param name="message">Message to log.</param>
+        /// <param name="args">Values to be replaced in log messages that are parameterized.</param>
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        void Log(LogLevel level, string message, params object[] args) => Log(level.ToString(), message, args);
+
+        /// <summary>
+        /// Log message catagorized by the given log level
+        /// <para>
+        /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
+        /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
+        /// </para>
+        /// </summary>
+        /// <param name="level">Log level of the message.</param>
+        /// <param name="exception">Exception to include with the logging.</param>
+        /// <param name="message">Message to log.</param>
+        /// <param name="args">Values to be replaced in log messages that are parameterized.</param>
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        void Log(LogLevel level, Exception exception, string message, params object[] args) => Log(level.ToString(), exception, message, args);
+
+        /// <summary>
+        /// Log trace message.
+        /// <para>
+        /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
+        /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
+        /// </para>
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        /// <param name="args">Values to be replaced in log messages that are parameterized.</param>
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        void LogTrace(string message, params object[] args) => Log(LogLevel.Trace.ToString(), message, args);
+
+        /// <summary>
+        /// Log trace message.
+        /// <para>
+        /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
+        /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
+        /// </para>
+        /// </summary>
+        /// <param name="exception">Exception to include with the logging.</param>
+        /// <param name="message">Message to log.</param>
+        /// <param name="args">Values to be replaced in log messages that are parameterized.</param>
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        void LogTrace(Exception exception, string message, params object[] args) => Log(LogLevel.Trace.ToString(), exception, message, args);
+
+        /// <summary>
+        /// Log debug message.
+        /// <para>
+        /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
+        /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
+        /// </para>
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        /// <param name="args">Values to be replaced in log messages that are parameterized.</param>
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        void LogDebug(string message, params object[] args) => Log(LogLevel.Debug.ToString(), message, args);
+
+        /// <summary>
+        /// Log debug message.
+        /// <para>
+        /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
+        /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
+        /// </para>
+        /// </summary>
+        /// <param name="exception">Exception to include with the logging.</param>
+        /// <param name="message">Message to log.</param>
+        /// <param name="args">Values to be replaced in log messages that are parameterized.</param>
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        void LogDebug(Exception exception, string message, params object[] args) => Log(LogLevel.Debug.ToString(), exception, message, args);
+
+        /// <summary>
+        /// Log information message.
+        /// <para>
+        /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
+        /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
+        /// </para>
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        /// <param name="args">Values to be replaced in log messages that are parameterized.</param>
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        void LogInformation(string message, params object[] args) => Log(LogLevel.Information.ToString(), message, args);
+
+        /// <summary>
+        /// Log information message.
+        /// <para>
+        /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
+        /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
+        /// </para>
+        /// </summary>
+        /// <param name="exception">Exception to include with the logging.</param>
+        /// <param name="message">Message to log.</param>
+        /// <param name="args">Values to be replaced in log messages that are parameterized.</param>
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        void LogInformation(Exception exception, string message, params object[] args) => Log(LogLevel.Information.ToString(), exception, message, args);
+
+        /// <summary>
+        /// Log warning message.
+        /// <para>
+        /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
+        /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
+        /// </para>
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        /// <param name="args">Values to be replaced in log messages that are parameterized.</param>
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        void LogWarning(string message, params object[] args) => Log(LogLevel.Warning.ToString(), message, args);
+
+        /// <summary>
+        /// Log warning message.
+        /// <para>
+        /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
+        /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
+        /// </para>
+        /// </summary>
+        /// <param name="exception">Exception to include with the logging.</param>
+        /// <param name="message">Message to log.</param>
+        /// <param name="args">Values to be replaced in log messages that are parameterized.</param>
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        void LogWarning(Exception exception, string message, params object[] args) => Log(LogLevel.Warning.ToString(), exception, message, args);
+
+        /// <summary>
+        /// Log error message.
+        /// <para>
+        /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
+        /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
+        /// </para>
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        /// <param name="args">Values to be replaced in log messages that are parameterized.</param>
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        void LogError(string message, params object[] args) => Log(LogLevel.Error.ToString(), message, args);
+
+        /// <summary>
+        /// Log error message.
+        /// <para>
+        /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
+        /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
+        /// </para>
+        /// </summary>
+        /// <param name="exception">Exception to include with the logging.</param>
+        /// <param name="message">Message to log.</param>
+        /// <param name="args">Values to be replaced in log messages that are parameterized.</param>
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        void LogError(Exception exception, string message, params object[] args) => Log(LogLevel.Error.ToString(), exception, message, args);
+
+        /// <summary>
+        /// Log critical message.
+        /// <para>
+        /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
+        /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
+        /// </para>
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        /// <param name="args">Values to be replaced in log messages that are parameterized.</param>
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        void LogCritical(string message, params object[] args) => Log(LogLevel.Critical.ToString(), message, args);
+
+        /// <summary>
+        /// Log critical message.
+        /// <para>
+        /// To configure the minimum log level set the AWS_LAMBDA_HANDLER_LOG_LEVEL environment variable. The value should be set
+        /// to one of the values in the LogLevel enumeration. The default minimum log level is "Information".
+        /// </para>
+        /// </summary>
+        /// <param name="exception">Exception to include with the logging.</param>
+        /// <param name="message">Message to log.</param>
+        /// <param name="args">Values to be replaced in log messages that are parameterized.</param>
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        void LogCritical(Exception exception, string message, params object[] args) => Log(LogLevel.Critical.ToString(), exception, message, args);
+
 #endif
 
     }

--- a/Libraries/src/Amazon.Lambda.Core/ILambdaLogger.cs
+++ b/Libraries/src/Amazon.Lambda.Core/ILambdaLogger.cs
@@ -150,8 +150,8 @@ namespace Amazon.Lambda.Core
         private const string ParameterizedPreviewMessage =
             "Parameterized logging is in preview till a new version of .NET Lambda runtime client that supports parameterized logging " +
             "has been deployed to the .NET Lambda managed runtime. Till deployment has been made the feature can be used by deploying as an " +
-            "executable including the latest version of Amazon.Lambda.RuntimeSupport and setting the \"LangVersion\" in the Lambda " +
-            "project file to \"preview\"";
+            "executable including the latest version of Amazon.Lambda.RuntimeSupport and setting the \"EnablePreviewFeatures\" in the Lambda " +
+            "project file to \"true\"";
 
         /// <summary>
         /// Log message catagorized by the given log level
@@ -164,7 +164,7 @@ namespace Amazon.Lambda.Core
         /// <param name="message">Message to log.</param>
         /// <param name="args">Values to be replaced in log messages that are parameterized.</param>
         [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
-        void Log(string level, string message, params object[] args) => Log(level, message);
+        void Log(string level, string message, params object[] args) => Log(level, message, args);
 
         /// <summary>
         /// Log message catagorized by the given log level
@@ -177,11 +177,11 @@ namespace Amazon.Lambda.Core
         /// <param name="exception">Exception to include with the logging.</param>
         /// <param name="message">Message to log.</param>
         /// <param name="args">Values to be replaced in log messages that are parameterized.</param>
-        [RequiresPreviewFeatures("Parameterized logging is in preview till new version of .NET Lambda runtime client is deployed to the .NET Lambda managed runtime.")]
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
         void Log(string level, Exception exception, string message, params object[] args)
         {
-            Log(level, message);
-            Log(level, exception.ToString());
+            Log(level, message, args);
+            Log(level, exception.ToString(), args);
         }
 
         /// <summary>

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
@@ -14,6 +14,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
+	<LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(ExecutableOutputType)'=='true' ">

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Context/LambdaConsoleLogger.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Context/LambdaConsoleLogger.cs
@@ -15,6 +15,7 @@
 using Amazon.Lambda.Core;
 using Amazon.Lambda.RuntimeSupport.Helpers;
 using System;
+using System.Runtime.Versioning;
 
 namespace Amazon.Lambda.RuntimeSupport
 {
@@ -43,6 +44,24 @@ namespace Amazon.Lambda.RuntimeSupport
         public void Log(string level, string message)
         {
             _consoleLoggerRedirector.FormattedWriteLine(level, message);
+        }
+
+        private const string ParameterizedPreviewMessage =
+            "Parameterized logging is in preview till a new version of .NET Lambda runtime client that supports parameterized logging " +
+            "has been deployed to the .NET Lambda managed runtime. Till deployment has been made the feature can be used by deploying as an " +
+            "executable including the latest version of Amazon.Lambda.RuntimeSupport and setting the \"LangVersion\" in the Lambda " +
+            "project file to \"preview\"";
+
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        public void Log(string level, string message, params object[] args)
+        {
+            _consoleLoggerRedirector.FormattedWriteLine(level, message, args);
+        }
+
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        public void Log(string level, Exception exception, string message, params object[] args)
+        {
+            _consoleLoggerRedirector.FormattedWriteLine(level, exception, message, args);
         }
 #endif
     }

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/ConsoleLoggerWriter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/ConsoleLoggerWriter.cs
@@ -21,6 +21,11 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+
+#if NET6_0_OR_GREATER
+using Amazon.Lambda.RuntimeSupport.Helpers.Logging;
+#endif
+
 namespace Amazon.Lambda.RuntimeSupport.Helpers
 {
     /// <summary>
@@ -45,7 +50,17 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
         /// </summary>
         /// <param name="level"></param>
         /// <param name="message"></param>
-        void FormattedWriteLine(string level, string message);
+        /// <param name="args"></param>
+        void FormattedWriteLine(string level, string message, params object[] args);
+
+        /// <summary>
+        /// Format message with given log level
+        /// </summary>
+        /// <param name="level"></param>
+        /// <param name="exception"></param>
+        /// <param name="message"></param>
+        /// <param name="args"></param>
+        void FormattedWriteLine(string level, Exception exception, string message, params object[] args);
     }
 
     /// <summary>
@@ -89,9 +104,15 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
             _writer.WriteLine(message);
         }
 
-        public void FormattedWriteLine(string level, string message)
+        public void FormattedWriteLine(string level, string message, params object[] args)
         {
             _writer.WriteLine(message);
+        }
+
+        public void FormattedWriteLine(string level, Exception exception, string message, params object[] args)
+        {
+            _writer.WriteLine(message);
+            _writer.WriteLine(exception.ToString());
         }
     }
 
@@ -107,7 +128,7 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
         /// Amazon.Lambda.Core can not be relied on because the Lambda Function could be using
         /// an older version of Amazon.Lambda.Core before LogLevel existed in Amazon.Lambda.Core.
         /// </summary>
-        enum LogLevel
+        public enum LogLevel
         {
             /// <summary>
             /// Trace level logging
@@ -227,9 +248,14 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
             _wrappedStdOutWriter.FormattedWriteLine(message);
         }
 
-        public void FormattedWriteLine(string level, string message)
+        public void FormattedWriteLine(string level, string message, params object[] args)
         {
-            _wrappedStdOutWriter.FormattedWriteLine(level, message);
+            _wrappedStdOutWriter.FormattedWriteLine(level, (Exception)null, message, args);
+        }
+
+        public void FormattedWriteLine(string level, Exception exception, string message, params object[] args)
+        {
+            _wrappedStdOutWriter.FormattedWriteLine(level, exception, message, args);
         }
 
 
@@ -243,14 +269,19 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
             private readonly TextWriter _innerWriter;
             private string _defaultLogLevel;
 
-            const string LOG_LEVEL_ENVIRONMENT_VARIABLE = "AWS_LAMBDA_HANDLER_LOG_LEVEL";
-            const string LOG_FORMAT_ENVIRONMENT_VARIABLE = "AWS_LAMBDA_HANDLER_LOG_FORMAT";
+            const string NET_RIC_LOG_LEVEL_ENVIRONMENT_VARIABLE = "AWS_LAMBDA_HANDLER_LOG_LEVEL";
+            const string NET_RIC_LOG_FORMAT_ENVIRONMENT_VARIABLE = "AWS_LAMBDA_HANDLER_LOG_FORMAT";
+
+            const string LAMBDA_LOG_LEVEL_ENVIRONMENT_VARIABLE = "AWS_LAMBDA_LOG_LEVEL";
+            const string LAMBDA_LOG_FORMAT_ENVIRONMENT_VARIABLE = "AWS_LAMBDA_LOG_FORMAT";
 
             private LogLevel _minmumLogLevel = LogLevel.Information;
 
-            enum LogFormatType { Default, Unformatted }
+            enum LogFormatType { Default, Unformatted, Json }
 
             private LogFormatType _logFormatType = LogFormatType.Default;
+
+            private ILogMessageFormatter _logMessageFormatter;
 
             public string CurrentAwsRequestId { get; set; } = string.Empty;
 
@@ -267,16 +298,21 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
                 _innerWriter = innerWriter;
                 _defaultLogLevel = defaultLogLevel;
 
-                var envLogLevel = Environment.GetEnvironmentVariable(LOG_LEVEL_ENVIRONMENT_VARIABLE);
+                var envLogLevel = GetEnviromentVariable(NET_RIC_LOG_LEVEL_ENVIRONMENT_VARIABLE, LAMBDA_LOG_LEVEL_ENVIRONMENT_VARIABLE);
                 if (!string.IsNullOrEmpty(envLogLevel))
                 {
-                    if (Enum.TryParse<LogLevel>(envLogLevel, true, out var result))
+                    // Map Lambda's fatal logging level to the .NET RIC critical
+                    if(string.Equals(envLogLevel, "fatal", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        _minmumLogLevel = LogLevel.Critical;
+                    }
+                    else if (Enum.TryParse<LogLevel>(envLogLevel, true, out var result))
                     {
                         _minmumLogLevel = result;
                     }
                 }
 
-                var envLogFormat = Environment.GetEnvironmentVariable(LOG_FORMAT_ENVIRONMENT_VARIABLE);
+                var envLogFormat = GetEnviromentVariable(NET_RIC_LOG_FORMAT_ENVIRONMENT_VARIABLE, LAMBDA_LOG_FORMAT_ENVIRONMENT_VARIABLE);
                 if (!string.IsNullOrEmpty(envLogFormat))
                 {
                     if (Enum.TryParse<LogFormatType>(envLogFormat, true, out var result))
@@ -284,14 +320,34 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
                         _logFormatType = result;
                     }
                 }
+
+                if(_logFormatType == LogFormatType.Json)
+                {
+                    _logMessageFormatter = new JsonLogMessageFormatter();
+                }
+                else
+                {
+                    _logMessageFormatter = new DefaultLogMessageFormatter(_logFormatType != LogFormatType.Unformatted);
+                }
+            }
+
+            private string GetEnviromentVariable(string envName, string fallbackEnvName)
+            {
+                var value = Environment.GetEnvironmentVariable(envName);
+                if(string.IsNullOrEmpty(value) && fallbackEnvName != null)
+                {
+                    value = Environment.GetEnvironmentVariable(fallbackEnvName);
+                }
+
+                return value;
             }
 
             internal void FormattedWriteLine(string message)
             {
-                FormattedWriteLine(_defaultLogLevel, message);
+                FormattedWriteLine(_defaultLogLevel, (Exception)null, message);
             }
 
-            internal void FormattedWriteLine(string level, string message)
+            internal void FormattedWriteLine(string level, Exception exeception, string messageTemplate, params object[] args)
             {
                 lock(LockObject)
                 {
@@ -300,28 +356,20 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
                     {
                         if (levelEnum < _minmumLogLevel)
                             return;
-
-                        displayLevel = ConvertLogLevelToLabel(levelEnum);
                     }
 
-                    if (_logFormatType == LogFormatType.Unformatted)
-                    {
-                        _innerWriter.WriteLine(message);
-                    }
-                    else
-                    {
-                        string line;
-                        if (!string.IsNullOrEmpty(displayLevel))
-                        {
-                            line = $"{DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")}\t{CurrentAwsRequestId}\t{displayLevel}\t{message ?? string.Empty}";
-                        }
-                        else
-                        {
-                            line = $"{DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")}\t{CurrentAwsRequestId}\t{message ?? string.Empty}";
-                        }
+                    var messageState = new MessageState();
 
-                        _innerWriter.WriteLine(line);
-                    }
+                    messageState.MessageTemplate = messageTemplate;
+                    messageState.MessageArguments = args;
+                    messageState.TimeStamp = DateTime.UtcNow;
+                    messageState.AwsRequestId = CurrentAwsRequestId;
+                    messageState.TraceId = Environment.GetEnvironmentVariable(LambdaEnvironment.EnvVarTraceId);
+                    messageState.Level = levelEnum;
+                    messageState.Exception = exeception;
+
+                    var message = _logMessageFormatter.FormatMessage(messageState);
+                    _innerWriter.WriteLine(message);
                 }
             }
 
@@ -329,32 +377,6 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
             {
                 FormattedWriteLine(message);
                 return Task.CompletedTask;
-            }
-
-            /// <summary>
-            /// Convert LogLevel enums to the the same string label that console provider for Microsoft.Extensions.Logging.ILogger uses.
-            /// </summary>
-            /// <param name="level"></param>
-            /// <returns></returns>
-            private string ConvertLogLevelToLabel(LogLevel level)
-            {
-                switch (level)
-                {
-                    case LogLevel.Trace:
-                        return "trce";
-                    case LogLevel.Debug:
-                        return "dbug";
-                    case LogLevel.Information:
-                        return "info";
-                    case LogLevel.Warning:
-                        return "warn";
-                    case LogLevel.Error:
-                        return "fail";
-                    case LogLevel.Critical:
-                        return "crit";
-                }
-
-                return level.ToString();
             }
 
             #region WriteLine redirects to formatting

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/ConsoleLoggerWriter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/ConsoleLoggerWriter.cs
@@ -36,30 +36,30 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
         /// <summary>
         /// The current aws request id
         /// </summary>
-        /// <param name="awsRequestId"></param>
+        /// <param name="awsRequestId">The AWS request id for the function invocation added to each log message.</param>
         void SetCurrentAwsRequestId(string awsRequestId);
 
         /// <summary>
         /// Format message with default log level
         /// </summary>
-        /// <param name="message"></param>
+        /// <param name="message">Message to log.</param>
         void FormattedWriteLine(string message);
 
         /// <summary>
         /// Format message with given log level
         /// </summary>
-        /// <param name="level"></param>
-        /// <param name="message"></param>
-        /// <param name="args"></param>
+        /// <param name="level">The level of the log message.</param>
+        /// <param name="message">Message to log.</param>
+        /// <param name="args">Arguments to be applied to the log message.</param>
         void FormattedWriteLine(string level, string message, params object[] args);
 
         /// <summary>
         /// Format message with given log level
         /// </summary>
-        /// <param name="level"></param>
-        /// <param name="exception"></param>
-        /// <param name="message"></param>
-        /// <param name="args"></param>
+        /// <param name="level">The level of the log message.</param>
+        /// <param name="exception">Exception to log.</param>
+        /// <param name="message">Message to log.</param>
+        /// <param name="args">Arguments to be applied to the log message.</param>
         void FormattedWriteLine(string level, Exception exception, string message, params object[] args);
     }
 
@@ -112,7 +112,10 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
         public void FormattedWriteLine(string level, Exception exception, string message, params object[] args)
         {
             _writer.WriteLine(message);
-            _writer.WriteLine(exception.ToString());
+            if (exception != null)
+            {
+                _writer.WriteLine(exception.ToString());
+            }
         }
     }
 
@@ -309,6 +312,10 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
                     else if (Enum.TryParse<LogLevel>(envLogLevel, true, out var result))
                     {
                         _minmumLogLevel = result;
+                    }
+                    else
+                    {
+                        InternalLogger.GetDefaultLogger().LogInformation($"Failed to parse log level enum value: {envLogLevel}");
                     }
                 }
 

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/ConsoleLoggerWriter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/ConsoleLoggerWriter.cs
@@ -70,6 +70,9 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
     {
         TextWriter _writer;
 
+        /// <summary>
+        /// Default Constructor
+        /// </summary>
         public SimpleLoggerWriter()
         {
             // Look to see if Lambda's telemetry log file descriptor is available. If so use that for logging.
@@ -95,20 +98,24 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
             }
         }
 
+        /// <inheritdoc/>
         public void SetCurrentAwsRequestId(string awsRequestId)
         {
         }
 
+        /// <inheritdoc/>
         public void FormattedWriteLine(string message)
         {
             _writer.WriteLine(message);
         }
 
+        /// <inheritdoc/>
         public void FormattedWriteLine(string level, string message, params object[] args)
         {
             _writer.WriteLine(message);
         }
 
+        /// <inheritdoc/>
         public void FormattedWriteLine(string level, Exception exception, string message, params object[] args)
         {
             _writer.WriteLine(message);
@@ -210,6 +217,11 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
             ConfigureLoggingActionField();
         }
 
+        /// <summary>
+        /// Construct an instance wrapping std out and std error.
+        /// </summary>
+        /// <param name="stdOutWriter"></param>
+        /// <param name="stdErrorWriter"></param>
         public LogLevelLoggerWriter(TextWriter stdOutWriter, TextWriter stdErrorWriter)
         {
             Initialize(stdOutWriter, stdErrorWriter);
@@ -240,22 +252,26 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
             loggingActionField.SetValue(null, callback);
         }
 
+        /// <inheritdoc/>
         public void SetCurrentAwsRequestId(string awsRequestId)
         {
             _wrappedStdOutWriter.CurrentAwsRequestId = awsRequestId;
             _wrappedStdErrorWriter.CurrentAwsRequestId = awsRequestId;
         }
 
+        /// <inheritdoc/>
         public void FormattedWriteLine(string message)
         {
             _wrappedStdOutWriter.FormattedWriteLine(message);
         }
 
+        /// <inheritdoc/>
         public void FormattedWriteLine(string level, string message, params object[] args)
         {
             _wrappedStdOutWriter.FormattedWriteLine(level, (Exception)null, message, args);
         }
 
+        /// <inheritdoc/>
         public void FormattedWriteLine(string level, Exception exception, string message, params object[] args)
         {
             _wrappedStdOutWriter.FormattedWriteLine(level, exception, message, args);
@@ -296,6 +312,11 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
             /// </summary>
             internal object LockObject { get; set; } = new object();
 
+            /// <summary>
+            /// Create an instance
+            /// </summary>
+            /// <param name="innerWriter"></param>
+            /// <param name="defaultLogLevel"></param>
             public WrapperTextWriter(TextWriter innerWriter, string defaultLogLevel)
             {
                 _innerWriter = innerWriter;

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/AbstractLogMessageFormatter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/AbstractLogMessageFormatter.cs
@@ -1,0 +1,279 @@
+﻿#if NET6_0_OR_GREATER
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
+{
+    /// <summary>
+    /// Base class of log message formatters.
+    /// </summary>
+    public abstract class AbstractLogMessageFormatter : ILogMessageFormatter
+    {
+        /// <summary>
+        /// Use a cache to look-up formatter so we don't have to parse the format for every entry.
+        /// </summary>
+        private static readonly ConcurrentDictionary<string, IReadOnlyList<MessageProperty>> MESSAGE_TEMPLATE_PARSE_CACHE = new ConcurrentDictionary<string, IReadOnlyList<MessageProperty>>();
+        private const int MESSAGE_TEMPLATE_PARSE_CACHE_MAXSIZE = 1024;
+
+        /// <summary>
+        /// States in the log format parser state machine.
+        /// </summary>
+        private enum LogFormatParserState : byte
+        {
+            InMessage,
+            PossibleParameterOpen,
+            InParameter
+        }
+
+        /// <summary>
+        /// Parse the message template for all message properties.
+        /// </summary>
+        /// <param name="messageTemplate"></param>
+        /// <returns></returns>
+        public virtual IReadOnlyList<MessageProperty> ParseProperties(string messageTemplate)
+        {
+            // Check to see if this message template has already been parsed before.
+            if (MESSAGE_TEMPLATE_PARSE_CACHE.TryGetValue(messageTemplate, out var cachedMessageProperties))
+            {
+                return cachedMessageProperties;
+            }
+
+            var messageProperties = new List<MessageProperty>();
+            var state = LogFormatParserState.InMessage;
+
+            int paramStartIdx = -1;
+            for (int i = 0, l = messageTemplate.Length; i < l; i++)
+            {
+                var c = messageTemplate[i];
+                switch (c)
+                {
+                    case '{':
+                        if (state == LogFormatParserState.InMessage)
+                        {
+                            state = LogFormatParserState.PossibleParameterOpen;
+                        }
+                        else if (state == LogFormatParserState.PossibleParameterOpen)
+                        {
+                            // this is an escaped brace
+                            state = LogFormatParserState.InMessage;
+                        }
+                        break;
+                    case '}':
+                        if (state != LogFormatParserState.InMessage)
+                        {
+                            if(paramStartIdx != -1)
+                            {
+                                // Since we have a closing bracket and there is at least a start to a message property label 
+                                // then we know we have hit the end of the message property.
+                                messageProperties.Add(new MessageProperty(messageTemplate.AsSpan().Slice(paramStartIdx, i - paramStartIdx)));
+                            }
+
+                            state = LogFormatParserState.InMessage;
+                            paramStartIdx = -1;
+                        }
+                        break;
+                    default:
+                        if (state == LogFormatParserState.PossibleParameterOpen)
+                        {
+                            // non-brace character after '{', transition to InParameter
+                            paramStartIdx = i;
+                            state = LogFormatParserState.InParameter;
+                        }
+                        break;
+                }
+            }
+
+            var readonlyMessagesProperties = messageProperties.AsReadOnly();
+
+            // If there is a room in the message template cache then cache the parse results for
+            // later logging performance increase.
+            if (MESSAGE_TEMPLATE_PARSE_CACHE.Count < MESSAGE_TEMPLATE_PARSE_CACHE_MAXSIZE)
+            {
+                MESSAGE_TEMPLATE_PARSE_CACHE.TryAdd(messageTemplate, readonlyMessagesProperties);
+            }
+
+            return readonlyMessagesProperties;
+        }
+
+        /// <summary>
+        /// Subclasses to implement to format the message given the requirements of the subclass.
+        /// </summary>
+        /// <param name="state"></param>
+        /// <returns></returns>
+        public abstract string FormatMessage(MessageState state);
+
+        internal const string DateFormat = "yyyy-MM-ddTHH:mm:ss.fffZ";
+
+        /// <summary>
+        /// Format the timestamp of the log message in format Lambda service prefers.
+        /// </summary>
+        /// <param name="state"></param>
+        /// <returns></returns>
+        protected string FormatTimestamp(MessageState state)
+        {
+            return state.TimeStamp.ToString(DateFormat, CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Replace all message properties in message templates with formatted values from the arguments passed in.
+        /// </summary>
+        /// <param name="messageTemplate"></param>
+        /// <param name="messageProperties"></param>
+        /// <param name="messageArguments"></param>
+        /// <returns></returns>
+        public string ApplyMessageProperties(string messageTemplate, IReadOnlyList<MessageProperty> messageProperties, object[] messageArguments)
+        {
+            if(messageProperties.Count == 0)
+            {
+                return messageTemplate;
+            }
+
+            // Check to see if the message template is using positions instead of names. For example
+            // "User bought {0} of {1}" is positional as opposed to "User bought {count} of {product"}.
+            var usePositional = UsingPositionalArguments(messageProperties);
+
+            var state = LogFormatParserState.InMessage;
+
+            // Builder used to create the message with the properties replaced. Set the initial capacity
+            // to the size of the message template plus 10% to give room for the values of message properties 
+            // to be larger then the message property in the message themselves.
+            StringBuilder messageBuilder = new StringBuilder(capacity: (int)(messageTemplate.Length * 1.1));
+
+            // Builder used store potential message properties as we parse through the message. If the 
+            // it turns out the potential message property is not a message property the contents of this
+            // builder are written back to the messageBuilder.
+            StringBuilder propertyBuilder = new StringBuilder();
+
+            int propertyIndex = 0;
+            for (int i = 0, l = messageTemplate.Length; i < l; i++)
+            {
+                var c = messageTemplate[i];
+
+                // If not using positional properties and we have hit the point there are more message properties then arguments
+                // then just add the rest of the message template onto the messageBuilder.
+                if (!usePositional && (messageProperties.Count <= propertyIndex || messageArguments?.Length <= propertyIndex))
+                {
+                    messageBuilder.Append(c);
+                    continue;
+                }
+
+                switch (c)
+                {
+                    case '{':
+                        if (state == LogFormatParserState.InMessage)
+                        {
+                            // regardless of whether this is the opening of a parameter we'd still need to add {
+                            propertyBuilder.Append(c);
+                            state = LogFormatParserState.PossibleParameterOpen;
+                        }
+                        else if (state == LogFormatParserState.PossibleParameterOpen)
+                        {
+                            // We have hit an escaped "{" by the user using "{{". Since we now know we are
+                            // not in a message properties write back the propertiesBuilder into 
+                            // messageBuilder and reset the propertyBuilder.
+                            messageBuilder.Append(propertyBuilder.ToString());
+                            propertyBuilder.Clear();
+                            messageBuilder.Append(c);
+                            state = LogFormatParserState.InMessage;
+                        }
+                        else
+                        {
+                            propertyBuilder.Append(c);
+                        }
+                        break;
+                    case '}':
+                        if (state == LogFormatParserState.InMessage)
+                        {
+                            messageBuilder.Append(c);
+                        }
+                        else
+                        {
+                            var property = messageProperties[propertyIndex];
+                            object argument = null;
+                            if(usePositional)
+                            {
+                                // If usePositional is true then we have confirmed the `Name` property is an int
+                                var index = int.Parse(property.Name, CultureInfo.InvariantCulture);
+                                if (index < messageArguments.Length)
+                                {
+                                    argument = messageArguments[index];
+                                }
+                            }
+                            else
+                            {
+                                argument = messageArguments[propertyIndex];
+                            }
+                            messageBuilder.Append(property.FormatForMessage(argument));
+
+                            propertyIndex++;
+                            propertyBuilder.Clear();
+                            state = LogFormatParserState.InMessage;
+                        }
+                        break;
+                    default:
+                        if (state == LogFormatParserState.InMessage)
+                        {
+                            messageBuilder.Append(c);
+                        }
+                        else if (state == LogFormatParserState.PossibleParameterOpen)
+                        {
+                            // non-brace character after '{', transition to InParameter
+                            propertyBuilder.Append(c);
+                            state = LogFormatParserState.InParameter;
+                        }
+                        break;
+                }
+            }
+
+            return messageBuilder.ToString();
+        }
+
+        /// <summary>
+        /// Check to see if the properties in a message are using a position instead of names.
+        /// Positional example:
+        ///     Log Message: "{0} {1} {0}"
+        ///     Arguments: "Arg1", "Arg2"
+        ///     Formatted Message: "Arg1 Arg2 Arg1"
+        /// Name example:
+        ///     Log Message: "{name} {age} {home}
+        ///     Arguments: "Lewis", 15, "Washington
+        ///     Formatted Message: "Lewis 15 Washington"
+        /// </summary>
+        /// <param name="messageProperties"></param>
+        /// <returns></returns>
+        public bool UsingPositionalArguments(IReadOnlyList<MessageProperty> messageProperties)
+        {
+            var min = int.MaxValue;
+            int max = int.MinValue;
+            HashSet<int> positions = new HashSet<int>();
+            foreach(var property in messageProperties)
+            {
+                if (!int.TryParse(property.Name, NumberStyles.Integer, CultureInfo.InvariantCulture, out var position))
+                {
+                    return false;
+                }
+
+                positions.Add(position);
+                if(position < min)
+                {
+                    min = position;
+                }
+                if (max < position)
+                {
+                    max = position;
+                }
+            }
+
+            if(positions.Count != (max + 1) || min != 0) 
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}
+#endif

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/AbstractLogMessageFormatter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/AbstractLogMessageFormatter.cs
@@ -130,7 +130,7 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
         /// <returns>The log message with logging arguments replaced with the values.</returns>
         public string ApplyMessageProperties(string messageTemplate, IReadOnlyList<MessageProperty> messageProperties, object[] messageArguments)
         {
-            if(messageProperties.Count == 0)
+            if(messageProperties.Count == 0 || messageArguments == null || messageArguments.Length == 0)
             {
                 return messageTemplate;
             }
@@ -158,7 +158,7 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
 
                 // If not using positional properties and we have hit the point there are more message properties then arguments
                 // then just add the rest of the message template onto the messageBuilder.
-                if (!usePositional && (messageProperties.Count <= propertyIndex || messageArguments?.Length <= propertyIndex))
+                if (!usePositional && (messageProperties.Count <= propertyIndex || messageArguments.Length <= propertyIndex))
                 {
                     messageBuilder.Append(c);
                     continue;

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/DefaultLogMessageFormatter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/DefaultLogMessageFormatter.cs
@@ -1,0 +1,95 @@
+﻿#if NET6_0_OR_GREATER
+
+namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
+{
+    /// <summary>
+    /// The default log message formatter that log the message as a simple string. Replacing any message properties
+    /// in the message with provided arguments. The message will be prefixed with the timestamp, request id and 
+    /// log level unless constructed passing in false for addPrefix.
+    /// 
+    /// This formatter matches is the logging format introduced as part of the .NET 6 managed runtime.
+    /// </summary>
+    public class DefaultLogMessageFormatter : AbstractLogMessageFormatter
+    {
+        /// <summary>
+        /// If true timestamp, request id and log level are added as a prefix to every log message.
+        /// </summary>
+        public bool AddPrefix { get; }
+
+        /// <summary>
+        /// Constructs an instance of DefaultLogMessageFormatter.
+        /// </summary>
+        /// <param name="addPrefix">If true timestamp, request id and log level are added as a prefix to every log message.</param>
+        public DefaultLogMessageFormatter(bool addPrefix)
+        {
+            AddPrefix = addPrefix;
+        }
+
+        /// <summary>
+        /// Format the log message applying in message property replacements and adding a prefix unless disabled.
+        /// </summary>
+        /// <param name="state"></param>
+        /// <returns></returns>
+        public override string FormatMessage(MessageState state)
+        {
+            string message;
+
+            // If there are no arguments then this is not a parameterized log message so skip parsing logic.
+            if(state.MessageArguments?.Length == 0)
+            {
+                message = state.MessageTemplate;
+            }
+            else
+            {
+                // Parse the message template for any message properties like "{count}".
+                var messageProperties = ParseProperties(state.MessageTemplate);
+
+                // Replace any message properties in the message template with the provided argument values.
+                message = ApplyMessageProperties(state.MessageTemplate, messageProperties, state.MessageArguments);
+            }
+
+            if (!AddPrefix)
+            {
+                return message;
+            }
+
+            var displayLevel = state.Level != null ? ConvertLogLevelToLabel(state.Level.Value) : null;
+
+            if (!string.IsNullOrEmpty(displayLevel))
+            {
+                return $"{FormatTimestamp(state)}\t{state.AwsRequestId}\t{displayLevel}\t{message ?? string.Empty}";
+            }
+            else
+            {
+                return $"{FormatTimestamp(state)}\t{state.AwsRequestId}\t{message ?? string.Empty}";
+            }
+        }
+
+        /// <summary>
+        /// Convert LogLevel enums to the the same string label that console provider for Microsoft.Extensions.Logging.ILogger uses.
+        /// </summary>
+        /// <param name="level"></param>
+        /// <returns></returns>
+        private string ConvertLogLevelToLabel(LogLevelLoggerWriter.LogLevel level)
+        {
+            switch (level)
+            {
+                case LogLevelLoggerWriter.LogLevel.Trace:
+                    return "trce";
+                case LogLevelLoggerWriter.LogLevel.Debug:
+                    return "dbug";
+                case LogLevelLoggerWriter.LogLevel.Information:
+                    return "info";
+                case LogLevelLoggerWriter.LogLevel.Warning:
+                    return "warn";
+                case LogLevelLoggerWriter.LogLevel.Error:
+                    return "fail";
+                case LogLevelLoggerWriter.LogLevel.Critical:
+                    return "crit";
+            }
+
+            return level.ToString();
+        }
+    }
+}
+#endif

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/ILogMessageFormatter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/ILogMessageFormatter.cs
@@ -1,0 +1,19 @@
+﻿#if NET6_0_OR_GREATER
+
+namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
+{
+    /// <summary>
+    /// The interface for defining log formatters that the ConsoleLogFormatter will use to format the incoming log messages
+    /// before sending the log message to the Lambda service.
+    /// </summary>
+    public interface ILogMessageFormatter
+    {
+        /// <summary>
+        /// Format the log message
+        /// </summary>
+        /// <param name="state"></param>
+        /// <returns></returns>
+        string FormatMessage(MessageState state);
+    }
+}
+#endif

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/JsonLogMessageFormatter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/JsonLogMessageFormatter.cs
@@ -1,0 +1,293 @@
+﻿#if NET6_0_OR_GREATER
+using System;
+using System.Buffers;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
+{
+    /// <summary>
+    /// Formats the log message as a structured JSON log message.
+    /// </summary>
+    public class JsonLogMessageFormatter : AbstractLogMessageFormatter
+    {
+        private static readonly UTF8Encoding UTF8NoBomNoThrow = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
+
+        // Options used when serializing any message property values as a JSON to be added to the structured log message.
+        private JsonSerializerOptions _jsonSerialiazationOptions;
+
+        /// <summary>
+        /// Constructs an instance of JsonLogMessageFormatter.
+        /// </summary>
+        public JsonLogMessageFormatter()
+        {
+            _jsonSerialiazationOptions = new JsonSerializerOptions
+            {
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                WriteIndented = false
+            };
+        }
+
+        private static readonly IReadOnlyList<MessageProperty> _emptyMessageProperties = new List<MessageProperty>();
+
+        /// <summary>
+        /// Format the log message as a structured JSON log message.
+        /// </summary>
+        /// <param name="state"></param>
+        /// <returns></returns>
+        public override string FormatMessage(MessageState state)
+        {
+            IReadOnlyList<MessageProperty> messageProperties;
+            string message;
+            // If there are no arguments then this is not a parameterized log message so skip parsing logic.
+            if (state.MessageArguments?.Length == 0)
+            {
+                messageProperties = _emptyMessageProperties;
+                message = state.MessageTemplate;
+            }
+            else
+            {
+                // Parse the message template for any message properties like "{count}".
+                messageProperties = ParseProperties(state.MessageTemplate);
+
+                // Replace any message properties in the message template with the provided argument values.
+                message = ApplyMessageProperties(state.MessageTemplate, messageProperties, state.MessageArguments);
+            }
+
+
+            var bufferWriter = new ArrayBufferWriter<byte>();
+            using var writer = new Utf8JsonWriter(bufferWriter, new JsonWriterOptions
+            {
+                Indented = false
+            });
+            writer.WriteStartObject();
+
+            writer.WriteString("timestamp", FormatTimestamp(state));
+
+            // Following Serilog's example and use the full name of the level instead of the
+            // abbreviating done DefaultLogMessageFormatter which follows Microsoft's ILogger console format.
+            // All structured logging should have a log level. If one is not given the default to Information as the log level.
+            writer.WriteString("level", state.Level?.ToString() ?? LogLevelLoggerWriter.LogLevel.Information.ToString());
+
+            if (!string.IsNullOrEmpty(state.AwsRequestId))
+            {
+                writer.WriteString("requestId", state.AwsRequestId);
+            }
+            
+            if (!string.IsNullOrEmpty(state.TraceId))
+            {
+                writer.WriteString("traceId", state.TraceId);
+            }
+
+            writer.WriteString("message", message);
+
+            // Add any message properties as JSON properties to the structured log.
+            WriteMessageAttributes(writer, messageProperties, state);
+
+            WriteException(writer, state);
+
+            writer.WriteEndObject();
+            writer.Flush();
+
+            return UTF8NoBomNoThrow.GetString(bufferWriter.WrittenSpan);
+        }
+
+        /// <summary>
+        /// Write any message properties for the log message as top level JSON properties.
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="messageProperties"></param>
+        /// <param name="state"></param>
+        private void WriteMessageAttributes(Utf8JsonWriter writer, IReadOnlyList<MessageProperty> messageProperties, MessageState state)
+        {
+            // Check to see if the message template is using positions instead of names. For example
+            // "User bought {0} of {1}" is positional as opposed to "User bought {count} of {product"}.
+            var usePositional = UsingPositionalArguments(messageProperties);
+
+            if (messageProperties != null)
+            {
+                for (var i = 0; i < messageProperties.Count; i++)
+                {
+                    object messageArgument;
+                    if(usePositional)
+                    {
+                        // If usePositional is true then we have confirmed the `Name` property is an int.
+                        var index = int.Parse(messageProperties[i].Name, CultureInfo.InvariantCulture);
+                        if (index < state.MessageArguments.Length)
+                        {
+                            // Don't include null JSON properties
+                            if (state.MessageArguments[index] == null)
+                                continue;
+
+                            messageArgument = state.MessageArguments[index];
+                        }
+                        else
+                        {
+                            continue;
+                        }
+                    }
+                    else
+                    {
+                        // There are more message properties in the template then values for the properties. Skip 
+                        // adding anymore JSON properties since there are no more values.
+                        if (state.MessageArguments.Length <= i)
+                            break;
+
+                        // Don't include null JSON properties
+                        if (state.MessageArguments[i] == null)
+                            continue;
+
+                        messageArgument = state.MessageArguments[i];
+
+                    }
+
+                    writer.WritePropertyName(messageProperties[i].Name);
+
+                    if (messageArgument is IList && messageArgument is not IList<byte>)
+                    {
+                        writer.WriteStartArray();
+                        foreach (var item in ((IList)messageArgument))
+                        {
+                            FormatJsonValue(writer, item, messageProperties[i].FormatArgument, messageProperties[i].FormatDirective);
+                        }
+                        writer.WriteEndArray();
+                    }
+                    else if (messageArgument is IDictionary)
+                    {
+                        writer.WriteStartObject();
+                        foreach (DictionaryEntry entry in ((IDictionary)messageArgument))
+                        {
+                            writer.WritePropertyName(entry.Key.ToString());
+
+                            FormatJsonValue(writer, entry.Value, messageProperties[i].FormatArgument, messageProperties[i].FormatDirective);
+                        }
+                        writer.WriteEndObject();
+                    }
+                    else
+                    {
+                        FormatJsonValue(writer, messageArgument, messageProperties[i].FormatArgument, messageProperties[i].FormatDirective);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Add the exception information as top level JSON properties
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="state"></param>
+        private void WriteException(Utf8JsonWriter writer, MessageState state)
+        {
+            if (state.Exception != null)
+            {
+                writer.WriteString("errorType", state.Exception.GetType().FullName);
+                writer.WriteString("errorMessage", state.Exception.Message);
+                writer.WritePropertyName("stackTrace");
+                writer.WriteStartArray();
+
+                // TODO: Right now for stack trace we are just using a single array element doing a ToString to get the
+                // inner excepions. Working with the Lambda team to figure out how they want to handle inner exceptions with 
+                // stackTrace array.
+                writer.WriteStringValue(state.Exception.ToString());
+                writer.WriteEndArray();
+            }
+        }
+
+        /// <summary>
+        /// Format the value to be included in the structured log message.
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="value"></param>
+        /// <param name="formatArguments"></param>
+        /// <param name="directive"></param>
+        private void FormatJsonValue(Utf8JsonWriter writer, object value, string formatArguments, MessageProperty.Directive directive)
+        {
+            if(value == null)
+            {
+                writer.WriteNullValue();
+            }
+            else if (directive == MessageProperty.Directive.JsonSerialization)
+            {
+                writer.WriteRawValue(JsonSerializer.Serialize(value, _jsonSerialiazationOptions));
+            }
+            else if (!string.IsNullOrEmpty(formatArguments))
+            {
+                writer.WriteStringValue(MessageProperty.ApplyFormatArgument(value, formatArguments));
+            }
+            else
+            {
+                switch (value)
+                {
+                    case bool boolValue:
+                        writer.WriteBooleanValue(boolValue);
+                        break;
+                    case byte byteValue:
+                        writer.WriteNumberValue(byteValue);
+                        break;
+                    case sbyte sbyteValue:
+                        writer.WriteNumberValue(sbyteValue);
+                        break;
+                    case char charValue:
+                        writer.WriteStringValue(MemoryMarshal.CreateSpan(ref charValue, 1));
+                        break;
+                    case decimal decimalValue:
+                        writer.WriteNumberValue(decimalValue);
+                        break;
+                    case double doubleValue:
+                        writer.WriteNumberValue(doubleValue);
+                        break;
+                    case float floatValue:
+                        writer.WriteNumberValue(floatValue);
+                        break;
+                    case int intValue:
+                        writer.WriteNumberValue(intValue);
+                        break;
+                    case uint uintValue:
+                        writer.WriteNumberValue(uintValue);
+                        break;
+                    case long longValue:
+                        writer.WriteNumberValue(longValue);
+                        break;
+                    case ulong ulongValue:
+                        writer.WriteNumberValue(ulongValue);
+                        break;
+                    case short shortValue:
+                        writer.WriteNumberValue(shortValue);
+                        break;
+                    case ushort ushortValue:
+                        writer.WriteNumberValue(ushortValue);
+                        break;
+                    case null:
+                        writer.WriteNullValue();
+                        break;
+                    case DateTime dateTimeValue:
+                        writer.WriteStringValue(dateTimeValue.ToString(DateFormat, CultureInfo.InvariantCulture));
+                        break;
+                    case DateTimeOffset dateTimeOffsetValue:
+                        writer.WriteStringValue(dateTimeOffsetValue.ToString(DateFormat, CultureInfo.InvariantCulture));
+                        break;
+                    case byte[] byteArrayValue:
+                        writer.WriteStringValue(MessageProperty.FormatByteArray(byteArrayValue));
+                        break;
+                    case ReadOnlyMemory<byte> roByteArrayValue:
+                        writer.WriteStringValue(MessageProperty.FormatByteArray(roByteArrayValue.Span));
+                        break;
+                    case Memory<byte> meByteArrayValue:
+                        writer.WriteStringValue(MessageProperty.FormatByteArray(meByteArrayValue.Span));
+                        break;
+                    default:
+                        writer.WriteStringValue(ToInvariantString(value));
+                        break;
+                }
+            }
+        }
+
+        private static string ToInvariantString(object obj) => Convert.ToString(obj, CultureInfo.InvariantCulture);
+    }
+}
+#endif

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/JsonLogMessageFormatter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/JsonLogMessageFormatter.cs
@@ -19,14 +19,14 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
         private static readonly UTF8Encoding UTF8NoBomNoThrow = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
 
         // Options used when serializing any message property values as a JSON to be added to the structured log message.
-        private JsonSerializerOptions _jsonSerialiazationOptions;
+        private JsonSerializerOptions _jsonSerializationOptions;
 
         /// <summary>
         /// Constructs an instance of JsonLogMessageFormatter.
         /// </summary>
         public JsonLogMessageFormatter()
         {
-            _jsonSerialiazationOptions = new JsonSerializerOptions
+            _jsonSerializationOptions = new JsonSerializerOptions
             {
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                 WriteIndented = false
@@ -165,7 +165,7 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
                     writer.WriteStartObject();
                     foreach (DictionaryEntry entry in ((IDictionary)messageArgument))
                     {
-                        writer.WritePropertyName(entry.Key.ToString());
+                        writer.WritePropertyName(entry.Key.ToString() ?? string.Empty);
 
                         FormatJsonValue(writer, entry.Value, messageProperties[i].FormatArgument, messageProperties[i].FormatDirective);
                     }
@@ -215,7 +215,7 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
             }
             else if (directive == MessageProperty.Directive.JsonSerialization)
             {
-                writer.WriteRawValue(JsonSerializer.Serialize(value, _jsonSerialiazationOptions));
+                writer.WriteRawValue(JsonSerializer.Serialize(value, _jsonSerializationOptions));
             }
             else if (!string.IsNullOrEmpty(formatArguments))
             {

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/MessageProperty.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/MessageProperty.cs
@@ -16,7 +16,7 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
         private static readonly char[] PARAM_FORMAT_DELIMITERS = { ':' };
 
         /// <summary>
-        /// Parse the string string representation of the message property without the brackets 
+        /// Parse the string representation of the message property without the brackets 
         /// to construct the MessageProperty. 
         /// </summary>
         /// <param name="messageToken"></param>
@@ -57,7 +57,19 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
         /// </summary>
         public string MessageToken { get; private set; }
 
-        public enum Directive { Default, JsonSerialization };
+        /// <summary>
+        /// Enum for controlling the formatting of complex logging arguments.
+        /// </summary>
+        public enum Directive {
+            /// <summary>
+            /// Perform a string formatting for the logging argument.
+            /// </summary>
+            Default, 
+            /// <summary>
+            /// Perform a JSON serialization on the logging argument.
+            /// </summary>
+            JsonSerialization 
+        };
 
         /// <summary>
         /// The Name of the message property.
@@ -109,6 +121,14 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
             if (value is DateTimeOffset dto)
             {
                 return dto.ToString(AbstractLogMessageFormatter.DateFormat, CultureInfo.InvariantCulture);
+            }
+            if (value is DateOnly dateOnly)
+            {
+                return dateOnly.ToString(AbstractLogMessageFormatter.DateOnlyFormat, CultureInfo.InvariantCulture);
+            }
+            if (value is TimeOnly timeOnly)
+            {
+                return timeOnly.ToString(AbstractLogMessageFormatter.TimeOnlyFormat, CultureInfo.InvariantCulture);
             }
 
             return value.ToString();

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/MessageProperty.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/MessageProperty.cs
@@ -1,0 +1,171 @@
+﻿#if NET6_0_OR_GREATER
+using System;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+
+namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
+{
+    /// <summary>
+    /// Represents a message property in a message template. For example the message 
+    /// template "User bought {count} of {product}" has count and product as message properties.
+    /// 
+    /// </summary>
+    public class MessageProperty
+    {
+        private static readonly char[] PARAM_FORMAT_DELIMITERS = { ':' };
+
+        /// <summary>
+        /// Parse the string string representation of the message property without the brackets 
+        /// to construct the MessageProperty. 
+        /// </summary>
+        /// <param name="messageToken"></param>
+        public MessageProperty(ReadOnlySpan<char> messageToken)
+        {
+            // messageToken format is:
+            // <optional-directive><name>:<optional-format-argument>
+
+            this.MessageToken = "{" + messageToken.ToString() + "}";
+
+            this.FormatDirective = Directive.Default;
+
+            if (messageToken[0] == '@')
+            {
+                this.FormatDirective = Directive.JsonSerialization;
+                messageToken = messageToken.Slice(1);
+            }
+
+            var idxOfDelimeter = messageToken.IndexOfAny(PARAM_FORMAT_DELIMITERS);
+            if (idxOfDelimeter < 0)
+            {
+                this.Name = messageToken.ToString().Trim();
+                this.FormatArgument = null;
+            }
+            else
+            {
+                this.Name = messageToken.Slice(0, idxOfDelimeter).ToString().Trim();
+                this.FormatArgument = messageToken.Slice(idxOfDelimeter + 1).ToString().Trim();
+                if(this.FormatArgument == string.Empty)
+                {
+                    this.FormatArgument = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The original text of the message property.
+        /// </summary>
+        public string MessageToken { get; private set; }
+
+        public enum Directive { Default, JsonSerialization };
+
+        /// <summary>
+        /// The Name of the message property.
+        /// </summary>
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// Optional format argument. If used the value will be formatted using string.Format passing in this format argument.
+        /// </summary>
+        public string FormatArgument { get; private set; }
+
+        /// <summary>
+        /// Optional format directive. Gives users the ability
+        /// to indicate when types should be serialized to JSON when using structured logging.
+        /// </summary>
+        public Directive FormatDirective { get; private set; }
+
+        /// <summary>
+        /// Formats the value as a string that can be used to replace the message property token inside a message template.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public string FormatForMessage(object value)
+        {
+            if(value is byte[] bytes)
+            {
+                return FormatByteArray(bytes);
+            }
+            if (value is ReadOnlyMemory<byte> roBytes)
+            {
+                return FormatByteArray(roBytes.Span);
+            }
+            if (value is Memory<byte> meBytes)
+            {
+                return FormatByteArray(meBytes.Span);
+            }
+            if (value == null || value is IList || value is IDictionary)
+            {
+                return this.MessageToken;
+            }
+            if(!string.IsNullOrEmpty(this.FormatArgument))
+            {
+                return ApplyFormatArgument(value, this.FormatArgument);
+            }
+            if(value is DateTime dt)
+            {
+                return dt.ToString(AbstractLogMessageFormatter.DateFormat, CultureInfo.InvariantCulture);
+            }
+            if (value is DateTimeOffset dto)
+            {
+                return dto.ToString(AbstractLogMessageFormatter.DateFormat, CultureInfo.InvariantCulture);
+            }
+
+            return value.ToString();
+        }
+
+        /// <summary>
+        /// If format argument is provided formats the value using string.Format otherwise returns
+        /// the ToString value.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="formatArgument"></param>
+        /// <returns></returns>
+        public static string ApplyFormatArgument(object value, string formatArgument)
+        {
+            if(string.IsNullOrEmpty(formatArgument))
+            {
+                return value.ToString();
+            }
+
+            try
+            {
+                var formatedValue = string.Format("{0:" + formatArgument + "}", value);
+                return formatedValue;
+            }
+            catch(FormatException ex)
+            {
+                InternalLogger.GetDefaultLogger().LogError(ex, "Failed to apply logging format argument: " + formatArgument);
+                return value.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Formats byte span, including byte arrays, as a hex string. If the byte span is long the hex string
+        /// will be truncated with a suffix added for the count of the byte span.
+        /// </summary>
+        /// <param name="bytes"></param>
+        /// <returns></returns>
+        public static string FormatByteArray(ReadOnlySpan<byte> bytes)
+        {
+            // Follow Serilog's example of outputting at 16 bytes before stopping and adding a count suffix
+            const int MAX_LENGTH = 16;
+
+            var sb = new StringBuilder();
+            for(int i = 0; i < bytes.Length; i++)
+            {
+                if(i == MAX_LENGTH)
+                {
+                    sb.Append("... (");
+                    sb.Append(bytes.Length);
+                    sb.Append(" bytes)");
+                    break;
+                }
+
+                sb.Append(bytes[i].ToString("X2"));
+            }
+            return sb.ToString();
+        }
+    }
+}
+#endif

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/MessageProperty.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/MessageProperty.cs
@@ -150,8 +150,8 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
 
             try
             {
-                var formatedValue = string.Format("{0:" + formatArgument + "}", value);
-                return formatedValue;
+                var formattedValue = string.Format("{0:" + formatArgument + "}", value);
+                return formattedValue;
             }
             catch(FormatException ex)
             {

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/MessageState.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/MessageState.cs
@@ -1,0 +1,49 @@
+﻿#if NET6_0_OR_GREATER
+using System;
+
+namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
+{
+    /// <summary>
+    /// The state of the environment for a log message that needs to be logged.
+    /// </summary>
+    public class MessageState
+    {
+        /// <summary>
+        /// The timestamp of the log message.
+        /// </summary>
+        public DateTime TimeStamp { get; set; }
+
+        /// <summary>
+        /// The AWS request id for the Lambda invocation. This property can be null
+        /// if logging before the first event.
+        /// </summary>
+        public string AwsRequestId { get; set; }
+
+        /// <summary>
+        /// The current trace id if available.
+        /// </summary>
+        public string TraceId { get; set; }
+
+        /// <summary>
+        /// The message template the Lambda function has sent to RuntimeSupport. It may include message properties in the template
+        /// for example the message template "User bought {count} of {product}" has count and product as message properties.
+        /// </summary>
+        public string MessageTemplate { get; set; }
+
+        /// <summary>
+        /// The values to replace for any message properties in the message template.
+        /// </summary>
+        public object[] MessageArguments { get; set; }
+
+        /// <summary>
+        /// The log level of the message being logged.
+        /// </summary>
+        public LogLevelLoggerWriter.LogLevel? Level { get; set; }
+
+        /// <summary>
+        /// An exception to be logged along with the log message.
+        /// </summary>
+        public Exception Exception { get; set; }
+    }
+}
+#endif

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/Amazon.Lambda.RuntimeSupport.UnitTests.csproj
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/Amazon.Lambda.RuntimeSupport.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LogMessageFormatterTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LogMessageFormatterTests.cs
@@ -1,0 +1,509 @@
+﻿using Amazon.Lambda.RuntimeSupport.Helpers;
+using Amazon.Lambda.RuntimeSupport.Helpers.Logging;
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using Xunit;
+using static Amazon.Lambda.RuntimeSupport.UnitTests.LogMessageFormatterTests;
+
+namespace Amazon.Lambda.RuntimeSupport.UnitTests
+{
+    public class LogMessageFormatterTests
+    {
+        [Fact]
+        public void ParseLogMessageWithNoProperties()
+        {
+            var formatter = new JsonLogMessageFormatter();
+
+            var properties = formatter.ParseProperties("No message properties here");
+            Assert.Empty(properties);
+        }
+
+        [Fact]
+        public void ParseLogMessageWithProperties()
+        {
+            var formatter = new JsonLogMessageFormatter();
+
+            var properties = formatter.ParseProperties("User {user} bought {count:000} items of {@product} with an {{escaped}}");
+            Assert.Equal(3, properties.Count);
+
+            Assert.Equal("user", properties[0].Name);
+            Assert.Equal(MessageProperty.Directive.Default, properties[0].FormatDirective);
+
+            Assert.Equal("count", properties[1].Name);
+            Assert.Equal("000", properties[1].FormatArgument);
+            Assert.Equal(MessageProperty.Directive.Default, properties[1].FormatDirective);
+
+            Assert.Equal("product", properties[2].Name);
+            Assert.Equal(MessageProperty.Directive.JsonSerialization, properties[2].FormatDirective);
+        }
+
+        [Fact]
+        public void ParseLogMessageWithOpenBracketAndNoClosing()
+        {
+            var formatter = new JsonLogMessageFormatter();
+
+            var properties = formatter.ParseProperties("{hello} before { after");
+            Assert.Equal(1, properties.Count);
+
+            Assert.Equal("hello", properties[0].Name);
+            Assert.Equal(MessageProperty.Directive.Default, properties[0].FormatDirective);
+        }
+
+        [Fact]
+        public void FormatJsonWithNoMessageProperties()
+        {
+            var timestamp = DateTime.UtcNow;
+            var formattedTimestamp = timestamp.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+
+            var formatter = new JsonLogMessageFormatter();
+            var state = new MessageState()
+            {
+                AwsRequestId = "1234",
+                TraceId = "4321",
+                Level = Helpers.LogLevelLoggerWriter.LogLevel.Warning,
+                MessageTemplate = "Simple Log Message",
+                MessageArguments = null,
+                TimeStamp = timestamp
+            };
+
+            var json = formatter.FormatMessage(state);
+            var doc = JsonDocument.Parse(json);
+            Assert.Equal("1234", doc.RootElement.GetProperty("requestId").GetString());
+            Assert.Equal("4321", doc.RootElement.GetProperty("traceId").GetString());
+            Assert.Equal(formattedTimestamp, doc.RootElement.GetProperty("timestamp").GetString());
+            Assert.Equal("Warning", doc.RootElement.GetProperty("level").GetString());
+            Assert.Equal("Simple Log Message", doc.RootElement.GetProperty("message").GetString());
+        }
+
+        [Fact]
+        public void FormatJsonWithStringMessageProperties()
+        {
+            var timestamp = DateTime.UtcNow;
+            var formattedTimestamp = timestamp.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+
+            var formatter = new JsonLogMessageFormatter();
+            var state = new MessageState()
+            {
+                AwsRequestId = "1234",
+                Level = Helpers.LogLevelLoggerWriter.LogLevel.Warning,
+                MessageTemplate = "Hello {name}",
+                MessageArguments = new object[] { "AWS" },
+                TimeStamp = timestamp
+            };
+
+            var json = formatter.FormatMessage(state);
+            var doc = JsonDocument.Parse(json);
+            Assert.Equal("1234", doc.RootElement.GetProperty("requestId").GetString());
+            Assert.Equal(formattedTimestamp, doc.RootElement.GetProperty("timestamp").GetString());
+            Assert.Equal("Warning", doc.RootElement.GetProperty("level").GetString());
+            Assert.Equal("Hello AWS", doc.RootElement.GetProperty("message").GetString());
+        }
+
+        [Fact]
+        public void FormatJsonWithAllPossibleTypes()
+        {
+            var timestamp = DateTime.UtcNow;
+            var formattedTimestamp = timestamp.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+
+            var product = new Product() { Name = "Widget", Inventory = 100 };
+
+            var formatter = new JsonLogMessageFormatter();
+            var state = new MessageState()
+            {
+                AwsRequestId = "1234",
+                Level = Helpers.LogLevelLoggerWriter.LogLevel.Warning,
+                MessageTemplate = "bool: {bool}, byte: {byte}, char: {char}, decimal: {decimal}, double: {double}, float: {float}, " + 
+                                  "int: {int}, uint: {uint}, long: {long}, ulong: {ulong}, short: {short}, ushort: {ushort}, null: {null}, " + 
+                                  "DateTime: {DateTime}, DateTimeOffset: {DateTimeOffset}, default: {default}",
+                MessageArguments = new object[] {true, (byte)1, 'a', (decimal)4.5, (double)5.6, (float)7.7, (int)-10, (uint)10, (long)-100, (ulong)100, (short)-50, (ushort)50, null, timestamp, timestamp, product},
+                TimeStamp = timestamp
+            };
+
+            var json = formatter.FormatMessage(state);
+            var doc = JsonDocument.Parse(json);
+
+            Assert.Equal("bool: True, byte: 1, char: a, decimal: 4.5, double: 5.6, float: 7.7, " +
+                        "int: -10, uint: 10, long: -100, ulong: 100, short: -50, ushort: 50, null: {null}, " +
+                        $"DateTime: {formattedTimestamp}, DateTimeOffset: {formattedTimestamp}, default: Widget 100", 
+                        doc.RootElement.GetProperty("message").GetString());
+
+            Assert.True(doc.RootElement.GetProperty("bool").GetBoolean());
+            Assert.Equal((byte)1, doc.RootElement.GetProperty("byte").GetByte());
+            Assert.Equal("a", doc.RootElement.GetProperty("char").GetString());
+            Assert.Equal((decimal)4.5, doc.RootElement.GetProperty("decimal").GetDecimal());
+            Assert.Equal((double)5.6, doc.RootElement.GetProperty("double").GetDouble());
+            Assert.Equal((float)7.7, doc.RootElement.GetProperty("float").GetSingle());
+            Assert.Equal((int)-10, doc.RootElement.GetProperty("int").GetInt32());
+            Assert.Equal((uint)10, doc.RootElement.GetProperty("uint").GetUInt32());
+            Assert.Equal((long)-100, doc.RootElement.GetProperty("long").GetInt64());
+            Assert.Equal((ulong)100, doc.RootElement.GetProperty("ulong").GetUInt64());
+            Assert.Equal((short)-50, doc.RootElement.GetProperty("short").GetInt16());
+            Assert.Equal((ushort)50, doc.RootElement.GetProperty("ushort").GetUInt16());
+            Assert.False(doc.RootElement.TryGetProperty("null", out var _));
+            Assert.Equal(formattedTimestamp, doc.RootElement.GetProperty("DateTime").GetString());
+            Assert.Equal(formattedTimestamp, doc.RootElement.GetProperty("DateTimeOffset").GetString());
+            Assert.Equal("Widget 100", doc.RootElement.GetProperty("default").GetString());
+        }
+
+        [Fact]
+        public void FormatJsonWithPoco()
+        {
+            var timestamp = DateTime.UtcNow;
+
+            var product = new Product() { Name = "Widget", Inventory = 100 };
+
+            var formatter = new JsonLogMessageFormatter();
+            var state = new MessageState()
+            {
+                AwsRequestId = "1234",
+                Level = Helpers.LogLevelLoggerWriter.LogLevel.Warning,
+                MessageTemplate = "Our product is {product}",
+                MessageArguments = new object[] { product },
+                TimeStamp = timestamp
+            };
+
+            var json = formatter.FormatMessage(state);
+            var doc = JsonDocument.Parse(json);
+
+            Assert.Equal("Our product is Widget 100", doc.RootElement.GetProperty("message").GetString());
+
+            Assert.Equal(JsonValueKind.String, doc.RootElement.GetProperty("product").ValueKind);
+            Assert.Equal("Widget 100", doc.RootElement.GetProperty("product").GetString());
+        }
+
+        [Fact]
+        public void FormatJsonWithPocoSerialized()
+        {
+            var timestamp = DateTime.UtcNow;
+
+            var product = new Product() { Name = "Widget", Inventory = 100 };
+
+            var formatter = new JsonLogMessageFormatter();
+            var state = new MessageState()
+            {
+                AwsRequestId = "1234",
+                Level = Helpers.LogLevelLoggerWriter.LogLevel.Warning,
+                MessageTemplate = "Our product is {@product}",
+                MessageArguments = new object[] { product },
+                TimeStamp = timestamp
+            };
+
+            var json = formatter.FormatMessage(state);
+            var doc = JsonDocument.Parse(json);
+
+            Assert.Equal("Our product is Widget 100", doc.RootElement.GetProperty("message").GetString());
+
+            Assert.Equal(JsonValueKind.Object, doc.RootElement.GetProperty("product").ValueKind);
+            Assert.Equal("Widget", doc.RootElement.GetProperty("product").GetProperty("Name").GetString());
+            Assert.Equal(100, doc.RootElement.GetProperty("product").GetProperty("Inventory").GetInt32());
+        }
+
+        [Fact]
+        public void FormatJsonWithList()
+        {
+            var timestamp = DateTime.UtcNow;
+
+            var product1 = new Product() { Name = "Widget", Inventory = 100 };
+            var product2 = new Product() { Name = "Doohickey", Inventory = 200 };
+
+            var formatter = new JsonLogMessageFormatter();
+            var state = new MessageState()
+            {
+                AwsRequestId = "1234",
+                Level = Helpers.LogLevelLoggerWriter.LogLevel.Warning,
+                MessageTemplate = "Our products are {products}",
+                MessageArguments = new object[] { new Product[] { product1, product2 } },
+                TimeStamp = timestamp
+            };
+
+            var json = formatter.FormatMessage(state);
+            var doc = JsonDocument.Parse(json);
+
+            Assert.Equal("Our products are {products}", doc.RootElement.GetProperty("message").GetString());
+
+            Assert.Equal(JsonValueKind.Array, doc.RootElement.GetProperty("products").ValueKind);
+            Assert.Equal("Widget 100", doc.RootElement.GetProperty("products")[0].GetString());
+            Assert.Equal("Doohickey 200", doc.RootElement.GetProperty("products")[1].GetString());
+        }
+
+        [Fact]
+        public void FormatJsonWithListSerialzied()
+        {
+            var timestamp = DateTime.UtcNow;
+
+            var product1 = new Product() { Name = "Widget", Inventory = 100 };
+            var product2 = new Product() { Name = "Doohickey", Inventory = 200 };
+
+            var formatter = new JsonLogMessageFormatter();
+            var state = new MessageState()
+            {
+                AwsRequestId = "1234",
+                Level = Helpers.LogLevelLoggerWriter.LogLevel.Warning,
+                MessageTemplate = "Our products are {@products}",
+                MessageArguments = new object[] { new Product[] { product1, product2 } },
+                TimeStamp = timestamp
+            };
+
+            var json = formatter.FormatMessage(state);
+            var doc = JsonDocument.Parse(json);
+
+            Assert.Equal("Our products are {@products}", doc.RootElement.GetProperty("message").GetString());
+
+            Assert.Equal(JsonValueKind.Array, doc.RootElement.GetProperty("products").ValueKind);
+            Assert.Equal("Widget", doc.RootElement.GetProperty("products")[0].GetProperty("Name").GetString());
+            Assert.Equal(100, doc.RootElement.GetProperty("products")[0].GetProperty("Inventory").GetInt32());
+
+            Assert.Equal("Doohickey", doc.RootElement.GetProperty("products")[1].GetProperty("Name").GetString());
+            Assert.Equal(200, doc.RootElement.GetProperty("products")[1].GetProperty("Inventory").GetInt32());
+        }
+
+        [Fact]
+        public void FormatJsonWithDictionary()
+        {
+            var timestamp = DateTime.UtcNow;
+
+            var product1 = new Product() { Name = "Widget", Inventory = 100 };
+            var product2 = new Product() { Name = "Doohickey", Inventory = 200 };
+
+            var formatter = new JsonLogMessageFormatter();
+            var state = new MessageState()
+            {
+                AwsRequestId = "1234",
+                Level = Helpers.LogLevelLoggerWriter.LogLevel.Warning,
+                MessageTemplate = "Our products are {products}",
+                MessageArguments = new object[] { new Dictionary<string, Product> { { product1.Name, product1 }, { product2.Name, product2 } } },
+                TimeStamp = timestamp
+            };
+
+            var json = formatter.FormatMessage(state);
+            var doc = JsonDocument.Parse(json);
+
+            Assert.Equal("Our products are {products}", doc.RootElement.GetProperty("message").GetString());
+
+            Assert.Equal(JsonValueKind.Object, doc.RootElement.GetProperty("products").ValueKind);
+            Assert.Equal("Widget 100", doc.RootElement.GetProperty("products").GetProperty("Widget").GetString());
+            Assert.Equal("Doohickey 200", doc.RootElement.GetProperty("products").GetProperty("Doohickey").GetString());
+        }
+
+        [Fact]
+        public void FormatJsonWithDictionarySerialized()
+        {
+            var timestamp = DateTime.UtcNow;
+
+            var product1 = new Product() { Name = "Widget", Inventory = 100 };
+            var product2 = new Product() { Name = "Doohickey", Inventory = 200 };
+
+            var formatter = new JsonLogMessageFormatter();
+            var state = new MessageState()
+            {
+                AwsRequestId = "1234",
+                Level = Helpers.LogLevelLoggerWriter.LogLevel.Warning,
+                MessageTemplate = "Our products are {@products}",
+                MessageArguments = new object[] { new Dictionary<string, Product> { { product1.Name, product1 }, { product2.Name, product2 } } },
+                TimeStamp = timestamp
+            };
+
+            var json = formatter.FormatMessage(state);
+            var doc = JsonDocument.Parse(json);
+
+            Assert.Equal("Our products are {@products}", doc.RootElement.GetProperty("message").GetString());
+
+            Assert.Equal(JsonValueKind.Object, doc.RootElement.GetProperty("products").ValueKind);
+            Assert.Equal("Widget", doc.RootElement.GetProperty("products").GetProperty("Widget").GetProperty("Name").GetString());
+            Assert.Equal(100, doc.RootElement.GetProperty("products").GetProperty("Widget").GetProperty("Inventory").GetInt32());
+            Assert.Equal("Doohickey", doc.RootElement.GetProperty("products").GetProperty("Doohickey").GetProperty("Name").GetString());
+            Assert.Equal(200, doc.RootElement.GetProperty("products").GetProperty("Doohickey").GetProperty("Inventory").GetInt32());
+        }
+
+        [Theory]
+        [InlineData("No Properties", new object[] { }, "No Properties")]
+        [InlineData("No Properties", null, "No Properties")]
+        [InlineData("{name}", new object[] { "aws" } , "aws")]
+        [InlineData("{0}", new object[] { "aws" }, "aws")]
+        [InlineData("{0} {1}", new object[] { "aws" }, "aws {1}")]
+        [InlineData("{0}", new object[] { "aws", "s3" }, "aws")]
+        [InlineData("{{name}} {name}", new object[] { "aws" }, "{{name}} aws")]
+        [InlineData("Positional test {0} {1} {0}", new object[] {"Arg1", "Arg2" }, "Positional test Arg1 Arg2 Arg1")]
+        [InlineData("{category}", new object[] { Product.Category.Electronics }, "Electronics")]
+        [InlineData("{hextest}", new object[] { new byte[] { 1, 2, 3 } }, "010203")]
+        [InlineData("{}", new object[] { "dummy" }, "{}")] // Log message doesn't really make any sense but we need to make sure we protect ourselves from it.
+        public void PropertyReplacementVerification(string message, object[] arguments, string expectedMessage)
+        {
+            foreach(var formatter in new AbstractLogMessageFormatter[] { new DefaultLogMessageFormatter(false), new DefaultLogMessageFormatter(true), new JsonLogMessageFormatter() })
+            {
+                var timestamp = DateTime.UtcNow;
+
+                var state = new MessageState()
+                {
+                    AwsRequestId = "1234",
+                    Level = Helpers.LogLevelLoggerWriter.LogLevel.Warning,
+                    MessageTemplate = message,
+                    MessageArguments = arguments,
+                    TimeStamp = timestamp
+                };
+
+                var formattedMessage = formatter.FormatMessage(state);
+
+                if(formatter is JsonLogMessageFormatter)
+                {
+                    var doc = JsonDocument.Parse(formattedMessage);
+                    Assert.Equal(expectedMessage, doc.RootElement.GetProperty("message").GetString());
+                }
+                else if(formatter is DefaultLogMessageFormatter defaultFormatter)
+                {
+                    if(defaultFormatter.AddPrefix)
+                    {
+                        Assert.EndsWith(expectedMessage, formattedMessage);
+                    }
+                    else
+                    {
+                        Assert.Equal(expectedMessage, formattedMessage);
+                    }
+                }
+            }
+
+            if (arguments?.Length == 1 && arguments[0] is byte[] bytes)
+            {
+                // Can't create ReadOnlyMemory and Memory as part of the "InlineData" attribute so force check
+                // if we are doing the byte[] check and if so repeat for ReadonlyMemory and Memory
+                PropertyReplacementVerification(message, new object[] { new ReadOnlyMemory<byte>(bytes) }, expectedMessage);
+                PropertyReplacementVerification(message, new object[] { new Memory<byte>(bytes) }, expectedMessage);
+            }
+        }
+
+        [Fact]
+        public void OutOfOrderPositionalArgumentsWithJson()
+        {
+            var timestamp = DateTime.UtcNow;
+
+
+            var formatter = new JsonLogMessageFormatter();
+            var state = new MessageState()
+            {
+                AwsRequestId = "1234",
+                Level = Helpers.LogLevelLoggerWriter.LogLevel.Warning,
+                MessageTemplate = "{1} {0}",
+                MessageArguments = new object[] { "arg1", "arg2" },
+                TimeStamp = timestamp
+            };
+
+            var json = formatter.FormatMessage(state);
+            var doc = JsonDocument.Parse(json);
+
+            Assert.Equal("arg2 arg1", doc.RootElement.GetProperty("message").GetString());
+
+            Assert.Equal("arg1", doc.RootElement.GetProperty("0").GetString());
+            Assert.Equal("arg2", doc.RootElement.GetProperty("1").GetString()); ;
+
+        }
+
+        [Fact]
+        public void FormatLargeByteArray()
+        {
+            var timestamp = DateTime.UtcNow;
+
+            var bytes = new byte[10000];
+            for (var i = 0; i < bytes.Length; i++)
+            {
+                bytes[i] = 1;
+            }
+
+            foreach (var argument in new object [] { bytes, new ReadOnlyMemory<byte>(bytes), new Memory<byte>(bytes) })
+            {
+
+
+                var state = new MessageState()
+                {
+                    AwsRequestId = "1234",
+                    Level = Helpers.LogLevelLoggerWriter.LogLevel.Warning,
+                    MessageTemplate = "Binary data: {bytes}",
+                    MessageArguments = new object[] { argument },
+                    TimeStamp = timestamp
+                };
+
+                var formatter = new JsonLogMessageFormatter();
+                var json = formatter.FormatMessage(state);
+                var doc = JsonDocument.Parse(json);
+
+                Assert.Equal($"Binary data: 01010101010101010101010101010101... ({bytes.Length} bytes)", doc.RootElement.GetProperty("message").GetString());
+
+                Assert.Equal($"01010101010101010101010101010101... ({bytes.Length} bytes)", doc.RootElement.GetProperty("bytes").GetString());
+
+
+            }
+        }
+
+        [Fact]
+        public void FormatJsonException()
+        {
+            try
+            {
+                var nre = new NullReferenceException("You got a null");
+                throw new ApplicationException("This Will Fail", nre);
+            }
+            catch(Exception ex)
+            {
+                var timestamp = DateTime.UtcNow;
+
+                var state = new MessageState()
+                {
+                    AwsRequestId = "1234",
+                    Level = Helpers.LogLevelLoggerWriter.LogLevel.Warning,
+                    MessageTemplate = "What does an error look like?",
+                    MessageArguments = null,
+                    Exception = ex,
+                    TimeStamp = timestamp
+                };
+
+                var formatter = new JsonLogMessageFormatter();
+                var json = formatter.FormatMessage(state);
+                var doc = JsonDocument.Parse(json);
+
+                Assert.Equal("What does an error look like?", doc.RootElement.GetProperty("message").GetString());
+                Assert.Equal("This Will Fail", doc.RootElement.GetProperty("errorMessage").GetString());
+                Assert.Equal("System.ApplicationException", doc.RootElement.GetProperty("errorType").GetString());
+                Assert.Equal(JsonValueKind.Array, doc.RootElement.GetProperty("stackTrace").ValueKind);
+                Assert.Equal(ex.ToString(), doc.RootElement.GetProperty("stackTrace")[0].GetString());
+
+                // Confirm inner exceptions are being captured
+                Assert.Contains("System.NullReferenceException", doc.RootElement.GetProperty("stackTrace")[0].GetString());
+            }
+        }
+
+        [Theory]
+        [InlineData("{0}", true)]
+        [InlineData("{1} {0}", true)]
+        [InlineData("{1} {10}", false)]
+        [InlineData("{1} {2}", false)]
+        [InlineData("{0} {5} {6}", false)]
+        [InlineData("Arg1 {0} Arg2 {1}", true)]
+        [InlineData("Test {user}", false)]
+        [InlineData("Arg1 {0} Arg5 {5}", false)] // Not positional because there is a gap in between the numbers
+        [InlineData("Arg1 {@0} Arg2 {1:00}", true)]
+        public void CheckIfPositional(string message, bool expected)
+        {
+            var formatter = new DefaultLogMessageFormatter(true);
+            var properties = formatter.ParseProperties(message);
+            var isPositional = formatter.UsingPositionalArguments(properties);
+            Assert.Equal(expected, isPositional);
+        }
+
+        public class Product
+        {
+            public enum Category { Food, Electronics }
+            public string Name { get; set; }
+
+            public int Inventory { get; set; }
+
+            public Category? Cat { get; set; }
+
+            public override string ToString()
+            {
+                return $"{Name} {Inventory}";
+            }
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LogMessageFormatterTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LogMessageFormatterTests.cs
@@ -105,6 +105,8 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
         [Fact]
         public void FormatJsonWithAllPossibleTypes()
         {
+            var dateOnly = new DateOnly(2024, 2, 18);
+            var timeOnly = new TimeOnly(15, 19, 45, 545);
             var timestamp = DateTime.UtcNow;
             var formattedTimestamp = timestamp.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
 
@@ -117,8 +119,8 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 Level = Helpers.LogLevelLoggerWriter.LogLevel.Warning,
                 MessageTemplate = "bool: {bool}, byte: {byte}, char: {char}, decimal: {decimal}, double: {double}, float: {float}, " + 
                                   "int: {int}, uint: {uint}, long: {long}, ulong: {ulong}, short: {short}, ushort: {ushort}, null: {null}, " + 
-                                  "DateTime: {DateTime}, DateTimeOffset: {DateTimeOffset}, default: {default}",
-                MessageArguments = new object[] {true, (byte)1, 'a', (decimal)4.5, (double)5.6, (float)7.7, (int)-10, (uint)10, (long)-100, (ulong)100, (short)-50, (ushort)50, null, timestamp, timestamp, product},
+                                  "DateTime: {DateTime}, DateTimeOffset: {DateTimeOffset}, default: {default}, DateOnly {DateOnly}, TimeOnly: {TimeOnly}",
+                MessageArguments = new object[] {true, (byte)1, 'a', (decimal)4.5, (double)5.6, (float)7.7, (int)-10, (uint)10, (long)-100, (ulong)100, (short)-50, (ushort)50, null, timestamp, timestamp, product, dateOnly, timeOnly},
                 TimeStamp = timestamp
             };
 
@@ -127,7 +129,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
 
             Assert.Equal("bool: True, byte: 1, char: a, decimal: 4.5, double: 5.6, float: 7.7, " +
                         "int: -10, uint: 10, long: -100, ulong: 100, short: -50, ushort: 50, null: {null}, " +
-                        $"DateTime: {formattedTimestamp}, DateTimeOffset: {formattedTimestamp}, default: Widget 100", 
+                        $"DateTime: {formattedTimestamp}, DateTimeOffset: {formattedTimestamp}, default: Widget 100, DateOnly 2024-02-18, TimeOnly: 15:19:45.545", 
                         doc.RootElement.GetProperty("message").GetString());
 
             Assert.True(doc.RootElement.GetProperty("bool").GetBoolean());
@@ -146,6 +148,8 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             Assert.Equal(formattedTimestamp, doc.RootElement.GetProperty("DateTime").GetString());
             Assert.Equal(formattedTimestamp, doc.RootElement.GetProperty("DateTimeOffset").GetString());
             Assert.Equal("Widget 100", doc.RootElement.GetProperty("default").GetString());
+            Assert.Equal("2024-02-18", doc.RootElement.GetProperty("DateOnly").GetString());
+            Assert.Equal("15:19:45.545", doc.RootElement.GetProperty("TimeOnly").GetString());
         }
 
         [Fact]

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/MessagePropertyTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/MessagePropertyTests.cs
@@ -1,0 +1,98 @@
+﻿using Amazon.Lambda.RuntimeSupport.Helpers.Logging;
+
+using Xunit;
+
+namespace Amazon.Lambda.RuntimeSupport.UnitTests
+{
+
+    public class MessagePropertyTests
+    {
+        [Fact]
+        public void SimpleName()
+        {
+            var property = new MessageProperty("name");
+            Assert.Equal(MessageProperty.Directive.Default, property.FormatDirective);
+            Assert.Equal("name", property.Name);
+            Assert.Equal("name", property.MessageToken);
+            Assert.Null(property.FormatArgument);
+        }
+
+        [Fact]
+        public void WithFormatArgument()
+        {
+            var property = new MessageProperty("count:000");
+            Assert.Equal(MessageProperty.Directive.Default, property.FormatDirective);
+            Assert.Equal("count", property.Name);
+            Assert.Equal("count:000", property.MessageToken);
+            Assert.Equal("000", property.FormatArgument);
+        }
+
+        [Fact]
+        public void WithJsonDirective()
+        {
+            var property = new MessageProperty("@user");
+            Assert.Equal(MessageProperty.Directive.JsonSerialization, property.FormatDirective);
+            Assert.Equal("user", property.Name);
+            Assert.Equal("@user", property.MessageToken);
+            Assert.Null(property.FormatArgument);
+        }
+
+        [Fact]
+        public void WithJsonDirectiveAndIgnorableFormatArgument()
+        {
+            var property = new MessageProperty("@user:000");
+            Assert.Equal(MessageProperty.Directive.JsonSerialization, property.FormatDirective);
+            Assert.Equal("user", property.Name);
+            Assert.Equal("@user:000", property.MessageToken);
+            Assert.Equal("000", property.FormatArgument);
+        }
+
+        [Fact]
+        public void WithFormatArgumentMissingValues()
+        {
+            var property = new MessageProperty("count:");
+            Assert.Equal(MessageProperty.Directive.Default, property.FormatDirective);
+            Assert.Equal("count", property.Name);
+            Assert.Equal("count:", property.MessageToken);
+            Assert.Null(property.FormatArgument);
+        }
+
+        [Fact]
+        public void NameWithSpace()
+        {
+            var property = new MessageProperty(" first last ");
+            Assert.Equal(MessageProperty.Directive.Default, property.FormatDirective);
+            Assert.Equal("first last", property.Name);
+            Assert.Equal(" first last ", property.MessageToken);
+            Assert.Null(property.FormatArgument);
+        }
+
+        [Fact]
+        public void NameAndFormatArgumentWithSpace()
+        {
+            var property = new MessageProperty(" first last : 000 ");
+            Assert.Equal(MessageProperty.Directive.Default, property.FormatDirective);
+            Assert.Equal("first last", property.Name);
+            Assert.Equal(" first last : 000 ", property.MessageToken);
+            Assert.Equal("000", property.FormatArgument);
+        }
+
+        [Fact]
+        public void ApplyFormat()
+        {
+            var property = new MessageProperty("count:000");
+            var formattedValue = MessageProperty.ApplyFormatArgument(10, property.FormatArgument);
+            Assert.Equal("010", formattedValue);
+        }
+
+        [Fact]
+        public void ApplyFormatTriggersFormatException()
+        {
+            var property = new MessageProperty("count:0{0");
+
+            // Since a FormatException was thrown the code should fall back to "ToString()" on the value
+            var formattedValue = MessageProperty.ApplyFormatArgument(10, property.FormatArgument);
+            Assert.Equal("10", formattedValue);
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/MessagePropertyTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/MessagePropertyTests.cs
@@ -13,7 +13,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             var property = new MessageProperty("name");
             Assert.Equal(MessageProperty.Directive.Default, property.FormatDirective);
             Assert.Equal("name", property.Name);
-            Assert.Equal("name", property.MessageToken);
+            Assert.Equal("{name}", property.MessageToken);
             Assert.Null(property.FormatArgument);
         }
 
@@ -23,7 +23,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             var property = new MessageProperty("count:000");
             Assert.Equal(MessageProperty.Directive.Default, property.FormatDirective);
             Assert.Equal("count", property.Name);
-            Assert.Equal("count:000", property.MessageToken);
+            Assert.Equal("{count:000}", property.MessageToken);
             Assert.Equal("000", property.FormatArgument);
         }
 
@@ -33,7 +33,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             var property = new MessageProperty("@user");
             Assert.Equal(MessageProperty.Directive.JsonSerialization, property.FormatDirective);
             Assert.Equal("user", property.Name);
-            Assert.Equal("@user", property.MessageToken);
+            Assert.Equal("{@user}", property.MessageToken);
             Assert.Null(property.FormatArgument);
         }
 
@@ -43,7 +43,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             var property = new MessageProperty("@user:000");
             Assert.Equal(MessageProperty.Directive.JsonSerialization, property.FormatDirective);
             Assert.Equal("user", property.Name);
-            Assert.Equal("@user:000", property.MessageToken);
+            Assert.Equal("{@user:000}", property.MessageToken);
             Assert.Equal("000", property.FormatArgument);
         }
 
@@ -53,7 +53,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             var property = new MessageProperty("count:");
             Assert.Equal(MessageProperty.Directive.Default, property.FormatDirective);
             Assert.Equal("count", property.Name);
-            Assert.Equal("count:", property.MessageToken);
+            Assert.Equal("{count:}", property.MessageToken);
             Assert.Null(property.FormatArgument);
         }
 
@@ -63,7 +63,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             var property = new MessageProperty(" first last ");
             Assert.Equal(MessageProperty.Directive.Default, property.FormatDirective);
             Assert.Equal("first last", property.Name);
-            Assert.Equal(" first last ", property.MessageToken);
+            Assert.Equal("{ first last }", property.MessageToken);
             Assert.Null(property.FormatArgument);
         }
 
@@ -73,7 +73,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             var property = new MessageProperty(" first last : 000 ");
             Assert.Equal(MessageProperty.Directive.Default, property.FormatDirective);
             Assert.Equal("first last", property.Name);
-            Assert.Equal(" first last : 000 ", property.MessageToken);
+            Assert.Equal("{ first last : 000 }", property.MessageToken);
             Assert.Equal("000", property.FormatArgument);
         }
 

--- a/Libraries/test/TestServerlessApp/serverless.template
+++ b/Libraries/test/TestServerlessApp/serverless.template
@@ -718,6 +718,26 @@
           ]
         }
       }
+    },
+    "TestServerlessAppIntrinsicExampleHasIntrinsicGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations"
+      },
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.IntrinsicExample_HasIntrinsic_Generated::HasIntrinsic"
+          ]
+        }
+      }
     }
   },
   "Outputs": {


### PR DESCRIPTION
*Description of changes:*

This PR is the initial work to add support for structured logging natively in the Amazon.Lambda.RuntimeSupport the .NET Lambda runtime client (RIC). Serilog was used as the example of the experience but is not used directly so that we would not take a hard dependency on Serilog or interfere with anybody wanting to implement their own structured logging using Serilog.

Changes made:
* The ILambdaLogger has new parameterized logging methods
* The ConsoleLoggerWriter was refactored to have formatting being done in separate formatting classes that are swapped out depending on the environment variable configuring formatter. The `DefaultLogMessageFormatter` formatter represents what we do today and `JsonLogMessageFormatter` is the new structured logging.


**NOTE**: The new parameterize logging methods on ILambadLogger are marked with the .NET attribute `RequiresPreviewFeatures`. This requires users that want to use these methods to have to turn on preview language features in the project file, `<LangVersion>preview</LangVersion>`. This is done due to the fact that `Amazon.Lambda.Core` with these new APIs will go out before the .NET managed runtime is deployed with the version of `Amazon.Lambda.RuntimeSupport`. If users call these methods before the runtime is updated the message will be logged ignoring the parameters. For users that deploy as an executable with the latest version version of `Amazon.Lambda.RuntimeSupport` they will be able to use these methods with no problems. Once `Amazon.Lambda.RuntimeSupport` has been updated in the managed runtime a new version of `Amazon.Lambda.Core` will be released removing the `RequiresPreviewFeatures` attribute.

This PR uses a lot of the code ideas from PR https://github.com/aws/aws-lambda-dotnet/pull/1323 by @dhhoang. The major difference are 
* Pushing more of the work into Amazon.Lambda.RuntimeSupport instead Amazon.Lambda.Core
* Add more scenarios supported by Serilog
* Match work Lambda team is doing in other language runtimes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
