### PR TITLE
chore: Update System.Text.Json in test projects per CVE-2024-30105

### DIFF
--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
@@ -16,7 +16,7 @@
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
         <PackageReference Include="System.Memory" Version="4.5.5" />
-        <PackageReference Include="System.Text.Json" Version="8.0.3" />
+        <PackageReference Include="System.Text.Json" Version="8.0.4" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Libraries/test/TestServerlessApp/TestServerlessApp.csproj
+++ b/Libraries/test/TestServerlessApp/TestServerlessApp.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Amazon.Lambda.Annotations.SourceGenerator\Amazon.Lambda.Annotations.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-lambda-dotnet/security/dependabot/46 and https://github.com/aws/aws-lambda-dotnet/security/dependabot/45

*Description of changes:* Upgrades the `System.Text.Json` per https://github.com/advisories/GHSA-hh2w-p6rv-4g7w

We aren't using the impacted API, but updating to avoid scanner findings.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
