### PR TITLE
chore: Update Semgrep GitHub action to use the returntocorp/semgrep container

### DIFF
--- a/.github/workflows/semgrep-analysis.yml
+++ b/.github/workflows/semgrep-analysis.yml
@@ -1,30 +1,41 @@
-# This workflow file requires a free account on Semgrep.dev to
-# manage rules, file ignores, notifications, and more.
-#
-# See https://semgrep.dev/docs
-
 name: Semgrep
 
 on:
-  push:
-    branches:
-      - feature/annotations
+  # Scan changed files in PRs, block on new issues only (existing issues ignored)
   pull_request:
+
+  push:
+    branches: ["dev", "main"]
+
   schedule:
     - cron: '23 20 * * 1'
+
+  # Manually trigger the workflow
+  workflow_dispatch:
 
 jobs:
   semgrep:
     name: Scan
+    permissions:
+      security-events: write
     runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
     # Skip any PR created by dependabot to avoid permission issues
     if: (github.actor != 'dependabot[bot]')
     steps:
       # Fetch project source
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: returntocorp/semgrep-action@v1
-        with:
-          config: >- # more at semgrep.dev/explore
+      - run: semgrep ci --sarif > semgrep.sarif
+        env:
+          SEMGREP_RULES: >- # more at semgrep.dev/explore
             p/security-audit
             p/secrets
+            p/owasp-top-ten
+
+      - name: Upload SARIF file for GitHub Advanced Security Dashboard
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: semgrep.sarif
+        if: always()


### PR DESCRIPTION
*Description of changes:*
This PR updates the Semgrep GitHub action to use the returntocorp/semgrep container.

Inspired by the sample GitHub action Semgrep configuration - https://semgrep.dev/docs/semgrep-ci/sample-ci-configs/#sample-github-actions-configuration-file

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
