### PR TITLE
Fixed AwsResolver.CreateProperties() to use logical OR condition when checking for Amazon.Lambda.CloudWatchEvents.CloudWatchEvent type.

### DIFF
--- a/Libraries/src/Amazon.Lambda.Serialization.Json/AwsResolver.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.Json/AwsResolver.cs
@@ -130,8 +130,9 @@ namespace Amazon.Lambda.Serialization.Json
                     }
                 }
             }
+            // If user is directly using CloudWatchEvent class or using a derived type created in custom namespace.
             else if (type.FullName.StartsWith("Amazon.Lambda.CloudWatchEvents.")
-                     && (type.GetTypeInfo().BaseType?.FullName?.StartsWith("Amazon.Lambda.CloudWatchEvents.CloudWatchEvent`",
+                     || (type.GetTypeInfo().BaseType?.FullName?.StartsWith("Amazon.Lambda.CloudWatchEvents.CloudWatchEvent`",
                              StringComparison.Ordinal) ?? false))
             {
                 foreach (JsonProperty property in properties)


### PR DESCRIPTION
*Issue #, if available:* #634

*Description of changes:*
Fixed an issue `AwsResolver.CreateProperties()` to use `logical OR` condition when checking for `Amazon.Lambda.CloudWatchEvents.CloudWatchEvent` type.

Version bump to `Amazon.Lambda.Serialization.Json` has been done in PR https://github.com/aws/aws-lambda-dotnet/pull/1779.
___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
