### PR TITLE
Avoid double processing of default cert bundle in AL2023

### DIFF
--- a/LambdaRuntimeDockerfiles/Images/net8/amd64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net8/amd64/Dockerfile
@@ -40,8 +40,8 @@ RUN dotnet build "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=t
 FROM builder AS publish
 RUN dotnet publish "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net8.0 -f net8.0 --runtime linux-x64 --self-contained false -p:PublishReadyToRun=true -c Release -o /app/publish
 RUN apt-get update && apt-get install -y dos2unix
-RUN dos2unix /app/publish/bootstrap.sh && \
-    mv /app/publish/bootstrap.sh /app/publish/bootstrap && \
+RUN dos2unix /app/publish/bootstrap-al2023.sh && \
+    mv /app/publish/bootstrap-al2023.sh /app/publish/bootstrap && \
     chmod +x /app/publish/bootstrap
 
 

--- a/LambdaRuntimeDockerfiles/Images/net8/arm64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net8/arm64/Dockerfile
@@ -40,8 +40,8 @@ RUN dotnet build "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=t
 FROM builder AS publish
 RUN dotnet publish "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net8.0 -f net8.0 --runtime linux-arm64 --self-contained false -p:PublishReadyToRun=true -c Release -o /app/publish
 RUN apt-get update && apt-get install -y dos2unix
-RUN dos2unix /app/publish/bootstrap.sh && \
-    mv /app/publish/bootstrap.sh /app/publish/bootstrap && \
+RUN dos2unix /app/publish/bootstrap-al2023.sh && \
+    mv /app/publish/bootstrap-al2023.sh /app/publish/bootstrap && \
     chmod +x /app/publish/bootstrap
 
 

--- a/LambdaRuntimeDockerfiles/SmokeTests/test/ImageFunction.SmokeTests/ImageFunctionTests.cs
+++ b/LambdaRuntimeDockerfiles/SmokeTests/test/ImageFunction.SmokeTests/ImageFunctionTests.cs
@@ -114,7 +114,45 @@ namespace ImageFunction.SmokeTests
             Assert.Equal(expectedErrorMessage, exception["errorMessage"].ToString());
         }
 
-        private async Task UpdateHandlerAsync(string handler)
+        /// <summary>
+        /// This test is checking the logic added to the bootstrap.sh to change the SSL_CERT_FILE
+        /// environment variable for AL2023.
+        /// </summary>
+        /// <param name="envName"></param>
+        /// <param name="expectedValue"></param>
+        /// <param name="setValue"></param>
+        /// <returns></returns>
+        [Theory]
+#if NET8_0_OR_GREATER
+        [InlineData("SSL_CERT_FILE", "\"/tmp/noop\"", null)]
+        [InlineData("SSL_CERT_FILE", "\"/tmp/my-bundle\"", "/tmp/my-bundle")]
+#else
+        [InlineData("SSL_CERT_FILE", "", null)]
+        [InlineData("SSL_CERT_FILE", "/tmp/my-bundle", "/tmp/my-bundle")]
+#endif
+        public async Task CheckEnvironmentVariable(string envName, string expectedValue, string setValue)
+        {
+            var envVariables = new Dictionary<string, string>();
+            if(setValue != null)
+            {
+                envVariables[envName] = setValue;
+            }    
+
+            await UpdateHandlerAsync("ImageFunction::ImageFunction.Function::GetEnvironmentVariable", envVariables);
+
+            var payload = JsonConvert.SerializeObject(envName);
+            var invokeResponse = await InvokeFunctionAsync(payload);
+
+            Assert.True(invokeResponse.HttpStatusCode == System.Net.HttpStatusCode.OK);
+            Assert.True(invokeResponse.FunctionError == null, "Failed invoke with error: " + invokeResponse.FunctionError);
+
+            await using var responseStream = invokeResponse.Payload;
+            var actualValue = new StreamReader(responseStream).ReadToEnd();
+
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        private async Task UpdateHandlerAsync(string handler, Dictionary<string, string> environmentVariables = null)
         {
             var updateFunctionConfigurationRequest = new UpdateFunctionConfigurationRequest
             {
@@ -122,6 +160,10 @@ namespace ImageFunction.SmokeTests
                 ImageConfig = new ImageConfig()
                 {
                     Command = {handler},
+                },
+                Environment = new Amazon.Lambda.Model.Environment
+                {
+                    Variables = environmentVariables ?? new Dictionary<string, string>()
                 }
             };
             await _lambdaClient.UpdateFunctionConfigurationAsync(updateFunctionConfigurationRequest);

--- a/LambdaRuntimeDockerfiles/SmokeTests/test/ImageFunction/Function.cs
+++ b/LambdaRuntimeDockerfiles/SmokeTests/test/ImageFunction/Function.cs
@@ -128,6 +128,11 @@ namespace ImageFunction
             return SuccessResult;
         }
 
+        public string GetEnvironmentVariable(string  name)
+        {
+            return Environment.GetEnvironmentVariable(name) ?? string.Empty;
+        }
+
         #endregion
 
         #region Private methods

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
@@ -45,5 +45,8 @@
     <None Update="bootstrap.sh">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="bootstrap-al2023.sh">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>	  
   </ItemGroup>
 </Project>

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/bootstrap-al2023.sh
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/bootstrap-al2023.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# .NET on Linux uses OpenSSL to handle certificates. The .NET runtime will load the certs by first reading
+# the default cert bundle file which can be overriden by the SSL_CERT_FILE env var. Then it will load the
+# certs in the default cert directory which can be overriden by the SSL_CERT_DIR env var. On AL2023
+# The default cert bundle file, via symbolic links, resolves to being in a file under the default cert directory.
+# This means the default cert bundle file is double loaded causing a cold start performance hit. This logic
+# sets the SSL_CERT_FILE to a noop file if SSL_CERT_FILE hasn't been explicitly
+# set. This avoid the double load of the default cert bundle file.
+if [ -z "${SSL_CERT_FILE}"]; then
+  export SSL_CERT_FILE="/tmp/noop"
+fi
+
 # This script is used to locate 2 files in the /var/task folder, where the end-user assembly is located
 # The 2 files are <assembly name>.deps.json and <assembly name>.runtimeconfig.json
 # These files are used to add the end-user assembly into context and make the code reachable to the dotnet process


### PR DESCRIPTION
*Description of changes:*
We detected a cold start performance regression with .NET on Amazon Linux 2023 (AL2023) when making HTTPS calls. When the first HTTPS call is made it [loads the machine store certificates](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCachedSystemStoreProvider.cs#L139). At a high level the function loads the cert bundle from OpenSSL default file and then from the default directory.

On AL2023 after you follow the symbolic links the default file resolves inside the default directory . This triggers a double load of the default cert bundle causing a regression in cold start performance.

This console below demonstrates how file structure layout for the default file and default directory for loading cert bundles into the machine store.
```
[ec2-user@ip-172-31-31-127 ~]$ openssl version -d
OPENSSLDIR: "/etc/pki/tls"
**File Processing**
[ec2-user@ip-172-31-31-127 ~]$ ls -la /etc/pki/tls/cert.pem 
lrwxrwxrwx. 1 root root 49 Aug 29 17:21 /etc/pki/tls/cert.pem -> /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
**Directory Processing**
[ec2-user@ip-172-31-31-127 ~]$ ls -la /etc/pki/tls/certs
total 0
drwxr-xr-x. 2 root root  54 Nov  8 07:41 .
drwxr-xr-x. 5 root root 126 Nov  8 07:41 ..
lrwxrwxrwx. 1 root root  49 Aug 29 17:21 ca-bundle.crt -> /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
lrwxrwxrwx. 1 root root  55 Aug 29 17:21 ca-bundle.trust.crt -> /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
```

To prevent the double loading the bootstrap shell script sets the `SSL_CERT_FILE` environment variable to a non existing file. This allows the default cert file bundle to be loaded as part of the default directory load. The bootstrap script only sets the `SSL_CERT_FILE` if the user hasn't explicit set it themselves. This allows users to override environment variable for their own cert bundles.

### Solution
The solution was to add the following to the top of the bootstrap shell script.
```
if [ -z "${SSL_CERT_FILE}"]; then
  export SSL_CERT_FILE="/tmp/noop"
fi
```
We don't want to affect the behavior of .NET 6 on AL2 so a new bootstrap script was created. The only difference between `bootstrap.sh` and `bootstrap-al2023.sh` is the code above added. I decided against having a single file that checks to see if it is on AL2023 because those extra syscalls could affect cold start. I also debated building a mechanism to prefix the above script to the `bootstrap.sh` when building for .NET 8 but decided against it because it seemed unnecessary since .NET 6 goes out of support in 11 months. Once it does we can just remove the old `bootstrap.sh` file.

### Testing
Lots of manual testing to confirm behavior stays the same. Check comparisons of the number of certs loaded from the bundle before and after the change and confirmed the number stayed the same. Also added new smoke tests to confirm the environment variable is set for AL2023 and not AL2.

### Long term fix
A PR has been submitted to the `dotnet/runtime` to avoid double loading certs in the .NET runtime level. When that is merged and released we can revert setting this environment variable. https://github.com/dotnet/runtime/pull/97267


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
