### PR TITLE
Remove missed rd.xml reference in blueprint readme

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTFunction/template/src/BlueprintBaseName.1/Readme.md
@@ -3,7 +3,6 @@
 This starter project consists of:
 * Function.cs - contains a class with a `Main` method that starts the bootstrap and a single function handler method.
 * aws-lambda-tools-defaults.json - default argument settings for use with Visual Studio and command line deployment tools for AWS.
-* rd.xml - Runtime directives configuration file used to tell the Native AOT compiler what code to not trim out of .NET assemblies.
 
 You may also have a test project depending on the options selected.
 


### PR DESCRIPTION
*Description of changes:*
Missed removing this in a previous PR. We no longer include or recommend using rd.xml

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
