### PR TITLE
chore: fix lambda images workflow

### DIFF
--- a/.github/workflows/update-Dockerfiles.yml
+++ b/.github/workflows/update-Dockerfiles.yml
@@ -61,7 +61,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          ref: 'dev'
 
       - name: Update .NET 6 AMD64
         id: update-net6-amd64
@@ -118,7 +120,7 @@ jobs:
           git add "**/*Dockerfile"
           git commit -m "chore: ASP.NET Core version update in Dockerfiles"
           git push origin $branch
-          echo "BRANCH=$branch" >> $GITHUB_OUTPUT
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "BRANCH=$branch"
 
       # Create a Pull Request from the pushed branch
       - name: Pull Request
@@ -127,7 +129,7 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           source_branch: ${{ steps.commit-push.outputs.BRANCH }}
-          destination_branch: "master"
+          destination_branch: "dev"
           pr_title: 'chore: ASP.NET Core version update in Dockerfiles'
           pr_body: "This PR updates the Dockerfiles to use the latest ASP.NET Core version.
             Verify listed Dockerfiles that they have correct version and matching SHA512 checksum for ASP.NET Core runtime.
@@ -136,12 +138,12 @@ jobs:
             \n${{ format
                 (
                   '{0}\n{1}\n{2}\n{3}\n{4}\n{5}',
-                  join(steps.update-net6-amd64.outputs.*, '\n'),
-                  join(steps.update-net6-arm64.outputs.*, '\n'),
-                  join(steps.update-net7-amd64.outputs.*, '\n'),
-                  join(steps.update-net7-arm64.outputs.*, '\n'),
-                  join(steps.update-net8-amd64.outputs.*, '\n'),
-                  join(steps.update-net8-arm64.outputs.*, '\n')
+                  join(steps.update-net6-amd64.outputs.MESSAGE, '\n'),
+                  join(steps.update-net6-arm64.outputs.MESSAGE, '\n'),
+                  join(steps.update-net7-amd64.outputs.MESSAGE, '\n'),
+                  join(steps.update-net7-arm64.outputs.MESSAGE, '\n'),
+                  join(steps.update-net8-amd64.outputs.MESSAGE, '\n'),
+                  join(steps.update-net8-arm64.outputs.MESSAGE, '\n')
                 )
             }}"
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/LambdaRuntimeDockerfiles/update-dockerfile.ps1
+++ b/LambdaRuntimeDockerfiles/update-dockerfile.ps1
@@ -26,7 +26,8 @@ function Update-Dockerfile ([string]$DockerfilePath, [string]$NextVersion) {
 
     # This allows checksumring the $DockerfilePath variable between steps
     # which is needed to update the description of the PR
-    Write-Host "::set-output name=${DockerfilePath}::- Updated ${DockerfilePath} to ${NextVersion}<br> - Artifact: ${artifact}<br> - Checksum Source: ${checksumUri}"
+    $message = "- Updated ${DockerfilePath} to ${NextVersion}<br> - Artifact: ${artifact}<br> - Checksum Source: ${checksumUri}"
+    Add-Content -Path $env:GITHUB_OUTPUT -Value "MESSAGE=$message"
 }
 
 # Returns Checksum of given ASP.NET Core version from the give Checksum file


### PR DESCRIPTION
*Description of changes:*
* The workflow currently fails to create a PR. This change fixes the issue where the BRANCH variable was not properly set.
* Remove warnings related to ::set-output and Node16
* Change base for checkout and PR to `dev` branch instead of `main`. Workflow should always be triggered from `dev` branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
