### PR TITLE
Fixed an issue in JsonSerializer where JsonSerializerSettings.NullValueHandling was being set to NullValueHandling.Ignore after custom settings were applied.

### DIFF
--- a/Libraries/src/Amazon.Lambda.Serialization.Json/Amazon.Lambda.Serialization.Json.csproj
+++ b/Libraries/src/Amazon.Lambda.Serialization.Json/Amazon.Lambda.Serialization.Json.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>Amazon.Lambda.Serialization.Json</AssemblyName>
     <PackageId>Amazon.Lambda.Serialization.Json</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
-    <VersionPrefix>2.2.2</VersionPrefix>
+    <VersionPrefix>2.2.3</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libraries/src/Amazon.Lambda.Serialization.Json/JsonIncludeNullValueSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.Json/JsonIncludeNullValueSerializer.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using Amazon.Lambda.Core;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Amazon.Lambda.Serialization.Json
+{
+    /// <summary>
+    /// Custom ILambdaSerializer implementation which uses Newtonsoft.Json 
+    /// for serialization that includes null values.
+    /// 
+    /// <para>
+    /// If the environment variable LAMBDA_NET_SERIALIZER_DEBUG is set to true the JSON coming
+    /// in from Lambda and being sent back to Lambda will be logged.
+    /// </para>
+    /// </summary>
+    public class JsonIncludeNullValueSerializer : JsonSerializer
+    {
+        /// <summary>
+        /// Constructs instance of serializer.
+        /// </summary>
+        public JsonIncludeNullValueSerializer()
+        : base(CreateCustomizer())
+        { }
+
+        private static Action<JsonSerializerSettings> CreateCustomizer()
+        {
+            return (JsonSerializerSettings customSerializerSettings) =>
+            {
+                customSerializerSettings.NullValueHandling = NullValueHandling.Include;
+            };
+        }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.Serialization.Json/JsonSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.Json/JsonSerializer.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json.Serialization;
 namespace Amazon.Lambda.Serialization.Json
 {
     /// <summary>
-    /// Custom ILambdaSerializer implementation which uses Newtonsoft.Json 9.0.1
+    /// Custom ILambdaSerializer implementation which uses Newtonsoft.Json 
     /// for serialization.
     /// 
     /// <para>
@@ -41,8 +41,8 @@ namespace Amazon.Lambda.Serialization.Json
         public JsonSerializer(Action<JsonSerializerSettings> customizeSerializerSettings, NamingStrategy namingStrategy)
         {
             JsonSerializerSettings settings = new JsonSerializerSettings();
+            settings.NullValueHandling = NullValueHandling.Ignore;
             customizeSerializerSettings(settings);
-
             
             // Set the contract resolver *after* the custom callback has been 
             // invoked. This makes sure that we always use the good resolver.
@@ -52,7 +52,6 @@ namespace Amazon.Lambda.Serialization.Json
                 resolver.NamingStrategy = namingStrategy;
             };
             settings.ContractResolver = resolver;
-            settings.NullValueHandling = NullValueHandling.Ignore;
 
             serializer = Newtonsoft.Json.JsonSerializer.Create(settings);
 

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -23,6 +23,7 @@ namespace Amazon.Lambda.Tests
     using Amazon.Lambda.LexV2Events;
     using Amazon.Lambda.MQEvents;
     using Amazon.Lambda.S3Events;
+    using Amazon.Lambda.Serialization.Json;
     using Amazon.Lambda.SimpleEmailEvents;
     using Amazon.Lambda.SNSEvents;
     using Amazon.Lambda.SQSEvents;
@@ -3879,6 +3880,28 @@ namespace Amazon.Lambda.Tests
 
             }
         }
+
+        [Fact]
+        public void TestJsonIncludeNullValueSerializer()
+        {
+            var serializer = new JsonIncludeNullValueSerializer();
+
+            var response = new ClassUsingPascalCase
+            {
+                SomeValue = 123,
+                SomeOtherValue = null
+            };
+
+            MemoryStream ms = new MemoryStream();
+            serializer.Serialize(response, ms);
+            ms.Position = 0;
+            var json = new StreamReader(ms).ReadToEnd();
+
+            var serialized = JObject.Parse(json);
+            Assert.Equal(123, serialized["SomeValue"]);
+            Assert.Equal(JTokenType.Null, serialized["SomeOtherValue"].Type); // System.NullReferenceException is thrown if value is missing.
+        }
+
         class ClassUsingPascalCase
         {
             public int SomeValue { get; set; }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- Fixed an issue in `JsonSerializer` where `JsonSerializerSettings.NullValueHandling` was being set to `NullValueHandling.Ignore` after custom settings were applied.
- Added new `JsonIncludeNullValueSerializer` derived from `JsonSerializer` that includes null values in serialized JSON. 
___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
