### PR TITLE
chore: Update Message Processing Framework VS blueprint

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2022/MessageProcessingFramework/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/MessageProcessingFramework/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -11,7 +11,7 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.3.0" />
+    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.5.0" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />

--- a/Blueprints/BlueprintDefinitions/vs2022/MessageProcessingFramework/template/src/BlueprintBaseName.1/Functions.cs
+++ b/Blueprints/BlueprintDefinitions/vs2022/MessageProcessingFramework/template/src/BlueprintBaseName.1/Functions.cs
@@ -1,5 +1,5 @@
 using Amazon.Lambda.Annotations;
-using Amazon.Lambda.Annotations.APIGateway;
+using Amazon.Lambda.Annotations.SQS;
 using Amazon.Lambda.Core;
 using Amazon.Lambda.SQSEvents;
 using AWS.Messaging;
@@ -56,6 +56,7 @@ public class Functions
     /// <param name="context">Lambda execution context</param>
     /// <returns>Set of messages whose handler invocations failed, only these will be reprocessed</returns>
     [LambdaFunction(Policies = "AWSLambdaSQSQueueExecutionRole")]
+    [SQSEvent("@MessageProcessingFrameworkDemoQueue", ResourceName = "SQSEvent")]
     public async Task<SQSBatchResponse> Handler(SQSEvent evnt, ILambdaContext context)
     {
         // Pass the SQSEvent into the framework

--- a/Blueprints/BlueprintDefinitions/vs2022/MessageProcessingFramework/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2022/MessageProcessingFramework/template/src/BlueprintBaseName.1/serverless.template
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "AWS Message Processing Framework for .NET Template. This template is partially managed by Amazon.Lambda.Annotations (v1.2.0.0).",
+  "Description": "AWS Message Processing Framework for .NET Template. This template is partially managed by Amazon.Lambda.Annotations (v1.5.0.0).",
   "Resources": {
     "MessageProcessingFrameworkDemoQueue": {
       "Type": "AWS::SQS::Queue"
@@ -9,7 +9,16 @@
     "BlueprintBaseName._1FunctionsHandlerGenerated": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
-        "Tool": "Amazon.Lambda.Annotations"
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "SQSEvent"
+        ],
+        "SyncedEventProperties": {
+          "SQSEvent": [
+            "Queue.Fn::GetAtt",
+            "FunctionResponseTypes"
+          ]
+        }
       },
       "Properties": {
         "Runtime": "dotnet8",

--- a/Blueprints/BlueprintDefinitions/vs2022/template.nuspec
+++ b/Blueprints/BlueprintDefinitions/vs2022/template.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Amazon.Lambda.Templates</id>
-    <version>7.1.1</version>
+    <version>7.2.0</version>
     <authors>Amazon Web Services</authors>
     <tags>AWS Amazon Lambda</tags>
     <description>AWS Lambda templates for Microsoft Template Engine accessible with the dotnet CLI's new command</description>


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7528

*Description of changes:*
This PR updates the `Amazon.Lambda.Annotations` dependency to 1.5.0 in the Message Processing Framework VS blueprint. It also adds the `SQSEvent` attribute to set up SQS event source mapping for the message handler Lambda function.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
