### PR TITLE
fix: Handle null AttributeValues when serializing DynamoDBEvent to JSON

### DIFF
--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents/Amazon.Lambda.DynamoDBEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents/Amazon.Lambda.DynamoDBEvents.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>netcoreapp3.1;net8.0</TargetFrameworks>
     <Description>Amazon Lambda .NET Core support - DynamoDBEvents package.</Description>
     <AssemblyTitle>Amazon.Lambda.DynamoDBEvents</AssemblyTitle>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.1.1</VersionPrefix>
     <AssemblyName>Amazon.Lambda.DynamoDBEvents</AssemblyName>
     <PackageId>Amazon.Lambda.DynamoDBEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents/ExtensionMethods.cs
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents/ExtensionMethods.cs
@@ -152,6 +152,10 @@ namespace Amazon.Lambda.DynamoDBEvents
                 }
                 writer.WriteEndArray();
             }
+            else
+            {
+                writer.WriteNullValue();
+            }
         }
     }
 }

--- a/Libraries/test/EventsTests.Shared/DynamoDBEventJsonTests.cs
+++ b/Libraries/test/EventsTests.Shared/DynamoDBEventJsonTests.cs
@@ -441,5 +441,58 @@ namespace Amazon.Lambda.Tests
             Assert.Equal("hello world", Encoding.UTF8.GetString(list[0].AsByteArray()));
             Assert.Equal("hello world!", Encoding.UTF8.GetString(list[1].AsByteArray()));
         }
+
+        [Fact]
+        public void NullAttributes_ToJson()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "Null", new AttributeValue {NULL = null } },
+                { "Empty", new AttributeValue() }
+            });
+
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+
+            Assert.Equal("{\"Null\":null,\"Empty\":null}", json);
+        }
+
+        [Fact]
+        public void NullAttributes_ToDocument()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>()
+            {
+                { "Null", new AttributeValue {NULL = null } },
+                { "Empty", new AttributeValue() }
+            });
+
+            // Convert the event from the Lambda package to the SDK type
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+            var document = Document.FromJson(json);
+
+            Assert.Equal(DynamoDBNull.Null, document["Null"].AsDynamoDBNull());
+            Assert.Equal(DynamoDBNull.Null, document["Empty"].AsDynamoDBNull());
+        }
+
+        [Fact]
+        public void NoAttributes_ToJson()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>());
+
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+
+            Assert.Equal("{}", json);
+        }
+
+        [Fact]
+        public void NoAttributes_ToDocument()
+        {
+            var evnt = PrepareEvent(new Dictionary<string, AttributeValue>());
+
+            // Convert the event from the Lambda package to the SDK type
+            var json = evnt.Records[0].Dynamodb.NewImage.ToJson();
+            var document = Document.FromJson(json);
+
+            Assert.Equal(0, document.Count);
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:* #1657

*Description of changes:* Follow-up to #1685 to handle the issue reported in https://github.com/aws/aws-lambda-dotnet/issues/1657#issuecomment-198113111.

I believe we expect there to be a type with a value for each attribute when actually working with DynamoDB (otherwise you would have seen a validation error when saving the item), but this allows more flexibility when mocking data.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
