### PR TITLE
Add trimming support for RuntimeSupport, SystemTextJson serializer and Lambda event packages

### DIFF
--- a/.github/workflows/source-generator-ci.yml
+++ b/.github/workflows/source-generator-ci.yml
@@ -22,6 +22,10 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 8.0.x        
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:

--- a/.github/workflows/source-generator-ci.yml
+++ b/.github/workflows/source-generator-ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup .NET 8.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 8.0.x        
+        dotnet-version: 8.0.100-rc.2.23502.2
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:

--- a/.github/workflows/source-generator-ci.yml
+++ b/.github/workflows/source-generator-ci.yml
@@ -77,6 +77,10 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 8.0.100-rc.2.23502.2        
     - name: Restore dependencies
       run: dotnet restore Libraries/test/TestServerlessApp/TestServerlessApp.csproj
     - name: Build

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerPolicy.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerPolicy.cs
@@ -10,7 +10,7 @@
         /// <summary>
         /// Gets or sets the IAM API version.
         /// </summary>
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("Version")]
 #endif
         public string Version { get; set; } = "2012-10-17";
@@ -18,7 +18,7 @@
         /// <summary>
         /// Gets or sets a list of IAM policy statements to apply.
         /// </summary>
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("Statement")]
 #endif
         public List<IAMPolicyStatement> Statement { get; set; } = new List<IAMPolicyStatement>();
@@ -31,7 +31,7 @@
             /// <summary>
             /// Gets or sets the effect the statement has.
             /// </summary>
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("Effect")]
 #endif
             public string Effect { get; set; } = "Allow";
@@ -39,7 +39,7 @@
             /// <summary>
             /// Gets or sets the action/s the statement has.
             /// </summary>
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("Action")]
 #endif
             public HashSet<string> Action { get; set; }
@@ -47,7 +47,7 @@
             /// <summary>
             /// Gets or sets the resources the statement applies to.
             /// </summary>
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("Resource")]
 #endif
             public HashSet<string> Resource { get; set; }

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerResponse.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerResponse.cs
@@ -12,7 +12,7 @@
         /// Gets or sets the ID of the principal.
         /// </summary>
         [DataMember(Name = "principalId")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("principalId")]
 #endif
         public string PrincipalID { get; set; }
@@ -21,7 +21,7 @@
         /// Gets or sets the <see cref="APIGatewayCustomAuthorizerPolicy"/> policy document.
         /// </summary>
         [DataMember(Name = "policyDocument")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("policyDocument")]
 #endif
         public APIGatewayCustomAuthorizerPolicy PolicyDocument { get; set; } = new APIGatewayCustomAuthorizerPolicy();
@@ -30,7 +30,7 @@
         /// Gets or sets the <see cref="APIGatewayCustomAuthorizerContext"/> property.
         /// </summary>
         [DataMember(Name = "context")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("context")]
 #endif
         public APIGatewayCustomAuthorizerContextOutput Context { get; set; }
@@ -39,7 +39,7 @@
         /// Gets or sets the usageIdentifierKey.
         /// </summary>
         [DataMember(Name = "usageIdentifierKey")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("usageIdentifierKey")]
 #endif
         public string UsageIdentifierKey { get; set; }

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerV2IamResponse.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerV2IamResponse.cs
@@ -14,7 +14,7 @@
         /// Gets or sets the ID of the principal.
         /// </summary>
         [DataMember(Name = "principalId")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("principalId")]
 #endif
         public string PrincipalID { get; set; }
@@ -23,7 +23,7 @@
         /// Gets or sets the <see cref="APIGatewayCustomAuthorizerPolicy"/> policy document.
         /// </summary>
         [DataMember(Name = "policyDocument")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("policyDocument")]
 #endif
         public APIGatewayCustomAuthorizerPolicy PolicyDocument { get; set; } = new APIGatewayCustomAuthorizerPolicy();
@@ -32,7 +32,7 @@
         /// Gets or sets the <see cref="APIGatewayCustomAuthorizerContext"/> property.
         /// </summary>
         [DataMember(Name = "context")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("context")]
 #endif
         public Dictionary<string, object> Context { get; set; }

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerV2SimpleResponse.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerV2SimpleResponse.cs
@@ -14,7 +14,7 @@
         /// Gets or sets authorization result.
         /// </summary>
         [DataMember(Name = "isAuthorized")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("isAuthorized")]
 #endif
         public bool IsAuthorized { get; set; }
@@ -23,7 +23,7 @@
         /// Gets or sets the <see cref="APIGatewayCustomAuthorizerContext"/> property.
         /// </summary>
         [DataMember(Name = "context")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("context")]
 #endif
         public Dictionary<string, object> Context { get; set; }

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayHttpApiV2ProxyResponse.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayHttpApiV2ProxyResponse.cs
@@ -17,7 +17,7 @@ namespace Amazon.Lambda.APIGatewayEvents
         /// The HTTP status code for the request
         /// </summary>
         [DataMember(Name = "statusCode")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("statusCode")]
 #endif
         public int StatusCode { get; set; }
@@ -26,7 +26,7 @@ namespace Amazon.Lambda.APIGatewayEvents
         /// The Http headers returned in the response. Multiple header values set for the the same header should be separate by a comma.
         /// </summary>
         [DataMember(Name = "headers")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("headers")]
 #endif
         public IDictionary<string, string> Headers { get; set; }
@@ -67,7 +67,7 @@ namespace Amazon.Lambda.APIGatewayEvents
         /// The cookies returned in the response.
         /// </summary>
         [DataMember(Name = "cookies")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("cookies")]
 #endif
         public string[] Cookies { get; set; }
@@ -76,7 +76,7 @@ namespace Amazon.Lambda.APIGatewayEvents
         /// The response body
         /// </summary>
         [DataMember(Name = "body")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("body")]
 #endif
         public string Body { get; set; }
@@ -85,7 +85,7 @@ namespace Amazon.Lambda.APIGatewayEvents
         /// Flag indicating whether the body should be treated as a base64-encoded string
         /// </summary>
         [DataMember(Name = "isBase64Encoded")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("isBase64Encoded")]
 #endif
         public bool IsBase64Encoded { get; set; }

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayProxyResponse.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayProxyResponse.cs
@@ -14,7 +14,7 @@
         /// The HTTP status code for the request
         /// </summary>
         [DataMember(Name = "statusCode")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("statusCode")]
 #endif
         public int StatusCode { get; set; }
@@ -25,7 +25,7 @@
         /// before returning back the headers to the caller.
         /// </summary>
         [DataMember(Name = "headers")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("headers")]
 #endif
         public IDictionary<string, string> Headers { get; set; }
@@ -36,7 +36,7 @@
         /// before returning back the headers to the caller.
         /// </summary>
         [DataMember(Name = "multiValueHeaders")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("multiValueHeaders")]
 #endif
         public IDictionary<string, IList<string>> MultiValueHeaders { get; set; }
@@ -45,7 +45,7 @@
         /// The response body
         /// </summary>
         [DataMember(Name = "body")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("body")]
 #endif
         public string Body { get; set; }
@@ -54,7 +54,7 @@
         /// Flag indicating whether the body should be treated as a base64-encoded string
         /// </summary>
         [DataMember(Name = "isBase64Encoded")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("isBase64Encoded")]
 #endif
         public bool IsBase64Encoded { get; set; }

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/Amazon.Lambda.APIGatewayEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/Amazon.Lambda.APIGatewayEvents.csproj
@@ -3,10 +3,10 @@
   <Import Project="..\..\..\buildtools\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>    
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>    
     <Description>Amazon Lambda .NET Core support - API Gateway package.</Description>
     <AssemblyTitle>Amazon.Lambda.APIGatewayEvents</AssemblyTitle>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.7.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.APIGatewayEvents</AssemblyName>
     <PackageId>Amazon.Lambda.APIGatewayEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
@@ -17,9 +17,6 @@
     <DefineConstants>NETSTANDARD_2_0</DefineConstants>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <DefineConstants>NETCOREAPP_3_1</DefineConstants>
-  </PropertyGroup>
   <ItemGroup>
 	<None Include="README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>	
@@ -28,4 +25,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+		<IsTrimmable>true</IsTrimmable>
+	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/Amazon.Lambda.APIGatewayEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/Amazon.Lambda.APIGatewayEvents.csproj
@@ -28,5 +28,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.ApplicationLoadBalancerEvents/Amazon.Lambda.ApplicationLoadBalancerEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.ApplicationLoadBalancerEvents/Amazon.Lambda.ApplicationLoadBalancerEvents.csproj
@@ -15,5 +15,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
+        <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>	
 </Project>

--- a/Libraries/src/Amazon.Lambda.ApplicationLoadBalancerEvents/Amazon.Lambda.ApplicationLoadBalancerEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.ApplicationLoadBalancerEvents/Amazon.Lambda.ApplicationLoadBalancerEvents.csproj
@@ -3,13 +3,17 @@
     <Import Project="..\..\..\buildtools\common.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>
         <Description>Amazon Lambda .NET Core support - Application Load Balancer package.</Description>
         <AssemblyTitle>Amazon.Lambda.ApplicationLoadBalancerEvents</AssemblyTitle>
-        <VersionPrefix>2.1.0</VersionPrefix>
+        <VersionPrefix>2.2.0</VersionPrefix>
         <AssemblyName>Amazon.Lambda.ApplicationLoadBalancerEvents</AssemblyName>
         <PackageId>Amazon.Lambda.ApplicationLoadBalancerEvents</PackageId>
         <PackageTags>AWS;Amazon;Lambda</PackageTags>
     </PropertyGroup>
-    
+
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+		<IsTrimmable>true</IsTrimmable>
+	</PropertyGroup>	
 </Project>

--- a/Libraries/src/Amazon.Lambda.ApplicationLoadBalancerEvents/ApplicationLoadBalancerResponse.cs
+++ b/Libraries/src/Amazon.Lambda.ApplicationLoadBalancerEvents/ApplicationLoadBalancerResponse.cs
@@ -14,7 +14,7 @@ namespace Amazon.Lambda.ApplicationLoadBalancerEvents
         /// The HTTP status code for the request
         /// </summary>
         [DataMember(Name = "statusCode")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("statusCode")]
 #endif
         public int StatusCode { get; set; }
@@ -23,7 +23,7 @@ namespace Amazon.Lambda.ApplicationLoadBalancerEvents
         /// The HTTP status description for the request
         /// </summary>
         [DataMember(Name = "statusDescription")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("statusDescription")]
 #endif
         public string StatusDescription { get; set; }
@@ -33,7 +33,7 @@ namespace Amazon.Lambda.ApplicationLoadBalancerEvents
         /// Note: Use this property when "Multi value headers" is disabled on ELB Target Group.
         /// </summary>
         [DataMember(Name = "headers")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("headers")]
 #endif
         public IDictionary<string, string> Headers { get; set; }
@@ -43,7 +43,7 @@ namespace Amazon.Lambda.ApplicationLoadBalancerEvents
         /// Note: Use this property when "Multi value headers" is enabled on ELB Target Group.
         /// </summary>
         [DataMember(Name = "multiValueHeaders")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("multiValueHeaders")]
 #endif
         public IDictionary<string, IList<string>> MultiValueHeaders { get; set; }
@@ -52,7 +52,7 @@ namespace Amazon.Lambda.ApplicationLoadBalancerEvents
         /// The response body
         /// </summary>
         [DataMember(Name = "body")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("body")]
 #endif
         public string Body { get; set; }
@@ -61,7 +61,7 @@ namespace Amazon.Lambda.ApplicationLoadBalancerEvents
         /// Flag indicating whether the body should be treated as a base64-encoded string
         /// </summary>
         [DataMember(Name = "isBase64Encoded")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("isBase64Encoded")]
 #endif
         public bool IsBase64Encoded { get; set; }        

--- a/Libraries/src/Amazon.Lambda.CloudWatchEvents/Amazon.Lambda.CloudWatchEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.CloudWatchEvents/Amazon.Lambda.CloudWatchEvents.csproj
@@ -3,17 +3,17 @@
   <Import Project="..\..\..\buildtools\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>
     <Description>Amazon Lambda .NET Core support - CloudWatchEvents package.</Description>
     <AssemblyTitle>Amazon.Lambda.CloudWatchEvents</AssemblyTitle>
-    <VersionPrefix>4.3.0</VersionPrefix>
+    <VersionPrefix>4.4.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.CloudWatchEvents</AssemblyName>
     <PackageId>Amazon.Lambda.CloudWatchEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <DefineConstants>NETCOREAPP_3_1</DefineConstants>
-  </PropertyGroup>
-
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+		<IsTrimmable>true</IsTrimmable>
+	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.CloudWatchEvents/Amazon.Lambda.CloudWatchEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.CloudWatchEvents/Amazon.Lambda.CloudWatchEvents.csproj
@@ -15,5 +15,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.CloudWatchEvents/CloudWatchEvent.cs
+++ b/Libraries/src/Amazon.Lambda.CloudWatchEvents/CloudWatchEvent.cs
@@ -40,8 +40,8 @@
         /// For example, ScheduledEvent will be null
         /// For example, ECSEvent could be "ECS Container Instance State Change" or "ECS Task State Change"
         /// </summary>
-#if NETCOREAPP_3_1
-            [System.Text.Json.Serialization.JsonPropertyName("detail-type")]
+#if NETCOREAPP3_1_OR_GREATER
+        [System.Text.Json.Serialization.JsonPropertyName("detail-type")]
 #endif
         public string DetailType { get; set; }
 

--- a/Libraries/src/Amazon.Lambda.CloudWatchEvents/S3Events/S3Object.cs
+++ b/Libraries/src/Amazon.Lambda.CloudWatchEvents/S3Events/S3Object.cs
@@ -30,7 +30,7 @@ namespace Amazon.Lambda.CloudWatchEvents.S3Events
         /// The version ID of the object.
         /// </summary>
         [DataMember(Name = "version-id")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("version-id")]
 #endif
         public string VersionId { get; set; }

--- a/Libraries/src/Amazon.Lambda.CloudWatchEvents/S3Events/S3ObjectCreate.cs
+++ b/Libraries/src/Amazon.Lambda.CloudWatchEvents/S3Events/S3ObjectCreate.cs
@@ -12,7 +12,7 @@ namespace Amazon.Lambda.CloudWatchEvents.S3Events
         /// The source IP of the API request.
         /// </summary>
         [DataMember(Name = "source-ip-address")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("source-ip-address")]
 #endif
         public string SourceIpAddress { get; set; }

--- a/Libraries/src/Amazon.Lambda.CloudWatchEvents/S3Events/S3ObjectDelete.cs
+++ b/Libraries/src/Amazon.Lambda.CloudWatchEvents/S3Events/S3ObjectDelete.cs
@@ -12,7 +12,7 @@ namespace Amazon.Lambda.CloudWatchEvents.S3Events
         /// The source IP of the API request.
         /// </summary>
         [DataMember(Name = "source-ip-address")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("source-ip-address")]
 #endif
         public string SourceIpAddress { get; set; }
@@ -27,7 +27,7 @@ namespace Amazon.Lambda.CloudWatchEvents.S3Events
         /// The type of object deletion event.
         /// </summary>
         [DataMember(Name = "deletion-type")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("deletion-type")]
 #endif
         public string DeletionType { get; set; }

--- a/Libraries/src/Amazon.Lambda.CloudWatchEvents/S3Events/S3ObjectEventDetails.cs
+++ b/Libraries/src/Amazon.Lambda.CloudWatchEvents/S3Events/S3ObjectEventDetails.cs
@@ -30,7 +30,7 @@ namespace Amazon.Lambda.CloudWatchEvents.S3Events
         /// The ID of the API request.
         /// </summary>
         [DataMember(Name = "request-id")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("request-id")]
 #endif
         public string RequestId { get; set; }

--- a/Libraries/src/Amazon.Lambda.CloudWatchEvents/S3Events/S3ObjectRestore.cs
+++ b/Libraries/src/Amazon.Lambda.CloudWatchEvents/S3Events/S3ObjectRestore.cs
@@ -12,7 +12,7 @@ namespace Amazon.Lambda.CloudWatchEvents.S3Events
         /// The time when the temporary copy of the object will be deleted from S3.
         /// </summary>
         [DataMember(Name = "restore-expiry-time")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("restore-expiry-time")]
 #endif
         public string RestoreExpiryTime { get; set; }
@@ -21,7 +21,7 @@ namespace Amazon.Lambda.CloudWatchEvents.S3Events
         /// The storage class of the object being restored.
         /// </summary>
         [DataMember(Name = "source-storage-class")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("source-storage-class")]
 #endif
         public string SourceStorageClass { get; set; }

--- a/Libraries/src/Amazon.Lambda.CloudWatchLogsEvents/Amazon.Lambda.CloudWatchLogsEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.CloudWatchLogsEvents/Amazon.Lambda.CloudWatchLogsEvents.csproj
@@ -2,15 +2,16 @@
   <Import Project="..\..\..\buildtools\common.props" />
   <PropertyGroup>
     <Description>Amazon Lambda .NET Core support - CloudWatchLogsEvents package.</Description>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.CloudWatchLogsEvents</AssemblyTitle>
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionPrefix>2.2.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.CloudWatchLogsEvents</AssemblyName>
     <PackageId>Amazon.Lambda.CloudWatchLogsEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <DefineConstants>NETCOREAPP_3_1</DefineConstants>
-  </PropertyGroup>  
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+		<IsTrimmable>true</IsTrimmable>
+	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.CloudWatchLogsEvents/Amazon.Lambda.CloudWatchLogsEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.CloudWatchLogsEvents/Amazon.Lambda.CloudWatchLogsEvents.csproj
@@ -13,5 +13,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.CloudWatchLogsEvents/CloudWatchLogsEvents.cs
+++ b/Libraries/src/Amazon.Lambda.CloudWatchLogsEvents/CloudWatchLogsEvents.cs
@@ -30,7 +30,7 @@ namespace Amazon.Lambda.CloudWatchLogsEvents
             /// The data that are base64 encoded and gziped messages in LogStreams.
             /// </summary>
             [DataMember(Name = "data", IsRequired = false)]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("data")]
 #endif
             public string EncodedData { get; set; }

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/Amazon.Lambda.CognitoEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/Amazon.Lambda.CognitoEvents.csproj
@@ -15,5 +15,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/Amazon.Lambda.CognitoEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/Amazon.Lambda.CognitoEvents.csproj
@@ -4,12 +4,16 @@
 
   <PropertyGroup>
     <Description>Amazon Lambda .NET Core support - CognitoEvents package.</Description>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.CognitoEvents</AssemblyTitle>
-    <VersionPrefix>2.1.1</VersionPrefix>
+    <VersionPrefix>2.2.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.CognitoEvents</AssemblyName>
     <PackageId>Amazon.Lambda.CognitoEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
   </PropertyGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+		<IsTrimmable>true</IsTrimmable>
+	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/ChallengeResultElement.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/ChallengeResultElement.cs
@@ -12,7 +12,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The challenge type.One of: CUSTOM_CHALLENGE, SRP_A, PASSWORD_VERIFIER, SMS_MFA, DEVICE_SRP_AUTH, DEVICE_PASSWORD_VERIFIER, or ADMIN_NO_SRP_AUTH.
         /// </summary>
         [DataMember(Name = "challengeName")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("challengeName")]
 # endif
         public string ChallengeName { get; set; }
@@ -21,7 +21,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// Set to true if the user successfully completed the challenge, or false otherwise.
         /// </summary>
         [DataMember(Name = "challengeResult")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("challengeResult")]
 # endif
         public bool ChallengeResult { get; set; }
@@ -30,7 +30,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// Your name for the custom challenge.Used only if challengeName is CUSTOM_CHALLENGE.
         /// </summary>
         [DataMember(Name = "challengeMetadata")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("challengeMetadata")]
 # endif
         public string ChallengeMetadata { get; set; }

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/ClaimOverrideDetails.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/ClaimOverrideDetails.cs
@@ -13,7 +13,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// A map of one or more key-value pairs of claims to add or override. For group related claims, use groupOverrideDetails instead.
         /// </summary>
         [DataMember(Name = "claimsToAddOrOverride")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("claimsToAddOrOverride")]
 # endif
         public Dictionary<string, string> ClaimsToAddOrOverride { get; set; } = new Dictionary<string, string>();
@@ -22,7 +22,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// A list that contains claims to be suppressed from the identity token.
         /// </summary>
         [DataMember(Name = "claimsToSuppress")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("claimsToSuppress")]
 # endif
         public List<string> ClaimsToSuppress { get; set; } = new List<string>();
@@ -31,7 +31,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The output object containing the current group configuration. It includes groupsToOverride, iamRolesToOverride, and preferredRole.
         /// </summary>
         [DataMember(Name = "groupOverrideDetails")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("groupOverrideDetails")]
 # endif
         public GroupConfiguration GroupOverrideDetails { get; set; } = new GroupConfiguration();

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoCreateAuthChallengeRequest.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoCreateAuthChallengeRequest.cs
@@ -12,7 +12,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// One or more key-value pairs that you can provide as custom input to the Lambda function that you specify for the pre sign-up trigger. You can pass this data to your Lambda function by using the ClientMetadata parameter in the following API actions: AdminCreateUser, AdminRespondToAuthChallenge, ForgotPassword, and SignUp.
         /// </summary>
         [DataMember(Name = "clientMetadata")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("clientMetadata")]
 # endif
         public Dictionary<string, string> ClientMetadata { get; set; } = new Dictionary<string, string>();
@@ -21,7 +21,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The name of the new challenge.
         /// </summary>
         [DataMember(Name = "challengeName")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("challengeName")]
 #endif
         public string ChallengeName { get; set; }
@@ -30,7 +30,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// an array of ChallengeResult elements
         /// </summary>
         [DataMember(Name = "session")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("session")]
 #endif
         public List<ChallengeResultElement> Session { get; set; } = new List<ChallengeResultElement>();
@@ -39,7 +39,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// A Boolean that is populated when PreventUserExistenceErrors is set to ENABLED for your user pool client. A value of true means that the user id (user name, email address, etc.) did not match any existing users. When PreventUserExistenceErrors is set to ENABLED, the service will not report back to the app that the user does not exist. The recommended best practice is for your Lambda functions to maintain the same user experience including latency so the caller cannot detect different behavior when the user exists or doesn’t exist.
         /// </summary>
         [DataMember(Name = "userNotFound")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("userNotFound")]
 #endif
         public bool UserNotFound { get; set; }

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoCreateAuthChallengeResponse.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoCreateAuthChallengeResponse.cs
@@ -12,7 +12,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// One or more key-value pairs for the client app to use in the challenge to be presented to the user.This parameter should contain all of the necessary information to accurately present the challenge to the user.
         /// </summary>
         [DataMember(Name = "publicChallengeParameters")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("publicChallengeParameters")]
 #endif
         public Dictionary<string, string> PublicChallengeParameters { get; set; } = new Dictionary<string, string>();
@@ -21,7 +21,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// This parameter is only used by the Verify Auth Challenge Response Lambda trigger. This parameter should contain all of the information that is required to validate the user's response to the challenge. In other words, the publicChallengeParameters parameter contains the question that is presented to the user and privateChallengeParameters contains the valid answers for the question.
         /// </summary>
         [DataMember(Name = "privateChallengeParameters")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("privateChallengeParameters")]
 #endif
         public Dictionary<string, string> PrivateChallengeParameters { get; set; } = new Dictionary<string, string>();
@@ -30,7 +30,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// Your name for the custom challenge, if this is a custom challenge.
         /// </summary>
         [DataMember(Name = "challengeMetadata")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("challengeMetadata")]
 #endif
         public string ChallengeMetadata { get; set; }

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoCustomEmailSenderRequest.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoCustomEmailSenderRequest.cs
@@ -11,7 +11,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The type of sender request.
         /// </summary>
         [DataMember(Name = "type")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("type")]
 # endif
         public string Type { get; set; }
@@ -20,7 +20,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The encrypted temporary authorization code.
         /// </summary>
         [DataMember(Name = "code")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("code")]
 #endif
         public string Code { get; set; }

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoCustomMessageRequest.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoCustomMessageRequest.cs
@@ -12,7 +12,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// A string for you to use as the placeholder for the verification code in the custom message.
         /// </summary>
         [DataMember(Name = "codeParameter")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("codeParameter")]
 #endif
         public string CodeParameter { get; set; }
@@ -21,7 +21,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The username parameter. It is a required request parameter for the admin create user flow.
         /// </summary>
         [DataMember(Name = "usernameParameter")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("usernameParameter")]
 #endif
         public string UsernameParameter { get; set; }
@@ -30,7 +30,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// One or more key-value pairs that you can provide as custom input to the Lambda function that you specify for the pre sign-up trigger. You can pass this data to your Lambda function by using the ClientMetadata parameter in the following API actions: AdminCreateUser, AdminRespondToAuthChallenge, ForgotPassword, and SignUp.
         /// </summary>
         [DataMember(Name = "clientMetadata")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("clientMetadata")]
 #endif
         public Dictionary<string, string> ClientMetadata { get; set; } = new Dictionary<string, string>();

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoCustomMessageResponse.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoCustomMessageResponse.cs
@@ -11,7 +11,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The custom SMS message to be sent to your users. Must include the codeParameter value received in the request.
         /// </summary>
         [DataMember(Name = "smsMessage")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("smsMessage")]
 #endif
         public string SmsMessage { get; set; }
@@ -20,7 +20,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The custom email message to be sent to your users. Must include the codeParameter value received in the request.
         /// </summary>
         [DataMember(Name = "emailMessage")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("emailMessage")]
 #endif
         public string EmailMessage { get; set; }
@@ -29,7 +29,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The subject line for the custom message.
         /// </summary>
         [DataMember(Name = "emailSubject")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("emailSubject")]
 #endif
         public string EmailSubject { get; set; }

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoCustomSmsSenderRequest.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoCustomSmsSenderRequest.cs
@@ -11,7 +11,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The type of sender request.
         /// </summary>
         [DataMember(Name = "type")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("type")]
 #endif
         public string Type { get; set; }
@@ -20,7 +20,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The encrypted temporary authorization code.
         /// </summary>
         [DataMember(Name = "code")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("code")]
 #endif
         public string Code { get; set; }

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoDefineAuthChallengeRequest.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoDefineAuthChallengeRequest.cs
@@ -12,7 +12,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// One or more key-value pairs that you can provide as custom input to the Lambda function that you specify for the pre sign-up trigger. You can pass this data to your Lambda function by using the ClientMetadata parameter in the following API actions: AdminCreateUser, AdminRespondToAuthChallenge, ForgotPassword, and SignUp.
         /// </summary>
         [DataMember(Name = "clientMetadata")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("clientMetadata")]
 # endif
         public Dictionary<string, string> ClientMetadata { get; set; } = new Dictionary<string, string>();
@@ -21,7 +21,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// an array of ChallengeResult elements
         /// </summary>
         [DataMember(Name = "session")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("session")]
 # endif
         public List<ChallengeResultElement> Session { get; set; } = new List<ChallengeResultElement>();
@@ -30,7 +30,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// A Boolean that is populated when PreventUserExistenceErrors is set to ENABLED for your user pool client. A value of true means that the user id (user name, email address, etc.) did not match any existing users. When PreventUserExistenceErrors is set to ENABLED, the service will not report back to the app that the user does not exist. The recommended best practice is for your Lambda functions to maintain the same user experience including latency so the caller cannot detect different behavior when the user exists or doesn’t exist.
         /// </summary>
         [DataMember(Name = "userNotFound")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("userNotFound")]
 #endif
         public bool UserNotFound { get; set; }

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoDefineAuthChallengeResponse.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoDefineAuthChallengeResponse.cs
@@ -11,7 +11,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// A string containing the name of the next challenge. If you want to present a new challenge to your user, specify the challenge name here.
         /// </summary>
         [DataMember(Name = "challengeName")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("challengeName")]
 #endif
         public string ChallengeName { get; set; }
@@ -20,7 +20,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// Set to true if you determine that the user has been sufficiently authenticated by completing the challenges, or false otherwise.
         /// </summary>
         [DataMember(Name = "issueTokens")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("issueTokens")]
 #endif
         public bool IssueTokens { get; set; }
@@ -29,7 +29,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// Set to true if you want to terminate the current authentication process, or false otherwise.
         /// </summary>
         [DataMember(Name = "failAuthentication")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("failAuthentication")]
 #endif
         public bool FailAuthentication { get; set; }

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoMigrateUserRequest.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoMigrateUserRequest.cs
@@ -12,7 +12,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The username entered by the user.
         /// </summary>
         [DataMember(Name = "userName")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("userName")]
 #endif
         public string UserName { get; set; }
@@ -21,7 +21,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The password entered by the user for sign-in. It is not set in the forgot-password flow.
         /// </summary>
         [DataMember(Name = "password")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("password")]
 #endif
         public string Password { get; set; }
@@ -30,7 +30,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// One or more name-value pairs containing the validation data in the request to register a user. The validation data is set and then passed from the client in the request to register a user. You can pass this data to your Lambda function by using the ClientMetadata parameter in the InitiateAuth and AdminInitiateAuth API actions.
         /// </summary>
         [DataMember(Name = "validationData")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("validationData")]
 #endif
         public Dictionary<string, string> ValidationData { get; set; } = new Dictionary<string, string>();
@@ -39,7 +39,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// One or more key-value pairs that you can provide as custom input to the Lambda function that you specify for the pre sign-up trigger. You can pass this data to your Lambda function by using the ClientMetadata parameter in the following API actions: AdminCreateUser, AdminRespondToAuthChallenge, ForgotPassword, and SignUp.
         /// </summary>
         [DataMember(Name = "clientMetadata")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("clientMetadata")]
 #endif
         public Dictionary<string, string> ClientMetadata { get; set; } = new Dictionary<string, string>();

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoMigrateUserResponse.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoMigrateUserResponse.cs
@@ -12,7 +12,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// It must contain one or more name-value pairs representing user attributes to be stored in the user profile in your user pool. You can include both standard and custom user attributes. Custom attributes require the custom: prefix to distinguish them from standard attributes.
         /// </summary>
         [DataMember(Name = "userAttributes")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("userAttributes")]
 #endif
         public Dictionary<string, string> UserAttributes { get; set; } = new Dictionary<string, string>();
@@ -21,7 +21,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// During sign-in, this attribute can be set to CONFIRMED, or not set, to auto-confirm your users and allow them to sign-in with their previous passwords. This is the simplest experience for the user.
         /// </summary>
         [DataMember(Name = "finalUserStatus")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("finalUserStatus")]
 #endif
         public string FinalUserStatus { get; set; }
@@ -30,7 +30,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// This attribute can be set to "SUPPRESS" to suppress the welcome message usually sent by Amazon Cognito to new users. If this attribute is not returned, the welcome message will be sent.
         /// </summary>
         [DataMember(Name = "messageAction")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("messageAction")]
 #endif
         public string MessageAction { get; set; }
@@ -39,7 +39,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// This attribute can be set to "EMAIL" to send the welcome message by email, or "SMS" to send the welcome message by SMS. If this attribute is not returned, the welcome message will be sent by SMS.
         /// </summary>
         [DataMember(Name = "desiredDeliveryMediums")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("desiredDeliveryMediums")]
 #endif
         public List<string> DesiredDeliveryMediums { get; set; } = new List<string>();
@@ -48,7 +48,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// If this parameter is set to "true" and the phone number or email address specified in the UserAttributes parameter already exists as an alias with a different user, the API call will migrate the alias from the previous user to the newly created user. The previous user will no longer be able to log in using that alias.
         /// </summary>
         [DataMember(Name = "forceAliasCreation")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("forceAliasCreation")]
 #endif
         public bool ForceAliasCreation { get; set; }

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoPostAuthenticationRequest.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoPostAuthenticationRequest.cs
@@ -13,7 +13,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// One or more name-value pairs containing the validation data in the request to register a user. The validation data is set and then passed from the client in the request to register a user. You can pass this data to your Lambda function by using the ClientMetadata parameter in the InitiateAuth and AdminInitiateAuth API actions.
         /// </summary>
         [DataMember(Name = "validationData")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("validationData")]
 # endif
         public Dictionary<string, string> ValidationData { get; set; } = new Dictionary<string, string>();
@@ -22,7 +22,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// This flag indicates if the user has signed in on a new device. It is set only if the remembered devices value of the user pool is set to Always or User Opt-In.
         /// </summary>
         [DataMember(Name = "newDeviceUsed")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("newDeviceUsed")]
 #endif
         public bool NewDevicedUsed { get; set; }
@@ -31,7 +31,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// One or more key-value pairs that you can provide as custom input to the Lambda function that you specify for the pre sign-up trigger. You can pass this data to your Lambda function by using the ClientMetadata parameter in the following API actions: AdminCreateUser, AdminRespondToAuthChallenge, ForgotPassword, and SignUp.
         /// </summary>
         [DataMember(Name = "clientMetadata")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("clientMetadata")]
 # endif
         public Dictionary<string, string> ClientMetadata { get; set; } = new Dictionary<string, string>();

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoPostConfirmationRequest.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoPostConfirmationRequest.cs
@@ -13,7 +13,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// One or more key-value pairs that you can provide as custom input to the Lambda function that you specify for the pre sign-up trigger. You can pass this data to your Lambda function by using the ClientMetadata parameter in the following API actions: AdminCreateUser, AdminRespondToAuthChallenge, ForgotPassword, and SignUp.
         /// </summary>
         [DataMember(Name = "clientMetadata")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("clientMetadata")]
 #endif
         public Dictionary<string, string> ClientMetadata { get; set; } = new Dictionary<string, string>();

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoPreAuthenticationRequest.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoPreAuthenticationRequest.cs
@@ -13,7 +13,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// One or more name-value pairs containing the validation data in the request to register a user. The validation data is set and then passed from the client in the request to register a user. You can pass this data to your Lambda function by using the ClientMetadata parameter in the InitiateAuth and AdminInitiateAuth API actions.
         /// </summary>
         [DataMember(Name = "validationData")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("validationData")]
 # endif
         public Dictionary<string, string> ValidationData { get; set; } = new Dictionary<string, string>();
@@ -22,7 +22,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// This boolean is populated when PreventUserExistenceErrors is set to ENABLED for your User Pool client.
         /// </summary>
         [DataMember(Name = "userNotFound")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("userNotFound")]
 #endif
         public bool UserNotFound { get; set; }

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoPreSignupRequest.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoPreSignupRequest.cs
@@ -13,7 +13,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// One or more name-value pairs containing the validation data in the request to register a user. The validation data is set and then passed from the client in the request to register a user. You can pass this data to your Lambda function by using the ClientMetadata parameter in the InitiateAuth and AdminInitiateAuth API actions.
         /// </summary>
         [DataMember(Name = "validationData")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("validationData")]
 #endif
         public Dictionary<string, string> ValidationData { get; set; } = new Dictionary<string, string>();
@@ -22,7 +22,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// One or more key-value pairs that you can provide as custom input to the Lambda function that you specify for the pre sign-up trigger. You can pass this data to your Lambda function by using the ClientMetadata parameter in the following API actions: AdminCreateUser, AdminRespondToAuthChallenge, ForgotPassword, and SignUp.
         /// </summary>
         [DataMember(Name = "clientMetadata")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("clientMetadata")]
 #endif
         public Dictionary<string, string> ClientMetadata { get; set; } = new Dictionary<string, string>();

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoPreSignupResponse.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoPreSignupResponse.cs
@@ -12,7 +12,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// Set to true to auto-confirm the user, or false otherwise.
         /// </summary>
         [DataMember(Name = "autoConfirmUser")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("autoConfirmUser")]
 #endif
         public bool AutoConfirmUser { get; set; }
@@ -21,7 +21,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// Set to true to set as verified the email of a user who is signing up, or false otherwise. If autoVerifyEmail is set to true, the email attribute must have a valid, non-null value. Otherwise an error will occur and the user will not be able to complete sign-up.
         /// </summary>
         [DataMember(Name = "autoVerifyPhone")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("autoVerifyPhone")]
 #endif
         public bool AutoVerifyPhone { get; set; }
@@ -30,7 +30,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// Set to true to set as verified the phone number of a user who is signing up, or false otherwise. If autoVerifyPhone is set to true, the phone_number attribute must have a valid, non-null value. Otherwise an error will occur and the user will not be able to complete sign-up.
         /// </summary>
         [DataMember(Name = "autoVerifyEmail")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("autoVerifyEmail")]
 #endif
         public bool AutoVerifyEmail { get; set; }

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoPreTokenGenerationRequest.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoPreTokenGenerationRequest.cs
@@ -12,7 +12,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The input object containing the current group configuration. It includes groupsToOverride, iamRolesToOverride, and preferredRole.
         /// </summary>
         [DataMember(Name = "groupConfiguration")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("groupConfiguration")]
 # endif
         public GroupConfiguration GroupConfiguration { get; set; } = new GroupConfiguration();
@@ -21,7 +21,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// One or more key-value pairs that you can provide as custom input to the Lambda function that you specify for the pre sign-up trigger. You can pass this data to your Lambda function by using the ClientMetadata parameter in the following API actions: AdminVerifyUser, AdminRespondToAuthChallenge, ForgotPassword, and SignUp.
         /// </summary>
         [DataMember(Name = "clientMetadata")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("clientMetadata")]
 # endif
         public Dictionary<string, string> ClientMetadata { get; set; } = new Dictionary<string, string>();

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoPreTokenGenerationResponse.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoPreTokenGenerationResponse.cs
@@ -11,7 +11,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// Pre token generation response parameters
         /// </summary>
         [DataMember(Name = "claimsOverrideDetails")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("claimsOverrideDetails")]
 # endif
         public ClaimOverrideDetails ClaimsOverrideDetails { get; set; } = new ClaimOverrideDetails();

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoTriggerCallerContext.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoTriggerCallerContext.cs
@@ -12,7 +12,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The AWS SDK version number.
         /// </summary>
         [DataMember(Name = "awsSdkVersion")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("awsSdkVersion")]
 #endif
         public string AwsSdkVersion { get; set; }
@@ -21,7 +21,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The ID of the client associated with the user pool.
         /// </summary>
         [DataMember(Name = "clientId")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("clientId")]
 #endif
         public string ClientId { get; set; }

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoTriggerEvent.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoTriggerEvent.cs
@@ -16,7 +16,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The version number of your Lambda function.
         /// </summary>
         [DataMember(Name = "version")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("version")]
 #endif
         public string Version { get; set; }
@@ -25,7 +25,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The AWS Region, as an AWSRegion instance.
         /// </summary>
         [DataMember(Name = "region")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("region")]
 #endif
         public string Region { get; set; }
@@ -34,7 +34,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The user pool ID for the user pool.
         /// </summary>
         [DataMember(Name = "userPoolId")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("userPoolId")]
 #endif
         public string UserPoolId { get; set; }
@@ -43,7 +43,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The username of the current user.
         /// </summary>
         [DataMember(Name = "userName")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("userName")]
 #endif
         public string UserName { get; set; }
@@ -52,7 +52,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The caller context
         /// </summary>
         [DataMember(Name = "callerContext")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("callerContext")]
 #endif
         public CognitoTriggerCallerContext CallerContext { get; set; } = new CognitoTriggerCallerContext();
@@ -61,7 +61,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The name of the event that triggered the Lambda function.For a description of each triggerSource see User pool Lambda trigger sources.
         /// </summary>
         [DataMember(Name = "triggerSource")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("triggerSource")]
 #endif
         public string TriggerSource { get; set; }
@@ -70,7 +70,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The request from the Amazon Cognito service
         /// </summary>
         [DataMember(Name = "request")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("request")]
 #endif
         public TRequest Request { get; set; } = new TRequest();
@@ -79,7 +79,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// The response from your Lambda trigger.The return parameters in the response depend on the triggering event.
         /// </summary>
         [DataMember(Name = "response")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("response")]
 #endif
         public TResponse Response { get; set; } = new TResponse();

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoTriggerRequest.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoTriggerRequest.cs
@@ -13,7 +13,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// One or more pairs of user attribute names and values.Each pair is in the form "name": "value".
         /// </summary>
         [DataMember(Name = "userAttributes")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("userAttributes")]
 #endif
         public Dictionary<string, string> UserAttributes { get; set; } = new Dictionary<string, string>();

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoVerifyAuthChallengeRequest.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoVerifyAuthChallengeRequest.cs
@@ -12,7 +12,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// This parameter comes from the Create Auth Challenge trigger, and is compared against a user’s challengeAnswer to determine whether the user passed the challenge.
         /// </summary>
         [DataMember(Name = "privateChallengeParameters")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("privateChallengeParameters")]
 # endif
         public Dictionary<string, string> PrivateChallengeParameters { get; set; } = new Dictionary<string, string>();
@@ -21,7 +21,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// This parameter comes from the Create Auth Challenge trigger, and is compared against a user’s challengeAnswer to determine whether the user passed the challenge.
         /// </summary>
         [DataMember(Name = "challengeAnswer")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("challengeAnswer")]
 # endif
         public string ChallengeAnswer { get; set; } = string.Empty;
@@ -30,7 +30,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// One or more key-value pairs that you can provide as custom input to the Lambda function that you specify for the pre sign-up trigger. You can pass this data to your Lambda function by using the ClientMetadata parameter in the following API actions: AdminVerifyUser, AdminRespondToAuthChallenge, ForgotPassword, and SignUp.
         /// </summary>
         [DataMember(Name = "clientMetadata")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("clientMetadata")]
 # endif
         public Dictionary<string, string> ClientMetadata { get; set; }
@@ -39,7 +39,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// This boolean is populated when PreventUserExistenceErrors is set to ENABLED for your User Pool client.
         /// </summary>
         [DataMember(Name = "userNotFound")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("userNotFound")]
 # endif
         public bool UserNotFound { get; set; }

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoVerifyAuthChallengeResponse.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/CognitoVerifyAuthChallengeResponse.cs
@@ -11,7 +11,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// Set to true if the user has successfully completed the challenge, or false otherwise.
         /// </summary>
         [DataMember(Name = "answerCorrect")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("answerCorrect")]
 #endif
         public bool AnswerCorrect { get; set; }

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/GroupConfiguration.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/GroupConfiguration.cs
@@ -13,7 +13,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// A list of the group names that are associated with the user that the identity token is issued for.
         /// </summary>
         [DataMember(Name = "groupsToOverride")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("groupsToOverride")]
 # endif
         public List<string> GroupsToOverride { get; set; } = new List<string>();
@@ -22,7 +22,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// A list of the current IAM roles associated with these groups.
         /// </summary>
         [DataMember(Name = "iamRolesToOverride")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("iamRolesToOverride")]
 # endif
         public List<string> IamRolesToOverride { get; set; } = new List<string>();
@@ -31,7 +31,7 @@ namespace Amazon.Lambda.CognitoEvents
         /// A string indicating the preferred IAM role.
         /// </summary>
         [DataMember(Name = "preferredRole")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("preferredRole")]
 # endif
         public string PreferredRole { get; set; }

--- a/Libraries/src/Amazon.Lambda.ConfigEvents/Amazon.Lambda.ConfigEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.ConfigEvents/Amazon.Lambda.ConfigEvents.csproj
@@ -3,13 +3,17 @@
   <Import Project="..\..\..\buildtools\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <Description>Amazon Lambda .NET Core support - ConfigEvents package.</Description>
     <AssemblyTitle>Amazon.Lambda.ConfigEvents</AssemblyTitle>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.ConfigEvents</AssemblyName>
     <PackageId>Amazon.Lambda.ConfigEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
   </PropertyGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+		<IsTrimmable>true</IsTrimmable>
+	</PropertyGroup>	
 </Project>

--- a/Libraries/src/Amazon.Lambda.ConfigEvents/Amazon.Lambda.ConfigEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.ConfigEvents/Amazon.Lambda.ConfigEvents.csproj
@@ -15,5 +15,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>	
 </Project>

--- a/Libraries/src/Amazon.Lambda.ConnectEvents/Amazon.Lambda.ConnectEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.ConnectEvents/Amazon.Lambda.ConnectEvents.csproj
@@ -6,7 +6,7 @@
     <Description>Amazon Lambda .NET Core support - Amazon Connect package.</Description>
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.ConnectEvents</AssemblyTitle>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.ConnectEvents</AssemblyName>
     <PackageId>Amazon.Lambda.ConnectEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda;Connect</PackageTags>
@@ -15,5 +15,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.ConnectEvents/Amazon.Lambda.ConnectEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.ConnectEvents/Amazon.Lambda.ConnectEvents.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>Amazon Lambda .NET Core support - Amazon Connect package.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.ConnectEvents</AssemblyTitle>
     <VersionPrefix>1.0.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.ConnectEvents</AssemblyName>
@@ -12,4 +12,8 @@
     <PackageTags>AWS;Amazon;Lambda;Connect</PackageTags>
   </PropertyGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+		<IsTrimmable>true</IsTrimmable>
+	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.Core/Amazon.Lambda.Core.csproj
+++ b/Libraries/src/Amazon.Lambda.Core/Amazon.Lambda.Core.csproj
@@ -20,5 +20,6 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
     <IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
   </PropertyGroup>		
 </Project>

--- a/Libraries/src/Amazon.Lambda.Core/Amazon.Lambda.Core.csproj
+++ b/Libraries/src/Amazon.Lambda.Core/Amazon.Lambda.Core.csproj
@@ -3,10 +3,10 @@
   <Import Project="..\..\..\buildtools\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <Description>Amazon Lambda .NET Core support - Core package.</Description>
     <AssemblyTitle>Amazon.Lambda.Core</AssemblyTitle>
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionPrefix>2.2.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.Core</AssemblyName>
     <PackageId>Amazon.Lambda.Core</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
@@ -17,4 +17,8 @@
 	<None Include="README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>	
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+    <IsTrimmable>true</IsTrimmable>
+  </PropertyGroup>		
 </Project>

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents/Amazon.Lambda.DynamoDBEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents/Amazon.Lambda.DynamoDBEvents.csproj
@@ -27,5 +27,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents/Amazon.Lambda.DynamoDBEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents/Amazon.Lambda.DynamoDBEvents.csproj
@@ -3,10 +3,10 @@
   <Import Project="..\..\..\buildtools\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>
     <Description>Amazon Lambda .NET Core support - DynamoDBEvents package.</Description>
     <AssemblyTitle>Amazon.Lambda.DynamoDBEvents</AssemblyTitle>
-    <VersionPrefix>2.2.0</VersionPrefix>
+    <VersionPrefix>2.3.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.DynamoDBEvents</AssemblyName>
     <PackageId>Amazon.Lambda.DynamoDBEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
@@ -23,5 +23,9 @@
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
     <Compile Include="Converters\DictionaryLongToStringJsonConverter.cs" />
   </ItemGroup>
-
+	
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+		<IsTrimmable>true</IsTrimmable>
+	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents/Converters/DictionaryLongToStringJsonConverter.cs
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents/Converters/DictionaryLongToStringJsonConverter.cs
@@ -47,8 +47,12 @@ namespace Amazon.Lambda.DynamoDBEvents.Converters
 
         public override void Write(Utf8JsonWriter writer, Dictionary<string, string> value, JsonSerializerOptions options)
         {
+#if NET8_0_OR_GREATER
+            JsonSerializer.Serialize(writer, value, typeof(Dictionary<string, string>), new DictionaryStringStringJsonSerializerContext(options));
+#else
             // Use the built-in serializer, because it can handle dictionaries with string keys.
             JsonSerializer.Serialize(writer, value, options);
+#endif
         }
 
         private string ExtractValue(ref Utf8JsonReader reader, JsonSerializerOptions options)
@@ -67,5 +71,18 @@ namespace Amazon.Lambda.DynamoDBEvents.Converters
                     throw new JsonException($"'{reader.TokenType}' is not supported.");
             }
         }
+
+
     }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Context used for writing converter
+    /// </summary>
+    [JsonSerializable(typeof(Dictionary<string, string>))]
+    public partial class DictionaryStringStringJsonSerializerContext : JsonSerializerContext
+    {
+
+    }
+#endif
 }

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents/Converters/DictionaryLongToStringJsonConverter.cs
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents/Converters/DictionaryLongToStringJsonConverter.cs
@@ -48,6 +48,7 @@ namespace Amazon.Lambda.DynamoDBEvents.Converters
         public override void Write(Utf8JsonWriter writer, Dictionary<string, string> value, JsonSerializerOptions options)
         {
 #if NET8_0_OR_GREATER
+            // For .NET 8+ use source generation for serialization to be trimming complaint
             JsonSerializer.Serialize(writer, value, typeof(Dictionary<string, string>), new DictionaryStringStringJsonSerializerContext(options));
 #else
             // Use the built-in serializer, because it can handle dictionaries with string keys.

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents/DynamoDBEvent.cs
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents/DynamoDBEvent.cs
@@ -9,6 +9,9 @@ namespace Amazon.Lambda.DynamoDBEvents
     /// http://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html
     /// http://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-ddb-update
     /// </summary>
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("DynamoDBEvent has a reference to the AWS SDK for .NET. The ConstantClass used to represent enums in the SDK is not supported in the Lambda serializer SourceGeneratorLambdaJsonSerializer for trimming scenarios.")]
+#endif
     public class DynamoDBEvent
     {
         /// <summary>

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents/StreamsEventResponse.cs
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents/StreamsEventResponse.cs
@@ -14,7 +14,7 @@
         /// A list of records which failed processing. Returning the first record which failed would retry all remaining records from the batch.
         /// </summary>
         [DataMember(Name = "batchItemFailures", EmitDefaultValue = false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("batchItemFailures")]
 #endif
         public IList<BatchItemFailure> BatchItemFailures { get; set; }
@@ -29,7 +29,7 @@
             /// Sequence number of the record which failed processing.
             /// </summary>
             [DataMember(Name = "itemIdentifier", EmitDefaultValue = false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("itemIdentifier")]
 #endif
             public string ItemIdentifier { get; set; }

--- a/Libraries/src/Amazon.Lambda.KafkaEvents/Amazon.Lambda.KafkaEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.KafkaEvents/Amazon.Lambda.KafkaEvents.csproj
@@ -15,5 +15,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.KafkaEvents/Amazon.Lambda.KafkaEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.KafkaEvents/Amazon.Lambda.KafkaEvents.csproj
@@ -3,13 +3,17 @@
   <Import Project="..\..\..\buildtools\common.props" />
 	
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <Description>Amazon Lambda .NET Core support - KafkaEvents package.</Description>
     <AssemblyTitle>Amazon.Lambda.KafkaEvents</AssemblyTitle>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.KafkaEvents</AssemblyName>
     <PackageId>Amazon.Lambda.KafkaEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda;Kafka</PackageTags>
   </PropertyGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+		<IsTrimmable>true</IsTrimmable>
+	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/Amazon.Lambda.KinesisAnalyticsEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/Amazon.Lambda.KinesisAnalyticsEvents.csproj
@@ -15,5 +15,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/Amazon.Lambda.KinesisAnalyticsEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/Amazon.Lambda.KinesisAnalyticsEvents.csproj
@@ -3,13 +3,17 @@
   <Import Project="..\..\..\buildtools\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>
     <Description>Amazon Lambda .NET Core support - Amazon Kinesis Analytics package.</Description>
     <AssemblyTitle>Amazon.Lambda.KinesisAnalyticsEvents</AssemblyTitle>
-    <VersionPrefix>2.2.1</VersionPrefix>
+    <VersionPrefix>2.3.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.KinesisAnalyticsEvents</AssemblyName>
     <PackageId>Amazon.Lambda.KinesisAnalyticsEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda;KinesisAnalytics</PackageTags>
   </PropertyGroup>
-  
+
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+		<IsTrimmable>true</IsTrimmable>
+	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsFirehoseInputPreprocessingEvent.cs
+++ b/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsFirehoseInputPreprocessingEvent.cs
@@ -69,7 +69,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The record metadata.
             /// </value>
             [DataMember(Name = "kinesisFirehoseRecordMetadata")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("kinesisFirehoseRecordMetadata")]
 #endif
             public KinesisFirehoseRecordMetadata RecordMetadata { get; set; }
@@ -84,7 +84,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
                 /// The approximate time the record was sent to Kinesis Firehose.
                 /// </summary>
                 [IgnoreDataMember]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
                 [System.Text.Json.Serialization.JsonIgnore]
 #endif
                 public DateTime ApproximateArrivalTimestamp
@@ -100,7 +100,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
                 /// The approximate time the record was sent to Kinesis Firehose in epoch.
                 /// </summary>
                 [DataMember(Name = "approximateArrivalTimestamp")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
                 [System.Text.Json.Serialization.JsonPropertyName("approximateArrivalTimestamp")]
 #endif
                 public long ApproximateArrivalEpoch { get; set; }
@@ -114,7 +114,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The base64 encoded data.
             /// </value>
             [DataMember(Name = "data")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("data")]
 #endif
             public string Base64EncodedData { get; set; }

--- a/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsInputPreprocessingResponse.cs
+++ b/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsInputPreprocessingResponse.cs
@@ -33,7 +33,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
         /// The records.
         /// </value>
         [DataMember(Name = "records")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("records")]
 #endif
         public IList<Record> Records { get; set; }
@@ -51,7 +51,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The record identifier.
             /// </value>
             [DataMember(Name = "recordId")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("recordId")]
 #endif
             public string RecordId { get; set; }
@@ -63,7 +63,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The result.
             /// </value>
             [DataMember(Name = "result")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("result")]
 #endif
             public string Result { get; set; }
@@ -75,7 +75,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The base64 encoded data.
             /// </value>
             [DataMember(Name = "data")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("data")]
 #endif
             public string Base64EncodedData { get; set; }

--- a/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsOutputDeliveryEvent.cs
+++ b/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsOutputDeliveryEvent.cs
@@ -85,7 +85,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The base64 encoded data.
             /// </value>
             [DataMember(Name = "data")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("data")]
 #endif
             public string Base64EncodedData { get; set; }

--- a/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsOutputDeliveryResponse.cs
+++ b/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsOutputDeliveryResponse.cs
@@ -28,7 +28,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
         /// The records.
         /// </value>
         [DataMember(Name = "records")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("records")]
 #endif
         public IList<Record> Records { get; set; }
@@ -46,7 +46,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The record identifier.
             /// </value>
             [DataMember(Name = "recordId")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("recordId")]
 #endif
             public string RecordId { get; set; }
@@ -58,7 +58,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The result.
             /// </value>
             [DataMember(Name = "result")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("result")]
 #endif
             public string Result { get; set; }

--- a/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsStreamsInputPreprocessingEvent.cs
+++ b/Libraries/src/Amazon.Lambda.KinesisAnalyticsEvents/KinesisAnalyticsStreamsInputPreprocessingEvent.cs
@@ -68,7 +68,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The record metadata.
             /// </value>
             [DataMember(Name = "kinesisStreamRecordMetadata")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("kinesisStreamRecordMetadata")]
 #endif
             public KinesisStreamRecordMetadata RecordMetadata { get; set; }
@@ -101,7 +101,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
                 /// The approximate time the record was sent to Kinesis Steam.
                 /// </summary>
                 [IgnoreDataMember]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
                 [System.Text.Json.Serialization.JsonIgnore]
 #endif
                 public DateTime ApproximateArrivalTimestamp
@@ -117,7 +117,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
                 /// The approximate time the record was sent to Kinesis stream in epoch.
                 /// </summary>
                 [DataMember(Name = "approximateArrivalTimestamp")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
                 [System.Text.Json.Serialization.JsonPropertyName("approximateArrivalTimestamp")]
 #endif
                 public long ApproximateArrivalEpoch { get; set; }
@@ -140,7 +140,7 @@ namespace Amazon.Lambda.KinesisAnalyticsEvents
             /// The base64 encoded data.
             /// </value>
             [DataMember(Name = "data")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("data")]
 #endif
             public string Base64EncodedData { get; set; }

--- a/Libraries/src/Amazon.Lambda.KinesisEvents/Amazon.Lambda.KinesisEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.KinesisEvents/Amazon.Lambda.KinesisEvents.csproj
@@ -3,10 +3,10 @@
   <Import Project="..\..\..\buildtools\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>
     <Description>Amazon Lambda .NET Core support - KinesisEvents package.</Description>
     <AssemblyTitle>Amazon.Lambda.KinesisEvents</AssemblyTitle>
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionPrefix>2.2.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.KinesisEvents</AssemblyName>
     <PackageId>Amazon.Lambda.KinesisEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
@@ -24,4 +24,8 @@
     <Compile Include="Converters\DictionaryLongToStringJsonConverter.cs" />
   </ItemGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+		<IsTrimmable>true</IsTrimmable>
+	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.KinesisEvents/Amazon.Lambda.KinesisEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.KinesisEvents/Amazon.Lambda.KinesisEvents.csproj
@@ -27,5 +27,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.KinesisEvents/Converters/DictionaryLongToStringJsonConverter.cs
+++ b/Libraries/src/Amazon.Lambda.KinesisEvents/Converters/DictionaryLongToStringJsonConverter.cs
@@ -47,8 +47,12 @@ namespace Amazon.Lambda.KinesisEvents.Converters
 
         public override void Write(Utf8JsonWriter writer, Dictionary<string, string> value, JsonSerializerOptions options)
         {
+#if NET8_0_OR_GREATER
+            JsonSerializer.Serialize(writer, value, typeof(Dictionary<string, string>), new DictionaryStringStringJsonSerializerContext(options));
+#else
             // Use the built-in serializer, because it can handle dictionaries with string keys.
             JsonSerializer.Serialize(writer, value, options);
+#endif
         }
 
         private string ExtractValue(ref Utf8JsonReader reader, JsonSerializerOptions options)
@@ -68,4 +72,15 @@ namespace Amazon.Lambda.KinesisEvents.Converters
             }
         }
     }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Context used for writing converter
+    /// </summary>
+    [JsonSerializable(typeof(Dictionary<string, string>))]
+    public partial class DictionaryStringStringJsonSerializerContext : JsonSerializerContext
+    {
+
+    }
+#endif
 }

--- a/Libraries/src/Amazon.Lambda.KinesisEvents/Converters/DictionaryLongToStringJsonConverter.cs
+++ b/Libraries/src/Amazon.Lambda.KinesisEvents/Converters/DictionaryLongToStringJsonConverter.cs
@@ -48,6 +48,7 @@ namespace Amazon.Lambda.KinesisEvents.Converters
         public override void Write(Utf8JsonWriter writer, Dictionary<string, string> value, JsonSerializerOptions options)
         {
 #if NET8_0_OR_GREATER
+            // For .NET 8+ use source generation for serialization to be trimming complaint
             JsonSerializer.Serialize(writer, value, typeof(Dictionary<string, string>), new DictionaryStringStringJsonSerializerContext(options));
 #else
             // Use the built-in serializer, because it can handle dictionaries with string keys.

--- a/Libraries/src/Amazon.Lambda.KinesisEvents/StreamsEventResponse.cs
+++ b/Libraries/src/Amazon.Lambda.KinesisEvents/StreamsEventResponse.cs
@@ -14,7 +14,7 @@
         /// A list of records which failed processing. Returning the first record which failed would retry all remaining records from the batch.
         /// </summary>
         [DataMember(Name = "batchItemFailures", EmitDefaultValue = false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("batchItemFailures")]
 #endif
         public IList<BatchItemFailure> BatchItemFailures { get; set; }
@@ -29,7 +29,7 @@
             /// Sequence number of the record which failed processing.
             /// </summary>
             [DataMember(Name = "itemIdentifier", EmitDefaultValue = false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("itemIdentifier")]
 #endif
             public string ItemIdentifier { get; set; }

--- a/Libraries/src/Amazon.Lambda.KinesisFirehoseEvents/Amazon.Lambda.KinesisFirehoseEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.KinesisFirehoseEvents/Amazon.Lambda.KinesisFirehoseEvents.csproj
@@ -14,5 +14,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.KinesisFirehoseEvents/Amazon.Lambda.KinesisFirehoseEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.KinesisFirehoseEvents/Amazon.Lambda.KinesisFirehoseEvents.csproj
@@ -2,16 +2,17 @@
   <Import Project="..\..\..\buildtools\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>
     <Description>Amazon Lambda .NET Core support - Amazon Kinesis Firehose package.</Description>
     <AssemblyTitle>Amazon.Lambda.KinesisFirehoseEvents</AssemblyTitle>
-    <VersionPrefix>2.2.0</VersionPrefix>
+    <VersionPrefix>2.3.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.KinesisFirehoseEvents</AssemblyName>
     <PackageId>Amazon.Lambda.KinesisFirehoseEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda;KinesisFirehose</PackageTags>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <DefineConstants>NETCOREAPP_3_1</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+		<IsTrimmable>true</IsTrimmable>
+	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.KinesisFirehoseEvents/KinesisFirehoseEvent.cs
+++ b/Libraries/src/Amazon.Lambda.KinesisFirehoseEvents/KinesisFirehoseEvent.cs
@@ -51,7 +51,7 @@ namespace Amazon.Lambda.KinesisFirehoseEvents
             /// The approximate time the record was sent to Kinesis Firehose as a Unix epoch.
             /// </summary>
             [DataMember(Name = "approximateArrivalTimestamp")]
-#if NETCOREAPP_3_1        
+#if NETCOREAPP3_1_OR_GREATER        
             [System.Text.Json.Serialization.JsonPropertyName("approximateArrivalTimestamp")]
 #endif
             public long ApproximateArrivalEpoch { get; set; }
@@ -60,7 +60,7 @@ namespace Amazon.Lambda.KinesisFirehoseEvents
             /// The approximate time the record was sent to Kinesis Firehose.
             /// </summary>
             [IgnoreDataMember]
-#if NETCOREAPP_3_1        
+#if NETCOREAPP3_1_OR_GREATER        
             [System.Text.Json.Serialization.JsonIgnore()]
 #endif            
             public DateTime ApproximateArrivalTimestamp
@@ -76,7 +76,7 @@ namespace Amazon.Lambda.KinesisFirehoseEvents
             /// The data sent through as a Kinesis Firehose record. The data is sent to the Lambda function base64 encoded.
             /// </summary>
             [DataMember(Name = "data")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("data")]
 #endif
             public string Base64EncodedData { get; set; }

--- a/Libraries/src/Amazon.Lambda.KinesisFirehoseEvents/KinesisFirehoseResponse.cs
+++ b/Libraries/src/Amazon.Lambda.KinesisFirehoseEvents/KinesisFirehoseResponse.cs
@@ -32,7 +32,7 @@ namespace Amazon.Lambda.KinesisFirehoseEvents
         /// The transformed records from the KinesisFirehoseEvent.
         /// </summary>        
         [DataMember(Name = "records")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("records")]
 #endif
         public IList<FirehoseRecord> Records { get; set; }
@@ -49,7 +49,7 @@ namespace Amazon.Lambda.KinesisFirehoseEvents
             ///transformed record is treated as a data transformation failure.
             /// </summary>
             [DataMember(Name = "recordId")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("recordId")]
 #endif
             public string RecordId { get; set; }
@@ -78,7 +78,7 @@ namespace Amazon.Lambda.KinesisFirehoseEvents
             /// </list>
             /// </summary>
             [DataMember(Name = "result")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("result")]
 #endif
             public string Result { get; set; }
@@ -87,7 +87,7 @@ namespace Amazon.Lambda.KinesisFirehoseEvents
             /// The transformed data payload, after base64-encoding.
             /// </summary>
             [DataMember(Name = "data")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("data")]
 #endif
             public string Base64EncodedData { get; set; }
@@ -96,7 +96,7 @@ namespace Amazon.Lambda.KinesisFirehoseEvents
             /// The response record metadata.
             /// </summary>
             [DataMember(Name = "metadata")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("metadata")]
 #endif
             public FirehoseResponseRecordMetadata Metadata { get; set; }
@@ -123,7 +123,7 @@ namespace Amazon.Lambda.KinesisFirehoseEvents
             /// https://docs.aws.amazon.com/firehose/latest/dev/dynamic-partitioning.html
             /// </summary>
             [DataMember(Name = "partitionKeys")]
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("partitionKeys")]
 #endif
             public Dictionary<string, string> PartitionKeys { get; set; }

--- a/Libraries/src/Amazon.Lambda.LexEvents/Amazon.Lambda.LexEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.LexEvents/Amazon.Lambda.LexEvents.csproj
@@ -15,5 +15,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.LexEvents/Amazon.Lambda.LexEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.LexEvents/Amazon.Lambda.LexEvents.csproj
@@ -4,12 +4,16 @@
 
   <PropertyGroup>
     <Description>Amazon Lambda .NET Core support - Amazon Lex package.</Description>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.LexEvents</AssemblyTitle>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.LexEvents</AssemblyName>
     <PackageId>Amazon.Lambda.LexEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda;Lex</PackageTags>
   </PropertyGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+		<IsTrimmable>true</IsTrimmable>
+	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.LexEvents/LexActiveContext.cs
+++ b/Libraries/src/Amazon.Lambda.LexEvents/LexActiveContext.cs
@@ -13,7 +13,7 @@ namespace Amazon.Lambda.LexEvents
         /// The length of time or number of turns in the conversation with the user that the context remains active.
         /// </summary>
         [DataMember(Name = "timeToLive", EmitDefaultValue = false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("timeToLive")]
 #endif
         public TimeToLive TimeToLive { get; set; }
@@ -22,7 +22,7 @@ namespace Amazon.Lambda.LexEvents
         /// The name of the context.
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("name")]
 #endif
         public string Name { get; set; }
@@ -31,7 +31,7 @@ namespace Amazon.Lambda.LexEvents
         /// A list of key/value pairs the contains the name and value of the slots from the intent that activated the context.
         /// </summary>
         [DataMember(Name = "parameters", EmitDefaultValue = false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("parameters")]
 #endif
         public IDictionary<string, string> Parameters { get; set; }
@@ -47,7 +47,7 @@ namespace Amazon.Lambda.LexEvents
         /// The length of time that the context remains active.
         /// </summary>
         [DataMember(Name = "timeToLiveInSeconds", EmitDefaultValue = false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("timeToLiveInSeconds")]
 #endif
         public int TimeToLiveInSeconds { get; set; }
@@ -56,7 +56,7 @@ namespace Amazon.Lambda.LexEvents
         /// The number of turns in the conversation with the user that the context remains active.
         /// </summary>
         [DataMember(Name = "turnsToLive", EmitDefaultValue = false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("turnsToLive")]
 #endif
         public int TurnsToLive { get; set; }

--- a/Libraries/src/Amazon.Lambda.LexEvents/LexRecentIntentSummaryViewType.cs
+++ b/Libraries/src/Amazon.Lambda.LexEvents/LexRecentIntentSummaryViewType.cs
@@ -13,7 +13,7 @@ namespace Amazon.Lambda.LexEvents
         /// Gets and sets the IntentName
         /// </summary>
         [DataMember(Name = "intentName", EmitDefaultValue = false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("intentName")]
 #endif
         public string IntentName { get; set; }
@@ -22,7 +22,7 @@ namespace Amazon.Lambda.LexEvents
         /// Gets and sets the CheckpointLabel
         /// </summary>
         [DataMember(Name = "checkpointLabel", EmitDefaultValue = false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("checkpointLabel")]
 #endif
         public string CheckpointLabel { get; set; }
@@ -31,7 +31,7 @@ namespace Amazon.Lambda.LexEvents
         /// Gets and sets the Slots
         /// </summary>
         [DataMember(Name = "slots", EmitDefaultValue = false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("slots")]
 #endif
         public IDictionary<string, string> Slots { get; set; }
@@ -40,7 +40,7 @@ namespace Amazon.Lambda.LexEvents
         /// Gets and sets the ConfirmationStatus
         /// </summary>
         [DataMember(Name = "confirmationStatus", EmitDefaultValue = false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("confirmationStatus")]
 #endif
         public string ConfirmationStatus { get; set; }
@@ -49,7 +49,7 @@ namespace Amazon.Lambda.LexEvents
         /// Gets and sets the DialogActionType
         /// </summary>
         [DataMember(Name = "dialogActionType", EmitDefaultValue = false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("dialogActionType")]
 #endif
         public string DialogActionType { get; set; }
@@ -58,7 +58,7 @@ namespace Amazon.Lambda.LexEvents
         /// Gets and sets the FulfillmentState
         /// </summary>
         [DataMember(Name = "fulfillmentState", EmitDefaultValue = false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("fulfillmentState")]
 #endif
         public string FulfillmentState { get; set; }
@@ -67,7 +67,7 @@ namespace Amazon.Lambda.LexEvents
         /// Gets and sets the SlotToElicit
         /// </summary>
         [DataMember(Name = "slotToElicit", EmitDefaultValue = false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("slotToElicit")]
 #endif
         public string SlotToElicit { get; set; }

--- a/Libraries/src/Amazon.Lambda.LexEvents/LexResponse.cs
+++ b/Libraries/src/Amazon.Lambda.LexEvents/LexResponse.cs
@@ -15,7 +15,7 @@
         /// Application-specific session attributes. This is an optional field.
         /// </summary>
         [DataMember(Name = "sessionAttributes", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("sessionAttributes")]
 #endif
         public IDictionary<string, string> SessionAttributes { get; set; }
@@ -26,7 +26,7 @@
         /// after Amazon Lex returns a response to the client.
         /// </summary>\
         [DataMember(Name = "dialogAction", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("dialogAction")]
 #endif
         public LexDialogAction DialogAction { get; set; }
@@ -36,7 +36,7 @@
         /// For example, you can include a context to make one or more intents that have that context as an input eligible for recognition in the next turn of the conversation.
         /// </summary>
         [DataMember(Name = "activeContexts", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("activeContexts")]
 #endif
         public IList<LexActiveContext> ActiveContexts { get; set; }
@@ -45,7 +45,7 @@
         /// If included, sets values for one or more recent intents. You can include information for up to three intents.
         /// </summary>
         [DataMember(Name = "recentIntentSummaryView", EmitDefaultValue = false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("recentIntentSummaryView")]
 #endif
         public IList<LexRecentIntentSummaryViewType> RecentIntentSummaryView { get; set; }
@@ -60,7 +60,7 @@
             /// The type of action for Lex to take with the response from the Lambda function.
             /// </summary>
             [DataMember(Name = "type", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("type")]
 #endif
             public string Type { get; set; }
@@ -69,7 +69,7 @@
             /// The state of the fullfillment. "Fulfilled" or "Failed"
             /// </summary>
             [DataMember(Name = "fulfillmentState", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("fulfillmentState")]
 #endif
             public string FulfillmentState { get; set; }
@@ -78,7 +78,7 @@
             /// The message to be sent to the user.
             /// </summary>
             [DataMember(Name = "message", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("message")]
 #endif
             public LexMessage Message { get; set; }
@@ -87,7 +87,7 @@
             /// The intent name you want to confirm or elicit.
             /// </summary>
             [DataMember(Name = "intentName", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("intentName")]
 #endif
             public string IntentName { get; set; }
@@ -96,7 +96,7 @@
             /// The values for all of the slots when response is of type "Delegate".
             /// </summary>
             [DataMember(Name = "slots", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("slots")]
 #endif
             public IDictionary<string, string> Slots { get; set; }
@@ -105,7 +105,7 @@
             /// The slot to elicit when the Type is "ElicitSlot"
             /// </summary>
             [DataMember(Name = "slotToElicit", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("slotToElicit")]
 #endif
             public string SlotToElicit { get; set; }
@@ -114,7 +114,7 @@
             /// The response card provides information back to the bot to display for the user.
             /// </summary>
             [DataMember(Name = "responseCard", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("responseCard")]
 #endif
             public LexResponseCard ResponseCard { get; set; }
@@ -130,7 +130,7 @@
             /// The content type of the message. PlainText or SSML
             /// </summary>
             [DataMember(Name = "contentType", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("contentType")]
 #endif
             public string ContentType { get; set; }
@@ -139,7 +139,7 @@
             /// The message to be asked to the user by the bot.
             /// </summary>
             [DataMember(Name = "content", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("content")]
 #endif
             public string Content { get; set; }
@@ -155,7 +155,7 @@
             /// The version of the response card.
             /// </summary>
             [DataMember(Name = "version", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("version")]
 #endif
             public int? Version { get; set; }
@@ -164,7 +164,7 @@
             /// The content type of the response card. The default is "application/vnd.amazonaws.card.generic".
             /// </summary>
             [DataMember(Name = "contentType", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("contentType")]
 #endif
             public string ContentType { get; set; } = "application/vnd.amazonaws.card.generic";
@@ -173,7 +173,7 @@
             /// The list of attachments sent back with the response card.
             /// </summary>
             [DataMember(Name = "genericAttachments", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("genericAttachments")]
 #endif
             public IList<LexGenericAttachments> GenericAttachments { get; set; }
@@ -189,7 +189,7 @@
             /// The card's title.
             /// </summary>
             [DataMember(Name = "title", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("title")]
 #endif
             public string Title { get; set; }
@@ -198,7 +198,7 @@
             /// The card's sub title.
             /// </summary>
             [DataMember(Name = "subTitle", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("subTitle")]
 #endif
             public string SubTitle { get; set; }
@@ -207,7 +207,7 @@
             /// URL to an image to be shown.
             /// </summary>
             [DataMember(Name = "imageUrl", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("imageUrl")]
 #endif
             public string ImageUrl { get; set; }
@@ -216,7 +216,7 @@
             /// URL of the attachment to be associated with the card.
             /// </summary>
             [DataMember(Name = "attachmentLinkUrl", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("attachmentLinkUrl")]
 #endif
             public string AttachmentLinkUrl { get; set; }
@@ -225,7 +225,7 @@
             /// The list of buttons to be displayed with the response card.
             /// </summary>
             [DataMember(Name = "buttons", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("buttons")]
 #endif
             public IList<LexButton> Buttons { get; set; }
@@ -241,7 +241,7 @@
             /// The text for the button.
             /// </summary>
             [DataMember(Name = "text", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("text")]
 #endif
             public string Text { get; set; }
@@ -250,7 +250,7 @@
             /// The value of the button sent back to the server.
             /// </summary>
             [DataMember(Name = "value", EmitDefaultValue=false)]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("value")]
 #endif
             public string Value { get; set; }

--- a/Libraries/src/Amazon.Lambda.LexV2Events/Amazon.Lambda.LexV2Events.csproj
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/Amazon.Lambda.LexV2Events.csproj
@@ -15,5 +15,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.LexV2Events/Amazon.Lambda.LexV2Events.csproj
+++ b/Libraries/src/Amazon.Lambda.LexV2Events/Amazon.Lambda.LexV2Events.csproj
@@ -4,12 +4,16 @@
 
   <PropertyGroup>
     <Description>Amazon Lambda .NET Core support - Amazon Lex V2 package.</Description>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net8.0</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.LexV2Events</AssemblyTitle>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.LexV2Events</AssemblyName>
     <PackageId>Amazon.Lambda.LexV2Events</PackageId>
     <PackageTags>AWS;Amazon;Lambda;Lex;LexV2</PackageTags>
   </PropertyGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+		<IsTrimmable>true</IsTrimmable>
+	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.MQEvents/Amazon.Lambda.MQEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.MQEvents/Amazon.Lambda.MQEvents.csproj
@@ -16,5 +16,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.MQEvents/Amazon.Lambda.MQEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.MQEvents/Amazon.Lambda.MQEvents.csproj
@@ -3,14 +3,18 @@
   <Import Project="..\..\..\buildtools\common.props" />
 	
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>
     <Description>Amazon Lambda .NET Core support - MQEvents package.</Description>
     <AssemblyTitle>Amazon.Lambda.MQEvents</AssemblyTitle>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.MQEvents</AssemblyName>
     <PackageId>Amazon.Lambda.MQEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda;Amazon MQ;Rabbit MQ;Apache Active MQ</PackageTags>
     <RootNamespace>Amazon.Lambda.MQEvents</RootNamespace>
   </PropertyGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+		<IsTrimmable>true</IsTrimmable>
+	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
@@ -22,6 +22,7 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
     <IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
   </PropertyGroup>	
 

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net8.0</TargetFrameworks>
-    <VersionPrefix>1.9.1</VersionPrefix>
+    <VersionPrefix>1.10.0</VersionPrefix>
     <Description>Provides a bootstrap and Lambda Runtime API Client to help you to develop custom .NET Core Lambda Runtimes.</Description>
     <AssemblyTitle>Amazon.Lambda.RuntimeSupport</AssemblyTitle>
     <AssemblyName>Amazon.Lambda.RuntimeSupport</AssemblyName>
@@ -18,6 +18,12 @@
   <PropertyGroup Condition=" '$(ExecutableOutputType)'=='true' ">
     <OutputType>Exe</OutputType>
   </PropertyGroup>
+	
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+    <IsTrimmable>true</IsTrimmable>
+	<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+  </PropertyGroup>	
 
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/InvokeDelegateBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/InvokeDelegateBuilder.cs
@@ -61,6 +61,9 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
         /// <param name="customerObject">Wrapped customer object.</param>
         /// <param name="customerSerializerInstance">Instance of lambda input & output serializer.</param>
         /// <returns>Action delegate pointing to customer's handler.</returns>
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ConstructInvokeDelegate does not support trimming and is meant to be used in class library based Lambda functions.")]
+#endif        
         public Action<Stream, ILambdaContext, Stream> ConstructInvokeDelegate(object customerObject, object customerSerializerInstance, bool isPreJit)
         {
             var inStreamParameter = Expression.Parameter(Types.StreamType, "inStream");
@@ -113,6 +116,9 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
         /// <param name="iLambdaContextType">Type of context passed for the invocation.</param>
         /// <returns>Expression that deserializes incoming stream to the customer method inputs or null if customer method takes no input.</returns>
         /// <exception cref="LambdaValidationException">Thrown when customer method inputs don't meet lambda requirements.</exception>
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("BuildInputExpressionOrNull does not support trimming and is meant to be used in class library based Lambda functions.")]
+#endif
         private Expression BuildInputExpressionOrNull(object customerSerializerInstance, Expression inStreamParameter, out Type iLambdaContextType)
         {
             Type inputType = null;
@@ -191,6 +197,10 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
         /// <param name="inputExpression">Input expression that defines customer input.</param>
         /// <param name="contextExpression">Context expression that defines context passed for the invocation.</param>
         /// <returns>Expression that unwraps customer object.</returns>
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("CreateHandlerCallExpression does not support trimming and is meant to be used in class library based Lambda functions.")]
+#endif
+
         private Expression CreateHandlerCallExpression(object customerObject, Expression inputExpression, Expression contextExpression)
         {
             Expression customerObjectConstant = null;
@@ -248,6 +258,9 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
         /// <param name="outStreamParameter">Expression that defines customer output.</param>
         /// <param name="handlerCallExpression">Expression that defines customer handler call.</param>
         /// <returns>Expression that serializes customer method output to outgoing stream.</returns>
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("CreateOutputExpression does not support trimming and is meant to be used in class library based Lambda functions.")]
+#endif        
         private Expression CreateOutputExpression(object customerSerializerInstance, Expression outStreamParameter, Expression handlerCallExpression)
         {
             var outputType = _customerMethodInfo.ReturnType;
@@ -303,6 +316,9 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
         /// <param name="outStreamParameter">Expression that defines customer output.</param>
         /// <returns>Expression that serializes returned object to output stream.</returns>
         /// <exception cref="LambdaValidationException">Thrown when customer input is serializable & serializer instance is null.</exception>
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("CreateSerializeExpression does not support trimming and is meant to be used in class library based Lambda functions.")]
+#endif           
         private Expression CreateSerializeExpression(object customerSerializerInstance, Type dataType, Expression customerObject, Expression outStreamParameter)
         {
             // generic types, null for String and Stream converters
@@ -357,6 +373,9 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
         /// <param name="inStream">Input expression that defines customer input.</param>
         /// <returns>Expression that deserializes incoming data to customer method input.</returns>
         /// <exception cref="LambdaValidationException">Thrown when customer serializer doesn't match with expected serializer definition</exception>
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("CreateDeserializeExpression does not support trimming and is meant to be used in class library based Lambda functions.")]
+#endif         
         private Expression CreateDeserializeExpression(object customerSerializerInstance, Type dataType, Expression inStream)
         {
             // generic types, null for String and Stream converters

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
@@ -114,7 +114,7 @@ namespace Amazon.Lambda.RuntimeSupport
         /// <returns>A Task that represents the operation.</returns>
 #if NET8_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
-            Justification = "Unreferenced code paths are excluding when RuntimeFeature.IsDynamicCodeSupported is false.")]
+            Justification = "Unreferenced code paths are excluded when RuntimeFeature.IsDynamicCodeSupported is false.")]
 #endif
 
         public async Task RunAsync(CancellationToken cancellationToken = default(CancellationToken))

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
@@ -112,6 +112,11 @@ namespace Amazon.Lambda.RuntimeSupport
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns>A Task that represents the operation.</returns>
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
+            Justification = "Unreferenced code paths are excluding when RuntimeFeature.IsDynamicCodeSupported is false.")]
+#endif
+
         public async Task RunAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
 #if NET8_0_OR_GREATER

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeInit.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeInit.cs
@@ -140,6 +140,9 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
             }
         }
 
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("PreJitAssembly is not used for Native AOT")]
+#endif
         public static void PreJitAssembly(Assembly a)
         {
             // Storage to ensure not loading the same assembly twice and optimize calls to GetAssemblies()

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeLoader.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeLoader.cs
@@ -28,6 +28,9 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
     /// <summary>
     /// Loads user code and prepares to invoke it.
     /// </summary>
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("UserCodeLoader does not support trimming and is meant to be used in class library based Lambda functions.")]
+#endif
     internal class UserCodeLoader
     {
         private const string UserInvokeException = "An exception occurred while invoking customer handler.";

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeValidator.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeValidator.cs
@@ -21,6 +21,9 @@ using Amazon.Lambda.RuntimeSupport.Helpers;
 
 namespace Amazon.Lambda.RuntimeSupport.Bootstrap
 {
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("UserCodeValidator does not support trimming and is meant to be used in class library based Lambda functions.")]
+#endif
     internal static class UserCodeValidator
     {
         /// <summary>

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/InternalClientAdapted.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/InternalClientAdapted.cs
@@ -584,39 +584,8 @@ namespace Amazon.Lambda.RuntimeSupport
             }
         }
 
-        private string ConvertToString(object value, System.Globalization.CultureInfo cultureInfo)
+        private string ConvertToString(string value, System.Globalization.CultureInfo cultureInfo)
         {
-            if (value is System.Enum)
-            {
-                string name = System.Enum.GetName(value.GetType(), value);
-                if (name != null)
-                {
-                    var field = System.Reflection.IntrospectionExtensions.GetTypeInfo(value.GetType()).GetDeclaredField(name);
-                    if (field != null)
-                    {
-                        var attribute = System.Reflection.CustomAttributeExtensions.GetCustomAttribute(field, typeof(System.Runtime.Serialization.EnumMemberAttribute))
-                            as System.Runtime.Serialization.EnumMemberAttribute;
-                        if (attribute != null)
-                        {
-                            return attribute.Value;
-                        }
-                    }
-                }
-            }
-            else if (value is bool)
-            {
-                return System.Convert.ToString(value, cultureInfo).ToLowerInvariant();
-            }
-            else if (value is byte[])
-            {
-                return System.Convert.ToBase64String((byte[])value);
-            }
-            else if (value != null && value.GetType().IsArray)
-            {
-                var array = System.Linq.Enumerable.OfType<object>((System.Array)value);
-                return string.Join(",", System.Linq.Enumerable.Select(array, o => ConvertToString(o, cultureInfo)));
-            }
-
             return System.Convert.ToString(value, cultureInfo);
         }
     }

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Program.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Program.cs
@@ -20,6 +20,11 @@ namespace Amazon.Lambda.RuntimeSupport
 {
     class Program
     {
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(
+            "The Main entry point is used in the managed runtime which loads Lambda functions as a class library. " + 
+            "The class library mode does not support Native AOT and trimming.")]
+#endif
         private static async Task Main(string[] args)
         {
             if (args.Length == 0)

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/RuntimeSupportInitializer.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/RuntimeSupportInitializer.cs
@@ -23,6 +23,9 @@ namespace Amazon.Lambda.RuntimeSupport
     /// <summary>
     /// RuntimeSupportInitializer class responsible for initializing the UserCodeLoader and LambdaBootstrap given a function handler.
     /// </summary>
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("RuntimeSupportInitializer does not support trimming and is meant to be used in class library based Lambda functions.")]
+#endif
     public class RuntimeSupportInitializer
     {
         private readonly string _handler;

--- a/Libraries/src/Amazon.Lambda.S3Events/Amazon.Lambda.S3Events.csproj
+++ b/Libraries/src/Amazon.Lambda.S3Events/Amazon.Lambda.S3Events.csproj
@@ -15,5 +15,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.S3Events/Amazon.Lambda.S3Events.csproj
+++ b/Libraries/src/Amazon.Lambda.S3Events/Amazon.Lambda.S3Events.csproj
@@ -4,12 +4,16 @@
 
   <PropertyGroup>
     <Description>Amazon Lambda .NET Core support - S3Events package.</Description>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net8.0</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.S3Events</AssemblyTitle>
-    <VersionPrefix>3.0.1</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.S3Events</AssemblyName>
     <PackageId>Amazon.Lambda.S3Events</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
   </PropertyGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+		<IsTrimmable>true</IsTrimmable>
+	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.S3Events/S3ObjectLambdaEvent.cs
+++ b/Libraries/src/Amazon.Lambda.S3Events/S3ObjectLambdaEvent.cs
@@ -15,7 +15,7 @@ namespace Amazon.Lambda.S3Events
         /// <summary>
         /// The Amazon S3 request ID for this request. We recommend that you log this value to help with debugging.
         /// </summary>
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("xAmzRequestId")]
 #endif
         public string XAmzRequestId { get; set; }

--- a/Libraries/src/Amazon.Lambda.SNSEvents/Amazon.Lambda.SNSEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.SNSEvents/Amazon.Lambda.SNSEvents.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>Amazon Lambda .NET Core support - SNSEvents package.</Description>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.SNSEvents</AssemblyTitle>
     <VersionPrefix>2.1.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.SNSEvents</AssemblyName>
@@ -15,5 +15,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.SNSEvents/Amazon.Lambda.SNSEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.SNSEvents/Amazon.Lambda.SNSEvents.csproj
@@ -4,12 +4,16 @@
 
   <PropertyGroup>
     <Description>Amazon Lambda .NET Core support - SNSEvents package.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.SNSEvents</AssemblyTitle>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.SNSEvents</AssemblyName>
     <PackageId>Amazon.Lambda.SNSEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
   </PropertyGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+		<IsTrimmable>true</IsTrimmable>
+	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.SQSEvents/Amazon.Lambda.SQSEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.SQSEvents/Amazon.Lambda.SQSEvents.csproj
@@ -15,5 +15,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.SQSEvents/Amazon.Lambda.SQSEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.SQSEvents/Amazon.Lambda.SQSEvents.csproj
@@ -4,12 +4,16 @@
 
   <PropertyGroup>
     <Description>Amazon Lambda .NET Core support - SQSEvents package.</Description>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.SQSEvents</AssemblyTitle>
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionPrefix>2.2.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.SQSEvents</AssemblyName>
     <PackageId>Amazon.Lambda.SQSEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
   </PropertyGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+		<IsTrimmable>true</IsTrimmable>
+	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.SQSEvents/SQSBatchResponse.cs
+++ b/Libraries/src/Amazon.Lambda.SQSEvents/SQSBatchResponse.cs
@@ -30,7 +30,7 @@ namespace Amazon.Lambda.SQSEvents
         /// Gets or sets the message failures within the batch failures
         /// </summary>
         [DataMember(Name = "batchItemFailures")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("batchItemFailures")]
 #endif
         public List<BatchItemFailure> BatchItemFailures { get; set; }
@@ -45,7 +45,7 @@ namespace Amazon.Lambda.SQSEvents
             /// MessageId that failed processing
             /// </summary>
             [DataMember(Name = "itemIdentifier")]
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             [System.Text.Json.Serialization.JsonPropertyName("itemIdentifier")]
 #endif
             public string ItemIdentifier { get; set; }

--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/Amazon.Lambda.Serialization.SystemTextJson.csproj
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/Amazon.Lambda.Serialization.SystemTextJson.csproj
@@ -3,13 +3,13 @@
     <Import Project="..\..\..\buildtools\common.props" />    
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net6</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net6;net8.0</TargetFrameworks>
         <Description>Amazon Lambda .NET Core support - Serialization.Json with System.Text.Json.</Description>
         <AssemblyTitle>Amazon.Lambda.Serialization.SystemTextJson</AssemblyTitle>
         <AssemblyName>Amazon.Lambda.Serialization.SystemTextJson</AssemblyName>
         <PackageId>Amazon.Lambda.Serialization.SystemTextJson</PackageId>
         <PackageTags>AWS;Amazon;Lambda</PackageTags>
-        <VersionPrefix>2.3.1</VersionPrefix>
+        <VersionPrefix>2.4.0</VersionPrefix>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 	<ItemGroup>
@@ -19,5 +19,11 @@
     <ItemGroup>
         <ProjectReference Include="..\Amazon.Lambda.Core\Amazon.Lambda.Core.csproj" />
     </ItemGroup>
+
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+		<IsTrimmable>true</IsTrimmable>
+		<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+	</PropertyGroup>
 
 </Project>

--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/CamelCaseLambdaJsonSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/CamelCaseLambdaJsonSerializer.cs
@@ -14,6 +14,10 @@ namespace Amazon.Lambda.Serialization.SystemTextJson
     /// in from Lambda and being sent back to Lambda will be logged.
     /// </para>
     /// </summary>
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("CamelCaseLambdaJsonSerializer does not support trimming. " +
+            "For trimmed Lambda functions SourceGeneratorLambdaJsonSerializer passing in JsonSerializerContext should be used instead.")]
+#endif
     public class CamelCaseLambdaJsonSerializer : DefaultLambdaJsonSerializer
     {
         /// <summary>

--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/Converters/ConstantClassConverter.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/Converters/ConstantClassConverter.cs
@@ -41,10 +41,14 @@ namespace Amazon.Lambda.Serialization.SystemTextJson.Converters
         /// <param name="typeToConvert"></param>
         /// <param name="options"></param>
         /// <returns></returns>
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067",
+            Justification = "Constant classes are only used in the DynamoDB event referencing the SDK. S3 originally referenced the SDK but has been rewritten to no longer reference the SDK or ConstantClass. Suppressing this trim warning because we have marked the DynamoDB event as ")]
+#endif
         public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             var value = reader.GetString();
-            return Activator.CreateInstance(typeToConvert, new object[] {value});
+            return Activator.CreateInstance(typeToConvert, new object[] { value });
         }
 
         /// <summary>

--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/Converters/ConstantClassConverter.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/Converters/ConstantClassConverter.cs
@@ -43,7 +43,7 @@ namespace Amazon.Lambda.Serialization.SystemTextJson.Converters
         /// <returns></returns>
 #if NET8_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067",
-            Justification = "Constant classes are only used in the DynamoDB event referencing the SDK. S3 originally referenced the SDK but has been rewritten to no longer reference the SDK or ConstantClass. Suppressing this trim warning because we have marked the DynamoDB event as ")]
+            Justification = "Constant classes are only used in the DynamoDB event referencing the SDK. S3 originally referenced the SDK but has been rewritten to no longer reference the SDK or ConstantClass. Suppressing this trim warning because we have marked the DynamoDB event with the RequiresUnreferencedCode attribute.")]
 #endif
         public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/DefaultLambdaJsonSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/DefaultLambdaJsonSerializer.cs
@@ -17,6 +17,10 @@ namespace Amazon.Lambda.Serialization.SystemTextJson
     /// in from Lambda and being sent back to Lambda will be logged.
     /// </para>
     /// </summary>    
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("DefaultLambdaJsonSerializer does not support trimming. " +
+            "For trimmed Lambda functions SourceGeneratorLambdaJsonSerializer passing in JsonSerializerContext should be used instead.")]
+#endif
     public class DefaultLambdaJsonSerializer : AbstractLambdaJsonSerializer, ILambdaSerializer
     {
         /// <summary>

--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/LambdaJsonSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/LambdaJsonSerializer.cs
@@ -23,6 +23,10 @@ namespace Amazon.Lambda.Serialization.SystemTextJson
     /// </para>
     /// </summary>    
     [Obsolete("This serializer is obsolete because it uses inconsistent name casing when serializing to JSON. Lambda functions should use the DefaultLambdaJsonSerializer type.")]
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("LambdaJsonSerializer does not support trimming. " +
+            "For trimmed Lambda functions SourceGeneratorLambdaJsonSerializer passing in JsonSerializerContext should be used instead.")]
+#endif    
     public class LambdaJsonSerializer : ILambdaSerializer
     {
         private const string DEBUG_ENVIRONMENT_VARIABLE_NAME = "LAMBDA_NET_SERIALIZER_DEBUG";

--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/SourceGeneratorLambdaJsonSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/SourceGeneratorLambdaJsonSerializer.cs
@@ -22,7 +22,7 @@ namespace Amazon.Lambda.Serialization.SystemTextJson
     /// 
     /// Register the serializer with the LambdaSerializer attribute specifying the defined JsonSerializerContext
     /// 
-    /// [assembly: LambdaSerializer(typeof(SourceGeneratorLambdaJsonSerializer&ly;APIGatewayExampleImage.MyJsonContext&gt;))]
+    /// [assembly: LambdaSerializer(typeof(SourceGeneratorLambdaJsonSerializer&lt;APIGatewayExampleImage.MyJsonContext&gt;))]
     /// 
     /// When the class is compiled it will generate all of the JSON serialization code to convert between JSON and the list types. This
     /// will avoid any reflection based serialization.
@@ -86,6 +86,22 @@ namespace Amazon.Lambda.Serialization.SystemTextJson
             }
 
             _jsonSerializerContext = constructor.Invoke(new object[] { this.SerializerOptions }) as TSGContext;
+        }
+
+        /// <summary>
+        /// Constructs instance of serializer with the option to customize the JsonWriterOptions after the 
+        /// Amazon.Lambda.Serialization.SystemTextJson's default settings have been applied.
+        /// </summary>
+        /// <param name="jsonSerializerContext"></param>
+        /// <param name="customizer"></param>
+        /// <param name="jsonWriterCustomizer"></param>
+        public SourceGeneratorLambdaJsonSerializer(TSGContext jsonSerializerContext, Action<JsonSerializerOptions> customizer = null, Action<JsonWriterOptions> jsonWriterCustomizer = null)
+            : base(jsonWriterCustomizer)
+        {
+            SerializerOptions = CreateDefaultJsonSerializationOptions();
+            customizer?.Invoke(this.SerializerOptions);
+
+            _jsonSerializerContext = jsonSerializerContext;
         }
 
 

--- a/Libraries/src/Amazon.Lambda.SimpleEmailEvents/Amazon.Lambda.SimpleEmailEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.SimpleEmailEvents/Amazon.Lambda.SimpleEmailEvents.csproj
@@ -15,5 +15,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.SimpleEmailEvents/Amazon.Lambda.SimpleEmailEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.SimpleEmailEvents/Amazon.Lambda.SimpleEmailEvents.csproj
@@ -4,12 +4,16 @@
 
   <PropertyGroup>
     <Description>Amazon Lambda .NET Core support - SimpleEmailEvents package.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.SimpleEmailEvents</AssemblyTitle>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.SimpleEmailEvents</AssemblyName>
     <PackageId>Amazon.Lambda.SimpleEmailEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
   </PropertyGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+		<IsTrimmable>true</IsTrimmable>
+	</PropertyGroup>
 </Project>

--- a/Libraries/test/EventsTests.NET6/EventsTests.NET6.csproj
+++ b/Libraries/test/EventsTests.NET6/EventsTests.NET6.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <PackageId>EventsTests31</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <RuntimeIdentifiers>win7-x64;win7-x86</RuntimeIdentifiers>
     <RootNamespace>EventsTests.NET6</RootNamespace>
   </PropertyGroup>
 

--- a/Libraries/test/EventsTests.NETCore31/EventsTests.NETCore31.csproj
+++ b/Libraries/test/EventsTests.NETCore31/EventsTests.NETCore31.csproj
@@ -9,13 +9,6 @@
   </PropertyGroup>
 
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <DefineConstants>NETCOREAPP_2_1</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <DefineConstants>NETCOREAPP_3_1</DefineConstants>
-  </PropertyGroup>
-  
   <ItemGroup>
     <Content Include="../EventsTests.Shared/*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -314,7 +314,13 @@ namespace Amazon.Lambda.Tests
                 Assert.Equal(record.EventSourceARN, "arn:aws:kinesis:us-east-1:123456789012:stream/simple-stream");
                 Assert.Equal(record.EventSource, "aws:kinesis");
                 Assert.Equal(record.AwsRegion, "us-east-1");
+#if NET8_0_OR_GREATER
+                // Starting with .NET 7 the precision of the underlying AddSeconds method was changed.
+                // https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/7.0/datetime-add-precision
+                Assert.Equal(636162383234769999, record.Kinesis.ApproximateArrivalTimestamp.ToUniversalTime().Ticks);
+#else
                 Assert.Equal(636162383234770000, record.Kinesis.ApproximateArrivalTimestamp.ToUniversalTime().Ticks);
+#endif
 
                 Handle(kinesisEvent);
             }
@@ -361,7 +367,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -421,7 +427,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -443,7 +449,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -600,7 +606,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -622,7 +628,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP_3_1        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -661,7 +667,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -703,7 +709,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -735,7 +741,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -769,7 +775,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -809,7 +815,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -860,7 +866,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -923,7 +929,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -968,7 +974,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -1030,7 +1036,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -1087,7 +1093,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -1126,7 +1132,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -1155,7 +1161,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -1209,7 +1215,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -1243,7 +1249,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -1283,7 +1289,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -1351,7 +1357,7 @@ namespace Amazon.Lambda.Tests
         }
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -1374,7 +1380,7 @@ namespace Amazon.Lambda.Tests
         }
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -1409,7 +1415,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -1457,7 +1463,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -1527,7 +1533,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -1564,7 +1570,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -1648,7 +1654,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -1683,7 +1689,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -1808,7 +1814,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -1840,7 +1846,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -1881,7 +1887,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -1924,7 +1930,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -1971,7 +1977,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -2038,7 +2044,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -2287,9 +2293,11 @@ namespace Amazon.Lambda.Tests
             }
         }
 
+        // Test is temporary disabled due to a bug in .NET 8 RC2
+        // https://github.com/dotnet/runtime/issues/93903
+#if !NET8_0
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -2313,7 +2321,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -2346,7 +2354,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -2366,7 +2374,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -2392,9 +2400,11 @@ namespace Amazon.Lambda.Tests
             }
         }
 
+        // Test is temporary disabled due to a bug in .NET 8 RC2
+        // https://github.com/dotnet/runtime/issues/93903
+#if !NET8_0
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -2416,7 +2426,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -2446,9 +2456,11 @@ namespace Amazon.Lambda.Tests
             }
         }
 
+        // Test is temporary disabled due to a bug in .NET 8 RC2
+        // https://github.com/dotnet/runtime/issues/93903
+#if !NET8_0
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -2474,9 +2486,11 @@ namespace Amazon.Lambda.Tests
             }
         }
 
+        // Test is temporary disabled due to a bug in .NET 8 RC2
+        // https://github.com/dotnet/runtime/issues/93903
+#if !NET8_0
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -2501,7 +2515,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -2531,7 +2545,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -2725,7 +2739,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -2757,7 +2771,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -2808,7 +2822,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -2908,7 +2922,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -2973,7 +2987,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif
@@ -3016,7 +3030,7 @@ namespace Amazon.Lambda.Tests
 
         [Theory]
         [InlineData(typeof(JsonSerializer))]
-#if NETCOREAPP3_1_OR_GREATER        
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 #endif

--- a/Libraries/test/PowerShellTests/ScriptInvokeTests.cs
+++ b/Libraries/test/PowerShellTests/ScriptInvokeTests.cs
@@ -123,7 +123,7 @@ namespace Amazon.Lambda.PowerShellTests
             Assert.Contains("AWS Lambda", resultString);
         }
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [Fact]
         public void ForObjectParallelTest()
         {

--- a/Libraries/test/TestFunctionFSharp/TestFunctionCSharp/TestFunctionCSharp.csproj
+++ b/Libraries/test/TestFunctionFSharp/TestFunctionCSharp/TestFunctionCSharp.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-   <!-- <PackageReference Include="FSharp.Core" Version="*" /> -->
     <PackageReference Include="Fable.JsonConverter" Version="1.0.7" />
   </ItemGroup>
   <ItemGroup>

--- a/Libraries/test/TestFunctionFSharp/TestFunctionCSharp/TestFunctionCSharp.csproj
+++ b/Libraries/test/TestFunctionFSharp/TestFunctionCSharp/TestFunctionCSharp.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="FSharp.Core" Version="*" />
+   <!-- <PackageReference Include="FSharp.Core" Version="*" /> -->
     <PackageReference Include="Fable.JsonConverter" Version="1.0.7" />
   </ItemGroup>
   <ItemGroup>

--- a/Libraries/test/TestWebApp/Startup.cs
+++ b/Libraries/test/TestWebApp/Startup.cs
@@ -62,7 +62,7 @@ namespace TestWebApp
             services.AddApplicationInsightsTelemetry(Configuration);
 
             services.AddMvc();
-#elif NETCOREAPP_3_1
+#elif NETCOREAPP3_1_OR_GREATER
             services.AddControllers();
 #endif
         }
@@ -73,7 +73,7 @@ namespace TestWebApp
             app.UseMiddleware<Middleware>();
             app.UseResponseCompression();
 
-#if NETCOREAPP_3_1
+#if NETCOREAPP3_1_OR_GREATER
             app.UseRouting();
 
             app.UseAuthorization();

--- a/Libraries/test/TestWebApp/TestWebApp.csproj
+++ b/Libraries/test/TestWebApp/TestWebApp.csproj
@@ -8,10 +8,6 @@
     <PackageId>TestWebApp</PackageId>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <DefineConstants>NETCOREAPP_3_1</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Amazon.Lambda.AspNetCoreServer\Amazon.Lambda.AspNetCoreServer.csproj" />
   </ItemGroup>


### PR DESCRIPTION
*Description of changes:*
Updated the Lambda RuntimeSupport, SystemTextJson serializer and Lambda events to support trimming.

* Replaced all `NETCOREAPP_3_1` preprocessor references to `NETCOREAPP3_1_OR_GREATER`
* Added `net8.0` target framework to projects and mark the projects as trimmable.
* Marked all serializer in the SystemTextJson as requiring unreferenced code except for the source generator seriralizer
* There were a couple places where an event was directly using the SystemTextJson serializer. For .NET 8 I switched it to use the source generator approach.
* In Amazon.Lambda.RuntimeSupport marked the code paths used by the class library approach of loading the customer function by reflection and build Expressions as `RequiresUnreferencedCode`. These code paths are not used when deployed as an executable which is the AOT use case.
* Updated the Events.NET6 project to multi target .NET 8. At some point we should rename this project but I don't want to mess with the CI system right now.
* Added a new constructor for `SourceGeneratorLambdaJsonSerializer` that takes in the JsonSerializerContext so the serializer doesn't have to use reflection to get an instance of the generic parameter.

I have verified with these changes I can package a Lambda function using just these libraries and received no trim warnings.

Work not included in this PR
* Update the ASP.NET Core bridge to support trimming
* Update Lambda Annotations to support .NET 8 and trimming

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
