### PR TITLE
Remove SDK dependency from DynamoDBEvent

### DIFF
--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents/Amazon.Lambda.DynamoDBEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents/Amazon.Lambda.DynamoDBEvents.csproj
@@ -3,18 +3,14 @@
   <Import Project="..\..\..\buildtools\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net8.0</TargetFrameworks>
     <Description>Amazon Lambda .NET Core support - DynamoDBEvents package.</Description>
     <AssemblyTitle>Amazon.Lambda.DynamoDBEvents</AssemblyTitle>
-    <VersionPrefix>2.3.0</VersionPrefix>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.DynamoDBEvents</AssemblyName>
     <PackageId>Amazon.Lambda.DynamoDBEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.24" />
-  </ItemGroup>
 
   <ItemGroup>
     <Compile Remove="Converters\DictionaryLongToStringJsonConverter.cs" />
@@ -23,10 +19,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
     <Compile Include="Converters\DictionaryLongToStringJsonConverter.cs" />
   </ItemGroup>
-	
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
-		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
-		<IsTrimmable>true</IsTrimmable>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
+    <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
-	</PropertyGroup>
+  </PropertyGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents/DynamoDBEvent.cs
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents/DynamoDBEvent.cs
@@ -226,7 +226,7 @@ namespace Amazon.Lambda.DynamoDBEvents
             ///  <c>"BOOL": true</c>
             /// </para>
             /// </summary>
-            public bool BOOL { get; set; }
+            public bool? BOOL { get; set; }
 
             /// <summary>
             /// <para>
@@ -304,7 +304,7 @@ namespace Amazon.Lambda.DynamoDBEvents
             ///  <c>"NULL": true</c> 
             /// </para>
             /// </summary>
-            public bool NULL { get; set; }
+            public bool? NULL { get; set; }
 
             /// <summary>
             /// <para>

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents/DynamoDBEvent.cs
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents/DynamoDBEvent.cs
@@ -1,17 +1,14 @@
 namespace Amazon.Lambda.DynamoDBEvents
 {
-    using Amazon.DynamoDBv2.Model;
     using System;
     using System.Collections.Generic;
+    using System.IO;
 
     /// <summary>
     /// AWS DynamoDB event
     /// http://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html
     /// http://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-ddb-update
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("DynamoDBEvent has a reference to the AWS SDK for .NET. The ConstantClass used to represent enums in the SDK is not supported in the Lambda serializer SourceGeneratorLambdaJsonSerializer for trimming scenarios.")]
-#endif
     public class DynamoDBEvent
     {
         /// <summary>
@@ -21,15 +18,315 @@ namespace Amazon.Lambda.DynamoDBEvents
 
         /// <summary>
         /// DynamoDB stream record
-        /// http://docs.aws.amazon.com/dynamodbstreams/latest/APIReference/API_StreamRecord.html
+        /// https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_Record.html
         /// </summary>
-        public class DynamodbStreamRecord : Record
+        public class DynamodbStreamRecord
         {
             /// <summary>
             /// The event source arn of DynamoDB.
             /// </summary>
             public string EventSourceArn { get; set; }
+
+            /// <summary>
+            /// The region in which the <c>GetRecords</c> request was received.
+            /// </summary>
+            public string AwsRegion { get; set; }
+
+            /// <summary>
+            /// The main body of the stream record, containing all of the DynamoDB-specific fields.
+            /// </summary>
+            public StreamRecord Dynamodb { get; set; }
+
+            /// <summary>
+            /// A globally unique identifier for the event that was recorded in this stream record.
+            /// </summary>
+            public string EventID { get; set; }
+
+            /// <summary>
+            /// <para>
+            /// The type of data modification that was performed on the DynamoDB table:
+            /// </para>
+            /// <ul> 
+            /// <li>
+            /// <para>
+            ///  <c>INSERT</c> - a new item was added to the table.
+            /// </para>
+            /// </li>
+            /// 
+            /// <li>
+            /// <para>
+            ///  <c>MODIFY</c> - one or more of an existing item's attributes were modified.
+            /// </para>
+            /// </li>
+            /// 
+            /// <li>
+            /// <para>
+            ///  <c>REMOVE</c> - the item was deleted from the table
+            /// </para>
+            /// </li>
+            /// </ul>
+            /// </summary>
+            public string EventName { get; set; }
+
+            /// <summary>
+            /// The Amazon Web Services service from which the stream record originated. For DynamoDB
+            /// Streams, this is <c>aws:dynamodb</c>.
+            /// </summary>
+            public string EventSource { get; set; }
+
+            /// <summary>
+            /// <para>
+            /// The version number of the stream record format. This number is updated whenever the
+            /// structure of <c>Record</c> is modified.
+            /// </para>
+            ///  
+            /// <para>
+            /// Client applications must not assume that <c>eventVersion</c> will remain at
+            /// a particular value, as this number is subject to change at any time. In general, <c>eventVersion</c>
+            /// will only increase as the low-level DynamoDB Streams API evolves.
+            /// </para>
+            /// </summary>
+            public string EventVersion { get; set; }
+
+            /// <summary>
+            /// <para>Items that are deleted by the Time to Live process after expiration have the following fields:</para>
+            /// <ul>
+            /// <li> 
+            ///   <para>Records[].userIdentity.type</para>
+            ///   <para>"Service"</para>
+            /// </li> 
+            /// <li> 
+            ///   <para>Records[].userIdentity.principalId</para>
+            ///   <para>"dynamodb.amazonaws.com"</para>
+            /// </li> 
+            /// </ul>
+            /// </summary>
+            public Identity UserIdentity { get; set; }
         }
 
+        /// <summary>
+        /// A description of a single data modification that was performed on an item in a DynamoDB table.
+        /// </summary>
+        public class StreamRecord
+        {
+            /// <summary>
+            /// The approximate date and time when the stream record was created, in <a href="http://www.epochconverter.com/">UNIX
+            /// epoch time</a> format and rounded down to the closest second.
+            /// </summary>
+            public DateTime ApproximateCreationDateTime { get; set; }
+
+            /// <summary>
+            /// The primary key attribute(s) for the DynamoDB item that was modified.
+            /// </summary>
+            public Dictionary<string, AttributeValue> Keys { get; set; }
+
+            /// <summary>
+            /// The item in the DynamoDB table as it appeared after it was modified.
+            /// </summary>
+            public Dictionary<string, AttributeValue> NewImage { get; set; }
+
+            /// <summary>
+            /// The item in the DynamoDB table as it appeared before it was modified.
+            /// </summary>
+            public Dictionary<string, AttributeValue> OldImage { get; set; }
+
+            /// <summary>
+            /// The sequence number of the stream record.
+            /// </summary>
+            public string SequenceNumber { get; set; }
+
+            /// <summary>
+            /// The size of the stream record, in bytes.
+            /// </summary>
+            public long SizeBytes { get; set; }
+
+            /// <summary>
+            /// <para>
+            /// The type of data from the modified DynamoDB item that was captured in this stream record:
+            /// </para>
+            /// 
+            /// <ul>
+            /// <li>
+            /// <para>
+            ///  <c>KEYS_ONLY</c> - only the key attributes of the modified item.
+            /// </para>
+            /// </li>
+            /// 
+            /// <li>
+            /// <para>
+            ///  <c>NEW_IMAGE</c> - the entire item, as it appeared after it was modified.
+            /// </para>
+            /// </li>
+            /// 
+            /// <li>
+            /// <para>
+            ///  <c>OLD_IMAGE</c> - the entire item, as it appeared before it was modified.
+            /// </para>
+            /// </li>
+            /// 
+            /// <li>
+            /// <para>
+            ///  <c>NEW_AND_OLD_IMAGES</c> - both the new and the old item images of the item.
+            /// </para>
+            /// </li>
+            /// </ul>
+            /// </summary>
+            public string StreamViewType { get; set; }
+        }
+
+        /// <summary>
+        /// Contains details about the type of identity that made the request.
+        /// </summary>
+        public class Identity
+        {
+            /// <summary>
+            /// A unique identifier for the entity that made the call. For Time To Live, the principalId
+            /// is "dynamodb.amazonaws.com".
+            /// </summary>
+            public string PrincipalId { get; set; }
+
+            /// <summary>
+            /// The type of the identity. For Time To Live, the type is "Service".
+            /// </summary>
+            public string Type { get; set; }
+        }
+
+        /// <summary>
+        /// Represents the data for an attribute.
+        ///  
+        /// <para>
+        /// Each attribute value is described as a name-value pair. The name is the data type,
+        /// and the value is the data itself.
+        /// </para>
+        ///  
+        /// <para>
+        /// For more information, see <a href="https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes">Data
+        /// Types</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+        /// </para>
+        /// </summary>
+        public class AttributeValue
+        {
+            /// <summary>
+            /// <para>
+            /// An attribute of type Binary. For example:
+            /// </para>
+            ///  
+            /// <para>
+            ///  <c>"B": "dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk"</c>
+            /// </para>
+            /// </summary>
+            public MemoryStream B { get; set; }
+
+            /// <summary>
+            /// <para>
+            /// An attribute of type Boolean. For example:
+            /// </para>
+            ///  
+            /// <para>
+            ///  <c>"BOOL": true</c>
+            /// </para>
+            /// </summary>
+            public bool BOOL { get; set; }
+
+            /// <summary>
+            /// <para>
+            /// An attribute of type Binary Set. For example:
+            /// </para>
+            ///  
+            /// <para>
+            ///  <c>"BS": ["U3Vubnk=", "UmFpbnk=", "U25vd3k="]</c>
+            /// </para>
+            /// </summary>
+            public List<MemoryStream> BS { get; set; }
+
+            /// <summary>
+            /// <para>
+            /// An attribute of type List. For example:
+            /// </para>
+            ///  
+            /// <para>
+            ///  <c>"L": [ {"S": "Cookies"} , {"S": "Coffee"}, {"N": "3.14159"}]</c>
+            /// </para>
+            /// </summary>
+            public List<AttributeValue> L { get; set; }
+
+            /// <summary>
+            /// <para>
+            /// An attribute of type Map. For example:
+            /// </para>
+            ///  
+            /// <para>
+            ///  <c>"M": {"Name": {"S": "Joe"}, "Age": {"N": "35"}}</c> 
+            /// </para>
+            /// </summary>
+            public Dictionary<string, AttributeValue> M { get; set; }
+
+            /// <summary>
+            /// <para>
+            /// An attribute of type Number. For example:
+            /// </para>
+            ///  
+            /// <para>
+            ///  <c>"N": "123.45"</c>
+            /// </para>
+            ///  
+            /// <para>
+            /// Numbers are sent across the network to DynamoDB as strings, to maximize compatibility
+            /// across languages and libraries. However, DynamoDB treats them as number type attributes
+            /// for mathematical operations.
+            /// </para>
+            /// </summary>
+            public string N { get; set; }
+
+            /// <summary>
+            /// <para>
+            /// An attribute of type Number Set. For example:
+            /// </para>
+            ///  
+            /// <para>
+            ///  <c>"NS": ["42.2", "-19", "7.5", "3.14"]</c>
+            /// </para>
+            ///  
+            /// <para>
+            /// Numbers are sent across the network to DynamoDB as strings, to maximize compatibility
+            /// across languages and libraries. However, DynamoDB treats them as number type attributes
+            /// for mathematical operations.
+            /// </para>
+            /// </summary>
+            public List<string> NS { get; set; }
+
+            /// <summary>
+            /// <para>
+            /// An attribute of type Null. For example:
+            /// </para>
+            ///  
+            /// <para>
+            ///  <c>"NULL": true</c> 
+            /// </para>
+            /// </summary>
+            public bool NULL { get; set; }
+
+            /// <summary>
+            /// <para>
+            /// An attribute of type String. For example:
+            /// </para>
+            ///  
+            /// <para>
+            ///  <c>"S": "Hello"</c> 
+            /// </para>
+            /// </summary>
+            public string S { get; set; }
+
+            /// <summary>
+            /// <para>
+            /// An attribute of type String Set. For example:
+            /// </para>
+            ///  
+            /// <para>
+            ///  <c>"SS": ["Giraffe", "Hippo" ,"Zebra"]</c> 
+            /// </para>
+            /// </summary>
+            public List<string> SS { get; set; }
+        }
     }
 }

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents/README.md
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents/README.md
@@ -2,8 +2,6 @@
 
 This package contains classes that can be used as input types for Lambda functions that process Amazon DynamoDB events.
 
-This package has a dependency on the [AWS SDK for .NET package DynamoDBv2](https://www.nuget.org/packages/AWSSDK.DynamoDBv2/) in order to use the `Amazon.DynamoDBv2.Model.Record` type. 
-
 # Sample Function
 
 The following is a sample class and Lambda function that receives Amazon DynamoDB event record data as an input and writes some of the incoming event data to CloudWatch Logs. (Note that by default anything written to Console will be logged as CloudWatch Logs events.)

--- a/Libraries/src/Amazon.Lambda.Serialization.Json/Amazon.Lambda.Serialization.Json.csproj
+++ b/Libraries/src/Amazon.Lambda.Serialization.Json/Amazon.Lambda.Serialization.Json.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>Amazon.Lambda.Serialization.Json</AssemblyName>
     <PackageId>Amazon.Lambda.Serialization.Json</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
-    <VersionPrefix>2.1.1</VersionPrefix>
+    <VersionPrefix>2.2.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libraries/src/Amazon.Lambda.Serialization.Json/AwsResolver.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.Json/AwsResolver.cs
@@ -86,7 +86,7 @@ namespace Amazon.Lambda.Serialization.Json
                     }
                 }
             }
-            else if (type.FullName.Equals("Amazon.DynamoDBv2.Model.StreamRecord", StringComparison.Ordinal))
+            else if (type.FullName.Equals("Amazon.Lambda.DynamoDBEvents.DynamoDBEvent+StreamRecord", StringComparison.Ordinal))
             {
                 foreach (JsonProperty property in properties)
                 {
@@ -96,7 +96,7 @@ namespace Amazon.Lambda.Serialization.Json
                     }
                 }
             }
-            else if (type.FullName.Equals("Amazon.DynamoDBv2.Model.AttributeValue", StringComparison.Ordinal))
+            else if (type.FullName.Equals("Amazon.Lambda.DynamoDBEvents.DynamoDBEvent+AttributeValue", StringComparison.Ordinal))
             {
                 foreach (JsonProperty property in properties)
                 {

--- a/Libraries/src/Amazon.Lambda.Serialization.Json/AwsResolver.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.Json/AwsResolver.cs
@@ -86,7 +86,10 @@ namespace Amazon.Lambda.Serialization.Json
                     }
                 }
             }
-            else if (type.FullName.Equals("Amazon.Lambda.DynamoDBEvents.DynamoDBEvent+StreamRecord", StringComparison.Ordinal))
+            else if (
+                type.FullName.Equals("Amazon.Lambda.DynamoDBEvents.DynamoDBEvent+StreamRecord", StringComparison.Ordinal) ||
+                type.FullName.Equals("Amazon.DynamoDBv2.Model.StreamRecord", StringComparison.Ordinal)
+            )
             {
                 foreach (JsonProperty property in properties)
                 {
@@ -96,7 +99,10 @@ namespace Amazon.Lambda.Serialization.Json
                     }
                 }
             }
-            else if (type.FullName.Equals("Amazon.Lambda.DynamoDBEvents.DynamoDBEvent+AttributeValue", StringComparison.Ordinal))
+            else if (
+                type.FullName.Equals("Amazon.Lambda.DynamoDBEvents.DynamoDBEvent+AttributeValue", StringComparison.Ordinal) ||
+                type.FullName.Equals("Amazon.DynamoDBv2.Model.AttributeValue", StringComparison.Ordinal)
+            )
             {
                 foreach (JsonProperty property in properties)
                 {

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -466,8 +466,17 @@ namespace Amazon.Lambda.Tests
             Assert.Equal(record.Dynamodb.Keys.Count, 2);
             Assert.Equal(record.Dynamodb.Keys["key"].S, "binary");
             Assert.Equal(record.Dynamodb.Keys["val"].S, "data");
+            Assert.Null(record.UserIdentity);
+            Assert.Null(record.Dynamodb.OldImage);
             Assert.Equal(record.Dynamodb.NewImage["val"].S, "data");
             Assert.Equal(record.Dynamodb.NewImage["key"].S, "binary");
+            Assert.Null(record.Dynamodb.NewImage["key"].BOOL);
+            Assert.Null(record.Dynamodb.NewImage["key"].L);
+            Assert.Null(record.Dynamodb.NewImage["key"].M);
+            Assert.Null(record.Dynamodb.NewImage["key"].N);
+            Assert.Null(record.Dynamodb.NewImage["key"].NS);
+            Assert.Null(record.Dynamodb.NewImage["key"].NULL);
+            Assert.Null(record.Dynamodb.NewImage["key"].SS);
             Assert.Equal(MemoryStreamToBase64String(record.Dynamodb.NewImage["asdf1"].B), "AAEqQQ==");
             Assert.Equal(record.Dynamodb.NewImage["asdf2"].BS.Count, 2);
             Assert.Equal(MemoryStreamToBase64String(record.Dynamodb.NewImage["asdf2"].BS[0]), "AAEqQQ==");
@@ -498,6 +507,15 @@ namespace Amazon.Lambda.Tests
             Assert.NotNull(secondRecord.UserIdentity);
             Assert.Equal("dynamodb.amazonaws.com", secondRecord.UserIdentity.PrincipalId);
             Assert.Equal("Service", secondRecord.UserIdentity.Type);
+            Assert.Null(secondRecord.Dynamodb.NewImage);
+            Assert.NotNull(secondRecord.Dynamodb.OldImage["asdf1"].B);
+            Assert.Null(secondRecord.Dynamodb.OldImage["asdf1"].S);
+            Assert.Null(secondRecord.Dynamodb.OldImage["asdf1"].L);
+            Assert.Null(secondRecord.Dynamodb.OldImage["asdf1"].M);
+            Assert.Null(secondRecord.Dynamodb.OldImage["asdf1"].N);
+            Assert.Null(secondRecord.Dynamodb.OldImage["asdf1"].NS);
+            Assert.Null(secondRecord.Dynamodb.OldImage["asdf1"].NULL);
+            Assert.Null(secondRecord.Dynamodb.OldImage["asdf1"].SS);
 
             Handle(dynamodbEvent);
         }

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -482,6 +482,23 @@ namespace Amazon.Lambda.Tests
             var recordDateTime = record.Dynamodb.ApproximateCreationDateTime;
             Assert.Equal(recordDateTime.Ticks, 636162388200000000);
 
+            var topLevelList = record.Dynamodb.NewImage["misc1"].L;
+            Assert.Equal(0, topLevelList.Count);
+
+            var nestedMap = record.Dynamodb.NewImage["misc2"].M;
+            Assert.NotNull(nestedMap);
+            Assert.Equal(0, nestedMap["ItemsEmpty"].L.Count);
+            Assert.Equal(3, nestedMap["ItemsNonEmpty"].L.Count);
+            Assert.False(nestedMap["ItemBoolean"].BOOL);
+            Assert.True(nestedMap["ItemNull"].NULL);
+            Assert.Equal(3, nestedMap["ItemNumberSet"].NS.Count);
+            Assert.Equal(2, nestedMap["ItemStringSet"].SS.Count);
+
+            var secondRecord = dynamodbEvent.Records[1];
+            Assert.NotNull(secondRecord.UserIdentity);
+            Assert.Equal("dynamodb.amazonaws.com", secondRecord.UserIdentity.PrincipalId);
+            Assert.Equal("Service", secondRecord.UserIdentity.Type);
+
             Handle(dynamodbEvent);
         }
 
@@ -564,7 +581,7 @@ namespace Amazon.Lambda.Tests
                 Assert.Equal(record1.Dynamodb.NewImage.Count, 2);
                 Assert.Equal(record1.Dynamodb.NewImage["Message"].S, "New item!");
                 Assert.Equal(record1.Dynamodb.NewImage["Id"].N, "101");
-                Assert.Equal(record1.Dynamodb.OldImage.Count, 0);
+                Assert.Null(record1.Dynamodb.OldImage);
 
                 var record2 = dynamoDBTimeWindowEvent.Records[1];
                 Assert.Equal(record2.EventID, "2");
@@ -597,7 +614,7 @@ namespace Amazon.Lambda.Tests
                 Assert.Equal(record3.Dynamodb.SequenceNumber, "333");
                 Assert.Equal(record3.Dynamodb.SizeBytes, 38);
                 Assert.Equal(record3.Dynamodb.StreamViewType, "NEW_AND_OLD_IMAGES");
-                Assert.Equal(record3.Dynamodb.NewImage.Count, 0);
+                Assert.Null(record3.Dynamodb.NewImage);
                 Assert.Equal(record3.Dynamodb.OldImage.Count, 2);
                 Assert.Equal(record3.Dynamodb.OldImage["Message"].S, "This item has changed");
                 Assert.Equal(record3.Dynamodb.OldImage["Id"].N, "101");

--- a/Libraries/test/EventsTests.Shared/dynamodb-event.json
+++ b/Libraries/test/EventsTests.Shared/dynamodb-event.json
@@ -29,6 +29,19 @@
                      "QSoBAA=="
                   ]
                },
+               "misc1": {
+                  "L": []
+               },
+               "misc2": {
+                 "M": {
+                   "ItemsEmpty": { "L": [] },
+                   "ItemsNonEmpty": { "L": [{"S": "Cookies"} , {"S": "Coffee"}, {"N": "3.14159"}] },
+                   "ItemBoolean": { "BOOL": false },
+                   "ItemNumberSet": { "NS": ["0", "50", "150"] },
+                   "ItemNull": { "NULL": true },
+                   "ItemStringSet": { "SS": ["Hippo", "Zebra"] }
+                 }
+               },
                "key":{
                   "S":"binary"
                }
@@ -41,10 +54,14 @@
       },
       {
          "eventID":"f07f8ca4b0b26cb9c4e5e77e42f274ee",
-         "eventName":"INSERT",
+         "eventName":"REMOVE",
          "eventVersion":"1.1",
          "eventSource":"aws:dynamodb",
          "awsRegion":"us-east-1",
+         "userIdentity": {
+            "type": "Service",
+            "principalId": "dynamodb.amazonaws.com"
+         }, 
          "dynamodb":{
             "ApproximateCreationDateTime":1480642020,
             "Keys":{
@@ -55,27 +72,27 @@
                   "S":"binary"
                }
             },
-          "NewImage": {
-            "val": {
-              "S": "data"
+            "OldImage": {
+              "val": {
+                "S": "data"
+              },
+              "asdf1": {
+                "B": "AAEqQQ=="
+              },
+              "asdf2": {
+                "BS": [
+                  "AAEqQQ==",
+                  "QSoBAA==",
+                  "AAEqQQ=="
+                ]
+              },
+              "key": {
+                "S": "binary"
+              }
             },
-            "asdf1": {
-              "B": "AAEqQQ=="
-            },
-            "asdf2": {
-              "BS": [
-                "AAEqQQ==",
-                "QSoBAA==",
-                "AAEqQQ=="
-              ]
-            },
-            "key": {
-              "S": "binary"
-            }
-          },
             "SequenceNumber":"1405400000000002063282832",
             "SizeBytes":54,
-            "StreamViewType":"NEW_AND_OLD_IMAGES"
+            "StreamViewType":"OLD_IMAGE"
          },
          "eventSourceARN":"arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
       }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-sdk-net/issues/1116 (and internal issue `DOTNET-4497`)

*Description of changes:* Similar to #1237, this PR removes the `AWSSDK.DynamoDBv2` dependency from the `DynamoDBEvent` class (by moving the properties from the `Amazon.DynamoDBv2.Model.Record` class).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
