### PR TITLE
[UA update] chore: Update User-Agent string in Lambda test tool

### DIFF
--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj
@@ -6,7 +6,7 @@
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET Core AWS Lambda functions locally.</Description>
     <LangVersion>Latest</LangVersion>
-    <VersionPrefix>0.15.1</VersionPrefix>
+    <VersionPrefix>0.15.2</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester60-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester60-pack.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET 6.0 AWS Lambda functions locally.</Description>
-    <VersionPrefix>0.15.1</VersionPrefix>
+    <VersionPrefix>0.15.2</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester70-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester70-pack.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET 7.0 AWS Lambda functions locally.</Description>
-    <VersionPrefix>0.15.1</VersionPrefix>
+    <VersionPrefix>0.15.2</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester80-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester80-pack.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET 8.0 AWS Lambda functions locally.</Description>
-    <VersionPrefix>0.15.1</VersionPrefix>
+    <VersionPrefix>0.15.2</VersionPrefix>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Program.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Program.cs
@@ -15,7 +15,11 @@ namespace Amazon.Lambda.TestTool.BlazorTester
     {
         public static void Main(string[] args)
         {
-            Environment.SetEnvironmentVariable("AWS_EXECUTION_ENV", "AWS_DOTNET_LAMDBA_TEST_TOOL_BLAZOR_" + Utils.DetermineToolVersion());
+            var version = Utils.DetermineToolVersion();
+            // The leading and trailing whitespaces are intentional
+            var userAgent = $" lib/AWS_DOTNET_LAMDBA_TEST_TOOL_BLAZOR#{version} ";
+
+            Environment.SetEnvironmentVariable("AWS_EXECUTION_ENV", userAgent);
             TestToolStartup.Startup(Constants.PRODUCT_NAME, (options, showUI) => Startup.LaunchWebTester(options, showUI), args);
         }
     }

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.SSO" Version="3.7.200.18" />
-    <PackageReference Include="AWSSDK.SSOOIDC" Version="3.7.200.18" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
+    <PackageReference Include="AWSSDK.SSO" Version="3.7.300.80" />
+    <PackageReference Include="AWSSDK.SSOOIDC" Version="3.7.301.75" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="YamlDotNet.Signed" Version="5.2.1" />
 
-    <PackageReference Include="AWSSDK.Core" Version="3.7.200.18" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.200.19" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.303.20" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.300.80" />
   </ItemGroup>
 
 	

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Utils.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Utils.cs
@@ -25,7 +25,7 @@ namespace Amazon.Lambda.TestTool
                 var assembly = Assembly.GetEntryAssembly();
                 if (assembly == null)
                     return null;
-                attribute = Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+                attribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
             }
             catch (Exception)
             {
@@ -35,7 +35,7 @@ namespace Amazon.Lambda.TestTool
             var version = attribute?.InformationalVersion;
 
             // Check to see if the version has a git commit id suffix and if so remove it.
-            if (version == null && version.IndexOf('+') != -1)
+            if (version != null && version.IndexOf('+') != -1)
             {
                 version = version.Substring(0, version.IndexOf('+'));
             }


### PR DESCRIPTION
*Issue #, if available:*
SDK-169882

*Description of changes:*
chore: Update User-Agent string in Lambda test tool

*Testing*
Verified that the UA string is set as `lib/AWS_DOTNET_LAMDBA_TEST_TOOL_BLAZOR#0.15.2` 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
