### PR TITLE
fix: Fixed failing unit test due to unsupported operation in latest .NET patches

### DIFF
--- a/Tools/LambdaTestTool/tests/LambdaFunctions/AspNetCoreAPIExample/LocalEntryPoint.cs
+++ b/Tools/LambdaTestTool/tests/LambdaFunctions/AspNetCoreAPIExample/LocalEntryPoint.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace AspNetCoreAPIExample
@@ -14,14 +16,39 @@ namespace AspNetCoreAPIExample
     {
         public static void Main(string[] args)
         {
-            CreateHostBuilder(args).Build().Run();
+            CreateHostBuilder(args).Run();
         }
 
-        public static WebApplicationBuilder CreateHostBuilder(string[] args)
+        public static WebApplication CreateHostBuilder(string[] args)
         {
             var builder = WebApplication.CreateBuilder(args);
-            builder.WebHost.UseStartup<Startup>();
-            return builder;
+
+            builder.Services.AddScoped<IFakeDependency, FakeDependency>();
+            builder.Services.AddControllers();
+
+            var app = builder.Build();
+
+            if (app.Environment.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseHttpsRedirection();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+                endpoints.MapGet("/", async context =>
+                {
+                    await context.Response.WriteAsync("Welcome to running ASP.NET Core on AWS Lambda");
+                });
+            });
+
+            return app;
         }
     }
 }


### PR DESCRIPTION
*Description of changes:*
After upgrading our pipelines to the latest .NET 8 patches, a unit test started to fail due to the error:
```
error ASP0010: UseStartup cannot be used with WebApplicationBuilder.WebHost
```
I have updated the test to not use `UseStartup` for the local entry point.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
