### PR TITLE
Update Lambda blueprints for .NET 8

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -14,8 +14,8 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
-    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.0.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
+    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.2.0" />
   </ItemGroup>
   <!-- 
     The FrameworkReference is used to reduce the deployment bundle size by not having to include 

--- a/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/src/BlueprintBaseName.1/Functions.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/src/BlueprintBaseName.1/Functions.cs
@@ -49,8 +49,8 @@ You can make the following requests to invoke other Lambda functions perform cal
     /// <summary>
     /// Perform x + y
     /// </summary>
-    /// <param name="x"></param>
-    /// <param name="y"></param>
+    /// <param name="x">Left hand operand of the arithmetic operation.</param>
+    /// <param name="y">Right hand operand of the arithmetic operation.</param>
     /// <returns>Sum of x and y.</returns>
     [LambdaFunction()]
     [HttpApi(LambdaHttpMethod.Get, "/add/{x}/{y}")]
@@ -65,8 +65,8 @@ You can make the following requests to invoke other Lambda functions perform cal
     /// <summary>
     /// Perform x - y.
     /// </summary>
-    /// <param name="x"></param>
-    /// <param name="y"></param>
+    /// <param name="x">Left hand operand of the arithmetic operation.</param>
+    /// <param name="y">Right hand operand of the arithmetic operation.</param>
     /// <returns>x subtract y</returns>
     [LambdaFunction()]
     [HttpApi(LambdaHttpMethod.Get, "/subtract/{x}/{y}")]
@@ -81,8 +81,8 @@ You can make the following requests to invoke other Lambda functions perform cal
     /// <summary>
     /// Perform x * y.
     /// </summary>
-    /// <param name="x"></param>
-    /// <param name="y"></param>
+    /// <param name="x">Left hand operand of the arithmetic operation.</param>
+    /// <param name="y">Right hand operand of the arithmetic operation.</param>
     /// <returns>x multiply y</returns>
     [LambdaFunction()]
     [HttpApi(LambdaHttpMethod.Get, "/multiply/{x}/{y}")]
@@ -97,8 +97,8 @@ You can make the following requests to invoke other Lambda functions perform cal
     /// <summary>
     /// Perform x / y.
     /// </summary>
-    /// <param name="x"></param>
-    /// <param name="y"></param>
+    /// <param name="x">Left hand operand of the arithmetic operation.</param>
+    /// <param name="y">Right hand operand of the arithmetic operation.</param>
     /// <returns>x divide y</returns>
     [LambdaFunction()]
     [HttpApi(LambdaHttpMethod.Get, "/divide/{x}/{y}")]

--- a/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/src/BlueprintBaseName.1/Readme.md
@@ -226,7 +226,7 @@ remove the `Tool` metadata property.
         ]
     },
     "Properties": {
-    "Runtime": "dotnet6",
+    "Runtime": "dotnet8",
     "CodeUri": ".",
 
   ...
@@ -271,7 +271,7 @@ public class Functions
         ]
       },
       "Properties": {
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
 
 ...
         "Role": {
@@ -424,9 +424,9 @@ The `HttpApi` attribute also adds the API Gateway event source.
         ]
       },
       "Properties": {
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": ".",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "PackageType": "Zip",
         "Handler": "CloudCalculator::CloudCalculator.Functions_Add_Generated::Add",
@@ -615,7 +615,7 @@ In this example the function is modified to define the event source in this case
         "Tool": "Amazon.Lambda.Annotations"
       },
       "Properties": {
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": ".",
         "MemorySize": 1024,
         "Timeout": 120,

--- a/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/src/BlueprintBaseName.1/serverless.template
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "An AWS Serverless Application.",
+  "Description": "An AWS Serverless Application. This template is partially managed by Amazon.Lambda.Annotations (v1.2.0.0).",
   "Resources": {
     "BlueprintBaseName1FunctionsDefaultGenerated": {
       "Type": "AWS::Serverless::Function",
@@ -12,9 +12,9 @@
         ]
       },
       "Properties": {
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": ".",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
@@ -41,9 +41,9 @@
         ]
       },
       "Properties": {
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": ".",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
@@ -70,9 +70,9 @@
         ]
       },
       "Properties": {
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": ".",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
@@ -99,9 +99,9 @@
         ]
       },
       "Properties": {
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": ".",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
@@ -128,9 +128,9 @@
         ]
       },
       "Properties": {
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": ".",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"

--- a/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
@@ -18,6 +18,6 @@
     <None Include="serverless.template" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="8.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-FSharp/template/src/BlueprintBaseName.1/serverless.template
@@ -8,9 +8,9 @@
       "Type": "AWS::Serverless::Function",
       "Properties": {
         "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.LambdaEntryPoint::FunctionHandlerAsync",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": "",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Role": null,
         "Policies": [

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <EnableDefaultContentItems>False</EnableDefaultContentItems>
   </PropertyGroup>
   <ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/.template.config/template.json
@@ -6,7 +6,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Lambda ASP.NET Core Web API (.NET 6 Container Image)",
+  "name": "Lambda ASP.NET Core Web API (.NET 8 Container Image)",
   "identity": "AWS.Lambda.Serverless.Image.AspNetCoreWebAPI.FSharp",
   "groupIdentity": "AWS.Lambda.Serverless.Image.AspNetCoreWebAPI",
   "shortName": "serverless.image.AspNetCoreWebAPI",

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
@@ -18,6 +18,6 @@
     <None Include="serverless.template" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="8.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/Dockerfile
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/Dockerfile
@@ -1,5 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:7
-
+FROM public.ecr.aws/lambda/dotnet:8
 WORKDIR /var/task
 
 # This COPY command copies the .NET Lambda project's build artifacts from the host machine into the image. 

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -44,9 +44,9 @@ Alternatively the Docker file could be written to use [multi-stage](https://docs
 have the .NET project built inside the container. Below is an example of building the .NET project inside the image.
 
 ```dockerfile
-FROM public.ecr.aws/lambda/dotnet:7 AS base
+FROM public.ecr.aws/lambda/dotnet:8 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim as build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.csproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.csproj"

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/serverless.template
@@ -14,7 +14,7 @@
           ]
         },
         "ImageUri": "",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Role": null,
         "Policies": [

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <EnableDefaultContentItems>False</EnableDefaultContentItems>
   </PropertyGroup>
   <ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": "ASP.NET Core 7 (Container Image)",
+  "display-name": "ASP.NET Core 8 (Container Image)",
   "system-name": "AspNetCoreWebAPIImage",
-  "description": "Serverless ASP.NET Core 7 Web API packaged as a container image.",
+  "description": "Serverless ASP.NET Core 8 Web API packaged as a container image.",
   "sort-order": 250,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/.template.config/template.json
@@ -6,7 +6,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Lambda ASP.NET Core Web API (.NET 6 Container Image)",
+  "name": "Lambda ASP.NET Core Web API (.NET 8 Container Image)",
   "identity": "AWS.Lambda.Serverless.Image.AspNetCoreWebAPI.CSharp",
   "groupIdentity": "AWS.Lambda.Serverless.Image.AspNetCoreWebAPI",
   "shortName": "serverless.image.AspNetCoreWebAPI",

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -12,6 +12,6 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="8.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/Dockerfile
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:7
+FROM public.ecr.aws/lambda/dotnet:8
 
 WORKDIR /var/task
 

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/LambdaEntryPoint.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/LambdaEntryPoint.cs
@@ -25,7 +25,7 @@ public class LambdaEntryPoint :
     /// The builder has configuration, logging and Amazon API Gateway already configured. The startup class
     /// needs to be configured in this method using the UseStartup<>() method.
     /// </summary>
-    /// <param name="builder"></param>
+    /// <param name="builder">The IWebHostBuilder to configure.</param>
     protected override void Init(IWebHostBuilder builder)
     {
         builder
@@ -38,7 +38,7 @@ public class LambdaEntryPoint :
     /// It is recommended not to call ConfigureWebHostDefaults to configure the IWebHostBuilder inside this method.
     /// Instead customize the IWebHostBuilder in the Init(IWebHostBuilder) overload.
     /// </summary>
-    /// <param name="builder"></param>
+    /// <param name="builder">The IHostBuilder to configure.</param>
     protected override void Init(IHostBuilder builder)
     {
     }

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/Readme.md
@@ -51,9 +51,8 @@ Alternatively the Docker file could be written to use [multi-stage](https://docs
 have the .NET project built inside the container. Below is an example of building the .NET project inside the image.
 
 ```dockerfile
-FROM public.ecr.aws/lambda/dotnet:7 AS base
-
-FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim as build
+FROM public.ecr.aws/lambda/dotnet:8
+FROM mcr.microsoft.com/dotnet/sdk:8.0-bullseye-slim as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.csproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.csproj"

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/serverless.template
@@ -15,7 +15,7 @@
           ]
         },
         "ImageUri": "",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Role": null,
         "Policies": [

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI-Image/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI.MinimalAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI.MinimalAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -11,6 +11,6 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.6.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.7.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI.MinimalAPI/template/src/BlueprintBaseName.1/Controllers/CalculatorController.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI.MinimalAPI/template/src/BlueprintBaseName.1/Controllers/CalculatorController.cs
@@ -16,8 +16,8 @@ public class CalculatorController : ControllerBase
     /// <summary>
     /// Perform x + y
     /// </summary>
-    /// <param name="x"></param>
-    /// <param name="y"></param>
+    /// <param name="x">Left hand operand of the arithmetic operation.</param>
+    /// <param name="y">Right hand operand of the arithmetic operation.</param>
     /// <returns>Sum of x and y.</returns>
     [HttpGet("add/{x}/{y}")]
     public int Add(int x, int y)
@@ -29,8 +29,8 @@ public class CalculatorController : ControllerBase
     /// <summary>
     /// Perform x - y.
     /// </summary>
-    /// <param name="x"></param>
-    /// <param name="y"></param>
+    /// <param name="x">Left hand operand of the arithmetic operation.</param>
+    /// <param name="y">Right hand operand of the arithmetic operation.</param>
     /// <returns>x subtract y</returns>
     [HttpGet("subtract/{x}/{y}")]
     public int Subtract(int x, int y)
@@ -42,8 +42,8 @@ public class CalculatorController : ControllerBase
     /// <summary>
     /// Perform x * y.
     /// </summary>
-    /// <param name="x"></param>
-    /// <param name="y"></param>
+    /// <param name="x">Left hand operand of the arithmetic operation.</param>
+    /// <param name="y">Right hand operand of the arithmetic operation.</param>
     /// <returns>x multiply y</returns>
     [HttpGet("multiply/{x}/{y}")]
     public int Multiply(int x, int y)
@@ -55,8 +55,8 @@ public class CalculatorController : ControllerBase
     /// <summary>
     /// Perform x / y.
     /// </summary>
-    /// <param name="x"></param>
-    /// <param name="y"></param>
+    /// <param name="x">Left hand operand of the arithmetic operation.</param>
+    /// <param name="y">Right hand operand of the arithmetic operation.</param>
     /// <returns>x divide y</returns>
     [HttpGet("divide/{x}/{y}")]
     public int Divide(int x, int y)

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI.MinimalAPI/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI.MinimalAPI/template/src/BlueprintBaseName.1/serverless.template
@@ -9,9 +9,9 @@
       "Type": "AWS::Serverless::Function",
       "Properties": {
         "Handler": "BlueprintBaseName.1",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": "",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Role": null,
         "Policies": [

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -12,6 +12,6 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="8.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/LambdaEntryPoint.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/LambdaEntryPoint.cs
@@ -25,7 +25,7 @@ public class LambdaEntryPoint :
     /// The builder has configuration, logging and Amazon API Gateway already configured. The startup class
     /// needs to be configured in this method using the UseStartup<>() method.
     /// </summary>
-    /// <param name="builder"></param>
+    /// <param name="builder">The IWebHostBuilder to configure.</param>
     protected override void Init(IWebHostBuilder builder)
     {
         builder
@@ -38,7 +38,7 @@ public class LambdaEntryPoint :
     /// It is recommended not to call ConfigureWebHostDefaults to configure the IWebHostBuilder inside this method.
     /// Instead customize the IWebHostBuilder in the Init(IWebHostBuilder) overload.
     /// </summary>
-    /// <param name="builder"></param>
+    /// <param name="builder">The IHostBuilder to configure.</param>
     protected override void Init(IHostBuilder builder)
     {
     }

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI/template/src/BlueprintBaseName.1/serverless.template
@@ -9,9 +9,9 @@
       "Type": "AWS::Serverless::Function",
       "Properties": {
         "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.LambdaEntryPoint::FunctionHandlerAsync",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": "",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Role": null,
         "Policies": [

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebAPI/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebApp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebApp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -12,7 +12,7 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="8.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="wwwroot\images\" />

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebApp/template/src/BlueprintBaseName.1/LambdaEntryPoint.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebApp/template/src/BlueprintBaseName.1/LambdaEntryPoint.cs
@@ -25,7 +25,7 @@ public class LambdaEntryPoint :
     /// The builder has configuration, logging and Amazon API Gateway already configured. The startup class
     /// needs to be configured in this method using the UseStartup<>() method.
     /// </summary>
-    /// <param name="builder"></param>
+    /// <param name="builder">The IWebHostBuilder to configure.</param>
     protected override void Init(IWebHostBuilder builder)
     {
         builder
@@ -38,7 +38,7 @@ public class LambdaEntryPoint :
     /// It is recommended not to call ConfigureWebHostDefaults to configure the IWebHostBuilder inside this method.
     /// Instead customize the IWebHostBuilder in the Init(IWebHostBuilder) overload.
     /// </summary>
-    /// <param name="builder"></param>
+    /// <param name="builder">The IHostBuilder to configure.</param>
     protected override void Init(IHostBuilder builder)
     {
     }

--- a/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebApp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/AspNetCoreWebApp/template/src/BlueprintBaseName.1/serverless.template
@@ -18,7 +18,7 @@
       "Type": "AWS::Serverless::Function",
       "Properties": {
         "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.LambdaEntryPoint::FunctionHandlerAsync",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": "",
         "MemorySize": 512,
         "Timeout": 30,

--- a/Blueprints/BlueprintDefinitions/vs2022/ChatBotTutorial/template/src/BlueprintBaseName.1/AbstractIntentProcessor.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/ChatBotTutorial/template/src/BlueprintBaseName.1/AbstractIntentProcessor.cs
@@ -15,8 +15,8 @@ public abstract class AbstractIntentProcessor : IIntentProcessor
     /// <summary>
     /// Main method for proccessing the lex event for the intent.
     /// </summary>
-    /// <param name="lexEvent"></param>
-    /// <param name="context"></param>
+    /// <param name="lexEvent">The event coming from the Lex service.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     public abstract LexResponse Process(LexEvent lexEvent, ILambdaContext context);
 

--- a/Blueprints/BlueprintDefinitions/vs2022/ChatBotTutorial/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/ChatBotTutorial/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -13,6 +13,6 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.LexEvents" Version="3.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/ChatBotTutorial/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/ChatBotTutorial/template/src/BlueprintBaseName.1/Function.cs
@@ -14,8 +14,8 @@ public class Function
     /// Then entry point for the Lambda function that looks at the current intent and calls 
     /// the appropriate intent process.
     /// </summary>
-    /// <param name="input"></param>
-    /// <param name="context"></param>
+    /// <param name="lexEvent">The event coming from the Lex service.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     public LexResponse FunctionHandler(LexEvent lexEvent, ILambdaContext context)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/ChatBotTutorial/template/src/BlueprintBaseName.1/IIntentProcessor.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/ChatBotTutorial/template/src/BlueprintBaseName.1/IIntentProcessor.cs
@@ -11,8 +11,8 @@ public interface IIntentProcessor
     /// <summary>
     /// Main method for processing the Lex event for the intent.
     /// </summary>
-    /// <param name="lexEvent"></param>
-    /// <param name="context"></param>
+    /// <param name="lexEvent">The event coming from the Lex service.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     LexResponse Process(LexEvent lexEvent, ILambdaContext context);
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/ChatBotTutorial/template/src/BlueprintBaseName.1/OrderFlowersIntentProcessor.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/ChatBotTutorial/template/src/BlueprintBaseName.1/OrderFlowersIntentProcessor.cs
@@ -20,8 +20,8 @@ public class OrderFlowersIntentProcessor : AbstractIntentProcessor
     /// 1) Use of elicitSlot in slot validation and re-prompting
     /// 2) Use of sessionAttributes to pass information that can be used to guide the conversation
     /// </summary>
-    /// <param name="lexEvent"></param>
-    /// <param name="context"></param>
+    /// <param name="lexEvent">The event coming from the Lex service.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     public override LexResponse Process(LexEvent lexEvent, ILambdaContext context)
     {
@@ -103,7 +103,7 @@ public class OrderFlowersIntentProcessor : AbstractIntentProcessor
     /// <summary>
     /// Verifies that any values for slots in the intent are valid.
     /// </summary>
-    /// <param name="order"></param>
+    /// <param name="order">The FlowerOrder to validate.</param>
     /// <returns></returns>
     private ValidationResult Validate(FlowerOrder order)
     {
@@ -147,7 +147,7 @@ public class OrderFlowersIntentProcessor : AbstractIntentProcessor
     /// <summary>
     /// Verifies that any values for flower type slot in the intent is valid.
     /// </summary>
-    /// <param name="flowertypeString"></param>
+    /// <param name="flowertypeString">The flower type to validate.</param>
     /// <returns></returns>
     private ValidationResult ValidateFlowerType(string? flowerTypeString)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/ChatBotTutorial/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/ChatBotTutorial/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "function-runtime": "dotnet6",
-  "function-memory-size": 256,
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler"
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/ChatBotTutorial/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/ChatBotTutorial/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -33,7 +33,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="aws-lambda-tools-defaults.json" />

--- a/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -16,8 +16,8 @@ module Function =
     /// https://github.com/aws/aws-lambda-dotnet#events
     /// and change the string input parameter to the desired event type.
     /// </summary>
-    /// <param name="input"></param>
-    /// <param name="context"></param>
+    /// <param name="input">Input to the Lambda function handler.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     let functionHandler (input: string) (_: ILambdaContext) =
         match input with

--- a/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction-FSharp/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction-FSharp/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -9,7 +9,7 @@
   "region": "DefaultRegion",
   "configuration": "Release",
   "function-runtime": "provided.al2023",
-  "function-memory-size": 256,
+  "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "bootstrap",
   "function-name": "BlueprintBaseName.1",

--- a/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -29,6 +29,6 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction/template/src/BlueprintBaseName.1/Function.cs
@@ -9,7 +9,7 @@ public class Function
     /// <summary>
     /// The main entry point for the custom runtime.
     /// </summary>
-    /// <param name="args"></param>
+    /// <param name="args">Command line arguments.</param>
     private static async Task Main(string[] args)
     {
         Func<string, ILambdaContext, string> handler = FunctionHandler;
@@ -25,8 +25,8 @@ public class Function
     /// https://github.com/aws/aws-lambda-dotnet#events
     /// and change the string input parameter to the desired event type.
     /// </summary>
-    /// <param name="input"></param>
-    /// <param name="context"></param>
+    /// <param name="input">The input to the Lambda function handler.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     public static string FunctionHandler(string input, ILambdaContext context)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/CustomRuntimeFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -9,7 +9,7 @@
   "region": "DefaultRegion",
   "configuration": "Release",
   "function-runtime": "provided.al2023",
-  "function-memory-size": 256,
+  "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "bootstrap",
   "msbuild-parameters": "--self-contained true"

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
@@ -9,10 +9,10 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.300.0" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.300.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.305.28" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.301.15" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -39,8 +39,8 @@ type Function(s3Client: IAmazonS3, rekognitionClient: IAmazonRekognition, minCon
     /// A function for responding to S3 create events. It will determine if the object is an image
     /// and use Amazon Rekognition to detect labels and add the labels as tags on the S3 object.
     /// </summary>
-    /// <param name="input"></param>
-    /// <param name="context"></param>
+    /// <param name="input">The S3 event to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     member __.FunctionHandler (input: S3Event) (context: ILambdaContext) = task {
 

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels-FSharp/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "function-runtime": "dotnet6",
-  "function-memory-size": 256,
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler"
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="sample-pic.jpg">
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -11,10 +11,10 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.300.0" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.300.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.305.28" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.301.15" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.1.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels/template/src/BlueprintBaseName.1/Function.cs
@@ -69,9 +69,9 @@ public class Function
     /// <summary>
     /// Constructor used for testing which will pass in the already configured service clients.
     /// </summary>
-    /// <param name="s3Client"></param>
-    /// <param name="rekognitionClient"></param>
-    /// <param name="minConfidence"></param>
+    /// <param name="s3Client">Service client for accessing Amazon S3.</param>
+    /// <param name="rekognitionClient">Service client for accessing Amazon Rekognition.</param>
+    /// <param name="minConfidence">The min confidence for accepting a label from Amazon Rekognition.</param>
     public Function(IAmazonS3 s3Client, IAmazonRekognition rekognitionClient, float minConfidence)
     {
         this.S3Client = s3Client;
@@ -83,8 +83,8 @@ public class Function
     /// A function for responding to S3 create events. It will determine if the object is an image and use Amazon Rekognition
     /// to detect labels and add the labels as tags on the S3 object.
     /// </summary>
-    /// <param name="input"></param>
-    /// <param name="context"></param>
+    /// <param name="input">The S3 event to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     public async Task FunctionHandler(S3Event input, ILambdaContext context)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "function-runtime": "dotnet6",
-  "function-memory-size": 256,
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler"
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabels/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
@@ -9,10 +9,10 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.300.0" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.300.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.305.28" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.301.15" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -38,8 +38,8 @@ type Function(s3Client: IAmazonS3, rekognitionClient: IAmazonRekognition, minCon
     /// A function for responding to S3 create events. It will determine if the object is an image
     /// and use Amazon Rekognition to detect labels and add the labels as tags on the S3 object.
     /// </summary>
-    /// <param name="input"></param>
-    /// <param name="context"></param>
+    /// <param name="input">The S3 event to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     member __.FunctionHandler (input: S3Event) (context: ILambdaContext) = task {
 

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/src/BlueprintBaseName.1/serverless.template
@@ -40,10 +40,10 @@
       "Type": "AWS::Serverless::Function",
       "Properties": {
         "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": "",
         "Description": "Default function",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Role": null,
         "Policies": [

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="sample-pic.jpg">
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -11,10 +11,10 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.300.0" />
-    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.300.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.305.28" />
+    <PackageReference Include="AWSSDK.Rekognition" Version="3.7.301.15" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.1.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/Function.cs
@@ -69,9 +69,9 @@ public class Function
     /// <summary>
     /// Constructor used for testing which will pass in the already configured service clients.
     /// </summary>
-    /// <param name="s3Client"></param>
-    /// <param name="rekognitionClient"></param>
-    /// <param name="minConfidence"></param>
+    /// <param name="s3Client">Service client for accessing Amazon S3.</param>
+    /// <param name="rekognitionClient">Service client for accessing Amazon Rekognition.</param>
+    /// <param name="minConfidence">The min confidence for accepting a label from Amazon Rekognition.</param>
     public Function(IAmazonS3 s3Client, IAmazonRekognition rekognitionClient, float minConfidence)
     {
         this.S3Client = s3Client;
@@ -83,8 +83,8 @@ public class Function
     /// A function for responding to S3 create events. It will determine if the object is an image and use Amazon Rekognition
     /// to detect labels and add the labels as tags on the S3 object.
     /// </summary>
-    /// <param name="input"></param>
-    /// <param name="context"></param>
+    /// <param name="input">The S3 event to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     public async Task FunctionHandler(S3Event input, ILambdaContext context)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless/template/src/BlueprintBaseName.1/serverless.template
@@ -40,10 +40,10 @@
       "Type": "AWS::Serverless::Function",
       "Properties": {
         "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": "",
         "Description": "Default function",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Role": null,
         "Policies": [

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
@@ -16,7 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="aws-lambda-tools-defaults.json" />

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -15,8 +15,8 @@ type Function() =
     /// <summary>
     /// A simple function that takes a string and does a ToUpper
     /// </summary>
-    /// <param name="input"></param>
-    /// <param name="context"></param>
+    /// <param name="input">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     member __.FunctionHandler (input: string) (_: ILambdaContext) =
         match input with

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-FSharp/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-FSharp/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "function-runtime": "dotnet6",
-  "function-memory-size": 256,
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler"
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="FunctionTest.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": ".NET 7 (Container Image)",
+  "display-name": ".NET 8 (Container Image)",
   "system-name": "EmptyImageFunction",
-  "description": "A .NET 7 Lambda function packaged as a container image.",
+  "description": "A .NET 8 Lambda function packaged as a container image.",
   "sort-order": 225,
   "hidden-tags": [
     "F#",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Function"
   ],
-  "name": "Lambda Empty Function (.NET 7 Container Image)",
+  "name": "Lambda Empty Function (.NET 8 Container Image)",
   "identity": "AWS.Lambda.Function.Image.Empty.FSharp",
   "groupIdentity": "AWS.Lambda.Function.Image.Empty",
   "shortName": "lambda.image.EmptyFunction",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
@@ -16,7 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="aws-lambda-tools-defaults.json" />

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/Dockerfile
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:7
+FROM public.ecr.aws/lambda/dotnet:8
 
 WORKDIR /var/task
 

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -15,8 +15,8 @@ type Function() =
     /// <summary>
     /// A simple function that takes a string and does a ToUpper
     /// </summary>
-    /// <param name="input"></param>
-    /// <param name="context"></param>
+    /// <param name="input">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     member __.FunctionHandler (input: string) (_: ILambdaContext) =
         match input with

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -22,9 +22,9 @@ Alternatively the Docker file could be written to use [multi-stage](https://docs
 have the .NET project built inside the container. Below is an example of building the .NET project inside the image.
 
 ```dockerfile
-FROM public.ecr.aws/lambda/dotnet:7 AS base
+FROM public.ecr.aws/lambda/dotnet:8 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim as build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.fsproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.fsproj"

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -9,7 +9,7 @@
   "region": "DefaultRegion",
   "configuration": "Release",
   "package-type": "image",
-  "function-memory-size": 256,
+  "function-memory-size": 512,
   "function-timeout": 30,
   "image-command": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler",
   "docker-host-build-output-dir": "./bin/Release/lambda-publish"

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="FunctionTest.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": ".NET 7 (Container Image)",
+  "display-name": ".NET 8 (Container Image)",
   "system-name": "EmptyImageFunction",
-  "description": "A .NET 7 Lambda function packaged as a container image.",
+  "description": "A .NET 8 Lambda function packaged as a container image.",
   "sort-order": 225,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Function"
   ],
-  "name": "Lambda Empty Function (.NET 7 Container Image)",
+  "name": "Lambda Empty Function (.8 Container Image)",
   "identity": "AWS.Lambda.Function.Image.Empty.CSharp",
   "groupIdentity": "AWS.Lambda.Function.Image.Empty",
   "shortName": "lambda.image.EmptyFunction",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Function"
   ],
-  "name": "Lambda Empty Function (.8 Container Image)",
+  "name": "Lambda Empty Function (.NET .8 Container Image)",
   "identity": "AWS.Lambda.Function.Image.Empty.CSharp",
   "groupIdentity": "AWS.Lambda.Function.Image.Empty",
   "shortName": "lambda.image.EmptyFunction",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -12,6 +12,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/Dockerfile
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:7
+FROM public.ecr.aws/lambda/dotnet:8
 
 WORKDIR /var/task
 

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/Function.cs
@@ -11,8 +11,8 @@ public class Function
     /// <summary>
     /// A simple function that takes a string and returns both the upper and lower case version of the string.
     /// </summary>
-    /// <param name="input"></param>
-    /// <param name="context"></param>
+    /// <param name="input">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     public Casing FunctionHandler(string input, ILambdaContext context)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/Readme.md
@@ -22,9 +22,9 @@ Alternatively the Docker file could be written to use [multi-stage](https://docs
 have the .NET project built inside the container. Below is an example of building the .NET project inside the image.
 
 ```dockerfile
-FROM public.ecr.aws/lambda/dotnet:7 AS base
+FROM public.ecr.aws/lambda/dotnet:8 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim as build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.csproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.csproj"

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -9,7 +9,7 @@
   "region": "DefaultRegion",
   "configuration": "Release",
   "package-type": "image",
-  "function-memory-size": 256,
+  "function-memory-size": 512,
   "function-timeout": 30,
   "image-command": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler",
   "docker-host-build-output-dir": "./bin/Release/lambda-publish"

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction-Image/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -12,6 +12,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction/template/src/BlueprintBaseName.1/Function.cs
@@ -11,8 +11,8 @@ public class Function
     /// <summary>
     /// A simple function that takes a string and does a ToUpper
     /// </summary>
-    /// <param name="input"></param>
-    /// <param name="context"></param>
+    /// <param name="input">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     public string FunctionHandler(string input, ILambdaContext context)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -9,8 +9,8 @@
   "region": "DefaultRegion",
   "configuration": "Release",
   "function-architecture": "x86_64",
-  "function-runtime": "dotnet6",
-  "function-memory-size": 256,
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler"
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
@@ -16,7 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-FSharp/template/src/BlueprintBaseName.1/Functions.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-FSharp/template/src/BlueprintBaseName.1/Functions.fs
@@ -16,8 +16,8 @@ type Functions() =
     /// <summary>
     /// A Lambda function to respond to HTTP Get methods from API Gateway
     /// </summary>
-    /// <param name="request"></param>
-    /// <param name="context"></param>
+    /// <param name="request">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     member __.Get (request: APIGatewayProxyRequest) (context: ILambdaContext) =
         sprintf "Request: %s" request.Path

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-FSharp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-FSharp/template/src/BlueprintBaseName.1/serverless.template
@@ -7,9 +7,9 @@
       "Type": "AWS::Serverless::Function",
       "Properties": {
         "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Functions::Get",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": "",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Role": null,
         "Policies": [

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="FunctionsTest.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": ".NET 7 (Container Image) Serverless Application",
+  "display-name": ".NET 8 (Container Image) Serverless Application",
   "system-name": "EmptyImageServerless",
-  "description": ".NET 7 Lambda function packaged as a container image and deploy through AWS CloudFormation.",
+  "description": ".NET 8 Lambda function packaged as a container image and deploy through AWS CloudFormation.",
   "sort-order": 225,
   "hidden-tags": [
     "F#",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Lambda Empty Serverless (.NET 7 Container Image)",
+  "name": "Lambda Empty Serverless (.NET 8 Container Image)",
   "identity": "AWS.Lambda.Serverless.Image.Empty.FSharp",
   "groupIdentity": "AWS.Lambda.Image.Serverless.Empty",
   "shortName": "serverless.image.EmptyServerless",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
@@ -16,7 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/Dockerfile
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:7
+FROM public.ecr.aws/lambda/dotnet:8
 
 WORKDIR /var/task
 

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/Functions.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/Functions.fs
@@ -16,8 +16,8 @@ type Functions() =
     /// <summary>
     /// A Lambda function to respond to HTTP Get methods from API Gateway
     /// </summary>
-    /// <param name="request"></param>
-    /// <param name="context"></param>
+    /// <param name="request">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     member __.Get (request: APIGatewayProxyRequest) (context: ILambdaContext) =
         sprintf "Request: %s" request.Path

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -24,9 +24,9 @@ Alternatively the Docker file could be written to use [multi-stage](https://docs
 have the .NET project built inside the container. Below is an example of building the .NET project inside the image.
 
 ```dockerfile
-FROM public.ecr.aws/lambda/dotnet:7 AS base
+FROM public.ecr.aws/lambda/8 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim as build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.csproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.csproj"

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/serverless.template
@@ -13,7 +13,7 @@
           ]
         },
         "ImageUri": "",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Role": null,
         "Policies": [

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="FunctionsTest.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": ".NET 7 (Container Image) Serverless Application",
+  "display-name": ".NET 8 (Container Image) Serverless Application",
   "system-name": "EmptyImageServerless",
-  "description": ".NET 7 Lambda function packaged as a container image and deploy through AWS CloudFormation.",
+  "description": ".NET 8 Lambda function packaged as a container image and deploy through AWS CloudFormation.",
   "sort-order": 225,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Lambda Empty Serverless (.NET 7 Container Image)",
+  "name": "Lambda Empty Serverless (.NET 8 Container Image)",
   "identity": "AWS.Lambda.Serverless.Image.Empty.CSharp",
   "groupIdentity": "AWS.Lambda.Image.Serverless.Empty",
   "shortName": "serverless.image.EmptyServerless",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -11,9 +11,9 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.0.0" />
+    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.2.0" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/Dockerfile
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:7
+FROM public.ecr.aws/lambda/dotnet:8
 
 WORKDIR /var/task
 

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/Functions.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/Functions.cs
@@ -34,7 +34,7 @@ public class Functions
     /// </remarks>
     /// <param name="context">Information about the invocation, function, and execution environment</param>
     /// <returns>The response as an implicit <see cref="APIGatewayProxyResponse"/></returns>
-    [LambdaFunction(PackageType = LambdaPackageType.Image, Policies = "AWSLambdaBasicExecutionRole", MemorySize = 256, Timeout = 30)]
+    [LambdaFunction(PackageType = LambdaPackageType.Image, Policies = "AWSLambdaBasicExecutionRole", MemorySize = 512, Timeout = 30)]
     [RestApi(LambdaHttpMethod.Get, "/")]
     public IHttpResult Get(ILambdaContext context)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/Readme.md
@@ -25,9 +25,9 @@ Alternatively the Docker file could be written to use [multi-stage](https://docs
 have the .NET project built inside the container. Below is an example of building the .NET project inside the image.
 
 ```dockerfile
-FROM public.ecr.aws/lambda/dotnet:7 AS base
+FROM public.ecr.aws/lambda/dotnet:8 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim as build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.csproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.csproj"

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/Readme.md
@@ -96,7 +96,7 @@ It also generates the function resources in a JSON or YAML CloudFormation templa
 ### Using Annotations without API Gateway
 You can still use Lambda Annotations without integrating with API Gateway. For example, this Lambda function processes messages from an Amazon Simple Queue Service (Amazon SQS) queue:
 ```
-[LambdaFunction(PackageType = LambdaPackageType.Image, Policies = "AWSLambdaSQSQueueExecutionRole", MemorySize = 256, Timeout = 30)]
+[LambdaFunction(PackageType = LambdaPackageType.Image, Policies = "AWSLambdaSQSQueueExecutionRole", MemorySize = 512, Timeout = 30)]
 public async Task FunctionHandler(SQSEvent evnt, ILambdaContext context) 
 { 
     foreach(var message in evnt.Records) 
@@ -136,7 +136,7 @@ You must also replace the function resource in `serverless.template` with:
           ]
         },
         "ImageUri": "",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Role": null,
         "Policies": [

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/serverless.template
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "An AWS Serverless Application.",
+  "Description": "An AWS Serverless Application. This template is partially managed by Amazon.Lambda.Annotations (v1.2.0.0).",
   "Resources": {
     "BlueprintBaseName._1FunctionsGetGenerated": {
       "Type": "AWS::Serverless::Function",
@@ -12,7 +12,7 @@
         ]
       },
       "Properties": {
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "PackageType": "Image",
         "Events": {
@@ -33,6 +33,38 @@
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ]
+      }
+    },
+    "BlueprintBaseName1FunctionsGetGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "MemorySize": 512,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "BlueprintBaseName.1::BlueprintBaseName._1.Functions_Get_Generated::Get"
+          ]
+        },
+        "Events": {
+          "RootGet": {
+            "Type": "Api",
+            "Properties": {
+              "Path": "/",
+              "Method": "GET"
+            }
+          }
+        }
       }
     }
   },

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -11,9 +11,9 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.0.0" />
+    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.2.0" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless/template/src/BlueprintBaseName.1/Functions.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless/template/src/BlueprintBaseName.1/Functions.cs
@@ -34,7 +34,7 @@ public class Functions
     /// </remarks>
     /// <param name="context">Information about the invocation, function, and execution environment</param>
     /// <returns>The response as an implicit <see cref="APIGatewayProxyResponse"/></returns>
-    [LambdaFunction(Policies = "AWSLambdaBasicExecutionRole", MemorySize = 256, Timeout = 30)]
+    [LambdaFunction(Policies = "AWSLambdaBasicExecutionRole", MemorySize = 512, Timeout = 30)]
     [RestApi(LambdaHttpMethod.Get, "/")]
     public IHttpResult Get(ILambdaContext context)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless/template/src/BlueprintBaseName.1/Readme.md
@@ -57,7 +57,7 @@ It also generates the function resources in a JSON or YAML CloudFormation templa
 ### Using Annotations without API Gateway
 You can still use Lambda Annotations without integrating with API Gateway. For example, this Lambda function processes messages from an Amazon Simple Queue Service (Amazon SQS) queue:
 ```
-[LambdaFunction(Policies = "AWSLambdaSQSQueueExecutionRole", MemorySize = 256, Timeout = 30)]
+[LambdaFunction(Policies = "AWSLambdaSQSQueueExecutionRole", MemorySize = 512, Timeout = 30)]
 public async Task FunctionHandler(SQSEvent evnt, ILambdaContext context) 
 { 
     foreach(var message in evnt.Records) 
@@ -91,9 +91,9 @@ You must also replace the function resource in `serverless.template` with:
       "Type": "AWS::Serverless::Function",
       "Properties": {
         "Handler": "<ASSEMBLY>::<TYPE>.Functions::Get",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": "",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Role": null,
         "Policies": [

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless/template/src/BlueprintBaseName.1/serverless.template
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "An AWS Serverless Application.",
+  "Description": "An AWS Serverless Application. This template is partially managed by Amazon.Lambda.Annotations (v1.2.0.0).",
   "Resources": {
     "BlueprintBaseName._1FunctionsGetGenerated": {
       "Type": "AWS::Serverless::Function",
@@ -16,14 +16,43 @@
           "x86_64"
         ],
         "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Functions::Get",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": ".",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
         "PackageType": "Zip",
+        "Events": {
+          "RootGet": {
+            "Type": "Api",
+            "Properties": {
+              "Path": "/",
+              "Method": "GET"
+            }
+          }
+        }
+      }
+    },
+    "BlueprintBaseName1FunctionsGetGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
+      "Properties": {
+        "Runtime": "dotnet8",
+        "CodeUri": ".",
+        "MemorySize": 512,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Zip",
+        "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Functions_Get_Generated::Get",
         "Events": {
           "RootGet": {
             "Type": "Api",

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Blueprints/BlueprintDefinitions/vs2022/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Giraffe" Version="5.0.0" />
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="8.1.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppHandlers.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/GiraffeWebApp-FSharp/template/src/BlueprintBaseName.1/serverless.template
@@ -9,9 +9,9 @@
       "Type": "AWS::Serverless::Function",
       "Properties": {
         "Handler": "BlueprintBaseName.1::Setup+LambdaEntryPoint::FunctionHandlerAsync",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": "",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Role": null,
         "Policies": [

--- a/Blueprints/BlueprintDefinitions/vs2022/GiraffeWebApp-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/GiraffeWebApp-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <EnableDefaultContentItems>False</EnableDefaultContentItems>
   </PropertyGroup>
   <ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2022/LexBookTripSample/template/src/BlueprintBaseName.1/AbstractIntentProcessor.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/LexBookTripSample/template/src/BlueprintBaseName.1/AbstractIntentProcessor.cs
@@ -19,8 +19,8 @@ public abstract class AbstractIntentProcessor : IIntentProcessor
     /// <summary>
     /// Main method for proccessing the lex event for the intent.
     /// </summary>
-    /// <param name="lexEvent"></param>
-    /// <param name="context"></param>
+    /// <param name="lexEvent">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     public abstract LexResponse Process(LexEvent lexEvent, ILambdaContext context);
 

--- a/Blueprints/BlueprintDefinitions/vs2022/LexBookTripSample/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/LexBookTripSample/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -13,6 +13,6 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.LexEvents" Version="3.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/LexBookTripSample/template/src/BlueprintBaseName.1/BookCarIntentProcessor.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/LexBookTripSample/template/src/BlueprintBaseName.1/BookCarIntentProcessor.cs
@@ -22,7 +22,8 @@ public class BookCarIntentProcessor : AbstractIntentProcessor
     /// 1) Use of elicitSlot in slot validation and re-prompting
     /// 2) Use of sessionAttributes to pass information that can be used to guide the conversation
     /// </summary>
-    /// <param name="lexEvent"></param>
+    /// <param name="lexEvent">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param> 
     /// <returns></returns>
     public override LexResponse Process(LexEvent lexEvent, ILambdaContext context)
     {
@@ -215,7 +216,7 @@ public class BookCarIntentProcessor : AbstractIntentProcessor
     /// <summary>
     /// Verifies that any values for slots in the intent are valid.
     /// </summary>
-    /// <param name="reservation"></param>
+    /// <param name="reservation">The reservation to validate.</param>
     /// <returns></returns>
     private ValidationResult Validate(Reservation reservation)
     {
@@ -295,7 +296,7 @@ public class BookCarIntentProcessor : AbstractIntentProcessor
     /// Generates a number within a reasonable range that might be expected for a flight.
     /// The price is fixed for a given pair of locations.
     /// </summary>
-    /// <param name="reservation"></param>
+    /// <param name="reservation">The reservation to generate a price for.</param>
     /// <returns></returns>
     private double GeneratePrice(Reservation reservation)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/LexBookTripSample/template/src/BlueprintBaseName.1/BookHotelIntentProcessor.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/LexBookTripSample/template/src/BlueprintBaseName.1/BookHotelIntentProcessor.cs
@@ -18,8 +18,8 @@ public class BookHotelIntentProcessor : AbstractIntentProcessor
     /// 1) Use of elicitSlot in slot validation and re-prompting
     /// 2) Use of sessionAttributes to pass information that can be used to guide the conversation
     /// </summary>
-    /// <param name="lexEvent"></param>
-    /// <param name="context"></param>
+    /// <param name="lexEvent">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     public override LexResponse Process(LexEvent lexEvent, ILambdaContext context)
     {
@@ -94,7 +94,7 @@ public class BookHotelIntentProcessor : AbstractIntentProcessor
     /// <summary>
     /// Verifies that any values for slots in the intent are valid.
     /// </summary>
-    /// <param name="reservation"></param>
+    /// <param name="reservation">The reservation to validate.</param>
     /// <returns></returns>
     private ValidationResult Validate(Reservation reservation)
     {
@@ -141,7 +141,7 @@ public class BookHotelIntentProcessor : AbstractIntentProcessor
     /// Generates a number within a reasonable range that might be expected for a hotel.
     /// The price is fixed for a pair of location and roomType.
     /// </summary>
-    /// <param name="reservation"></param>
+    /// <param name="reservation">The reservation to generate a price for.</param>
     /// <returns></returns>
     private double GeneratePrice(Reservation reservation)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/LexBookTripSample/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/LexBookTripSample/template/src/BlueprintBaseName.1/Function.cs
@@ -16,8 +16,8 @@ public class Function
     /// Then entry point for the Lambda function that looks at the current intent and calls 
     /// the appropriate intent process.
     /// </summary>
-    /// <param name="input"></param>
-    /// <param name="context"></param>
+    /// <param name="lexEvent">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     public LexResponse FunctionHandler(LexEvent lexEvent, ILambdaContext context)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/LexBookTripSample/template/src/BlueprintBaseName.1/IIntentProcessor.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/LexBookTripSample/template/src/BlueprintBaseName.1/IIntentProcessor.cs
@@ -11,8 +11,8 @@ public interface IIntentProcessor
     /// <summary>
     /// Main method for processing the Lex event for the intent.
     /// </summary>
-    /// <param name="lexEvent"></param>
-    /// <param name="context"></param>
+    /// <param name="lexEvent">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     LexResponse Process(LexEvent lexEvent, ILambdaContext context);
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/LexBookTripSample/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/LexBookTripSample/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "function-runtime": "dotnet6",
-  "function-memory-size": 256,
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler"
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/LexBookTripSample/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/LexBookTripSample/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": "Native AOT (.NET 7)",
+  "display-name": "Native AOT (.NET 8)",
   "system-name": "NativeAotFunction",
-  "description": "A project configured for deployment using .NET 7's Native AOT feature.",
+  "description": "A project configured for deployment using .NET 8's Native AOT feature.",
   "sort-order": 110,
   "hidden-tags": [
     "F#",

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Function"
   ],
-  "name": "Lambda Function project configured for deployment using .NET 7's Native AOT feature.",
+  "name": "Lambda Function project configured for deployment using .NET 8's Native AOT feature.",
   "identity": "AWS.Lambda.Function.NativeAot.FSharp",
   "groupIdentity": "AWS.Lambda.Function.NativeAOT",
   "shortName": "lambda.NativeAOT",

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,9 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AWSProjectType>Lambda</AWSProjectType>
-    <AssemblyName>bootstrap</AssemblyName>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <!-- Generate Native AOT image during publishing to improve cold start time. -->
@@ -21,18 +20,10 @@
   <ItemGroup>
     <Content Include="aws-lambda-tools-defaults.json" />
   </ItemGroup>
-  <!-- 
-  When publishing Lambda functions for ARM64 to the provided.al2 runtime a newer version of libicu needs to be included
-  in the deployment bundle because .NET requires a newer version of libicu then is preinstalled with Amazon Linux 2.
-  -->
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == 'linux-arm64'">
-    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2.0.9" />
-    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="aws-lambda-tools-defaults.json" />

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -23,8 +23,8 @@ module Function =
     // SDK for .NET does not support trimming. This will result in a larger executable size, and still does not 
     // guarantee runtime trimming errors won't be hit. 
     /// </summary>
-    /// <param name="input"></param>
-    /// <param name="context"></param>
+    /// <param name="input">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     let functionHandler (input: string) (_: ILambdaContext) =
         match input with
@@ -37,7 +37,7 @@ module Function =
     /// initializes the .NET Lambda runtime client passing in the function handler to invoke for each Lambda event and
     /// the JSON serializer to use for converting Lambda JSON format to the .NET types.
     /// </summary>
-    /// <param name="args"></param>
+    /// <param name="args">The command line arguments.</param>
     [<EntryPoint>]
     let main _args =
     

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -13,7 +13,7 @@ The function handler is a simple method accepting a string argument that returns
 
 ## Native AOT
 
-Native AOT is a feature of .NET 7 that compiles .NET assemblies into a single native executable. By using the native executable the .NET runtime 
+Native AOT is a feature that compiles .NET assemblies into a single native executable. By using the native executable the .NET runtime 
 is not required to be installed on the target platform. Native AOT can significantly improve Lambda cold starts for .NET Lambda functions. 
 This project enables Native AOT by setting the .NET `PublishAot` property in the .NET project file to `true`. The `StripSymbols` property is also
 set to `true` to strip debugging symbols from the deployed executable to reduce the executable's size.
@@ -21,9 +21,9 @@ set to `true` to strip debugging symbols from the deployed executable to reduce 
 ### Building Native AOT
 
 When publishing with Native AOT the build OS and Architecture must match the target platform that the application will run. For AWS Lambda that target
-platform is Amazon Linux 2. The AWS tooling for Lambda like the AWS Toolkit for Visual Studio, .NET Global Tool Amazon.Lambda.Tools and SAM CLI will 
-perform a container build using a .NET 7 Amazon Linux 2 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
-when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2 build environments. To install docker go to https://www.docker.com/.
+platform is Amazon Linux 2023. The AWS tooling for Lambda like the AWS Toolkit for Visual Studio, .NET Global Tool Amazon.Lambda.Tools and SAM CLI will 
+perform a container build using a .NET 8 Amazon Linux 2023 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
+when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2023 build environments. To install docker go to https://www.docker.com/.
 
 ### Trimming
 
@@ -38,7 +38,7 @@ For information about trimming see the documentation: <https://learn.microsoft.c
 
 ## Docker requirement
 
-Docker is required to be installed and running when building .NET Native AOT Lambda functions on any platform besides Amazon Linux 2. Information on how acquire Docker can be found here: https://docs.docker.com/get-docker/
+Docker is required to be installed and running when building .NET Native AOT Lambda functions on any platform besides Amazon Linux 2023. Information on how acquire Docker can be found here: https://docs.docker.com/get-docker/
 
 ## Here are some steps to follow from Visual Studio:
 
@@ -80,8 +80,3 @@ Deploy function to AWS Lambda
     cd "BlueprintBaseName.1/src/BlueprintBaseName.1"
     dotnet lambda deploy-function
 ```
-
-## Arm64
-
-.NET 7 ARM requires a newer version of GLIBC than is available in the `provided.al2` Lambda runtime. .NET 7 functions that are deployed using
-the Arm64 architecture will fail to start with a runtime error stating the GLIBC version is below the required version for .NET 7.

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -30,7 +30,7 @@ when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2023 build e
 As part of the Native AOT compilation, .NET assemblies will be trimmed removing types and methods that the compiler does not find a reference to. This is important
 to keep the native executable size small. When types are used through reflection this can go undetected by the compiler causing necessary types and methods to
 be removed. When testing Native AOT Lambda functions in Lambda if a runtime error occurs about missing types or methods the most likely solution will
-be to remove references to trim-unsafe code or configure [trimming options](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options?pivots=dotnet-7-0).
+be to remove references to trim-unsafe code or configure [trimming options](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options).
 This sample defaults to partial TrimMode because currently the AWS SDK for .NET does not support trimming. This will result in a larger executable size, and still does not
 guarantee runtime trimming errors won't be hit.
 

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,9 +8,9 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "function-runtime": "provided.al2",
-  "function-memory-size": 256,
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
   "function-timeout": 30,
-  "function-handler": "bootstrap",
+  "function-handler": "BlueprintBaseName.1",
   "msbuild-parameters": "--self-contained true"
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="FunctionTest.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": "Native AOT (.NET 7)",
+  "display-name": "Native AOT (.NET 8)",
   "system-name": "NativeAotFunction",
-  "description": "A project configured for deployment using .NET 7's Native AOT feature.",
+  "description": "A project configured for deployment using .NET 8's Native AOT feature.",
   "sort-order": 110,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Function"
   ],
-  "name": "Lambda Function project configured for deployment using .NET 7's Native AOT feature.",
+  "name": "Lambda Function project configured for deployment using .NET 8's Native AOT feature.",
   "identity": "AWS.Lambda.Function.NativeAOT.CSharp",
   "groupIdentity": "AWS.Lambda.Function.NativeAOT",
   "shortName": "lambda.NativeAOT",

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AWSProjectType>Lambda</AWSProjectType>
-    <AssemblyName>bootstrap</AssemblyName>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <!-- Generate Native AOT image during publishing to improve cold start time. -->
@@ -17,17 +16,9 @@
     If there are trim warnings during build, you can hit errors at runtime.-->
     <TrimMode>partial</TrimMode>
   </PropertyGroup>
-  <!-- 
-  When publishing Lambda functions for ARM64 to the provided.al2 runtime a newer version of libicu needs to be included
-  in the deployment bundle because .NET requires a newer version of libicu then is preinstalled with Amazon Linux 2.
-  -->
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == 'linux-arm64'">
-    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2.0.9" />
-    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/src/BlueprintBaseName.1/Function.cs
@@ -37,8 +37,8 @@ public class Function
     // SDK for .NET does not support trimming. This will result in a larger executable size, and still does not 
     // guarantee runtime trimming errors won't be hit. 
     /// </summary>
-    /// <param name="input"></param>
-    /// <param name="context"></param>
+    /// <param name="input">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     public static string FunctionHandler(string input, ILambdaContext context)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/src/BlueprintBaseName.1/Readme.md
@@ -31,7 +31,7 @@ when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2023 build e
 As part of the Native AOT compilation, .NET assemblies will be trimmed removing types and methods that the compiler does not find a reference to. This is important
 to keep the native executable size small. When types are used through reflection this can go undetected by the compiler causing necessary types and methods to
 be removed. When testing Native AOT Lambda functions in Lambda if a runtime error occurs about missing types or methods the most likely solution will
-be to remove references to trim-unsafe code or configure [trimming options](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options?pivots=dotnet-7-0).
+be to remove references to trim-unsafe code or configure [trimming options](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options).
 This sample defaults to partial TrimMode because currently the AWS SDK for .NET does not support trimming. This will result in a larger executable size, and still does not
 guarantee runtime trimming errors won't be hit.
 

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/src/BlueprintBaseName.1/Readme.md
@@ -14,7 +14,7 @@ The function handler is a simple method accepting a string argument that returns
 
 ## Native AOT
 
-Native AOT is a feature of .NET 7 that compiles .NET assemblies into a single native executable. By using the native executable the .NET runtime 
+Native AOT is a feature that compiles .NET assemblies into a single native executable. By using the native executable the .NET runtime 
 is not required to be installed on the target platform. Native AOT can significantly improve Lambda cold starts for .NET Lambda functions. 
 This project enables Native AOT by setting the .NET `PublishAot` property in the .NET project file to `true`. The `StripSymbols` property is also
 set to `true` to strip debugging symbols from the deployed executable to reduce the executable's size.
@@ -22,9 +22,9 @@ set to `true` to strip debugging symbols from the deployed executable to reduce 
 ### Building Native AOT
 
 When publishing with Native AOT the build OS and Architecture must match the target platform that the application will run. For AWS Lambda that target
-platform is Amazon Linux 2. The AWS tooling for Lambda like the AWS Toolkit for Visual Studio, .NET Global Tool Amazon.Lambda.Tools and SAM CLI will 
-perform a container build using a .NET 7 Amazon Linux 2 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
-when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2 build environments. To install docker go to https://www.docker.com/.
+platform is Amazon Linux 2023. The AWS tooling for Lambda like the AWS Toolkit for Visual Studio, .NET Global Tool Amazon.Lambda.Tools and SAM CLI will 
+perform a container build using a .NET 8 Amazon Linux 2023 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
+when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2023 build environments. To install docker go to https://www.docker.com/.
 
 ### Trimming
 
@@ -39,7 +39,7 @@ For information about trimming see the documentation: <https://learn.microsoft.c
 
 ## Docker requirement
 
-Docker is required to be installed and running when building .NET Native AOT Lambda functions on any platform besides Amazon Linux 2. Information on how acquire Docker can be found here: https://docs.docker.com/get-docker/
+Docker is required to be installed and running when building .NET Native AOT Lambda functions on any platform besides Amazon Linux 2023. Information on how acquire Docker can be found here: https://docs.docker.com/get-docker/
 
 ## Here are some steps to follow from Visual Studio:
 

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,9 +8,9 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "function-runtime": "provided.al2",
-  "function-memory-size": 256,
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
   "function-timeout": 30,
-  "function-handler": "bootstrap",
+  "function-handler": "BlueprintBaseName.1",
   "msbuild-parameters": "--self-contained true"
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": "Native AOT (.NET 7)",
+  "display-name": "Native AOT (.NET 8)",
   "system-name": "NativeAotFunction",
-  "description": "A project configured for deployment using .NET 7's Native AOT feature.",
+  "description": "A project configured for deployment using .NET 8's Native AOT feature.",
   "sort-order": 120,
   "hidden-tags": [
     "F#",

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Serverless project configured for deployment using .NET 7's Native AOT feature.",
+  "name": "Serverless project configured for deployment using .NET 8's Native AOT feature.",
   "identity": "AWS.Serverless.NativeAot.FSharp",
   "groupIdentity": "AWS.Serverless.NativeAOT",
   "shortName": "serverless.NativeAOT",

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,9 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AWSProjectType>Lambda</AWSProjectType>
-    <AssemblyName>bootstrap</AssemblyName>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <!-- Generate Native AOT image during publishing to improve cold start time. -->
@@ -21,18 +20,10 @@
   <ItemGroup>
     <Content Include="aws-lambda-tools-defaults.json" />
   </ItemGroup>
-  <!-- 
-  When publishing Lambda functions for ARM64 to the provided.al2 runtime a newer version of libicu needs to be included
-  in the deployment bundle because .NET requires a newer version of libicu then is preinstalled with Amazon Linux 2.
-  -->
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == 'linux-arm64'">
-    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2.0.9" />
-    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -26,8 +26,8 @@ module Function =
     // guarantee runtime trimming errors won't be hit. 
 
     /// </summary>
-    /// <param name="input"></param>
-    /// <param name="context"></param>
+    /// <param name="input">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     let GetFunctionHandler (request: APIGatewayProxyRequest) (context: ILambdaContext) =
         sprintf "Request: %s" request.Path
@@ -46,7 +46,7 @@ module Function =
     /// the JSON serializer to use for converting Lambda JSON format to the .NET types. 
     ///
     /// </summary>
-    /// <param name="args"></param>
+    /// <param name="args">The command line arguments.</param>
     [<EntryPoint>]
     let main _args =
     

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -32,7 +32,7 @@ when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2023 build e
 As part of the Native AOT compilation, .NET assemblies will be trimmed removing types and methods that the compiler does not find a reference to. This is important
 to keep the native executable size small. When types are used through reflection this can go undetected by the compiler causing necessary types and methods to
 be removed. When testing Native AOT Lambda functions in Lambda if a runtime error occurs about missing types or methods the most likely solution will
-be to remove references to trim-unsafe code or configure [trimming options](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options?pivots=dotnet-7-0).
+be to remove references to trim-unsafe code or configure [trimming options](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options?pivots=dotnet-8-0).
 This sample defaults to partial TrimMode because currently the AWS SDK for .NET does not support trimming. This will result in a larger executable size, and still does not
 guarantee runtime trimming errors won't be hit.
 

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -15,7 +15,7 @@ the `serverless.template` file.
 
 ## Native AOT
 
-Native AOT is a feature of .NET 7 that compiles .NET assemblies into a single native executable. By using the native executable the .NET runtime 
+Native AOT is a feature that compiles .NET assemblies into a single native executable. By using the native executable the .NET runtime 
 is not required to be installed on the target platform. Native AOT can significantly improve Lambda cold starts for .NET Lambda functions. 
 This project enables Native AOT by setting the .NET `PublishAot` property in the .NET project file to `true`. The `StripSymbols` property is also
 set to `true` to strip debugging symbols from the deployed executable to reduce the executable's size.
@@ -23,9 +23,9 @@ set to `true` to strip debugging symbols from the deployed executable to reduce 
 ### Building Native AOT
 
 When publishing with Native AOT the build OS and Architecture must match the target platform that the application will run. For AWS Lambda that target
-platform is Amazon Linux 2. The AWS tooling for Lambda like the AWS Toolkit for Visual Studio, .NET Global Tool Amazon.Lambda.Tools and SAM CLI will 
-perform a container build using a .NET 7 Amazon Linux 2 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
-when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2 build environments. To install docker go to https://www.docker.com/.
+platform is Amazon Linux 2023. The AWS tooling for Lambda like the AWS Toolkit for Visual Studio, .NET Global Tool Amazon.Lambda.Tools and SAM CLI will 
+perform a container build using a .NET 8 Amazon Linux 2023 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
+when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2023 build environments. To install docker go to https://www.docker.com/.
 
 ### Trimming
 
@@ -40,7 +40,7 @@ For information about trimming see the documentation: <https://learn.microsoft.c
 
 ## Docker requirement
 
-Docker is required to be installed and running when building .NET Native AOT Lambda functions on any platform besides Amazon Linux 2. Information on how acquire Docker can be found here: https://docs.docker.com/get-docker/
+Docker is required to be installed and running when building .NET Native AOT Lambda functions on any platform besides Amazon Linux 2023. Information on how acquire Docker can be found here: https://docs.docker.com/get-docker/
 
 ## Here are some steps to follow from Visual Studio:
 
@@ -82,8 +82,3 @@ Deploy function to AWS Lambda
     cd "BlueprintBaseName.1/src/BlueprintBaseName.1"
     dotnet lambda deploy-function
 ```
-
-## Arm64
-
-.NET 7 ARM requires a newer version of GLIBC than is available in the `provided.al2` Lambda runtime. .NET 7 functions that are deployed using
-the Arm64 architecture will fail to start with a runtime error stating the GLIBC version is below the required version for .NET 7.

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/serverless.template
@@ -9,10 +9,10 @@
         "Architectures": [
           "x86_64"
         ],
-        "Handler": "bootstrap",
-        "Runtime": "provided.al2",
+        "Handler": "BlueprintBaseName.1",
+        "Runtime": "dotnet8",
         "CodeUri": "",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Role": null,
         "Policies": [

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="FunctionTest.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": "Native AOT (.NET 7)",
+  "display-name": "Native AOT (.NET 8)",
   "system-name": "NativeAotFunction",
-  "description": "A project configured for deployment using .NET 7's Native AOT feature.",
+  "description": "A project configured for deployment using .NET 8's Native AOT feature.",
   "sort-order": 120,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Serverless project configured for deployment using .NET 7's Native AOT feature.",
+  "name": "Serverless project configured for deployment using .NET 8's Native AOT feature.",
   "identity": "AWS.Serverless.NativeAOT.CSharp",
   "groupIdentity": "AWS.Serverless.NativeAOT",
   "shortName": "serverless.NativeAOT",

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AWSProjectType>Lambda</AWSProjectType>
-    <AssemblyName>bootstrap</AssemblyName>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <!-- Generate Native AOT image during publishing to improve cold start time. -->
@@ -17,18 +16,12 @@
     If there are trim warnings during build, you can hit errors at runtime.-->
     <TrimMode>partial</TrimMode>
   </PropertyGroup>
-  <!-- 
-  When publishing Lambda functions for ARM64 to the provided.al2 runtime a newer version of libicu needs to be included
-  in the deployment bundle because .NET requires a newer version of libicu then is preinstalled with Amazon Linux 2.
-  -->
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == 'linux-arm64'">
-    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2.0.9" />
-    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
+    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.2.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />    
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/Functions.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/Functions.cs
@@ -1,123 +1,96 @@
-using Amazon.Lambda.Core;
-using Amazon.Lambda.RuntimeSupport;
-using Amazon.Lambda.Serialization.SystemTextJson;
-using Amazon.Lambda.APIGatewayEvents;
 using System.Text.Json.Serialization;
-using System.Net;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.Serialization.SystemTextJson;
+using Amazon.Lambda.Annotations;
+using Amazon.Lambda.Annotations.APIGateway;
+using Amazon.Lambda.APIGatewayEvents;
+using BlueprintBaseName._1;
+
+[assembly:LambdaGlobalProperties(GenerateMain = true)]
+[assembly:LambdaSerializer(typeof(SourceGeneratorLambdaJsonSerializer<LambdaFunctionJsonSerializerContext>))]
 
 namespace BlueprintBaseName._1;
-
-public class Functions
-{
-    /// <summary>
-    /// The main entry point for the Lambda function. The main function is called once during the Lambda init phase. It
-    /// initializes the .NET Lambda runtime client passing in the function handler to invoke for each Lambda event and
-    /// the JSON serializer to use for converting Lambda JSON format to the .NET types. 
-    /// </summary>
-    private static async Task Main()
-    {
-        // The "_HANDLER" environment variable is set by the Lambda runtime to the configured value for the function
-        // handler property.
-        var configuredFunctionHandler = Environment.GetEnvironmentVariable("_HANDLER");
-
-        // Native AOT Lambda functions are deployed as a native executable using the provided.al2 Lambda runtime.
-        // The provided.al2 runtime ignores the function handler field and always looks for an executable called "bootstrap".
-        //
-        // As a convention this project template checks the value for the function handler field set in the
-        // serverless template to determine which method should be registered with the Lambda runtime client
-        // to respond to incoming Lambda events. This allows multiple Lambda functions be defined in the
-        // same .NET project using the provided.al2 runtime.
-        Func<APIGatewayProxyRequest, ILambdaContext, APIGatewayProxyResponse> handler = configuredFunctionHandler switch
-        {
-            nameof(GetFunctionHandler) => new Functions().GetFunctionHandler,
-            nameof(PutFunctionHandler) => new Functions().PutFunctionHandler,
-            _ => throw new Exception($"Unknown method to call for handler value {configuredFunctionHandler}")
-        };
-
-        await LambdaBootstrapBuilder.Create(handler, new SourceGeneratorLambdaJsonSerializer<LambdaFunctionJsonSerializerContext>())
-            .Build()
-            .RunAsync();
-    }
-
-    /// <summary>
-    /// A Lambda function to respond to HTTP Get methods from API Gateway.
-    ///
-    /// To use this handler to respond to an AWS event, reference the appropriate package from 
-    /// https://github.com/aws/aws-lambda-dotnet#events
-    /// and change the input parameter to the desired event type. When the event type
-    /// is changed, the handler type registered in the main method needs to be updated and the LambdaFunctionJsonSerializerContext 
-    /// defined below will need the JsonSerializable updated. If the return type and event type are different then the 
-    /// LambdaFunctionJsonSerializerContext must have two JsonSerializable attributes, one for each type.
-    ///
-    // When using Native AOT extra testing with the deployed Lambda functions is required to ensure
-    // the libraries used in the Lambda function work correctly with Native AOT. If a runtime 
-    // error occurs about missing types or methods the most likely solution will be to remove references to trim-unsafe 
-    // code or configure trimming options. This sample defaults to partial TrimMode because currently the AWS 
-    // SDK for .NET does not support trimming. This will result in a larger executable size, and still does not 
-    // guarantee runtime trimming errors won't be hit. 
-    /// </summary>
-    /// <param name="request"></param>
-    /// <param name="context"></param>
-    /// <returns></returns>
-    public APIGatewayProxyResponse GetFunctionHandler(APIGatewayProxyRequest request, ILambdaContext context)
-    {
-        context.Logger.LogInformation("Get Request\n");
-
-        var response = new APIGatewayProxyResponse
-        {
-            StatusCode = (int)HttpStatusCode.OK,
-            Body = "Hello AWS Serverless",
-            Headers = new Dictionary<string, string> { { "Content-Type", "text/plain" } }
-        };
-
-        return response;
-    }
-
-    /// <summary>
-    /// A Lambda function to respond to HTTP PUT methods from API Gateway
-    ///
-    /// To use this handler to respond to an AWS event, reference the appropriate package from 
-    /// https://github.com/aws/aws-lambda-dotnet#events
-    /// and change the input parameter to the desired event type. When the event type
-    /// is changed the handler type registered in the main needs to be updated and the LambdaFunctionJsonSerializerContext 
-    /// defined below will need the JsonSerializable updated. If the return type and event type are different then the 
-    /// LambdaFunctionJsonSerializerContext must have two JsonSerializable attributes, one for each type.
-    ///
-    // When using Native AOT extra testing with the deployed Lambda functions is required to ensure
-    // the libraries used in the Lambda function work correctly with Native AOT. If a runtime 
-    // error occurs about missing types or methods the most likely solution will be to remove references to trim-unsafe 
-    // code or configure trimming options. This sample defaults to partial TrimMode because currently the AWS 
-    // SDK for .NET does not support trimming. This will result in a larger executable size, and still does not 
-    // guarantee runtime trimming errors won't be hit. 
-    /// </summary>
-    /// <param name="request"></param>
-    /// <param name="context"></param>
-    /// <returns></returns>
-    public APIGatewayProxyResponse PutFunctionHandler(APIGatewayProxyRequest request, ILambdaContext context)
-    {
-        context.Logger.LogInformation("Put Request");
-
-        var response = new APIGatewayProxyResponse
-        {
-            StatusCode = (int)HttpStatusCode.OK,
-            Body = "Processed PUT request",
-            Headers = new Dictionary<string, string> { { "Content-Type", "text/plain" } }
-        };
-
-        return response;
-    } 
-}
 
 /// <summary>
 /// This class is used to register the input event and return type for the FunctionHandler method with the System.Text.Json source generator.
 /// There must be a JsonSerializable attribute for each type used as the input and return type or a runtime error will occur 
 /// from the JSON serializer unable to find the serialization information for unknown types.
+/// 
+/// Request and response types used with Annotations library must also have a JsonSerializable for the type. The Annotations library will use the same
+/// source generator serializer to use non-reflection based serialization. For example parameters with the [FromBody] or types returned using 
+/// the HttpResults utility class.
 /// </summary>
 [JsonSerializable(typeof(APIGatewayProxyRequest))]
 [JsonSerializable(typeof(APIGatewayProxyResponse))]
+[JsonSerializable(typeof(NewProductDTO))]
+[JsonSerializable(typeof(ProductDTO))]
 public partial class LambdaFunctionJsonSerializerContext : JsonSerializerContext
 {
     // By using this partial class derived from JsonSerializerContext, we can generate reflection free JSON Serializer code at compile time
     // which can deserialize our class and properties. However, we must attribute this class to tell it what types to generate serialization code for.
     // See https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-source-generation
+}
+
+public record NewProductDTO(string Name, string Description);
+
+public record ProductDTO(string ID, string Name, string Description);
+
+public class Functions
+{
+
+
+    /// <summary>
+    /// A Lambda function to respond to HTTP Get methods from API Gateway.
+    /// </summary>
+    /// <param name="context"></param>
+    /// <returns></returns>
+    [LambdaFunction(MemorySize = 512)]
+    [RestApi(LambdaHttpMethod.Get, "/")]
+    public IHttpResult GetFunctionHandler(ILambdaContext context)
+    {
+        context.Logger.LogInformation("Get Request");
+
+        return HttpResults.Ok("Hello AWS Serverless")
+                            .AddHeader("Content-Type", "text/plain");
+    }
+
+    /// <summary>
+    /// A Lambda function to respond to HTTP POST methods from API Gateway
+    /// </summary>
+    /// <param name="request"></param>
+    /// <param name="context"></param>
+    /// <returns></returns>
+    [LambdaFunction(MemorySize = 512)]
+    [RestApi(LambdaHttpMethod.Post, "/")]
+    public IHttpResult PostFunctionHandler([FromBody] NewProductDTO product, ILambdaContext context)
+    {
+        // TODO: Add business logic
+        ProductDTO savedProduct = new(Guid.NewGuid().ToString(), product.Name, product.Description);
+
+        context.Logger.LogInformation($"Saved product {savedProduct.ID} with name {product.Name}.");
+
+        return HttpResults.Ok(savedProduct);
+    }
+
+
+    /// <summary>
+    /// This method demonstrates methods being exposed as Lambda functions using Amazon.Lambda.Annotations without API Gateway attributes.
+    /// The event source for the Lambda function can be configured in the serverless.template. The method can also Lambda function can     
+    /// be invoked manually using the AWS SDKs.
+    /// </summary>
+    /// <returns></returns>
+    [LambdaFunction(MemorySize = 512)]
+    public async Task<string> GetCallingIPAsync(ILambdaContext context)
+    {
+        context.Logger.LogInformation("Checking IP address");
+
+        using var client = new HttpClient();
+
+        client.DefaultRequestHeaders.Accept.Clear();
+        client.DefaultRequestHeaders.Add("User-Agent", "AWS Lambda .Net Client");
+
+        var msg = await client.GetStringAsync("http://checkip.amazonaws.com/").ConfigureAwait(continueOnCapturedContext: false);
+
+        return msg.Replace("\n", "");
+    }
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/Functions.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/Functions.cs
@@ -37,12 +37,10 @@ public record ProductDTO(string ID, string Name, string Description);
 
 public class Functions
 {
-
-
     /// <summary>
     /// A Lambda function to respond to HTTP Get methods from API Gateway.
     /// </summary>
-    /// <param name="context"></param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     [LambdaFunction(MemorySize = 512)]
     [RestApi(LambdaHttpMethod.Get, "/")]
@@ -57,8 +55,8 @@ public class Functions
     /// <summary>
     /// A Lambda function to respond to HTTP POST methods from API Gateway
     /// </summary>
-    /// <param name="request"></param>
-    /// <param name="context"></param>
+    /// <param name="product">The new product to post to the system.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     [LambdaFunction(MemorySize = 512)]
     [RestApi(LambdaHttpMethod.Post, "/")]
@@ -75,8 +73,8 @@ public class Functions
 
     /// <summary>
     /// This method demonstrates methods being exposed as Lambda functions using Amazon.Lambda.Annotations without API Gateway attributes.
-    /// The event source for the Lambda function can be configured in the serverless.template. The method can also Lambda function can     
-    /// be invoked manually using the AWS SDKs.
+    /// The event source for the Lambda function can be configured in the serverless.template. The Lambda function can be invoked manually
+    /// using the AWS SDKs.
     /// </summary>
     /// <returns></returns>
     [LambdaFunction(MemorySize = 512)]

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/Readme.md
@@ -15,8 +15,9 @@ with the .NET methods marked with the LambdaAttribute.
 For Native AOT Lambda functions the project must be deployed as an executable and bootstrap the Lambda runtime client. Lambda Annotations
 will automatically generate the `Main` by using the `GenerateMain` property of `LambdaGlobalProperties` attribute to true. The generated
 `Main` method uses the environment variable `ANNOTATIONS_HANDLER` to switch to the correct function handler for the executable. Lambda
-Annotations will automatically set the `ANNOTATIONS_HANDLER` environment variable when synchronize the CloudFormation template. If deploying
-the project with a tool besides CloudFormation then the `ANNOTATIONS_HANDLER` must be manually set to the .NET method name that should be invoked.
+Annotations will automatically set the `ANNOTATIONS_HANDLER` environment variable when synchronizing the CloudFormation template. If deploying
+the project with a tool besides CloudFormation then the `ANNOTATIONS_HANDLER` environment variable must be manually set to the .NET method name 
+that should be invoked.
 
 For more information about Amazon.Lambda.Annotations library visit the docs in GitHub for the library. https://github.com/aws/aws-lambda-dotnet/tree/master/Libraries/src/Amazon.Lambda.Annotations
 

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/Readme.md
@@ -3,19 +3,26 @@
 This starter project consists of:
 * serverless.template - an AWS CloudFormation Serverless Application Model template file for declaring your Serverless functions and other AWS resources.
 * Function.cs - contains a class with a `Main` method that starts the bootstrap and a single function handler method.
+* Startup.cs - When using dependency injection the services can be registered in the ConfigureServices of this type.
 * aws-lambda-tools-defaults.json - default argument settings for use with Visual Studio and command line deployment tools for AWS.
 
 You may also have a test project depending on the options selected.
 
-The `Main` function is called once during the Lambda init phase. It initializes the .NET Lambda runtime client passing in the function 
-handler to invoke for each Lambda event and the JSON serializer to use for converting Lambda JSON format to the .NET types. 
+This project uses the [Amazon.Lambda.Annotations](https://www.nuget.org/packages/Amazon.Lambda.Annotations) library
+that uses .NET attributes to generate the boiler plate code needed for Lambda functions. It will also synchronize the CloudFormation template
+with the .NET methods marked with the LambdaAttribute.
 
-The function handler responds to events from API Gateway. The API Gateway and integration with the Lambda function are defined in 
-the `serverless.template` file.
+For Native AOT Lambda functions the project must be deployed as an executable and bootstrap the Lambda runtime client. Lambda Annotations
+will automatically generate the `Main` by using the `GenerateMain` property of `LambdaGlobalProperties` attribute to true. The generated
+`Main` method uses the environment variable `ANNOTATIONS_HANDLER` to switch to the correct function handler for the executable. Lambda
+Annotations will automatically set the `ANNOTATIONS_HANDLER` environment variable when synchronize the CloudFormation template. If deploying
+the project with a tool besides CloudFormation then the `ANNOTATIONS_HANDLER` must be manually set to the .NET method name that should be invoked.
+
+For more information about Amazon.Lambda.Annotations library visit the docs in GitHub for the library. https://github.com/aws/aws-lambda-dotnet/tree/master/Libraries/src/Amazon.Lambda.Annotations
 
 ## Native AOT
 
-Native AOT is a feature of .NET 7 that compiles .NET assemblies into a single native executable. By using the native executable the .NET runtime 
+Native AOT is a feature that compiles .NET assemblies into a single native executable. By using the native executable the .NET runtime 
 is not required to be installed on the target platform. Native AOT can significantly improve Lambda cold starts for .NET Lambda functions. 
 This project enables Native AOT by setting the .NET `PublishAot` property in the .NET project file to `true`. The `StripSymbols` property is also
 set to `true` to strip debugging symbols from the deployed executable to reduce the executable's size.
@@ -23,9 +30,9 @@ set to `true` to strip debugging symbols from the deployed executable to reduce 
 ### Building Native AOT
 
 When publishing with Native AOT the build OS and Architecture must match the target platform that the application will run. For AWS Lambda that target
-platform is Amazon Linux 2. The AWS tooling for Lambda like the AWS Toolkit for Visual Studio, .NET Global Tool Amazon.Lambda.Tools and SAM CLI will 
-perform a container build using a .NET 7 Amazon Linux 2 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
-when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2 build environments. To install docker go to https://www.docker.com/.
+platform is Amazon Linux 2023. The AWS tooling for Lambda like the AWS Toolkit for Visual Studio, .NET Global Tool Amazon.Lambda.Tools and SAM CLI will 
+perform a container build using a .NET 8 Amazon Linux 2023 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
+when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2023 build environments. To install docker go to https://www.docker.com/.
 
 ### Trimming
 
@@ -40,7 +47,7 @@ For information about trimming see the documentation: <https://learn.microsoft.c
 
 ## Docker requirement
 
-Docker is required to be installed and running when building .NET Native AOT Lambda functions on any platform besides Amazon Linux 2. Information on how acquire Docker can be found here: https://docs.docker.com/get-docker/
+Docker is required to be installed and running when building .NET Native AOT Lambda functions on any platform besides Amazon Linux 2023. Information on how acquire Docker can be found here: https://docs.docker.com/get-docker/
 
 ## Here are some steps to follow from Visual Studio:
 

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/Readme.md
@@ -40,7 +40,7 @@ when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2023 build e
 As part of the Native AOT compilation, .NET assemblies will be trimmed removing types and methods that the compiler does not find a reference to. This is important
 to keep the native executable size small. When types are used through reflection this can go undetected by the compiler causing necessary types and methods to
 be removed. When testing Native AOT Lambda functions in Lambda if a runtime error occurs about missing types or methods the most likely solution will
-be to remove references to trim-unsafe code or configure [trimming options](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options?pivots=dotnet-7-0).
+be to remove references to trim-unsafe code or configure [trimming options](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options).
 This sample defaults to partial TrimMode because currently the AWS SDK for .NET does not support trimming. This will result in a larger executable size, and still does not
 guarantee runtime trimming errors won't be hit.
 

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/Startup.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/Startup.cs
@@ -1,0 +1,31 @@
+using Amazon.Lambda.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BlueprintBaseName._1;
+
+[LambdaStartup]
+public class Startup
+{
+    /// <summary>
+    /// Services for Lambda functions can be registered in the services dependency injection container in this method. 
+    ///
+    /// The services can be injected into the Lambda function through the containing type's constructor or as a
+    /// parameter in the Lambda function using the FromService attribute. Services injected for the constructor have
+    /// the lifetime of the Lambda compute container. Services injected as parameters are created within the scope
+    /// of the function invocation.
+    /// </summary>
+    public void ConfigureServices(IServiceCollection services)
+    {
+        //// Example of creating the IConfiguration object and
+        //// adding it to the dependency injection container.
+        //var builder = new ConfigurationBuilder()
+        //                    .AddJsonFile("appsettings.json", true);
+
+        //// Add AWS Systems Manager as a potential provider for the configuration. This is 
+        //// available with the Amazon.Extensions.Configuration.SystemsManager NuGet package.
+        //builder.AddSystemsManager("/app/settings");
+
+        //var configuration = builder.Build();
+        //services.AddSingleton<IConfiguration>(configuration);
+    }
+}

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/serverless.template
@@ -1,23 +1,31 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "An AWS Serverless Application.",
+  "Description": "An AWS Serverless Application. This template is partially managed by Amazon.Lambda.Annotations (v1.2.0.0).",
   "Resources": {
-    "RootGet": {
+    "BlueprintBaseName1FunctionsGetFunctionHandlerGenerated": {
       "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootGet"
+        ]
+      },
       "Properties": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "Handler": "GetFunctionHandler",
-        "Runtime": "provided.al2",
-        "CodeUri": "",
-        "MemorySize": 256,
+        "Runtime": "dotnet8",
+        "CodeUri": ".",
+        "MemorySize": 512,
         "Timeout": 30,
-        "Role": null,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
+        "PackageType": "Zip",
+        "Handler": "BlueprintBaseName.1",
+        "Environment": {
+          "Variables": {
+            "ANNOTATIONS_HANDLER": "GetFunctionHandler"
+          }
+        },
         "Events": {
           "RootGet": {
             "Type": "Api",
@@ -29,28 +37,58 @@
         }
       }
     },
-    "RootPut": {
+    "BlueprintBaseName1FunctionsPostFunctionHandlerGenerated": {
       "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "RootPost"
+        ]
+      },
       "Properties": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "Handler": "PutFunctionHandler",
-        "Runtime": "provided.al2",
-        "CodeUri": "",
-        "MemorySize": 256,
+        "Runtime": "dotnet8",
+        "CodeUri": ".",
+        "MemorySize": 512,
         "Timeout": 30,
-        "Role": null,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
+        "PackageType": "Zip",
+        "Handler": "BlueprintBaseName.1",
+        "Environment": {
+          "Variables": {
+            "ANNOTATIONS_HANDLER": "PostFunctionHandler"
+          }
+        },
         "Events": {
-          "RootPut": {
+          "RootPost": {
             "Type": "Api",
             "Properties": {
               "Path": "/",
-              "Method": "PUT"
+              "Method": "POST"
             }
+          }
+        }
+      }
+    },
+    "BlueprintBaseName1FunctionsGetCallingIPAsyncGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations"
+      },
+      "Properties": {
+        "Runtime": "dotnet8",
+        "CodeUri": ".",
+        "MemorySize": 512,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Zip",
+        "Handler": "BlueprintBaseName.1",
+        "Environment": {
+          "Variables": {
+            "ANNOTATIONS_HANDLER": "GetCallingIPAsync"
           }
         }
       }

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/test/BlueprintBaseName.1.Tests/FunctionsTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/test/BlueprintBaseName.1.Tests/FunctionsTest.cs
@@ -1,27 +1,20 @@
 using Xunit;
-using Amazon.Lambda.Core;
 using Amazon.Lambda.TestUtilities;
-using Amazon.Lambda.APIGatewayEvents;
-
+using System.Net;
 
 namespace BlueprintBaseName._1.Tests;
 
 public class FunctionsTest
 {
     [Fact]
-    public void TestGetMethod()
+    public async Task TestGetMethod()
     {
-        TestLambdaContext context;
-        APIGatewayProxyRequest request;
-        APIGatewayProxyResponse response;
-
         Functions functions = new Functions();
+        var context = new TestLambdaContext();
 
 
-        request = new APIGatewayProxyRequest();
-        context = new TestLambdaContext();
-        response = functions.GetFunctionHandler(request, context);
-        Assert.Equal(200, response.StatusCode);
-        Assert.Equal("Hello AWS Serverless", response.Body);
+        var ip = await functions.GetCallingIPAsync(context);
+
+        Assert.True(IPAddress.TryParse(ip, out var _));
     }
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -13,9 +13,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
-    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.4.4" />
-    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.5.3" />
-    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.3.2" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
+    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.5.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.6.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.4.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/Function.cs
@@ -21,8 +21,8 @@ public class Function
     /// <summary>
     /// A simple function that takes a string and does a ToUpper
     /// </summary>
-    /// <param name="input"></param>
-    /// <param name="context"></param>
+    /// <param name="input">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     [Logging(LogEvent = true)]
     [Tracing]

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -9,8 +9,8 @@
   "region": "DefaultRegion",
   "configuration": "Release",
   "function-architecture": "x86_64",
-  "function-runtime": "dotnet6",
-  "function-memory-size": 256,
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler",
   "environment-variables": "POWERTOOLS_SERVICE_NAME=PowertoolsFunction;POWERTOOLS_LOG_LEVEL=Info;POWERTOOLS_LOGGER_CASE=PascalCase;POWERTOOLS_TRACER_CAPTURE_RESPONSE=true;POWERTOOLS_TRACER_CAPTURE_ERROR=true;POWERTOOLS_METRICS_NAMESPACE=powertools_function"

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -13,10 +13,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
-    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.4.4" />
-    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.5.3" />
-    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.3.2" />
+    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.5.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.6.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.4.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/Functions.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/Functions.cs
@@ -21,7 +21,8 @@ public class Functions
     /// <summary>
     /// A Lambda function to respond to HTTP Get methods from API Gateway
     /// </summary>
-    /// <param name="request"></param>
+    /// <param name="request">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns>The API Gateway response.</returns>
     [Logging(LogEvent = true, CorrelationIdPath = CorrelationIdPaths.ApiGatewayRest)]
     [Metrics(CaptureColdStart = true)]

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/src/BlueprintBaseName.1/serverless.template
@@ -10,9 +10,9 @@
           "x86_64"
         ],
         "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Functions::Get",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": "",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Role": null,
         "Policies": [

--- a/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/PowertoolsServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleApplicationLoadBalancer/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleApplicationLoadBalancer/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.ApplicationLoadBalancerEvents" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleApplicationLoadBalancer/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleApplicationLoadBalancer/template/src/BlueprintBaseName.1/Function.cs
@@ -16,8 +16,8 @@ public class Function
     /// on the ApplicationLoadBalancerRequest and ApplicationLoadBalancerResponse objects. If "Multi value headers" is enabled then
     /// use MultiValueHeaders and MultiValueQueryStringParameters properties.
     /// </summary>
-    /// <param name="request"></param>
-    /// <param name="context"></param>
+    /// <param name="request">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     public ApplicationLoadBalancerResponse FunctionHandler(ApplicationLoadBalancerRequest request, ILambdaContext context)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleApplicationLoadBalancer/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleApplicationLoadBalancer/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "function-runtime": "dotnet6",
-  "function-memory-size": 256,
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler"
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleApplicationLoadBalancer/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleApplicationLoadBalancer/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
@@ -10,9 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
-    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.3.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.300.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -17,8 +17,8 @@ type Function() =
     /// <summary>
     /// A simple function to print out the DynamoDB stream event
     /// </summary>
-    /// <param name="dynamoEvent"></param>
-    /// <param name="context"></param>
+    /// <param name="dynamoEvent">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     member __.FunctionHandler (dynamoEvent: DynamoDBEvent) (context: ILambdaContext) =
         sprintf "Beginning to process %i records..." dynamoEvent.Records.Count

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -26,7 +26,7 @@ type Function() =
 
         let processRecord (record: DynamoDBEvent.DynamodbStreamRecord) =
             context.Logger.LogInformation(sprintf "Event ID: %s" record.EventID)
-            context.Logger.LogInformation(sprintf "Event Name: %s" record.EventName.Value)
+            context.Logger.LogInformation(sprintf "Event Name: %s" record.EventName)
             // TODO: Add business logic processing the record.Dynamodb object.
 
         dynamoEvent.Records

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "function-runtime": "dotnet6",
-  "function-memory-size": 256,
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler"
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,13 +2,12 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.3.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.300.0" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction-FSharp/template/test/BlueprintBaseName.1.Tests/FunctionTest.fs
@@ -1,12 +1,9 @@
 ﻿namespace BlueprintBaseName._1.Tests
 
-
 open Xunit
 open Amazon.Lambda.TestUtilities
 
 open Amazon.Lambda.DynamoDBEvents
-open Amazon.DynamoDBv2
-open Amazon.DynamoDBv2.Model
 
 open System
 open System.Collections.Generic
@@ -17,22 +14,22 @@ open BlueprintBaseName._1
 module FunctionTest =
     [<Fact>]
     let ``Test Reading DynamoDB Stream Event``() =
-        let keys = dict [ ("id", AttributeValue(S = "MyId")) ]
+        let keys = dict [ ("id", DynamoDBEvent.AttributeValue(S = "MyId")) ]
 
         let newImage = dict [
-                            ("field1", AttributeValue(S = "NewValue"))
-                            ("field2", AttributeValue(S = "AnotherNewValue"))
+                            ("field1", DynamoDBEvent.AttributeValue(S = "NewValue"))
+                            ("field2", DynamoDBEvent.AttributeValue(S = "AnotherNewValue"))
                         ]
 
         let oldImages = dict [
-                            ("field1", AttributeValue(S = "OldValue"))
-                            ("field2", AttributeValue(S = "AnotherOldValue"))
+                            ("field1", DynamoDBEvent.AttributeValue(S = "OldValue"))
+                            ("field2", DynamoDBEvent.AttributeValue(S = "AnotherOldValue"))
                         ]
 
         let streamRecord =
-            StreamRecord(
+            DynamoDBEvent.StreamRecord(
                 ApproximateCreationDateTime = DateTime.Now,
-                StreamViewType = StreamViewType.NEW_AND_OLD_IMAGES,
+                StreamViewType = "NEW_AND_OLD_IMAGES",
                 Keys = Dictionary(keys),
                 NewImage = Dictionary(newImage),
                 OldImage = Dictionary(oldImages)
@@ -41,7 +38,7 @@ module FunctionTest =
         let ddbStreamRecords = [
             DynamoDBEvent.DynamodbStreamRecord(
                 EventID = "id-foo",
-                EventName = OperationType.INSERT,
+                EventName = "INSERT",
                 AwsRegion = "us-west-2",
                 Dynamodb = streamRecord
             )

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -12,8 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
-    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.3.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.300.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/Function.cs
@@ -1,6 +1,5 @@
 using Amazon.Lambda.Core;
 using Amazon.Lambda.DynamoDBEvents;
-using Amazon.DynamoDBv2.Model;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
 [assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "function-runtime": "dotnet6",
-  "function-memory-size": 256,
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler"
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>
@@ -8,8 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.3.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.300.0" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleDynamoDBFunction/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
@@ -1,11 +1,9 @@
 using Xunit;
 
-using Amazon;
-using Amazon.Lambda.Core;
+
 using Amazon.Lambda.DynamoDBEvents;
 using Amazon.Lambda.TestUtilities;
-using Amazon.DynamoDBv2;
-using Amazon.DynamoDBv2.Model;
+
 
 
 
@@ -23,18 +21,17 @@ public class FunctionTest
                 new DynamoDBEvent.DynamodbStreamRecord
                 {
                     AwsRegion = "us-west-2",
-                    Dynamodb = new StreamRecord
+                    Dynamodb = new DynamoDBEvent.StreamRecord
                     {
                         ApproximateCreationDateTime = DateTime.Now,
-                        Keys = new Dictionary<string, AttributeValue> { {"id", new AttributeValue { S = "MyId" } } },
-                        NewImage = new Dictionary<string, AttributeValue> { { "field1", new AttributeValue { S = "NewValue" } }, { "field2", new AttributeValue { S = "AnotherNewValue" } } },
-                        OldImage = new Dictionary<string, AttributeValue> { { "field1", new AttributeValue { S = "OldValue" } }, { "field2", new AttributeValue { S = "AnotherOldValue" } } },
-                        StreamViewType = StreamViewType.NEW_AND_OLD_IMAGES
+                        Keys = new Dictionary<string, DynamoDBEvent.AttributeValue> { {"id", new DynamoDBEvent.AttributeValue { S = "MyId" } } },
+                        NewImage = new Dictionary<string, DynamoDBEvent.AttributeValue> { { "field1", new DynamoDBEvent.AttributeValue { S = "NewValue" } }, { "field2", new DynamoDBEvent.AttributeValue { S = "AnotherNewValue" } } },
+                        OldImage = new Dictionary<string, DynamoDBEvent.AttributeValue> { { "field1", new DynamoDBEvent.AttributeValue { S = "OldValue" } }, { "field2", new DynamoDBEvent.AttributeValue { S = "AnotherOldValue" } } },
+                        StreamViewType = "NEW_AND_OLD_IMAGES"
                     }
                 }
             }
         };
-
 
         var context = new TestLambdaContext();
         var function = new Function();

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFirehoseFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFirehoseFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.KinesisFirehoseEvents" Version="2.3.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFirehoseFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFirehoseFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "function-runtime": "dotnet6",
-  "function-memory-size": 256,
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler"
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFirehoseFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFirehoseFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFunction-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.KinesisEvents" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFunction-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFunction-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -17,8 +17,8 @@ type Function() =
     /// <summary>
     /// A function to process Kinesis events
     /// </summary>
-    /// <param name="kinesisEvent"></param>
-    /// <param name="context"></param>
+    /// <param name="kinesisEvent">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     member __.FunctionHandler (kinesisEvent: KinesisEvent) (context: ILambdaContext) =
         sprintf "Beginning to process % i records..." kinesisEvent.Records.Count

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFunction-FSharp/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFunction-FSharp/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "function-runtime": "dotnet6",
-  "function-memory-size": 256,
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler"
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFunction-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.KinesisEvents" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "function-runtime": "dotnet6",
-  "function-memory-size": 256,
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler"
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleKinesisFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.1.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.300.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.305.28" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -20,8 +20,8 @@ type Function(s3Client: IAmazonS3) =
     /// This method is called for every Lambda invocation. This method takes in an S3 event object and can be used
     /// to respond to S3 notifications.
     /// </summary>
-    /// <param name="event"></param>
-    /// <param name="context"></param>
+    /// <param name="event">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     member __.FunctionHandler (event: S3Event) (context: ILambdaContext) = task {
 

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "function-runtime": "dotnet6",
-  "function-memory-size": 256,
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler"
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,13 +2,13 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.1.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.300.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.305.28" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -12,8 +12,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.1.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.300.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.305.28" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/src/BlueprintBaseName.1/Function.cs
@@ -25,7 +25,7 @@ public class Function
     /// <summary>
     /// Constructs an instance with a preconfigured S3 client. This can be used for testing outside of the Lambda environment.
     /// </summary>
-    /// <param name="s3Client"></param>
+    /// <param name="s3Client">The service client to access Amazon S3.</param>
     public Function(IAmazonS3 s3Client)
     {
         this.S3Client = s3Client;
@@ -35,8 +35,8 @@ public class Function
     /// This method is called for every Lambda invocation. This method takes in an S3 event object and can be used 
     /// to respond to S3 notifications.
     /// </summary>
-    /// <param name="evnt"></param>
-    /// <param name="context"></param>
+    /// <param name="evnt">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     public async Task FunctionHandler(S3Event evnt, ILambdaContext context)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "function-runtime": "dotnet6",
-  "function-memory-size": 256,
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler"
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3Function/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>
@@ -9,7 +9,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.1.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.300.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.305.28" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.1.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.300.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.305.28" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Function.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/Function.fs
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/Function.fs
@@ -20,8 +20,8 @@ type Function(s3Client: IAmazonS3) =
     /// This method is called for every Lambda invocation. This method takes in an S3 event object and can be used
     /// to respond to S3 notifications.
     /// </summary>
-    /// <param name="event"></param>
-    /// <param name="context"></param>
+    /// <param name="event">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     member __.FunctionHandler (event: S3Event) (context: ILambdaContext) = task {
 

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/src/BlueprintBaseName.1/serverless.template
@@ -40,10 +40,10 @@
       "Type": "AWS::Serverless::Function",
       "Properties": {
         "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": "",
         "Description": "Default function",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Role": null,
         "Policies": [

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,13 +2,13 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.1.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.300.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.305.28" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -12,8 +12,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.1.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.300.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.305.28" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/Function.cs
@@ -25,7 +25,7 @@ public class Function
     /// <summary>
     /// Constructs an instance with a preconfigured S3 client. This can be used for testing the outside of the Lambda environment.
     /// </summary>
-    /// <param name="s3Client"></param>
+    /// <param name="s3Client">The service client to access Amazon S3.</param>
     public Function(IAmazonS3 s3Client)
     {
         this.S3Client = s3Client;
@@ -35,8 +35,8 @@ public class Function
     /// This method is called for every Lambda invocation. This method takes in an S3 event object and can be used 
     /// to respond to S3 notifications.
     /// </summary>
-    /// <param name="evnt"></param>
-    /// <param name="context"></param>
+    /// <param name="evntThe event for the Lambda function handler to process.
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     public async Task<string?> FunctionHandler(S3Event evnt, ILambdaContext context)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/src/BlueprintBaseName.1/serverless.template
@@ -40,10 +40,10 @@
       "Type": "AWS::Serverless::Function",
       "Properties": {
         "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": "",
         "Description": "Default function",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Role": null,
         "Policies": [

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>
@@ -9,7 +9,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.1.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.300.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.305.28" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleSNSFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleSNSFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.SNSEvents" Version="2.1.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleSNSFunction/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleSNSFunction/template/src/BlueprintBaseName.1/Function.cs
@@ -24,8 +24,8 @@ public class Function
     /// This method is called for every Lambda invocation. This method takes in an SNS event object and can be used 
     /// to respond to SNS messages.
     /// </summary>
-    /// <param name="evnt"></param>
-    /// <param name="context"></param>
+    /// <param name="evnt">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     public async Task FunctionHandler(SNSEvent evnt, ILambdaContext context)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleSNSFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleSNSFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "function-runtime": "dotnet6",
-  "function-memory-size": 256,
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler"
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleSNSFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleSNSFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleSQSFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleSQSFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleSQSFunction/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleSQSFunction/template/src/BlueprintBaseName.1/Function.cs
@@ -24,8 +24,8 @@ public class Function
     /// This method is called for every Lambda invocation. This method takes in an SQS event object and can be used 
     /// to respond to SQS messages.
     /// </summary>
-    /// <param name="evnt"></param>
-    /// <param name="context"></param>
+    /// <param name="evnt">The event for the Lambda function handler to process.</param>
+    /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
     public async Task FunctionHandler(SQSEvent evnt, ILambdaContext context)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleSQSFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleSQSFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "function-runtime": "dotnet6",
-  "function-memory-size": 256,
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler"
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleSQSFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleSQSFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld-FSharp/template/src/BlueprintBaseName.1/BlueprintBaseName.1.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="StepFunctionTasks.fs" />

--- a/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld-FSharp/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld-FSharp/template/src/BlueprintBaseName.1/serverless.template
@@ -13,8 +13,8 @@
             "Arn"
           ]
         },
-        "Runtime": "dotnet6",
-        "MemorySize": 256,
+        "Runtime": "dotnet8",
+        "MemorySize": 512,
         "Timeout": 30,
         "Code": {
           "S3Bucket": "",
@@ -32,8 +32,8 @@
             "Arn"
           ]
         },
-        "Runtime": "dotnet6",
-        "MemorySize": 256,
+        "Runtime": "dotnet8",
+        "MemorySize": 512,
         "Timeout": 30,
         "Code": {
           "S3Bucket": "",

--- a/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld-FSharp/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />

--- a/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -12,6 +12,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld/template/src/BlueprintBaseName.1/serverless.template
@@ -13,8 +13,8 @@
             "Arn"
           ]
         },
-        "Runtime": "dotnet6",
-        "MemorySize": 256,
+        "Runtime": "dotnet8",
+        "MemorySize": 512,
         "Timeout": 30,
         "Code": {
           "S3Bucket": "",
@@ -32,8 +32,8 @@
             "Arn"
           ]
         },
-        "Runtime": "dotnet6",
-        "MemorySize": 256,
+        "Runtime": "dotnet8",
+        "MemorySize": 512,
         "Timeout": 30,
         "Code": {
           "S3Bucket": "",

--- a/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Blueprints/BlueprintDefinitions/vs2022/TopLevelStatementsFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/TopLevelStatementsFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -14,6 +14,6 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/TopLevelStatementsFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/TopLevelStatementsFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "function-runtime": "dotnet6",
-  "function-memory-size": 256,
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
   "function-timeout": 30,
   "function-handler": "BlueprintBaseName.1"
 }

--- a/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -12,9 +12,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
-    <PackageReference Include="AWSSDK.ApiGatewayManagementApi" Version="3.7.300.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.300.0" />
+    <PackageReference Include="AWSSDK.ApiGatewayManagementApi" Version="3.7.300.52" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.301.13" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/template/src/BlueprintBaseName.1/Functions.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/template/src/BlueprintBaseName.1/Functions.cs
@@ -65,9 +65,9 @@ public class Functions
     /// <summary>
     /// Constructor used for testing allow tests to pass in moq versions of the service clients.
     /// </summary>
-    /// <param name="ddbClient"></param>
-    /// <param name="apiGatewayManagementApiClientFactory"></param>
-    /// <param name="connectionMappingTable"></param>
+    /// <param name="ddbClient">The service client for accessing Amazon DynamoDB.</param>
+    /// <param name="apiGatewayManagementApiClientFactory">The service client for accessing Amazon API Gateway.</param>
+    /// <param name="connectionMappingTable">Name of the DynamoDB table to store websocket connection mappings.</param>
     public Functions(IAmazonDynamoDB ddbClient, Func<string, IAmazonApiGatewayManagementApi> apiGatewayManagementApiClientFactory, string connectionMappingTable)
     {
         this.DDBClient = ddbClient;

--- a/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/template/src/BlueprintBaseName.1/serverless.template
@@ -38,9 +38,9 @@
       "Type": "AWS::Serverless::Function",
       "Properties": {
         "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Functions::OnConnectHandler",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": "",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Role": null,
         "Policies": [
@@ -65,9 +65,9 @@
       "Type": "AWS::Serverless::Function",
       "Properties": {
         "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Functions::OnDisconnectHandler",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": "",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Role": null,
         "Policies": [
@@ -92,9 +92,9 @@
       "Type": "AWS::Serverless::Function",
       "Properties": {
         "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Functions::SendMessageHandler",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": "",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Role": null,
         "Policies": [

--- a/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/Blueprints/BlueprintDefinitions/vs2022/template.nuspec
+++ b/Blueprints/BlueprintDefinitions/vs2022/template.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Amazon.Lambda.Templates</id>
-    <version>6.15.1</version>
+    <version>7.0.0</version>
     <authors>Amazon Web Services</authors>
     <tags>AWS Amazon Lambda</tags>
     <description>AWS Lambda templates for Microsoft Template Engine accessible with the dotnet CLI's new command</description>


### PR DESCRIPTION
*Description of changes:*
In preparation for .NET 8 Lambda support update the blueprints. The update has the following changes.

* Update all TargetFramework tags to `net8.0`.
* Update Lambda runtime targets to `dotnet8`
* Update the default memory size to 512 to match what is done in other languages like Java.
* Updated referenced in README files for target frameworks and Amazon Linux versions.
* Update Simple DynamoDB blueprint to handle the recent major version bump of the event package. That major version bump removed the dependency from the event package to the AWSSDK.DynamoDBv2 package.
* Update the serverless Native AOT blueprint to use Amazon.Lambda.Annotations. This takes care of generating the required main method.
* Update all of the AWS package references in the blueprints project files. This includes Lambda, SDK and PowerTools packages. The versions are updated using the following msbuild command from our build.proj file
```
dotnet msbuild .\buildtools\build.proj /t:run-blueprint-packager /p:UpdateBlueprintPackageVersions=true
```
* Native AOT projects will target the `dotnet8` runtime instead of `provided.al2023`. This is done because `provided.al2023` does not have the required `libicu` system library and avoid having to include it with the deployment bundle. You will see in the project files the removal of the logic to include libicu. This also remove the need to name the assembly as `bootstrap`.

## Testing
Run the msbuild target `/t:test-blueprints-dotnew` that confirms all blueprints can be instantiated and compiled
Manually deployments of the Native AOT and DynamoDB blueprints that had significant changes. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
