### PR TITLE
Handle when Lambda events are sent unix epoch dates in milliseconds

### DIFF
--- a/Libraries/src/Amazon.Lambda.Serialization.Json/Amazon.Lambda.Serialization.Json.csproj
+++ b/Libraries/src/Amazon.Lambda.Serialization.Json/Amazon.Lambda.Serialization.Json.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>Amazon.Lambda.Serialization.Json</AssemblyName>
     <PackageId>Amazon.Lambda.Serialization.Json</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
-    <VersionPrefix>2.2.0</VersionPrefix>
+    <VersionPrefix>2.2.1</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/Amazon.Lambda.Serialization.SystemTextJson.csproj
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/Amazon.Lambda.Serialization.SystemTextJson.csproj
@@ -9,7 +9,7 @@
         <AssemblyName>Amazon.Lambda.Serialization.SystemTextJson</AssemblyName>
         <PackageId>Amazon.Lambda.Serialization.SystemTextJson</PackageId>
         <PackageTags>AWS;Amazon;Lambda</PackageTags>
-        <VersionPrefix>2.4.1</VersionPrefix>
+        <VersionPrefix>2.4.2</VersionPrefix>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 	<ItemGroup>

--- a/Libraries/test/EventsTests.Shared/EventsTests.Shared.projitems
+++ b/Libraries/test/EventsTests.Shared/EventsTests.Shared.projitems
@@ -30,6 +30,7 @@
     <Content Include="$(MSBuildThisFileDirectory)cognito-presignup-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)cognito-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)config-event.json" />
+    <Content Include="$(MSBuildThisFileDirectory)dynamodb-with-ms-event.json" />
     <Content Include="$(MSBuildThisFileDirectory)kinesis-batchitemfailures-response.json" />
     <Content Include="$(MSBuildThisFileDirectory)dynamodb-batchitemfailures-response.json" />
     <Content Include="$(MSBuildThisFileDirectory)dynamodb-event.json" />

--- a/Libraries/test/EventsTests.Shared/dynamodb-with-ms-event.json
+++ b/Libraries/test/EventsTests.Shared/dynamodb-with-ms-event.json
@@ -1,0 +1,100 @@
+﻿{
+   "Records":[
+      {
+         "eventID":"f07f8ca4b0b26cb9c4e5e77e69f274ee",
+         "eventName":"INSERT",
+         "eventVersion":"1.1",
+         "eventSource":"aws:dynamodb",
+         "awsRegion":"us-east-1",
+         "dynamodb":{
+            "ApproximateCreationDateTime":1480642020000,
+            "Keys":{
+               "val":{
+                  "S":"data"
+               },
+               "key":{
+                  "S":"binary"
+               }
+            },
+            "NewImage":{
+               "val":{
+                  "S":"data"
+               },
+               "asdf1":{
+                  "B":"AAEqQQ=="
+               },
+               "asdf2":{
+                  "BS":[
+                     "AAEqQQ==",
+                     "QSoBAA=="
+                  ]
+               },
+               "misc1": {
+                  "L": []
+               },
+               "misc2": {
+                 "M": {
+                   "ItemsEmpty": { "L": [] },
+                   "ItemsNonEmpty": { "L": [{"S": "Cookies"} , {"S": "Coffee"}, {"N": "3.14159"}] },
+                   "ItemBoolean": { "BOOL": false },
+                   "ItemNumberSet": { "NS": ["0", "50", "150"] },
+                   "ItemNull": { "NULL": true },
+                   "ItemStringSet": { "SS": ["Hippo", "Zebra"] }
+                 }
+               },
+               "key":{
+                  "S":"binary"
+               }
+            },
+            "SequenceNumber":"1405400000000002063282832",
+            "SizeBytes":54,
+            "StreamViewType":"NEW_AND_OLD_IMAGES"
+         },
+         "eventSourceARN":"arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+      },
+      {
+         "eventID":"f07f8ca4b0b26cb9c4e5e77e42f274ee",
+         "eventName":"REMOVE",
+         "eventVersion":"1.1",
+         "eventSource":"aws:dynamodb",
+         "awsRegion":"us-east-1",
+         "userIdentity": {
+            "type": "Service",
+            "principalId": "dynamodb.amazonaws.com"
+         }, 
+         "dynamodb":{
+            "ApproximateCreationDateTime":1480642020,
+            "Keys":{
+               "val":{
+                  "S":"data"
+               },
+               "key":{
+                  "S":"binary"
+               }
+            },
+            "OldImage": {
+              "val": {
+                "S": "data"
+              },
+              "asdf1": {
+                "B": "AAEqQQ=="
+              },
+              "asdf2": {
+                "BS": [
+                  "AAEqQQ==",
+                  "QSoBAA==",
+                  "AAEqQQ=="
+                ]
+              },
+              "key": {
+                "S": "binary"
+              }
+            },
+            "SequenceNumber":"1405400000000002063282832",
+            "SizeBytes":54,
+            "StreamViewType":"OLD_IMAGE"
+         },
+         "eventSourceARN":"arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+      }
+   ]
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/839

*Description of changes:*
When Kinesis streams are used to handle DynamoDB events they send the approximate date a unix epoch in milliseconds. When coming from a DynamoDB stream event they are seconds which is the normal format.

Since there isn't a way to detect the source of the event the serializers are updated to look to see if the `long` in the event would be greater then the number of seconds for the year `5000`. If so then assume the value is in milliseconds. The other alternative I could have done is try to create the `DateTime` with the millisecond epoch and if I got an out of range exception fallback to creating the DateTime from milliseconds but I wanted to avoid control flow by exceptions.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
