### PR TITLE
Add width to .main to prevent window overflow

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/wwwroot/css/site.css
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/wwwroot/css/site.css
@@ -167,6 +167,10 @@ app {
         position: sticky;
         top: 0;
     }
+    
+    .main {
+        width: calc(100% - 250px);
+    }
 
     .main .top-row {
         position: sticky;


### PR DESCRIPTION
**Issue**
The main container would expand for long log lines, causing the viewable screen to be reduced and requiring horizontal scrolling. This also caused the sidebar to have some messed up formatting

*Description of changes:*
Set the width of the main class to be fixed to the screen size

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


Before:
![lambdatoolbefore](https://github.com/aws/aws-lambda-dotnet/assets/6925381/e712a683-ffef-4663-87ac-ae0ece77d4f1)


After:
![lambdatoolafter](https://github.com/aws/aws-lambda-dotnet/assets/6925381/a4fb11ab-19d2-4ace-932a-b407ac0d0b91)


Tested on Edge
