### PR TITLE
Change setting SSL_CERT_FILE to an empty file in /var/runtime

### DIFF
--- a/LambdaRuntimeDockerfiles/Images/net8/amd64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net8/amd64/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update && apt-get install -y dos2unix
 RUN dos2unix /app/publish/bootstrap-al2023.sh && \
     mv /app/publish/bootstrap-al2023.sh /app/publish/bootstrap && \
     chmod +x /app/publish/bootstrap
+RUN touch /app/publish/empty-certificates.crt
 
 
 FROM base

--- a/LambdaRuntimeDockerfiles/Images/net8/arm64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net8/arm64/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update && apt-get install -y dos2unix
 RUN dos2unix /app/publish/bootstrap-al2023.sh && \
     mv /app/publish/bootstrap-al2023.sh /app/publish/bootstrap && \
     chmod +x /app/publish/bootstrap
+RUN touch /app/publish/empty-certificates.crt
 
 
 FROM base

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/bootstrap-al2023.sh
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/bootstrap-al2023.sh
@@ -5,10 +5,10 @@
 # certs in the default cert directory which can be overriden by the SSL_CERT_DIR env var. On AL2023
 # The default cert bundle file, via symbolic links, resolves to being in a file under the default cert directory.
 # This means the default cert bundle file is double loaded causing a cold start performance hit. This logic
-# sets the SSL_CERT_FILE to a noop file if SSL_CERT_FILE hasn't been explicitly
+# sets the SSL_CERT_FILE to an empty file if SSL_CERT_FILE hasn't been explicitly
 # set. This avoid the double load of the default cert bundle file.
 if [ -z "${SSL_CERT_FILE}"]; then
-  export SSL_CERT_FILE="/tmp/noop"
+  export SSL_CERT_FILE="/var/runtime/empty-certificates.crt"
 fi
 
 # This script is used to locate 2 files in the /var/task folder, where the end-user assembly is located


### PR DESCRIPTION
*Description of changes:*
This is an addendum to the previous PR that set the `SSL_CERT_FILE` to /tmp/noop` https://github.com/aws/aws-lambda-dotnet/pull/1661

This PR changes to an actual empty file that does exists. It uses the `/var/runtime` directory instead of `/tmp`. The concern with `/tmp` is it is a mutable directory which might have unforeseen side effects depending on what the function is doing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
