### PR TITLE
Adds support for Condition element in APIGatewayCustomAuthorizerPolicy.IAMPolicyStatement.

### DIFF
--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerPolicy.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayCustomAuthorizerPolicy.cs
@@ -51,6 +51,15 @@
             [System.Text.Json.Serialization.JsonPropertyName("Resource")]
 #endif
             public HashSet<string> Resource { get; set; }
+
+            /// <summary>
+            /// Gets or sets the conditions for when a policy is in effect. 
+            /// https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html
+            /// </summary>
+#if NETCOREAPP3_1_OR_GREATER
+            [System.Text.Json.Serialization.JsonPropertyName("Condition")]
+#endif
+            public IDictionary<string, IDictionary<string, object>> Condition { get; set; }
         }
     }
 }

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/Amazon.Lambda.APIGatewayEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/Amazon.Lambda.APIGatewayEvents.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>    
     <Description>Amazon Lambda .NET Core support - API Gateway package.</Description>
     <AssemblyTitle>Amazon.Lambda.APIGatewayEvents</AssemblyTitle>
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.7.1</VersionPrefix>
     <AssemblyName>Amazon.Lambda.APIGatewayEvents</AssemblyName>
     <PackageId>Amazon.Lambda.APIGatewayEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Libraries/src/Amazon.Lambda.Serialization.Json/Amazon.Lambda.Serialization.Json.csproj
+++ b/Libraries/src/Amazon.Lambda.Serialization.Json/Amazon.Lambda.Serialization.Json.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>Amazon.Lambda.Serialization.Json</AssemblyName>
     <PackageId>Amazon.Lambda.Serialization.Json</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
-    <VersionPrefix>2.2.1</VersionPrefix>
+    <VersionPrefix>2.2.2</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libraries/src/Amazon.Lambda.Serialization.Json/JsonSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.Json/JsonSerializer.cs
@@ -52,6 +52,7 @@ namespace Amazon.Lambda.Serialization.Json
                 resolver.NamingStrategy = namingStrategy;
             };
             settings.ContractResolver = resolver;
+            settings.NullValueHandling = NullValueHandling.Ignore;
 
             serializer = Newtonsoft.Json.JsonSerializer.Create(settings);
 

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestCallingWebAPI.cs
@@ -215,7 +215,7 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
                 Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
             });
             Assert.NotNull(json);
-            var expected = "{\"principalId\":\"com.amazon.someuser\",\"policyDocument\":{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"execute-api:Invoke\"],\"Resource\":[\"arn:aws:execute-api:us-west-2:1234567890:apit123d45/Prod/GET/*\"]}]},\"context\":{\"stringKey\":\"Hey I'm a string\",\"boolKey\":true,\"numKey\":9},\"usageIdentifierKey\":null}";
+            var expected = "{\"principalId\":\"com.amazon.someuser\",\"policyDocument\":{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"execute-api:Invoke\"],\"Resource\":[\"arn:aws:execute-api:us-west-2:1234567890:apit123d45/Prod/GET/*\"],\"Condition\":null}]},\"context\":{\"stringKey\":\"Hey I'm a string\",\"boolKey\":true,\"numKey\":9},\"usageIdentifierKey\":null}";
             Assert.Equal(expected, json);
         }
 

--- a/Libraries/test/TestServerlessApp.IntegrationTests/DeploymentScript.ps1
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/DeploymentScript.ps1
@@ -38,9 +38,22 @@ try
     $content = Get-Content .\aws-lambda-tools-defaults.json
     $content | ForEach-Object {$_ -replace $line, "`"function-architecture`" : `"$arch`""} | Set-Content .\aws-lambda-tools-defaults.json
 
+    # Extract region
+    $json =  Get-Content .\aws-lambda-tools-defaults.json | Out-String | ConvertFrom-Json
+    $region = $json.region
+
     dotnet tool install -g Amazon.Lambda.Tools
     Write-Host "Creating S3 Bucket $identifier"
-    aws s3 mb s3://$identifier
+
+    if(![string]::IsNullOrEmpty($region))
+    {
+        aws s3 mb s3://$identifier --region $region
+    }
+    else
+    {
+        aws s3 mb s3://$identifier
+    }
+    
     if (!$?)
     {
         throw "Failed to create the following bucket: $identifier"


### PR DESCRIPTION
*Issue #, if available:* #588

*Description of changes:*
Adds support for `Condition` element in `APIGatewayCustomAuthorizerPolicy.IAMPolicyStatement`.

Kindly note the following:
- Used https://github.com/awslabs/aws-apigateway-lambda-authorizer-blueprints/ as a reference.
  - The [Java type](https://github.com/awslabs/aws-apigateway-lambda-authorizer-blueprints/blob/1e79ad02a4dcbbd0fe2951cf9a5de4aff7915823/blueprints/java/src/io/AuthPolicy.java#L228) defines return type for `Condition` property as `Map<String, Map<String, Object>>`.
  - The [.NET type](https://github.com/awslabs/aws-apigateway-lambda-authorizer-blueprints/blob/master/blueprints/dotnet/src/APIGatewayAuthorizerHandler/Model/Auth/Statement.cs) specifies return type of `Condition` property as `IDictionary<ConditionOperator, IDictionary<ConditionKey, string>>`.
- Refer [IAM JSON policy elements: Condition](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html) for IAM policy `Condition` reference. Per this reference, it is of the format `"Condition" : { "{condition-operator}" : { "{condition-key}" : "{condition-value}" }}`.
- The return type of `APIGatewayCustomAuthorizerPolicy.IAMPolicyStatement.Condition` is `IDictionary<string, IDictionary<string, object>>` similar to Java version due to following reasons:
  - Keep implementation simple to avoid to maintain enum types `ConditionOperator` and `ConditionKey`.
  - [IAM JSON policy elements: Condition](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html) specifies support for complex types for `condition-value`. Hence, it is modeled as `object` type.
- The PR also initialized `settings.NullValueHandling = NullValueHandling.Ignore` in [Amazon.Lambda.Serialization.Json.JsonSerializer](https://github.com/aws/aws-lambda-dotnet/blob/1f0b6a598f65d8f97ef45b860f05d75eaf041e84/Libraries/src/Amazon.Lambda.Serialization.Json/JsonSerializer.cs#L54).
  - This is to keep the behavior same as [Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer](https://github.com/aws/aws-lambda-dotnet/blob/1f0b6a598f65d8f97ef45b860f05d75eaf041e84/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/LambdaJsonSerializer.cs#L44) and [Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer](https://github.com/aws/aws-lambda-dotnet/blob/1f0b6a598f65d8f97ef45b860f05d75eaf041e84/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/DefaultLambdaJsonSerializer.cs#L60) (per invocation of [AbstractLambdaJsonSerializer.CreateDefaultJsonSerializationOptions()](https://github.com/aws/aws-lambda-dotnet/blob/1f0b6a598f65d8f97ef45b860f05d75eaf041e84/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/AbstractLambdaJsonSerializer.cs#L134)).
  - So that null `Condition` property (if not set) is not rendered in IAM Policy statement.
- Due to change above, **reviewer**,
  -  Check the version bump.
  - Do we need to ensure that customer also updates to latest `Amazon.Lambda.Serialization.Json.JsonSerializer` package? The events classes do not have any direct reference to this package as expected. We use this package in event tests?
  - Should we also add test case to ASP.NET tests?
___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
