### PR TITLE
feat: onboard the repo to the testing infra

### DIFF
--- a/.github/workflows/aws-ci.yml
+++ b/.github/workflows/aws-ci.yml
@@ -1,0 +1,47 @@
+
+name: AWS CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      - dev
+      - 'feature/**'
+
+permissions:
+  id-token: write
+
+jobs:
+  run-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 #v4
+        with:
+          role-to-assume: ${{ secrets.CI_MAIN_TESTING_ACCOUNT_ROLE_ARN }}
+          role-duration-seconds: 7200
+          aws-region: us-west-2
+      - name: Invoke Load Balancer Lambda
+        id: lambda
+        shell: pwsh
+        run: |
+          aws lambda invoke response.json --function-name "${{ secrets.CI_TESTING_LOAD_BALANCER_LAMBDA_NAME }}" --cli-binary-format raw-in-base64-out --payload '{"Roles": "${{ secrets.CI_TEST_RUNNER_ACCOUNT_ROLES }}", "ProjectName": "${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}", "Branch": "${{ github.sha }}"}'
+          $roleArn=$(cat ./response.json)
+          "roleArn=$($roleArn -replace '"', '')" >> $env:GITHUB_OUTPUT
+      - name: Configure Test Runner Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 #v4
+        with:
+          role-to-assume: ${{ steps.lambda.outputs.roleArn }}
+          role-duration-seconds: 7200
+          aws-region: us-west-2
+      - name: Run Tests on AWS
+        id: codebuild
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: ${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}
+      - name: CodeBuild Link
+        shell: pwsh
+        run: |
+          $buildId = "${{ steps.codebuild.outputs.aws-build-id }}"
+          echo $buildId

--- a/buildtools/build.proj
+++ b/buildtools/build.proj
@@ -38,9 +38,11 @@
         <Exec Command="dotnet restore BlueprintPackager.sln" WorkingDirectory="..\Blueprints\BlueprintPackager"/>
     </Target>
     <Target Name="package-blueprints" DependsOnTargets="init;run-blueprint-packager">
-        <Exec Command="$(MSBuildThisFileDirectory)nuget.exe pack template.nuspec -OutputDirectory ../../../Deployment/nuget-packages" WorkingDirectory="../Blueprints/BlueprintDefinitions/vs2022"/>
-		
-		<Exec Command="$(MSBuildThisFileDirectory)nuget.exe pack template.nuspec -OutputDirectory ../../../Deployment/nuget-packages" WorkingDirectory="../Blueprints/BlueprintDefinitions/vs2019"/>
+        <Exec Condition=" '$(OS)' != 'Windows_NT' " Command="mono $(MSBuildThisFileDirectory)nuget.exe pack template.nuspec -OutputDirectory ../../../Deployment/nuget-packages" WorkingDirectory="../Blueprints/BlueprintDefinitions/vs2022"/>
+		<Exec Condition=" '$(OS)' != 'Windows_NT' " Command="mono $(MSBuildThisFileDirectory)nuget.exe pack template.nuspec -OutputDirectory ../../../Deployment/nuget-packages" WorkingDirectory="../Blueprints/BlueprintDefinitions/vs2019"/>
+
+        <Exec Condition=" '$(OS)' == 'Windows_NT' " Command="$(MSBuildThisFileDirectory)nuget.exe pack template.nuspec -OutputDirectory ../../../Deployment/nuget-packages" WorkingDirectory="../Blueprints/BlueprintDefinitions/vs2022"/>
+		<Exec Condition=" '$(OS)' == 'Windows_NT' " Command="$(MSBuildThisFileDirectory)nuget.exe pack template.nuspec -OutputDirectory ../../../Deployment/nuget-packages" WorkingDirectory="../Blueprints/BlueprintDefinitions/vs2019"/>
     </Target>
     <Target Name="run-blueprint-packager">
         <Exec Command="dotnet run -c $(Configuration) $(BlueprintPackagerArguments)" WorkingDirectory="..\Blueprints\BlueprintPackager"/>

--- a/buildtools/ci.buildspec.yml
+++ b/buildtools/ci.buildspec.yml
@@ -1,0 +1,16 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      dotnet: 8.x
+    commands:
+      # The tests need .NET 3.1, 6 and 8. .NET6 is installed by default. .NET8 is added in the runtime-versions. .NET 3.1 is installed manually.
+      - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 3.1
+      # Mono is needed to run the unit tests on Linux
+      - curl https://download.mono-project.com/repo/centos8-stable.repo | tee /etc/yum.repos.d/mono-stable.repo
+      - dnf install -y mono-complete mono-devel
+  build:
+    commands:
+      - dotnet msbuild buildtools/build.proj /t:unit-tests /p:Cicd=true 
+      - dotnet msbuild buildtools/build.proj /t:integ-tests /p:Cicd=true


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7477

*Description of changes:*
* Added GitHub workflow that runs unit tests and integ tests using the testing infrastructure on PRs targeting `main`, `dev` and feature branches.
* Updated the build project to use `mono` to run unit tests on Linux. Previously, they only supported Windows.
* Added a `buildspec` file that the testing infrastructure will use to run the tests. The `buildspec` adds `mono` to the base image.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
