### PR TITLE
Update README file for ASP.NET Core integration

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer.Hosting/README.md
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer.Hosting/README.md
@@ -9,6 +9,11 @@ This package allows ASP .NET Core applications written using the minimal api sty
 The `AddAWSLambdaHosting` will setup the `Amazon.Lambda.AspNetCoreServer` package to process 
 the incoming Lambda events as ASP .NET Core requests. It will also initialize `Amazon.Lambda.RuntimeSupport` package to interact with the Lambda service.
 
+## Supported .NET versions
+
+This library supports .NET 6 and above. Lambda provides managed runtimes for long term supported (LTS) versions like .NET 6 and .NET 8. To use standard term supported (STS) versions like .NET 9
+the Lambda function must be bundled as a self contained executable or an OCI image.
+
 ## Sample ASP .NET Core application
 
 The code sample below is the typical initilization code for an ASP .NET Core application using the minimal api style. The one difference is the extra line of code calling `AddAWSLambdaHosting`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AWS Lambda for .NET [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/aws/aws-lambda-dotnet?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+# AWS Lambda for .NET
 
 Repository for the AWS NuGet packages and Blueprints to support writing AWS Lambda functions using .NET Core.
 


### PR DESCRIPTION
*Description of changes:*
Refresh the README file's for the ASP.NET Core integration.

* Removed references of .NET Core 3.1
* Added a section describing the supported versions of .NET
* Added an explanation of the difference between Amazon.Lambda.AspNetCoreServer and Amazon.Lambda.AspNetCoreServer.Hosting
* Removed the link to Gitter since it isn't something we monitor and there hasn't been any activity in it for years.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
