### PR TITLE
feat: add  .NET 8 support in the  Amazon.Lambda.TestTool.

### DIFF
--- a/Tools/LambdaTestTool/README.md
+++ b/Tools/LambdaTestTool/README.md
@@ -35,6 +35,7 @@ that the Lambda function will be run in. Below is the list of published versions
 | .NET 5.0 (Deprecated) | Amazon.Lambda.TestTool-5.0 | dotnet-lambda-test-tool-5.0.exe |
 | .NET 6.0 | Amazon.Lambda.TestTool-6.0 | dotnet-lambda-test-tool-6.0.exe |
 | .NET 7.0 | Amazon.Lambda.TestTool-7.0 | dotnet-lambda-test-tool-7.0.exe |
+| .NET 8.0 | Amazon.Lambda.TestTool-8.0 | dotnet-lambda-test-tool-8.0.exe |
 
 ## AWS Credentials
 

--- a/Tools/LambdaTestTool/aws-lambda-test-tool-netcore.sln
+++ b/Tools/LambdaTestTool/aws-lambda-test-tool-netcore.sln
@@ -44,7 +44,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "net6", "net6", "{F08BF489-B
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SourceGeneratorExample", "tests\LambdaFunctions\net6\SourceGeneratorExample\SourceGeneratorExample.csproj", "{9F8D7697-46FC-45E4-B795-11CCDA2B68B3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.Lambda.TestTool.Tests.NET6", "tests\Amazon.Lambda.TestTool.Tests.NET6\Amazon.Lambda.TestTool.Tests.NET6.csproj", "{2C69BEB2-858E-43E3-9951-74E780FEB1BF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.Lambda.TestTool.Tests.NET6", "tests\Amazon.Lambda.TestTool.Tests.NET6\Amazon.Lambda.TestTool.Tests.NET6.csproj", "{2C69BEB2-858E-43E3-9951-74E780FEB1BF}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "net8", "net8", "{58A7CCF8-3EE7-40E6-A405-7BEF5BBFCDFA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SourceGeneratorExampleNET8", "tests\LambdaFunctions\net8\SourceGeneratorExampleNET8\SourceGeneratorExampleNET8.csproj", "{C42AADC5-0924-42DD-897A-0F1F1FF9DDFA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -104,6 +108,10 @@ Global
 		{2C69BEB2-858E-43E3-9951-74E780FEB1BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2C69BEB2-858E-43E3-9951-74E780FEB1BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2C69BEB2-858E-43E3-9951-74E780FEB1BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C42AADC5-0924-42DD-897A-0F1F1FF9DDFA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C42AADC5-0924-42DD-897A-0F1F1FF9DDFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C42AADC5-0924-42DD-897A-0F1F1FF9DDFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C42AADC5-0924-42DD-897A-0F1F1FF9DDFA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -126,6 +134,8 @@ Global
 		{F08BF489-BD05-4DC1-9772-AB5E137B87B8} = {BFD718DB-4526-4BED-B2B0-BB446EDFFEA1}
 		{9F8D7697-46FC-45E4-B795-11CCDA2B68B3} = {F08BF489-BD05-4DC1-9772-AB5E137B87B8}
 		{2C69BEB2-858E-43E3-9951-74E780FEB1BF} = {28C935E3-4FB4-4B09-A9DB-26A1EB04CDE0}
+		{58A7CCF8-3EE7-40E6-A405-7BEF5BBFCDFA} = {BFD718DB-4526-4BED-B2B0-BB446EDFFEA1}
+		{C42AADC5-0924-42DD-897A-0F1F1FF9DDFA} = {58A7CCF8-3EE7-40E6-A405-7BEF5BBFCDFA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E6C77567-6F16-4EE3-8743-ADE6B68434FD}

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj
@@ -12,7 +12,7 @@
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
     <NoWarn>1701;1702;1591;1587;3021;NU5100;CS1591</NoWarn>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
-	<TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+	<TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>  
 
 
@@ -30,7 +30,11 @@
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.0" />
-    </ItemGroup>		
+    </ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.0" />
+	</ItemGroup>
 
   <ItemGroup>
 	  <PackageReference Include="Blazored.Modal" Version="3.1.2" />

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Constants.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Constants.cs
@@ -13,6 +13,8 @@ namespace Amazon.Lambda.TestTool.BlazorTester
         public const string PRODUCT_NAME = "AWS .NET Core 6.0 Mock Lambda Test Tool";
 #elif NET7_0
         public const string PRODUCT_NAME = "AWS .NET Core 7.0 Mock Lambda Test Tool";
+#elif NET8_0
+        public const string PRODUCT_NAME = "AWS .NET Core 8.0 Mock Lambda Test Tool";
 #else
         Update for new target framework!!!
 #endif

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\..\..\buildtools\common.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Common code for the AWS .NET Core Lambda Mock Test Tool.</Description>
     <NoWarn>1701;1702;1591;1587;3021;NU5100;CS1591</NoWarn>
   </PropertyGroup>
@@ -33,6 +33,14 @@
 	
   <PropertyGroup Condition=" '$(Configuration)' == 'PackNET60' ">
     <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>  
+	
+  <PropertyGroup Condition=" '$(Configuration)' == 'PackNET70' ">
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>  
+	
+<PropertyGroup Condition=" '$(Configuration)' == 'PackNET80' ">
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>  	
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
@@ -46,6 +54,11 @@
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
 		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
 	</ItemGroup>
+	
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
+	</ItemGroup>
+	
 
 	<ItemGroup>
     <EmbeddedResource Include="Resources\**" />

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/TestToolStartup.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/TestToolStartup.cs
@@ -62,6 +62,8 @@ namespace Amazon.Lambda.TestTool
                 var targetFramework = "net6.0";
 #elif NET7_0
                 var targetFramework = "net7.0";
+#elif NET8_0
+                var targetFramework = "net8.0";
 #endif
 
                 // Check to see if running in debug mode from this project's directory which means the test tool is being debugged.

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/net8/SourceGeneratorExampleNET8/Function.cs
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/net8/SourceGeneratorExampleNET8/Function.cs
@@ -1,0 +1,39 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.Serialization.SystemTextJson;
+using System.Text.Json.Serialization;
+
+[assembly: LambdaSerializer(typeof(SourceGeneratorLambdaJsonSerializer<SourceGeneratorExample.CustomTypesSerializerContext>))]
+
+namespace SourceGeneratorExample;
+
+[JsonSerializable(typeof(Input))]
+[JsonSerializable(typeof(Output))]
+public partial class CustomTypesSerializerContext : JsonSerializerContext
+{
+}
+
+
+public class Input
+{
+    public string Name { get; set; }
+}
+
+public class Output
+{
+    public string Response { get; set;}
+}
+
+public class Function
+{
+
+    public Output FunctionHandler(Input request, ILambdaContext context)
+    {
+        return new Output { Response = "Response = " + request.Name};
+    }
+
+    public Task VoidReturnFunctionHandler(Input request, ILambdaContext context)
+    {
+        context.Logger.LogInformation("Calling function with: " + request.Name);
+        return Task.CompletedTask;
+    }
+}

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/net8/SourceGeneratorExampleNET8/SourceGeneratorAsyncInputOnly.json
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/net8/SourceGeneratorExampleNET8/SourceGeneratorAsyncInputOnly.json
@@ -1,0 +1,15 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+    "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+    "dotnet lambda help",
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+  "profile": "default",
+  "region": "us-west-2",
+  "configuration": "Release",
+  "function-runtime": "dotnet8",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "function-handler": "SourceGeneratorExampleNET8::SourceGeneratorExampleNET8.Function::VoidReturnFunctionHandler"
+}

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/net8/SourceGeneratorExampleNET8/SourceGeneratorExampleNET8.csproj
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/net8/SourceGeneratorExampleNET8/SourceGeneratorExampleNET8.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AWSProjectType>Lambda</AWSProjectType>
+    <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!-- Generate ready to run images during publishing to improve cold start time. -->
+    <PublishReadyToRun>true</PublishReadyToRun>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
+  </ItemGroup>
+</Project>

--- a/Tools/LambdaTestTool/tests/LambdaFunctions/net8/SourceGeneratorExampleNET8/SourceGeneratorInputAndOutput.json
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/net8/SourceGeneratorExampleNET8/SourceGeneratorInputAndOutput.json
@@ -1,0 +1,15 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+    "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+    "dotnet lambda help",
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+  "profile": "default",
+  "region": "us-west-2",
+  "configuration": "Release",
+  "function-runtime": "dotnet8",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "function-handler": "SourceGeneratorExampleNET8::SourceGeneratorExampleNET8.Function::FunctionHandler"
+}


### PR DESCRIPTION

*Description of changes:*

Add  .NET 8 support in the  Amazon.Lambda.TestTool.

- Added `net8.0` framework in .csproj files
- Update .csproj file conditions
- Update package `Microsoft.Extensions.DependencyModel` when target framework selected is `net8.0`
 to version `8.0.0`.
- Update environment flags


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
