### PR TITLE
Easier support for application/x-protobuf with lambda functions

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
@@ -75,6 +75,7 @@ namespace Amazon.Lambda.AspNetCoreServer
             ["image/x-icon"] = ResponseContentEncoding.Base64,
             ["application/zip"] = ResponseContentEncoding.Base64,
             ["application/pdf"] = ResponseContentEncoding.Base64,
+            ["application/x-protobuf"] = ResponseContentEncoding.Base64,
         };
 
         // Defines a mapping from registered content encodings to the response encoding format


### PR DESCRIPTION
*Issue #, if available:*

application/x-protobuf is binary format, thus always to be base64 encoded.
with this code people who use it in lambdas will not have to manually add this encoding


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
