### PR TITLE
chore: update .NET8 OCIs to use AL2023 preview image

### DIFF
--- a/LambdaRuntimeDockerfiles/Images/net8/amd64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net8/amd64/Dockerfile
@@ -4,9 +4,11 @@ ARG ASPNET_VERSION=8.0.0-rc.1.23421.29
 ARG ASPNET_SHA512=d5f9e7bffbf2b48b26a317dd1d78bc866973b4a2cda448cd7a7ee64c0ffaf98fa3c4b8584d32528026674bdfd99f602f0fdac8242176815705e080df83825efa
 
 ARG LAMBDA_RUNTIME_NAME=dotnet8
-ARG AMAZON_LINUX=public.ecr.aws/lambda/provided:al2
+ARG AMAZON_LINUX=public.ecr.aws/lambda/provided:al2023-preview
 
 FROM $AMAZON_LINUX AS base
+
+RUN dnf install libicu-67.1-7.amzn2023.0.3.x86_64 --assumeyes
 
 FROM base AS builder-net8
 ARG ASPNET_VERSION
@@ -15,7 +17,7 @@ ARG ASPNET_SHA512
 WORKDIR /dotnet
 
 # Install tar and gzip for unarchiving downloaded tar.gz
-RUN yum install tar gzip --assumeyes
+RUN dnf install tar gzip --assumeyes
 
 # Install the ASP.NET Core shared framework
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-x64.tar.gz \

--- a/LambdaRuntimeDockerfiles/Images/net8/arm64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net8/arm64/Dockerfile
@@ -3,40 +3,12 @@
 ARG ASPNET_VERSION=8.0.0-rc.1.23421.29
 ARG ASPNET_SHA512=ba8035da535cb3bffa720e962e6f9e0f88b36e1221b588f2a126ee4b43c02e4d8c27958017d29e5ab68121fab6a564fe0a27099c4103ee3d527f8554b4ab495e
 
-ARG ICU_VERSION=68.1
-ARG ICU_MD5=6a99b541ea01f271257b121a4433c7c0
-
 ARG LAMBDA_RUNTIME_NAME=dotnet8
-ARG AMAZON_LINUX=public.ecr.aws/lambda/provided:al2
+ARG AMAZON_LINUX=public.ecr.aws/lambda/provided:al2023-preview
 
 FROM $AMAZON_LINUX AS base
 
-FROM base AS builder-libicu
-WORKDIR /
-
-# Install depedencies to extract and build ICU library
-RUN yum install -d1 -y \
-    tar \
-    gzip \
-    make \
-    gcc-c++
-
-# Download, validate and extract ICU library
-# https://github.com/unicode-org/icu/releases/tag/release-68-1
-ARG ICU_VERSION
-ARG ICU_MD5
-RUN curl -SL https://github.com/unicode-org/icu/releases/download/release-${ICU_VERSION//./-}/icu4c-${ICU_VERSION//./_}-src.tgz -o icu-src.tgz \
-    && echo "$ICU_MD5  icu-src.tgz" | md5sum -c - \
-    && tar -xzf icu-src.tgz \
-    && rm icu-src.tgz
-
-# Build ICU library
-RUN mkdir /libicu
-WORKDIR /icu/source/
-RUN ./configure --prefix=/libicu \
-    && make \
-    && make install
-
+RUN dnf install libicu-67.1-7.amzn2023.0.3.aarch64 --assumeyes
 
 FROM base AS builder-net8
 ARG ASPNET_VERSION
@@ -45,7 +17,7 @@ ARG ASPNET_SHA512
 WORKDIR /dotnet
 
 # Install tar and gzip for unarchiving downloaded tar.gz
-RUN yum install tar gzip --assumeyes
+RUN dnf install tar gzip --assumeyes
 
 # Install the ASP.NET Core shared framework
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-arm64.tar.gz \
@@ -71,9 +43,6 @@ RUN apt-get update && apt-get install -y dos2unix
 RUN dos2unix /app/publish/bootstrap.sh && \
     mv /app/publish/bootstrap.sh /app/publish/bootstrap && \
     chmod +x /app/publish/bootstrap
-
-# Copy native dependencies
-COPY --from=builder-libicu  /libicu         /app/publish
 
 
 FROM base

--- a/LambdaRuntimeDockerfiles/SmokeTests/test/ImageFunction.SmokeTests/ImageFunctionTests.cs
+++ b/LambdaRuntimeDockerfiles/SmokeTests/test/ImageFunction.SmokeTests/ImageFunctionTests.cs
@@ -43,22 +43,6 @@ namespace ImageFunction.SmokeTests
         private readonly AmazonIdentityManagementServiceClient _iamClient;
         private string _executionRoleArn;
 
-        private static readonly string LambdaAssumeRolePolicy =
-            @"
-            {
-              ""Version"": ""2012-10-17"",
-              ""Statement"": [
-                {
-                  ""Sid"": """",
-                  ""Effect"": ""Allow"",
-                  ""Principal"": {
-                    ""Service"": ""lambda.amazonaws.com""
-                  },
-                  ""Action"": ""sts:AssumeRole""
-                }
-              ]
-            }".Trim();
-
         private readonly string _functionName;
         private readonly string _imageUri;
         private const string TestIdentifier = "image-function-tests";


### PR DESCRIPTION
*Description of changes:*
* Switch from using Amazon AL2 base image to AL2023
* Use `dnf` package manager instead of `yum` as it is not available on AL2023
* Install LIBICU on both AMD64 and ARM64 as it is not available by default in AL2023
* Install LIBICU using `dnf` instead of building from source

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
