### PR TITLE
Issue 1639 - LambdaTestTool - Sync Invoke Endpoint

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Runtime.razor
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Runtime.razor
@@ -13,7 +13,7 @@
 
 <p>
     For Lambda functions written as executable assemblies, i.e. custom runtimes functions and top level statement functions, this page can be used for testing the functions locally. 
-    Set the <b>AWS_LAMBDA_RUNTIME_API</b> environment variable to <b>@httpContextAccessor.HttpContext.Request.Host</b> while debugging executable assembly 
+    Set the <b>AWS_LAMBDA_RUNTIME_API</b> environment variable to <b>@httpContextAccessor?.HttpContext?.Request?.Host</b> while debugging executable assembly 
     Lambda function. More information can be found in the <a href="/documentation">documentation</a>.
 </p>
 

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Runtime.razor
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Pages/Runtime.razor
@@ -75,6 +75,13 @@
                               <pre class="form-control" style="@Constants.ResponseErrorStyleSizeConstraint" >@RuntimeApiModel.ActiveEvent.ErrorResponse</pre>
                           </p>
                       }
+                      else if (RuntimeApiModel.ActiveEvent.Response == null)
+                      {
+                            <p>
+                                <b>Response:</b>
+                                <pre class="form-control" style="@Constants.ResponseErrorStyleSizeConstraint" >No Response Received</pre>
+                            </p>
+                      }
                       else
                       {
                           <p>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Services/RuntimeApiDataStore.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Services/RuntimeApiDataStore.cs
@@ -213,7 +213,10 @@ namespace Amazon.Lambda.TestTool.BlazorTester.Services
 
     public class EventContainer : IEventContainer
     {
-        
+        public Action OnSuccess { get; set; }
+
+        public Action OnError { get; set; }
+
         private const string defaultFunctionArn = "arn:aws:lambda:us-west-2:123412341234:function:Function";
         public string AwsRequestId { get; }
         public string EventJson { get; }
@@ -255,6 +258,7 @@ namespace Amazon.Lambda.TestTool.BlazorTester.Services
             LastUpdated = DateTime.Now;
             this.Response = response;
             this.EventStatus = IEventContainer.Status.Success;
+            OnSuccess?.Invoke();
             _dataStore.RaiseStateChanged();
         }
         
@@ -264,6 +268,7 @@ namespace Amazon.Lambda.TestTool.BlazorTester.Services
             this.ErrorType = errorType;
             this.ErrorResponse = errorBody;
             this.EventStatus = IEventContainer.Status.Failure;
+            OnError?.Invoke();
             _dataStore.RaiseStateChanged();
         }
     }

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Services/RuntimeApiDataStore.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Services/RuntimeApiDataStore.cs
@@ -267,9 +267,8 @@ namespace Amazon.Lambda.TestTool.BlazorTester.Services
 
         public DateTime LastUpdated { get; private set; }
 
-        public Task TimeoutTask { get; set; }
         public TaskCompletionSource DispatchedTCS { get; private set; } = new ();
-        public CancellationTokenSource TimedOutCTS { get; private set; } = new (1000);
+        public CancellationTokenSource TimedOutCTS { get; private set; }
         private readonly object _statusLock = new();
         private IEventContainer.Status _status = IEventContainer.Status.Queued;
         public IEventContainer.Status EventStatus
@@ -289,6 +288,8 @@ namespace Amazon.Lambda.TestTool.BlazorTester.Services
             this._dataStore = dataStore;
             this.AwsRequestId = eventCount.ToString("D12");
             this.EventJson = eventJson;
+            // TODO: Parse the JSON so we can get the timeout value
+            this.TimedOutCTS = new (1000);
         }
 
         public string FunctionArn
@@ -329,6 +330,10 @@ namespace Amazon.Lambda.TestTool.BlazorTester.Services
                 if (EventStatus == IEventContainer.Status.Queued)
                 {
                     ReportErrorResponse("Throttled", errorBody);
+                }
+                else
+                {
+                    ReportErrorResponse("Failed", errorBody);
                 }
             }
         }

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Startup.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Startup.cs
@@ -80,7 +80,8 @@ namespace Amazon.Lambda.TestTool.BlazorTester
             services.AddControllers();
             services.AddRazorPages();
             services.AddServerSideBlazor()
-                    .AddHubOptions(options => options.MaximumReceiveMessageSize = null);
+                    .AddHubOptions(options => options.MaximumReceiveMessageSize = null)
+                    .AddHubOptions(options => options.ClientTimeoutInterval = TimeSpan.FromMinutes(10));
             services.AddHttpContextAccessor();
 
             services.AddBlazoredModal();

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.BlazorTester.Tests/RuntimeApiControllerTests.cs
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.BlazorTester.Tests/RuntimeApiControllerTests.cs
@@ -151,7 +151,8 @@ namespace Amazon.Lambda.TestTool.BlazorTester.Tests
                 var uriString = Utils.DetermineLaunchUrl(session.Host, session.Port, Constants.DEFAULT_HOST);
                 session.Client = new HttpClient()
                 {
-                    BaseAddress = new Uri(uriString)
+                    BaseAddress = new Uri(uriString),
+                    Timeout = TimeSpan.FromMinutes(15)
                 };
 
                 session.Store = session.WebHost.Services.GetService<IRuntimeApiDataStore>();


### PR DESCRIPTION
*Issue #, if available:* #1639

*Relates to:* #1349

*Description of changes:*
- Draft PR for feedback on approach
- Allows `AmazonLambdaClient.InvokeAsync` to work locally for testing complex projects that involve sync Invokes between a caller and Lambda
- Feedback needed:
  - Is the hard-coded function name `function` invoke endpoint in usage for async event testing?
    - If so, I assume I can determine the sync/async invoke type from the payload or context and only wait for sync
  - Use of `Action` for completion notifications - Is there a preferred alternative?
  - Thoughts on how to allow configuration of the two timeouts that were changed
    - For the immediately-returning endpoints this was not a problem, but it is a problem for sync invokes that block
    - Unfortunately it seems that Blazor does not allow changing the timeouts on a per-route basis
 - The test pages were throwing exceptions due to the `Response` not being available
    - I made a fix but I think there may be a more comprehensive change needed for the UI?
    - My solution was acceptable for my testing: it just showed the event as still running with no response
    - When the response was received the item moved into the finished events section and a new event was processed, so there did not appear to be any harm from my approach

I have personally been using this for a week now to build and test just such a project using .NET 8.0.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
