### PR TITLE
Lambda JSON Exception handling and frame type

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/Constants.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/Constants.cs
@@ -33,6 +33,14 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
         internal const string AWS_LAMBDA_INITIALIZATION_TYPE_PC = "provisioned-concurrency";
         internal const string AWS_LAMBDA_INITIALIZATION_TYPE_ON_DEMAND = "on-demand";
 
+        internal const string NET_RIC_LOG_LEVEL_ENVIRONMENT_VARIABLE = "AWS_LAMBDA_HANDLER_LOG_LEVEL";
+        internal const string NET_RIC_LOG_FORMAT_ENVIRONMENT_VARIABLE = "AWS_LAMBDA_HANDLER_LOG_FORMAT";
+
+        internal const string LAMBDA_LOG_LEVEL_ENVIRONMENT_VARIABLE = "AWS_LAMBDA_LOG_LEVEL";
+        internal const string LAMBDA_LOG_FORMAT_ENVIRONMENT_VARIABLE = "AWS_LAMBDA_LOG_FORMAT";
+
+        internal const string LAMBDA_LOG_FORMAT_JSON = "Json";
+
         internal enum AwsLambdaDotNetPreJit
         {
             Never,

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
@@ -18,6 +18,7 @@ using System.IO;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Amazon.Lambda.Core;
 using Amazon.Lambda.RuntimeSupport.Bootstrap;
 using Amazon.Lambda.RuntimeSupport.Helpers;
 
@@ -252,9 +253,11 @@ namespace Amazon.Lambda.RuntimeSupport
 
         private void WriteUnhandledExceptionToLog(Exception exception)
         {
-            // Console.Error.WriteLine are redirected to the IConsoleLoggerWriter which
-            // will take care of writing to the function's log stream.
+#if NET6_0_OR_GREATER
+            Client.ConsoleLogger.FormattedWriteLine(LogLevel.Error.ToString(), exception, null);
+#else
             Console.Error.WriteLine(exception);
+#endif
         }
 
 #if NET8_0_OR_GREATER

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/IRuntimeApiClient.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/IRuntimeApiClient.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+using Amazon.Lambda.RuntimeSupport.Helpers;
 using System;
 using System.IO;
 using System.Threading;
@@ -25,6 +26,11 @@ namespace Amazon.Lambda.RuntimeSupport
     /// </summary>
     public interface IRuntimeApiClient
     {
+        /// <summary>
+        /// Logger used for formatting log messages into the user's CloudWatch Log stream.
+        /// </summary>
+        IConsoleLoggerWriter ConsoleLogger { get; }
+
         /// <summary>
         /// Report an initialization error as an asynchronous operation.
         /// </summary>

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/RuntimeApiClient.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/RuntimeApiClient.cs
@@ -39,6 +39,9 @@ namespace Amazon.Lambda.RuntimeSupport
         internal Func<Exception, ExceptionInfo> ExceptionConverter { get;  set; }
         internal LambdaEnvironment LambdaEnvironment { get; set; }
 
+        /// <inheritdoc/>
+        public IConsoleLoggerWriter ConsoleLogger => _consoleLoggerRedirector;
+
         /// <summary>
         /// Create a new RuntimeApiClient
         /// </summary>

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/ConsoleLoggerWriter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/ConsoleLoggerWriter.cs
@@ -288,12 +288,6 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
             private readonly TextWriter _innerWriter;
             private string _defaultLogLevel;
 
-            const string NET_RIC_LOG_LEVEL_ENVIRONMENT_VARIABLE = "AWS_LAMBDA_HANDLER_LOG_LEVEL";
-            const string NET_RIC_LOG_FORMAT_ENVIRONMENT_VARIABLE = "AWS_LAMBDA_HANDLER_LOG_FORMAT";
-
-            const string LAMBDA_LOG_LEVEL_ENVIRONMENT_VARIABLE = "AWS_LAMBDA_LOG_LEVEL";
-            const string LAMBDA_LOG_FORMAT_ENVIRONMENT_VARIABLE = "AWS_LAMBDA_LOG_FORMAT";
-
             private LogLevel _minmumLogLevel = LogLevel.Information;
 
             enum LogFormatType { Default, Unformatted, Json }
@@ -322,7 +316,7 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
                 _innerWriter = innerWriter;
                 _defaultLogLevel = defaultLogLevel;
 
-                var envLogLevel = GetEnviromentVariable(NET_RIC_LOG_LEVEL_ENVIRONMENT_VARIABLE, LAMBDA_LOG_LEVEL_ENVIRONMENT_VARIABLE);
+                var envLogLevel = GetEnvironmentVariable(Constants.NET_RIC_LOG_LEVEL_ENVIRONMENT_VARIABLE, Constants.LAMBDA_LOG_LEVEL_ENVIRONMENT_VARIABLE);
                 if (!string.IsNullOrEmpty(envLogLevel))
                 {
                     // Map Lambda's fatal logging level to the .NET RIC critical
@@ -340,7 +334,7 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
                     }
                 }
 
-                var envLogFormat = GetEnviromentVariable(NET_RIC_LOG_FORMAT_ENVIRONMENT_VARIABLE, LAMBDA_LOG_FORMAT_ENVIRONMENT_VARIABLE);
+                var envLogFormat = GetEnvironmentVariable(Constants.NET_RIC_LOG_FORMAT_ENVIRONMENT_VARIABLE, Constants.LAMBDA_LOG_FORMAT_ENVIRONMENT_VARIABLE);
                 if (!string.IsNullOrEmpty(envLogFormat))
                 {
                     if (Enum.TryParse<LogFormatType>(envLogFormat, true, out var result))
@@ -359,7 +353,7 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
                 }
             }
 
-            private string GetEnviromentVariable(string envName, string fallbackEnvName)
+            private string GetEnvironmentVariable(string envName, string fallbackEnvName)
             {
                 var value = Environment.GetEnvironmentVariable(envName);
                 if(string.IsNullOrEmpty(value) && fallbackEnvName != null)

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/DefaultLogMessageFormatter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/DefaultLogMessageFormatter.cs
@@ -1,5 +1,7 @@
 ﻿#if NET6_0_OR_GREATER
 
+using System.Text;
+
 namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
 {
     /// <summary>
@@ -48,21 +50,53 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
                 message = ApplyMessageProperties(state.MessageTemplate, messageProperties, state.MessageArguments);
             }
 
+            var displayLevel = state.Level != null ? ConvertLogLevelToLabel(state.Level.Value) : null;
+
+            var sb = new StringBuilder(
+                                    25 + // Length for timestamp
+                                    (state.AwsRequestId?.Length).GetValueOrDefault() +
+                                    displayLevel.Length +
+                                    (message?.Length).GetValueOrDefault() +
+                                    5 // Padding for tabs
+                                    );
+
             if (!AddPrefix)
             {
                 return message;
             }
 
-            var displayLevel = state.Level != null ? ConvertLogLevelToLabel(state.Level.Value) : null;
 
-            if (!string.IsNullOrEmpty(displayLevel))
+            if (AddPrefix)
             {
-                return $"{FormatTimestamp(state)}\t{state.AwsRequestId}\t{displayLevel}\t{message ?? string.Empty}";
+                sb.Append(FormatTimestamp(state));
+                sb.Append('\t');
+                sb.Append(state.AwsRequestId);
+
+                if (!string.IsNullOrEmpty(displayLevel))
+                {
+                    sb.Append('\t');
+                    sb.Append(displayLevel);
+                }
+
+                sb.Append('\t');
             }
-            else
+
+
+            if (!string.IsNullOrEmpty(message))
             {
-                return $"{FormatTimestamp(state)}\t{state.AwsRequestId}\t{message ?? string.Empty}";
+                sb.Append(message);
             }
+
+            if (state.Exception != null)
+            {
+                if (!string.IsNullOrEmpty(message))
+                {
+                    sb.Append('\n');
+                }
+                sb.Append(state.Exception.ToString());
+            }
+
+            return sb.ToString();
         }
 
         /// <summary>

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/DefaultLogMessageFormatter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/DefaultLogMessageFormatter.cs
@@ -60,12 +60,6 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
                                     5 // Padding for tabs
                                     );
 
-            if (!AddPrefix)
-            {
-                return message;
-            }
-
-
             if (AddPrefix)
             {
                 sb.Append(FormatTimestamp(state));

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/JsonLogMessageFormatter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/JsonLogMessageFormatter.cs
@@ -191,11 +191,10 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
                 writer.WriteString("errorMessage", state.Exception.Message);
                 writer.WritePropertyName("stackTrace");
                 writer.WriteStartArray();
-
-                // TODO: Right now for stack trace we are just using a single array element doing a ToString to get the
-                // inner excepions. Working with the Lambda team to figure out how they want to handle inner exceptions with 
-                // stackTrace array.
-                writer.WriteStringValue(state.Exception.ToString());
+                foreach(var line in state.Exception.ToString().Split('\n'))
+                {
+                    writer.WriteStringValue(line.Trim());
+                }
                 writer.WriteEndArray();
             }
         }

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LogMessageFormatterTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LogMessageFormatterTests.cs
@@ -3,6 +3,7 @@ using Amazon.Lambda.RuntimeSupport.Helpers.Logging;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Text.Json;
 using Xunit;
@@ -470,10 +471,14 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 Assert.Equal("This Will Fail", doc.RootElement.GetProperty("errorMessage").GetString());
                 Assert.Equal("System.ApplicationException", doc.RootElement.GetProperty("errorType").GetString());
                 Assert.Equal(JsonValueKind.Array, doc.RootElement.GetProperty("stackTrace").ValueKind);
-                Assert.Equal(ex.ToString(), doc.RootElement.GetProperty("stackTrace")[0].GetString());
 
-                // Confirm inner exceptions are being captured
-                Assert.Contains("System.NullReferenceException", doc.RootElement.GetProperty("stackTrace")[0].GetString());
+                var stackLines = ex.ToString().Split('\n').Select(x => x.Trim()).ToList();
+                var jsonExArray = doc.RootElement.GetProperty("stackTrace");
+                Assert.Equal(stackLines.Count, jsonExArray.GetArrayLength());
+                for(var i =  0; i < stackLines.Count; i++)
+                {
+                    Assert.Equal(stackLines[i], jsonExArray[i].GetString());
+                }
             }
         }
 

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestRuntimeApiClient.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestRuntimeApiClient.cs
@@ -12,6 +12,7 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+using Amazon.Lambda.RuntimeSupport.Helpers;
 using Amazon.Lambda.RuntimeSupport.UnitTests.TestHelpers;
 using System;
 using System.Collections.Generic;
@@ -27,6 +28,8 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
     {
         private IEnvironmentVariables _environmentVariables;
         private Dictionary<string, IEnumerable<string>> _headers;
+
+        public IConsoleLoggerWriter ConsoleLogger { get; } = new LogLevelLoggerWriter();
 
         public TestRuntimeApiClient(IEnvironmentVariables environmentVariables, Dictionary<string, IEnumerable<string>> headers)
         {


### PR DESCRIPTION
*Description of changes:*
Following the example of other Lambda runtimes supporting JSON exceptions stack traces are being recorded as a an array of frames. This basically means splitting the `ToString()` of the exception on `\n` and writing each line to the exception array. The `ToString()` method will include the inner exceptions.

```json
{
    "timestamp": "2024-04-22T06:22:05.689Z",
    "level": "Error",
    "requestId": "677a8f5f-fcc3-47b5-a24a-a4850b166225",
    "traceId": "Root=1-6626020d-10f21fb539ab9e440248641f;Parent=469d66f203a29809;Sampled=0;Lineage=cd25c10f:0",
    "message": null,
    "errorType": "System.ApplicationException",
    "errorMessage": "Exception 1 Application goes bad",
    "stackTrace": [
        "System.ApplicationException: Exception 1 Application goes bad",
        "---> System.InvalidOperationException: Exception 2 Invalid operation",
        "---> System.ArgumentNullException: Value cannot be null. (Parameter 'Exception 3 This is the argument')",
        "at Program.<<Main>$>g__Exception3|0_3() in C:\\Users\\normj\\source\\repos\\LambdaStructuredLoggingSample\\SimpleLoggingLambda\\Function.cs:line 72",
        "at Program.<<Main>$>g__Exception2|0_2() in C:\\Users\\normj\\source\\repos\\LambdaStructuredLoggingSample\\SimpleLoggingLambda\\Function.cs:line 61",
        "--- End of inner exception stack trace ---",
        "at Program.<<Main>$>g__Exception2|0_2() in C:\\Users\\normj\\source\\repos\\LambdaStructuredLoggingSample\\SimpleLoggingLambda\\Function.cs:line 65",
        "at Program.<<Main>$>g__Exception1|0_1() in C:\\Users\\normj\\source\\repos\\LambdaStructuredLoggingSample\\SimpleLoggingLambda\\Function.cs:line 48",
        "--- End of inner exception stack trace ---",
        "at Program.<<Main>$>g__Exception1|0_1() in C:\\Users\\normj\\source\\repos\\LambdaStructuredLoggingSample\\SimpleLoggingLambda\\Function.cs:line 52",
        "at Program.<>c.<<Main>$>b__0_0(String input, ILambdaContext context) in C:\\Users\\normj\\source\\repos\\LambdaStructuredLoggingSample\\SimpleLoggingLambda\\Function.cs:line 24",
        "at Amazon.Lambda.RuntimeSupport.HandlerWrapper.<>c__DisplayClass44_0`2.<GetHandlerWrapper>b__0(InvocationRequest invocation) in C:\\codebase\\aws-lambda-dotnet\\Libraries\\src\\Amazon.Lambda.RuntimeSupport\\Bootstrap\\HandlerWrapper.cs:line 709",
        "at Amazon.Lambda.RuntimeSupport.LambdaBootstrap.InvokeOnceAsync(CancellationToken cancellationToken) in C:\\codebase\\aws-lambda-dotnet\\Libraries\\src\\Amazon.Lambda.RuntimeSupport\\Bootstrap\\LambdaBootstrap.cs:line 186"
    ]
}
```
Other fixes
* The default text formatter was not including the exception when using the new log overrides that include exception.
* If the Lambda function throws an unhandled exception the exception wasn't being formatted as JSON. I addressed that issue.
* When righting the Lambda telemetry API for logging there is a new frame type value to use when logging for JSON. You can see an example of this frame type being set in the Node Lambda RIC: https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/commit/7374a4e338fc3b070811d55ee337740f3f6cb382#diff-dbac4c3a97d9e1a1e2c03568f241259ee85788f64583d8431d9578ac9fcfefc2R122


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
