### PR TITLE
1728 - Enhance/Fix ByteArrayConverter to support base64 deserialization of byte[]

### DIFF
--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/Converters/ByteArrayConverter.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/Converters/ByteArrayConverter.cs
@@ -18,6 +18,11 @@ namespace Amazon.Lambda.Serialization.SystemTextJson.Converters
                 return null;
             }
 
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                return reader.GetBytesFromBase64();
+            }
+
             var byteList = new List<byte>();
 
             while (reader.Read())

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/ByteArrayConverterTests.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/ByteArrayConverterTests.cs
@@ -1,0 +1,34 @@
+﻿using Amazon.Lambda.Serialization.SystemTextJson;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Amazon.Lambda.AspNetCoreServer.Test;
+
+public class DefaultLambdaJsonSerializerTests
+{
+    private const string SampleValue = "Hello World!";
+
+    [Fact]
+    public void CanDeserializeIntArrayEncodedString() =>
+        RunTest("{\"Value\":[72,101,108,108,111,32,87,111,114,108,100,33]}");
+
+    [Fact]
+    public void CanDeserializeBase64EncodedString() =>
+        RunTest("{\"Value\":\"SGVsbG8gV29ybGQh\"}");
+
+    private void RunTest(string jsonPayload)
+    {
+        using var ms = new MemoryStream(Encoding.UTF8.GetBytes(jsonPayload));
+
+        var defaultLambdaJsonSerializer = new DefaultLambdaJsonSerializer();
+        var inputFromMemoryStream = defaultLambdaJsonSerializer.Deserialize<ClassWithByteArrayProperty>(ms);
+
+        Assert.Equal(SampleValue, Encoding.UTF8.GetString(inputFromMemoryStream.Value));
+    }
+
+    private class ClassWithByteArrayProperty
+    {
+        public byte[] Value { get; set; }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* [1728](https://github.com/aws/aws-lambda-dotnet/issues/1728)

*Description of changes:*
Add support for deserializing a base64 `string` to a `byte[]`.

If the token is a string, assume it is base64 encoded string and get bytes.

Otherwise, continue to do what it did before.

I added xunit tests for both conditions. To ensure my desired behavior works, and the existing behavior also works. I'm not strong in xunit, so if there are tweaks needed, please advise. Also wasn't sure where the best home/project for those tests might be.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
