### PR TITLE
Update Lambda PowerShell to target .NET 8 runtime

### DIFF
--- a/Libraries/src/Amazon.Lambda.PowerShellHost/Amazon.Lambda.PowerShellHost.csproj
+++ b/Libraries/src/Amazon.Lambda.PowerShellHost/Amazon.Lambda.PowerShellHost.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.1" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.18" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.1" />

--- a/Libraries/src/Amazon.Lambda.PowerShellHost/Amazon.Lambda.PowerShellHost.csproj
+++ b/Libraries/src/Amazon.Lambda.PowerShellHost/Amazon.Lambda.PowerShellHost.csproj
@@ -3,20 +3,20 @@
   <Import Project="..\..\..\buildtools\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <Description>AWS Lambda PowerShell Host.</Description>
     <AssemblyTitle>Amazon.Lambda.PowerShellHost</AssemblyTitle>
-    <VersionPrefix>2.2.0</VersionPrefix>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.PowerShellHost</AssemblyName>
     <PackageId>Amazon.Lambda.PowerShellHost</PackageId>
     <PackageTags>AWS;Amazon;Lambda;PowerShell</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.0.4" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.1" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Amazon.Lambda.Core\Amazon.Lambda.Core.csproj" />

--- a/Libraries/test/PowerShellTests/PowerShellTests.csproj
+++ b/Libraries/test/PowerShellTests/PowerShellTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>PowerShellTests</AssemblyName>
     <PackageId>PowerShellTests</PackageId>
   </PropertyGroup>
@@ -13,9 +13,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.4.5" />
   </ItemGroup>
 
 

--- a/Libraries/test/TestPowerShellFunctions/PowerShellScriptsAsFunctions/PowerShellScriptsAsFunctions.csproj
+++ b/Libraries/test/TestPowerShellFunctions/PowerShellScriptsAsFunctions/PowerShellScriptsAsFunctions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>

--- a/PowerShell/Module/AWSLambdaPSCore.psd1
+++ b/PowerShell/Module/AWSLambdaPSCore.psd1
@@ -12,7 +12,7 @@
 RootModule = 'AWSLambdaPSCore.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.0.1.0'
+ModuleVersion = '4.0.0.0'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core'
@@ -27,7 +27,7 @@ Author = 'Amazon.com, Inc'
 CompanyName = 'Amazon.com, Inc'
 
 # Copyright statement for this module
-Copyright = 'Copyright 2012-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.'
+Copyright = 'Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.'
 
 # Description of the functionality provided by this module
 Description = 'The AWS Lambda Tools for Powershell can be used to create and deploy AWS Lambda functions written in PowerShell.'

--- a/PowerShell/Module/Private/_Constants.ps1
+++ b/PowerShell/Module/Private/_Constants.ps1
@@ -20,15 +20,15 @@ if (!($AwsPowerShellFunctionEnvName))
 
 if (!($AwsPowerShellDefaultSdkVersion))
 {
-    New-Variable -Name AwsPowerShellDefaultSdkVersion -Value '7.2.1' -Option Constant
+    New-Variable -Name AwsPowerShellDefaultSdkVersion -Value '7.4.1' -Option Constant
 }
 
 if (!($AwsPowerShellTargetFramework))
 {
-    New-Variable -Name AwsPowerShellTargetFramework -Value 'net6.0' -Option Constant
+    New-Variable -Name AwsPowerShellTargetFramework -Value 'net8.0' -Option Constant
 }
 
 if (!($AwsPowerShellLambdaRuntime))
 {
-    New-Variable -Name AwsPowerShellLambdaRuntime -Value 'dotnet6' -Option Constant
+    New-Variable -Name AwsPowerShellLambdaRuntime -Value 'dotnet8' -Option Constant
 }

--- a/PowerShell/Module/Templates/Blueprints/Basic/basic.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/Basic/basic.ps1.txt
@@ -9,7 +9,7 @@
 # To include PowerShell modules with your Lambda function, like the AWS.Tools.S3 module, add a "#Requires" statement
 # indicating the module and version. If using an AWS.Tools.* module the AWS.Tools.Common module is also required.
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.29.0'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/CloudFormationCustomResource/cloudformationcustomresource.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/CloudFormationCustomResource/cloudformationcustomresource.ps1.txt
@@ -9,7 +9,7 @@
 # To include PowerShell modules with your Lambda function, like the AWS.Tools.S3 module, add a "#Requires" statement
 # indicating the module and version. If using an AWS.Tools.* module the AWS.Tools.Common module is also required.
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.29.0'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/CodeCommitTrigger/codecommittrigger.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/CodeCommitTrigger/codecommittrigger.ps1.txt
@@ -9,7 +9,7 @@
 # To include PowerShell modules with your Lambda function, like the AWS.Tools.S3 module, add a "#Requires" statement
 # indicating the module and version. If using an AWS.Tools.* module the AWS.Tools.Common module is also required.
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.29.0'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/DetectLabels/detectlabels.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/DetectLabels/detectlabels.ps1.txt
@@ -9,9 +9,9 @@
 # To include PowerShell modules with your Lambda function, like the AWS.Tools.S3 module, add a "#Requires" statement
 # indicating the module and version. If using an AWS.Tools.* module the AWS.Tools.Common module is also required.
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.29.0'}
-#Requires -Modules @{ModuleName='AWS.Tools.Rekognition';ModuleVersion='4.1.29.0'}
-#Requires -Modules @{ModuleName='AWS.Tools.S3';ModuleVersion='4.1.29.0'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
+#Requires -Modules @{ModuleName='AWS.Tools.Rekognition';ModuleVersion='4.1.518'}
+#Requires -Modules @{ModuleName='AWS.Tools.S3';ModuleVersion='4.1.518'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/KinesisStreamProcessor/kinesisstreamprocessor.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/KinesisStreamProcessor/kinesisstreamprocessor.ps1.txt
@@ -9,7 +9,7 @@
 # To include PowerShell modules with your Lambda function, like the AWS.Tools.S3 module, add a "#Requires" statement
 # indicating the module and version. If using an AWS.Tools.* module the AWS.Tools.Common module is also required.
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.29.0'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/S3Event/s3event.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/S3Event/s3event.ps1.txt
@@ -12,8 +12,8 @@
 # The following link contains documentation describing the structure of the S3 event object.
 # https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.29.0'}
-#Requires -Modules @{ModuleName='AWS.Tools.S3';ModuleVersion='4.1.29.0'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
+#Requires -Modules @{ModuleName='AWS.Tools.S3';ModuleVersion='4.1.518'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/S3EventToSNS/s3tosns.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/S3EventToSNS/s3tosns.ps1.txt
@@ -15,8 +15,8 @@
 # This example demonstrates how to process an S3 Event that follows the process:
 # S3 Event -> SNS Topic -> Lambda Function
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.29.0'}
-#Requires -Modules @{ModuleName='AWS.Tools.S3';ModuleVersion='4.1.29.0'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
+#Requires -Modules @{ModuleName='AWS.Tools.S3';ModuleVersion='4.1.518'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/S3EventToSNSToSQS/s3tosnstosqs.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/S3EventToSNSToSQS/s3tosnstosqs.ps1.txt
@@ -15,8 +15,8 @@
 # This example demonstrates how to process an S3 Event that follows the process:
 # S3 Event -> SNS Topic -> SQS Queue -> Lambda Function
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.29.0'}
-#Requires -Modules @{ModuleName='AWS.Tools.S3';ModuleVersion='4.1.29.0'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
+#Requires -Modules @{ModuleName='AWS.Tools.S3';ModuleVersion='4.1.518'}
 
 # Uncomment to send the input event to CloudWatch Logs
 #Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/S3EventToSQS/s3tosqs.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/S3EventToSQS/s3tosqs.ps1.txt
@@ -15,8 +15,8 @@
 # This example demonstrates how to process an S3 Event that follows the process:
 # S3 Event -> SQS Queue -> Lambda Function
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.29.0'}
-#Requires -Modules @{ModuleName='AWS.Tools.S3';ModuleVersion='4.1.29.0'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
+#Requires -Modules @{ModuleName='AWS.Tools.S3';ModuleVersion='4.1.518'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/SNSSubscription/snssubscription.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/SNSSubscription/snssubscription.ps1.txt
@@ -9,7 +9,7 @@
 # To include PowerShell modules with your Lambda function, like the AWS.Tools.S3 module, add a "#Requires" statement
 # indicating the module and version. If using an AWS.Tools.* module the AWS.Tools.Common module is also required.
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.29.0'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/SNSToSQS/snstosqs.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/SNSToSQS/snstosqs.ps1.txt
@@ -12,7 +12,7 @@
 # This example demonstrates how to process an SNS Message that follows the process:
 # SNS topic -> SQS Queue -> Lambda Function
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.29.0'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/SQSQueueProcessor/sqsprocessor.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/SQSQueueProcessor/sqsprocessor.ps1.txt
@@ -12,7 +12,7 @@
 # This example demonstrates how to process an SQS Queue:
 # SQS Queue -> Lambda Function
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.29.0'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/projectfile.csproj.txt
+++ b/PowerShell/Module/Templates/Blueprints/projectfile.csproj.txt
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     </PropertyGroup>
 
@@ -16,7 +16,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.PowerShell.SDK" Version="POWERSHELL_SDK_VERSION" />
 
-        <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-        <PackageReference Include="Amazon.Lambda.PowerShellHost" Version="2.2.0" />
+        <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
+        <PackageReference Include="Amazon.Lambda.PowerShellHost" Version="3.0.0" />
     </ItemGroup>
 </Project>

--- a/PowerShell/README.md
+++ b/PowerShell/README.md
@@ -9,19 +9,19 @@ Before we get started developing PowerShell based Lambda functions, let's set up
 development environment.
 
 First, we need to set up the correct version of PowerShell. AWS Lambda support 
-for PowerShell is based on the cross-platform PowerShell Core 6.0 release. This means 
+for PowerShell is based on the cross-platform PowerShell release. This means 
 you can develop your Lambda functions for PowerShell on Windows, Linux, or Mac. If you don't 
-have this version of PowerShell installed, you can find instructions [here](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.2).
+have this version of PowerShell installed, you can find instructions [here](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.4).
 
 If you are using Visual Studio Code on Windows as your IDE, you need to ensure it's 
 configured for PowerShell Core. To learn how to configure Visual Studio Code for 
-PowerShell Core, see the following: https://learn.microsoft.com/en-us/powershell/scripting/dev-cross-plat/vscode/using-vscode?view=powershell-7.2
+PowerShell Core, see the following: https://learn.microsoft.com/en-us/powershell/scripting/dev-cross-plat/vscode/using-vscode?view=powershell-7.4
 
-Next, we need to install the .NET 6 SDK. Because PowerShell Core is built on top of 
-.NET Core, the Lambda support for PowerShell uses the same .NET 6 Lambda runtime for 
-both .NET Core and PowerShell based Lambda functions. The .NET 6 SDK is used by 
+Next, we need to install the .NET 8 SDK. Because PowerShell Core is built on top of 
+.NET Core, the Lambda support for PowerShell uses the same .NET 8 Lambda runtime for 
+both .NET Core and PowerShell based Lambda functions. The .NET 8 SDK is used by 
 the new PowerShell publishing cmdlets for Lambda to create the Lambda deployment 
-package. You can find the .NET 6 SDK [here]( https://www.microsoft.com/net/download). Be 
+package. You can find the .NET 8 SDK [here]( https://www.microsoft.com/net/download). Be 
 sure to install the SDK, not the runtime installation.
 
 The last component we need for the development environment is the 


### PR DESCRIPTION
*Description of changes:*
In preparation for the upcoming .NET 8 release update the `AWSLambdaPSCore` module for publishing PowerShell scripts to target .NET 8 and the upcoming .NET 8 Lambda runtime.

This follows the pattern we have done for previous runtime releases. The module has a major version update to v4. Users that take the v4 major version update will deploy to .NET 8. If users want to stay with .NET 6 then they need to keep using the v3.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
