### PR TITLE
Fix issue with getting a 404 for blazor.server.js

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj
@@ -6,7 +6,7 @@
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET Core AWS Lambda functions locally.</Description>
     <LangVersion>Latest</LangVersion>
-    <VersionPrefix>0.15.0</VersionPrefix>
+    <VersionPrefix>0.15.1</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester60-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester60-pack.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET 6.0 AWS Lambda functions locally.</Description>
-    <VersionPrefix>0.15.0</VersionPrefix>
+    <VersionPrefix>0.15.1</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester70-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester70-pack.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET 7.0 AWS Lambda functions locally.</Description>
-    <VersionPrefix>0.15.0</VersionPrefix>
+    <VersionPrefix>0.15.1</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester80-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester80-pack.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET 8.0 AWS Lambda functions locally.</Description>
-    <VersionPrefix>0.15.0</VersionPrefix>
+    <VersionPrefix>0.15.1</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Startup.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Startup.cs
@@ -100,13 +100,8 @@ namespace Amazon.Lambda.TestTool.BlazorTester
                 {
                     var fileProvider = new ManifestEmbeddedFileProvider(typeof(Startup).Assembly, "wwwroot");
 
-                    var f1 = fileProvider.GetFileInfo("_framework/blazor.server.js");
-
                     // Make sure we don't remove the existing file providers (blazor needs this)
-                    o.FileProvider = new CompositeFileProvider(fileProvider);
-
-                    var f = o.FileProvider.GetFileInfo("_framework/blazor.server.js");
-                    Console.WriteLine(f.Name);
+                    o.FileProvider = new CompositeFileProvider(o.FileProvider, fileProvider);
                 });
 #endif
         }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1625

*Description of changes:*
With the creating the .NET 8 version of the test tool there was a breaking behavior in Blazor in how it static files were were handled to return turn the `_framework/blazor.server.js`. In the process of diagnosing this error some debugging code was introduced for .NET 6 and the fix was added in a conditional block just for .NET 8. The debugging code was left in the .NET 6 condition cause the tool to break not return `_framework/blazor.server.js`. This PR restores the original behavior.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
