### PR TITLE
chore: Update Annotations based VS blueprints

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/AnnotationsFramework/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
-    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.3.0" />
   </ItemGroup>
   <!-- 
     The FrameworkReference is used to reduce the deployment bundle size by not having to include 

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -11,7 +11,7 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.3.0" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/Functions.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless-Image/template/src/BlueprintBaseName.1/Functions.cs
@@ -34,7 +34,7 @@ public class Functions
     /// </remarks>
     /// <param name="context">Information about the invocation, function, and execution environment</param>
     /// <returns>The response as an implicit <see cref="APIGatewayProxyResponse"/></returns>
-    [LambdaFunction(PackageType = LambdaPackageType.Image, Policies = "AWSLambdaBasicExecutionRole", MemorySize = 512, Timeout = 30)]
+    [LambdaFunction(PackageType = LambdaPackageType.Image)]
     [RestApi(LambdaHttpMethod.Get, "/")]
     public IHttpResult Get(ILambdaContext context)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -11,7 +11,7 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.3.0" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />

--- a/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless/template/src/BlueprintBaseName.1/Functions.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/EmptyServerless/template/src/BlueprintBaseName.1/Functions.cs
@@ -34,7 +34,7 @@ public class Functions
     /// </remarks>
     /// <param name="context">Information about the invocation, function, and execution environment</param>
     /// <returns>The response as an implicit <see cref="APIGatewayProxyResponse"/></returns>
-    [LambdaFunction(Policies = "AWSLambdaBasicExecutionRole", MemorySize = 512, Timeout = 30)]
+    [LambdaFunction]
     [RestApi(LambdaHttpMethod.Get, "/")]
     public IHttpResult Get(ILambdaContext context)
     {

--- a/Blueprints/BlueprintDefinitions/vs2022/MessageProcessingFramework/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/MessageProcessingFramework/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -11,7 +11,7 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.3.0" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />

--- a/Blueprints/BlueprintDefinitions/vs2022/MessageProcessingFramework/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/MessageProcessingFramework/template/src/BlueprintBaseName.1/serverless.template
@@ -14,7 +14,7 @@
       "Properties": {
         "Runtime": "dotnet8",
         "CodeUri": ".",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaSQSQueueExecutionRole"
@@ -47,7 +47,7 @@
       "Properties": {
         "Runtime": "dotnet8",
         "CodeUri": ".",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Policies": [
           "AmazonSQSFullAccess"

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
-    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.3.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />    
   </ItemGroup>

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/Functions.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/src/BlueprintBaseName.1/Functions.cs
@@ -42,7 +42,7 @@ public class Functions
     /// </summary>
     /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
-    [LambdaFunction(MemorySize = 512)]
+    [LambdaFunction]
     [RestApi(LambdaHttpMethod.Get, "/")]
     public IHttpResult GetFunctionHandler(ILambdaContext context)
     {
@@ -58,7 +58,7 @@ public class Functions
     /// <param name="product">The new product to post to the system.</param>
     /// <param name="context">The ILambdaContext that provides methods for logging and describing the Lambda environment.</param>
     /// <returns></returns>
-    [LambdaFunction(MemorySize = 512)]
+    [LambdaFunction]
     [RestApi(LambdaHttpMethod.Post, "/")]
     public IHttpResult PostFunctionHandler([FromBody] NewProductDTO product, ILambdaContext context)
     {
@@ -77,7 +77,7 @@ public class Functions
     /// using the AWS SDKs.
     /// </summary>
     /// <returns></returns>
-    [LambdaFunction(MemorySize = 512)]
+    [LambdaFunction]
     public async Task<string> GetCallingIPAsync(ILambdaContext context)
     {
         context.Logger.LogInformation("Checking IP address");


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7433

*Description of changes:*
This PR updates the `Amazon.Lambda.Annotations` dependency to 1.3.0. It also updates the usage of `LambdaFunction` attribute by not explicitly passing the default values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
