### PR TITLE
Add ToJson for DynamoDBEvent

### DIFF
--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents/Amazon.Lambda.DynamoDBEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents/Amazon.Lambda.DynamoDBEvents.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>netcoreapp3.1;net8.0</TargetFrameworks>
     <Description>Amazon Lambda .NET Core support - DynamoDBEvents package.</Description>
     <AssemblyTitle>Amazon.Lambda.DynamoDBEvents</AssemblyTitle>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.DynamoDBEvents</AssemblyName>
     <PackageId>Amazon.Lambda.DynamoDBEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents/ExtensionMethods.cs
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents/ExtensionMethods.cs
@@ -1,0 +1,163 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using static Amazon.Lambda.DynamoDBEvents.DynamoDBEvent;
+
+namespace Amazon.Lambda.DynamoDBEvents
+{
+    /// <summary>
+    /// Extension methods for working with <see cref="DynamoDBEvent"/>
+    /// </summary>
+    public static class ExtensionMethods
+    {
+        /// <summary>
+        /// Converts a dictionary representing a DynamoDB item to a JSON string.
+        /// This may be useful when casting a DynamoDB Lambda event to the AWS SDK's 
+        /// higher-level document and object persistence classes.
+        /// </summary>
+        /// <remarks></remarks>
+        /// <param name="item">Dictionary representing a DynamoDB item</param>
+        /// <returns>Unformatted JSON string representing the DynamoDB item</returns>
+        public static string ToJson(this Dictionary<string, AttributeValue> item)
+        {
+            return ToJson(item, false);
+        }
+
+        /// <summary>
+        /// Converts a dictionary representing a DynamoDB item to a JSON string.
+        /// This may be useful when casting a DynamoDB Lambda event to the AWS SDK's 
+        /// higher-level document and object persistence classes.
+        /// </summary>
+        /// <remarks></remarks>
+        /// <param name="item">Dictionary representing a DynamoDB item</param>
+        /// <returns>Formatted JSON string representing the DynamoDB item</returns>
+        public static string ToJsonPretty(this Dictionary<string, AttributeValue> item)
+        {
+            return ToJson(item, true);
+        }
+
+        /// <summary>
+        /// Internal entry point for converting a dictionary representing a DynamoDB item to a JSON string.
+        /// </summary>
+        /// <param name="item">Dictionary representing a DynamoDB item</param>
+        /// <param name="prettyPrint">Whether the resulting JSON should be formatted</param>
+        /// <returns>JSON string representing the DynamoDB item</returns>
+        private static string ToJson(Dictionary<string, AttributeValue> item, bool prettyPrint)
+        {
+            if (item == null || item.Count == 0)
+            {
+                return "{}";
+            }
+
+            var stream = new MemoryStream();
+            var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = prettyPrint});
+
+            WriteJson(writer, item);
+
+            writer.Flush();
+            return Encoding.UTF8.GetString(stream.ToArray());
+        }
+
+        /// <summary>
+        /// Writes a single DynamoDB attribute as a json. May be called recursively for maps.
+        /// </summary>
+        /// <param name="writer">JSON writer</param>
+        /// <param name="item">Dictionary representing a DynamoDB item, or a map within an item</param>
+        private static void WriteJson(Utf8JsonWriter writer, Dictionary<string, AttributeValue> item)
+        {
+            writer.WriteStartObject();
+
+            foreach (var attribute in item)
+            {
+                writer.WritePropertyName(attribute.Key);
+                WriteJsonValue(writer, attribute.Value);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        /// <summary>
+        /// Writes a single DynamoDB attribute value as a json value
+        /// </summary>
+        /// <param name="writer">JSON writer</param>
+        /// <param name="attribute">DynamoDB attribute</param>
+        private static void WriteJsonValue(Utf8JsonWriter writer, AttributeValue attribute)
+        {
+            if (attribute.S != null)
+            {
+                writer.WriteStringValue(attribute.S);
+            }
+            else if (attribute.N != null)
+            {
+#if NETCOREAPP3_1  // WriteRawValue was added in .NET 6, but we need to write out Number values without quotes
+                using (var document = JsonDocument.Parse(attribute.N))
+                {
+                    document.WriteTo(writer);
+                }
+#else
+                writer.WriteRawValue(attribute.N);
+#endif
+            }
+            else if (attribute.B != null)
+            {
+                writer.WriteBase64StringValue(attribute.B.ToArray());
+            }
+            else if (attribute.BOOL != null)
+            {
+                writer.WriteBooleanValue(attribute.BOOL.Value);
+            }
+            else if (attribute.NULL != null)
+            {
+                writer.WriteNullValue();
+            }
+            else if (attribute.M != null)
+            {
+                WriteJson(writer, attribute.M);
+            }
+            else if (attribute.L != null)
+            {
+                writer.WriteStartArray();
+                foreach (var item in attribute.L)
+                {
+                    WriteJsonValue(writer, item);
+                }
+                writer.WriteEndArray();
+            }
+            else if (attribute.SS != null)
+            {
+                writer.WriteStartArray();
+                foreach (var item in attribute.SS)
+                {
+                    writer.WriteStringValue(item);
+                }
+                writer.WriteEndArray();
+            }
+            else if (attribute.NS != null)
+            {
+                writer.WriteStartArray();
+                foreach (var item in attribute.NS)
+                {
+#if NETCOREAPP3_1  // WriteRawValue was added in .NET 6, but we need to write out Number values without quotes
+                    using (var document = JsonDocument.Parse(item))
+                    {
+                        document.WriteTo(writer);
+                    }
+#else
+                    writer.WriteRawValue(item);
+#endif
+                }
+                writer.WriteEndArray();
+            }
+            else if (attribute.BS != null)
+            {
+                writer.WriteStartArray();
+                foreach (var item in attribute.BS)
+                {
+                    writer.WriteBase64StringValue(item.ToArray());
+                }
+                writer.WriteEndArray();
+            }
+        }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents/ExtensionMethods.cs
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents/ExtensionMethods.cs
@@ -16,7 +16,6 @@ namespace Amazon.Lambda.DynamoDBEvents
         /// This may be useful when casting a DynamoDB Lambda event to the AWS SDK's 
         /// higher-level document and object persistence classes.
         /// </summary>
-        /// <remarks></remarks>
         /// <param name="item">Dictionary representing a DynamoDB item</param>
         /// <returns>Unformatted JSON string representing the DynamoDB item</returns>
         public static string ToJson(this Dictionary<string, AttributeValue> item)
@@ -29,7 +28,6 @@ namespace Amazon.Lambda.DynamoDBEvents
         /// This may be useful when casting a DynamoDB Lambda event to the AWS SDK's 
         /// higher-level document and object persistence classes.
         /// </summary>
-        /// <remarks></remarks>
         /// <param name="item">Dictionary representing a DynamoDB item</param>
         /// <returns>Formatted JSON string representing the DynamoDB item</returns>
         public static string ToJsonPretty(this Dictionary<string, AttributeValue> item)
@@ -50,8 +48,8 @@ namespace Amazon.Lambda.DynamoDBEvents
                 return "{}";
             }
 
-            var stream = new MemoryStream();
-            var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = prettyPrint});
+            using var stream = new MemoryStream();
+            using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = prettyPrint});
 
             WriteJson(writer, item);
 
@@ -91,10 +89,8 @@ namespace Amazon.Lambda.DynamoDBEvents
             else if (attribute.N != null)
             {
 #if NETCOREAPP3_1  // WriteRawValue was added in .NET 6, but we need to write out Number values without quotes
-                using (var document = JsonDocument.Parse(attribute.N))
-                {
-                    document.WriteTo(writer);
-                }
+                using var document = JsonDocument.Parse(attribute.N);
+                document.WriteTo(writer);
 #else
                 writer.WriteRawValue(attribute.N);
 #endif
@@ -139,10 +135,8 @@ namespace Amazon.Lambda.DynamoDBEvents
                 foreach (var item in attribute.NS)
                 {
 #if NETCOREAPP3_1  // WriteRawValue was added in .NET 6, but we need to write out Number values without quotes
-                    using (var document = JsonDocument.Parse(item))
-                    {
-                        document.WriteTo(writer);
-                    }
+                    using var document = JsonDocument.Parse(item);
+                    document.WriteTo(writer);
 #else
                     writer.WriteRawValue(item);
 #endif

--- a/Libraries/test/EventsTests.NET6/EventsTests.NET6.csproj
+++ b/Libraries/test/EventsTests.NET6/EventsTests.NET6.csproj
@@ -5,6 +5,7 @@
     <PackageId>EventsTests31</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RootNamespace>EventsTests.NET6</RootNamespace>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
 
@@ -54,13 +55,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.301.14" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="AWSSDK.Core" Version="3.7.10.9" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.302.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Libraries/test/EventsTests.NETCore31/EventsTests.NETCore31.csproj
+++ b/Libraries/test/EventsTests.NETCore31/EventsTests.NETCore31.csproj
@@ -6,6 +6,7 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RuntimeIdentifiers>win7-x64;win7-x86</RuntimeIdentifiers>
     <RootNamespace>EventsTests31</RootNamespace>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
 
@@ -54,10 +55,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.301.14" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="AWSSDK.Core" Version="3.7.10.9" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.302.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Libraries/test/EventsTests.Shared/DynamoDBEventJsonTests.cs
+++ b/Libraries/test/EventsTests.Shared/DynamoDBEventJsonTests.cs
@@ -1,0 +1,445 @@
+﻿using Amazon.DynamoDBv2.DocumentModel;
+using Amazon.Lambda.DynamoDBEvents;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+using static Amazon.Lambda.DynamoDBEvents.DynamoDBEvent;
+
+namespace Amazon.Lambda.Tests
+{
+    /// <summary>
+    /// Tests converting <see cref="DynamoDBEvent"/> to JSON and AWS SDK types
+    /// </summary>
+    public class DynamoDBEventTests
+    {
+        /// <summary>
+        /// Internal helper that prepares a Lambda DynamoDB event containing a given DynamoDB item
+        /// </summary>
+        private DynamoDBEvent PrepareEvent(Dictionary<string, AttributeValue> attributes)
+        {
+            return new DynamoDBEvent
+            {
+                Records = new List<DynamodbStreamRecord>
+                {
+                    new DynamodbStreamRecord
+                    {
+                        Dynamodb = new StreamRecord()
+                        {
+                            NewImage = attributes
+                        }
+                    }
+                }
+            };
+        }
+
+        [Fact]
+        public void String_ToJson()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "Message", new AttributeValue {S = "This is a string" } }
+            });
+
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+
+            Assert.Equal("{\"Message\":\"This is a string\"}", json);
+        }
+
+        [Fact]
+        public void String_ToDocument()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "Message", new AttributeValue {S = "This is a string" } }
+            });
+
+            // Convert the event from the Lambda package to the SDK type
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+            var document = Document.FromJson(json);
+
+            Assert.NotNull(document["Message"]);
+            Assert.Equal("This is a string", document["Message"].AsString());
+        }
+
+        [Fact]
+        public void Number_ToJson()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "Integer", new AttributeValue {N = "123" } },
+                { "Double", new AttributeValue {N = "123.45" } }
+            });
+
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+
+            Assert.Equal("{\"Integer\":123,\"Double\":123.45}", json);
+        }
+
+        [Fact]
+        public void Number_ToDocument()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "Integer", new AttributeValue {N = "123" } },
+                { "Double", new AttributeValue {N = "123.45" } }
+            });
+
+            // Convert the event from the Lambda package to the SDK type
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+            var document = Document.FromJson(json);
+
+            Assert.Equal(123, document["Integer"].AsInt());
+            Assert.Equal(123.45, document["Double"].AsDouble());
+        }
+
+        [Fact]
+        public void Binary_ToJson()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "Binary", new AttributeValue {B = new MemoryStream(Encoding.UTF8.GetBytes("hello world")) } }
+            });
+
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+
+            Assert.Equal("{\"Binary\":\"aGVsbG8gd29ybGQ=\"}", json);
+        }
+
+        [Fact]
+        public void Binary_ToDocument()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "Binary", new AttributeValue {B = new MemoryStream(Encoding.UTF8.GetBytes("hello world"))  } }
+            });
+
+            // Convert the event from the Lambda package to the SDK type
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+            var document = Document.FromJson(json);
+
+            // Must opt in to binary decoding, since we can't distinguish from strings
+            document.DecodeBase64Attributes("Binary");
+
+            Assert.Equal("hello world", Encoding.UTF8.GetString(document["Binary"].AsByteArray()));
+        }
+
+        [Fact]
+        public void Bool_ToJson()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "False", new AttributeValue {BOOL = false } },
+            });
+
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+
+            Assert.Equal("{\"False\":false}", json);
+        }
+
+        [Fact]
+        public void Bool_ToDocument()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "False", new AttributeValue {BOOL = false } },
+            });
+
+            // Convert the event from the Lambda package to the SDK type
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+            var document = Document.FromJson(json);
+
+            Assert.False(document["False"].AsBoolean());
+        }
+
+        [Fact]
+        public void Null_ToJson()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "Null", new AttributeValue {NULL = true } }
+            });
+
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+
+            Assert.Equal("{\"Null\":null}", json);
+        }
+
+        [Fact]
+        public void Null_ToDocument()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "Null", new AttributeValue {NULL = true } }
+            });
+
+            // Convert the event from the Lambda package to the SDK type
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+            var document = Document.FromJson(json);
+
+            Assert.Equal(DynamoDBNull.Null, document["Null"].AsDynamoDBNull());
+        }
+
+        [Fact]
+        public void Map_ToJson()
+        {
+            var map = new Dictionary<string, AttributeValue>
+            {
+                { "string", new AttributeValue {S = "string"} },
+                { "number", new AttributeValue {N = "123.45"} },
+                { "boolean", new AttributeValue {BOOL = false} }
+            };
+
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>
+            {
+                { "Map", new AttributeValue { M = map } }
+            });
+
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+
+            Assert.Equal("{\"Map\":{\"string\":\"string\",\"number\":123.45,\"boolean\":false}}", json);
+        }
+
+        [Fact]
+        public void Map_ToDocument()
+        {
+            var map = new Dictionary<string, AttributeValue>
+            {
+                { "string", new AttributeValue {S = "string"} },
+                { "number", new AttributeValue {N = "123.45"} },
+                { "boolean", new AttributeValue {BOOL = false} }
+            };
+
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>
+            {
+                { "Map", new AttributeValue { M = map } }
+            });
+
+            // Convert the event from the Lambda package to the SDK type
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+            var document = Document.FromJson(json);
+
+            Assert.NotNull(document["Map"]);
+            Assert.NotNull(document["Map"].AsDocument());
+            Assert.Equal("string", document["Map"].AsDocument()["string"].AsString());
+            Assert.Equal(123.45, document["Map"].AsDocument()["number"].AsDouble());
+            Assert.Equal(false, document["Map"].AsDocument()["boolean"].AsBoolean());
+        }
+
+        [Fact]
+        public void EmptyMap_ToJson()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>
+            {
+                { "Map", new AttributeValue { M = new Dictionary<string, AttributeValue>() } }
+            });
+
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+
+            Assert.Equal("{\"Map\":{}}", json);
+        }
+
+        [Fact]
+        public void EmptyMap_ToDocument()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>
+            {
+                { "Map", new AttributeValue { M = new Dictionary<string, AttributeValue>() } }
+            });
+
+            // Convert the event from the Lambda package to the SDK type
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+            var document = Document.FromJson(json);
+
+            Assert.NotNull(document["Map"]);
+            Assert.NotNull(document["Map"].AsDocument());
+        }
+
+        [Fact]
+        public void List_ToJson()
+        {
+            var list = new List<AttributeValue>
+            {
+                new AttributeValue { S = "string"},
+                new AttributeValue { N = "123"},
+                new AttributeValue { BOOL = false}
+            };
+
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "List", new AttributeValue { L = list } }
+            });
+
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+
+            Assert.Equal("{\"List\":[\"string\",123,false]}", json);
+        }
+
+        [Fact]
+        public void List_ToDocument()
+        {
+            var list = new List<AttributeValue>
+            {
+                new AttributeValue { S = "string"},
+                new AttributeValue { N = "123"},
+                new AttributeValue { BOOL = false}
+            };
+
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "List", new AttributeValue { L = list } }
+            });
+
+            // Convert the event from the Lambda package to the SDK type
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+            var document = Document.FromJson(json);
+
+            Assert.NotNull(document["List"].AsDynamoDBList());
+            Assert.Equal("string", document["List"].AsDynamoDBList()[0].AsString());
+            Assert.Equal(123, document["List"].AsDynamoDBList()[1].AsInt());
+            Assert.False(document["List"].AsDynamoDBList()[2].AsBoolean());
+        }
+
+        [Fact]
+        public void EmptyList_ToJson()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "List", new AttributeValue { L = new List<AttributeValue>() } }
+            });
+
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+
+            Assert.Equal("{\"List\":[]}", json);
+        }
+
+        [Fact]
+        public void EmptyList_ToDocument()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "List", new AttributeValue { L = new List<AttributeValue>() } }
+            });
+
+            // Convert the event from the Lambda package to the SDK type
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+            var document = Document.FromJson(json);
+
+            Assert.NotNull(document["List"].AsDynamoDBList());
+            Assert.Empty(document["List"].AsDynamoDBList().AsArrayOfDynamoDBEntry());
+        }
+
+        [Fact]
+        public void StringSet_ToJson()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "StringSet", new AttributeValue { SS = new List<string> { "Black", "Green", "Red" }}}
+            });
+
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+
+            Assert.Equal("{\"StringSet\":[\"Black\",\"Green\",\"Red\"]}", json);
+        }
+
+        [Fact]
+        public void StringSet_ToDocument()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "StringSet", new AttributeValue { SS = new List<string> { "Black", "Green", "Red" }}}
+            });
+
+            // Convert the event from the Lambda package to the SDK type
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+            var document = Document.FromJson(json);
+
+            var hashSet = document["StringSet"].AsHashSetOfString();
+            Assert.NotNull(hashSet);
+            Assert.Equal(3, hashSet.Count);
+            Assert.True(hashSet.Contains("Black"));
+            Assert.True(hashSet.Contains("Green"));
+            Assert.True(hashSet.Contains("Red"));
+        }
+
+        [Fact]
+        public void NumberSet_ToJson()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "NumberSet", new AttributeValue { NS = new List<string> { "123", "123.45", "-123.45" } } }
+            });
+
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+
+            Assert.Equal("{\"NumberSet\":[123,123.45,-123.45]}", json);
+        }
+
+        [Fact]
+        public void NumberSet_ToDocument()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "NumberSet", new AttributeValue { NS = new List<string> { "123", "123.45", "-123.45" } } }
+            });
+
+            // Convert the event from the Lambda package to the SDK type
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+            var document = Document.FromJson(json);
+
+            var list = document["NumberSet"].AsListOfDynamoDBEntry();
+            Assert.NotNull(list);
+            Assert.Equal(3, list.Count);
+            Assert.Equal(123, list[0].AsInt());
+            Assert.Equal(123.45, list[1].AsDouble());
+            Assert.Equal(-123.45, list[2].AsDouble());
+        }
+
+        [Fact]
+        public void BinarySet_ToJson()
+        {
+            var set = new List<MemoryStream>
+            {
+                new MemoryStream(Encoding.UTF8.GetBytes("hello world")),
+                new MemoryStream(Encoding.UTF8.GetBytes("hello world!"))
+            };
+
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "BinarySet", new AttributeValue { BS = set } }
+            });
+
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+
+            Assert.Equal("{\"BinarySet\":[\"aGVsbG8gd29ybGQ=\",\"aGVsbG8gd29ybGQh\"]}", json);
+        }
+
+        [Fact]
+        public void BinarySet_ToDocument()
+        {
+            var set = new List<MemoryStream> 
+            {
+                new MemoryStream(Encoding.UTF8.GetBytes("hello world")),
+                new MemoryStream(Encoding.UTF8.GetBytes("hello world!"))
+            };
+
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "BinarySet", new AttributeValue { BS = set } }
+            });
+
+            // Convert the event from the Lambda package to the SDK type
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+            var document = Document.FromJson(json);
+
+            document.DecodeBase64Attributes("BinarySet");
+
+            var list = document["BinarySet"].AsListOfDynamoDBEntry();
+            Assert.NotNull(list);
+
+            Assert.Equal(2, list.Count);
+            Assert.Equal("hello world", Encoding.UTF8.GetString(list[0].AsByteArray()));
+            Assert.Equal("hello world!", Encoding.UTF8.GetString(list[1].AsByteArray()));
+        }
+    }
+}

--- a/Libraries/test/EventsTests.Shared/EventsTests.Shared.projitems
+++ b/Libraries/test/EventsTests.Shared/EventsTests.Shared.projitems
@@ -75,5 +75,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)EventTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DynamoDBEventJsonTests.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
*Issue #, if available:* #1654, #1657, DOTNET-7345

*Description of changes:* 
### Before
In #1648, we removed the dependency on `AWSSDK.DynamoDBv2` from `Amazon.Lambda.DynamoDBEvents`. This allowed us to address nullability issues related to the SDK's marshalling code, which is likely not relevant when working with a Lambda event. 

However, if you were working with the SDK's higher level document or object persistence representation of the DynamoDB event, that code may no longer work since the `AWSSDK.DynamoDBv2` dependency may no longer be present and we separated the previously shared types.

### After
Now, you can convert either the `OldImage` or `NewImage` on each DynamoDB event record to json via the new `ToJson` or `ToJsonPretty` methods. This can be used with `Document.FromJson` in `AWSSDK.DynamoDBv2` to initialize the higher-level programming models.

```
foreach (var record in dynamoEvent.Records)
{
    // Convert the event to a JSON string
    var json = record.Dynamodb.NewImage.ToJson();

    // Which you can convert to the mid-level document model
    var document = Document.FromJson(json);
    
    // And then to the high-level object model using an IDynamoDBContext
    var myClass = context.FromDocument<T>(document);
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
