### PR TITLE
Add AWS_LAMBDA_DOTNET_DISABLE_MEMORY_LIMIT_CHECK env variable to turn…

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net8.0</TargetFrameworks>
-    <VersionPrefix>1.9.0</VersionPrefix>
+    <VersionPrefix>1.9.1</VersionPrefix>
     <Description>Provides a bootstrap and Lambda Runtime API Client to help you to develop custom .NET Core Lambda Runtimes.</Description>
     <AssemblyTitle>Amazon.Lambda.RuntimeSupport</AssemblyTitle>
     <AssemblyName>Amazon.Lambda.RuntimeSupport</AssemblyName>

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/Constants.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/Constants.cs
@@ -24,6 +24,8 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
         // variable should never be set when function is deployed to Lambda.
         internal const string ENVIRONMENT_VARIABLE_AWS_LAMBDA_DOTNET_DEBUG_RUN_ONCE = "AWS_LAMBDA_DOTNET_DEBUG_RUN_ONCE";
 
+        internal const string ENVIRONMENT_VARIABLE_DISABLE_HEAP_MEMORY_LIMIT = "AWS_LAMBDA_DOTNET_DISABLE_MEMORY_LIMIT_CHECK";
+
         internal const string ENVIRONMENT_VARIABLE_AWS_LAMBDA_DOTNET_PREJIT = "AWS_LAMBDA_DOTNET_PREJIT";
         internal const string ENVIRONMENT_VARIABLE_AWS_LAMBDA_INITIALIZATION_TYPE = "AWS_LAMBDA_INITIALIZATION_TYPE";
         internal const string ENVIRONMENT_VARIABLE_LANG = "LANG";

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
@@ -265,6 +265,15 @@ namespace Amazon.Lambda.RuntimeSupport
         {
             try
             {
+                // Check the environment variable to see if the user has opted out of RuntimeSupport adjusting 
+                // the heap memory limit to match the Lambda configured environment. This can be useful for situations
+                // where the Lambda environment is being emulated for testing and more then just single Lambda function
+                // is running in the process. For example running a test runner over a series of Lambda emulated invocations.
+                var value = Environment.GetEnvironmentVariable(Constants.ENVIRONMENT_VARIABLE_DISABLE_HEAP_MEMORY_LIMIT);
+                if (string.Equals(value, "true", StringComparison.OrdinalIgnoreCase))
+                    return;
+
+
                 int lambdaMemoryInMb;
                 if (!int.TryParse(Environment.GetEnvironmentVariable(LambdaEnvironment.EnvVarFunctionMemorySize), out lambdaMemoryInMb))
                     return;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1594

*Description of changes:*
Add the `AWS_LAMBDA_DOTNET_DISABLE_MEMORY_LIMIT_CHECK` environment variable to disable the code added for .NET 8 that configures the .NET runtime to use the amount of memory the Lambda function is configured for. Code to deployed to Lambda should never need this but for tools that are emulating Lambda environment including the memory check can cause problems for things like test runners running Lambda functions in process with other components.

@martincostello Please let me know if this PR would work for you.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
