### PR TITLE
Resolving syntax error in .bootstrap-al2023

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/bootstrap-al2023.sh
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/bootstrap-al2023.sh
@@ -7,7 +7,7 @@
 # This means the default cert bundle file is double loaded causing a cold start performance hit. This logic
 # sets the SSL_CERT_FILE to an empty file if SSL_CERT_FILE hasn't been explicitly
 # set. This avoid the double load of the default cert bundle file.
-if [ -z "${SSL_CERT_FILE}"]; then
+if [ -z "${SSL_CERT_FILE}" ]; then
   export SSL_CERT_FILE="/var/runtime/empty-certificates.crt"
 fi
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When my team was building .NET 8 lambdas, we kept experiencing the following syntax error: **/var/runtime/boostrap: line 10: [: missing `]"**. I looked through this script and noticed there was a missing space before the closing bracket. The script runs absolutely fine outside of the syntax issue.

You can recreate it by adding the environment variable **SSL_CERT_FILE** and give it any value to a Lambda with a .NET 8 runtime.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
