### PR TITLE
Corrected the data type for ClaimsToAddOrOverride property in IdTokenGeneration and AccessTokenGeneration classes for CognitoPreTokenGenerationV2Event.

### DIFF
--- a/Libraries/src/Amazon.Lambda.CognitoEvents/AccessTokenGeneration.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/AccessTokenGeneration.cs
@@ -17,7 +17,7 @@ namespace Amazon.Lambda.CognitoEvents
 #if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("claimsToAddOrOverride")]
 # endif
-        public Dictionary<string, string> ClaimsToAddOrOverride { get; set; } = new Dictionary<string, string>();
+        public Dictionary<string, object> ClaimsToAddOrOverride { get; set; } = new Dictionary<string, object>();
         
         /// <summary>
         /// A list that contains claims to be suppressed from the identity token.

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/Amazon.Lambda.CognitoEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/Amazon.Lambda.CognitoEvents.csproj
@@ -6,7 +6,7 @@
     <Description>Amazon Lambda .NET Core support - CognitoEvents package.</Description>
     <TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.CognitoEvents</AssemblyTitle>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>4.0.0</VersionPrefix>
     <AssemblyName>Amazon.Lambda.CognitoEvents</AssemblyName>
     <PackageId>Amazon.Lambda.CognitoEvents</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>

--- a/Libraries/src/Amazon.Lambda.CognitoEvents/IdTokenGeneration.cs
+++ b/Libraries/src/Amazon.Lambda.CognitoEvents/IdTokenGeneration.cs
@@ -16,7 +16,7 @@ namespace Amazon.Lambda.CognitoEvents
 #if NETCOREAPP3_1_OR_GREATER
         [System.Text.Json.Serialization.JsonPropertyName("claimsToAddOrOverride")]
 # endif
-        public Dictionary<string, string> ClaimsToAddOrOverride { get; set; } = new Dictionary<string, string>();
+        public Dictionary<string, object> ClaimsToAddOrOverride { get; set; } = new Dictionary<string, object>();
         
         /// <summary>
         /// A list that contains claims to be suppressed from the identity token.

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -1258,20 +1258,26 @@ namespace Amazon.Lambda.Tests
                 Assert.Equal("scope_1", cognitoPreTokenGenerationV2Event.Request.Scopes.ToArray()[0]);
                 Assert.Equal("scope_2", cognitoPreTokenGenerationV2Event.Request.Scopes.ToArray()[1]);
                 
-                Assert.Equal(2, cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.IdTokenGeneration.ClaimsToAddOrOverride.Count);
-                Assert.Equal("claim_1", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.IdTokenGeneration.ClaimsToAddOrOverride.ToArray()[0].Key);
-                Assert.Equal("claim_1_value_1", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.IdTokenGeneration.ClaimsToAddOrOverride.ToArray()[0].Value);
-                Assert.Equal("claim_2", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.IdTokenGeneration.ClaimsToAddOrOverride.ToArray()[1].Key);
-                Assert.Equal("claim_1_value_2", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.IdTokenGeneration.ClaimsToAddOrOverride.ToArray()[1].Value);
+                // Value comparison would vary across different serializers. Skip it for now and validate the complete JSON later.
+                Assert.Equal(5, cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.IdTokenGeneration.ClaimsToAddOrOverride.Count);
+                Assert.Equal("id_claim_1", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.IdTokenGeneration.ClaimsToAddOrOverride.ToArray()[0].Key);
+                Assert.Equal("id_claim_2", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.IdTokenGeneration.ClaimsToAddOrOverride.ToArray()[1].Key);
+                Assert.Equal("id_claim_3", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.IdTokenGeneration.ClaimsToAddOrOverride.ToArray()[2].Key);
+                Assert.Equal("id_claim_4", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.IdTokenGeneration.ClaimsToAddOrOverride.ToArray()[3].Key);
+                Assert.Equal("id_claim_5", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.IdTokenGeneration.ClaimsToAddOrOverride.ToArray()[4].Key);
+                
                 Assert.Equal(2, cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.IdTokenGeneration.ClaimsToSuppress.Count);
                 Assert.Equal("suppress1", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.IdTokenGeneration.ClaimsToSuppress[0]);
                 Assert.Equal("suppress2", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.IdTokenGeneration.ClaimsToSuppress[1]);
 
-                Assert.Equal(2, cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.AccessTokenGeneration.ClaimsToAddOrOverride.Count);
-                Assert.Equal("claim_1", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.AccessTokenGeneration.ClaimsToAddOrOverride.ToArray()[0].Key);
-                Assert.Equal("claim_1_value_1", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.AccessTokenGeneration.ClaimsToAddOrOverride.ToArray()[0].Value);
-                Assert.Equal("claim_2", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.AccessTokenGeneration.ClaimsToAddOrOverride.ToArray()[1].Key);
-                Assert.Equal("claim_1_value_2", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.AccessTokenGeneration.ClaimsToAddOrOverride.ToArray()[1].Value);
+                // Value comparison would vary across different serializers. Skip it for now and validate the complete JSON later.
+                Assert.Equal(5, cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.AccessTokenGeneration.ClaimsToAddOrOverride.Count);
+                Assert.Equal("access_claim_1", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.AccessTokenGeneration.ClaimsToAddOrOverride.ToArray()[0].Key);
+                Assert.Equal("access_claim_2", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.AccessTokenGeneration.ClaimsToAddOrOverride.ToArray()[1].Key);
+                Assert.Equal("access_claim_3", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.AccessTokenGeneration.ClaimsToAddOrOverride.ToArray()[2].Key);
+                Assert.Equal("access_claim_4", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.AccessTokenGeneration.ClaimsToAddOrOverride.ToArray()[3].Key);
+                Assert.Equal("access_claim_5", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.AccessTokenGeneration.ClaimsToAddOrOverride.ToArray()[4].Key);
+                
                 Assert.Equal(2, cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.AccessTokenGeneration.ClaimsToSuppress.Count);
                 Assert.Equal("suppress1", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.AccessTokenGeneration.ClaimsToSuppress[0]);
                 Assert.Equal("suppress2", cognitoPreTokenGenerationV2Event.Response.ClaimsAndScopeOverrideDetails.AccessTokenGeneration.ClaimsToSuppress[1]);

--- a/Libraries/test/EventsTests.Shared/cognito-pretokengenerationv2-event.json
+++ b/Libraries/test/EventsTests.Shared/cognito-pretokengenerationv2-event.json
@@ -37,8 +37,11 @@
     "claimsAndScopeOverrideDetails": {
       "idTokenGeneration": {
         "claimsToAddOrOverride": {
-          "claim_1": "claim_1_value_1",
-          "claim_2": "claim_1_value_2"
+          "id_claim_1": "id_claim_1_value",
+          "id_claim_2": "id_claim_2_value",
+          "id_claim_3": 1234,
+          "id_claim_4": true,
+          "id_claim_5": [ "id_claim_5_value", 5678, false ]
         },
         "claimsToSuppress": [
           "suppress1",
@@ -47,8 +50,11 @@
       },
       "accessTokenGeneration": {
         "claimsToAddOrOverride": {
-          "claim_1": "claim_1_value_1",
-          "claim_2": "claim_1_value_2"
+          "access_claim_1": "access_claim_1_value",
+          "access_claim_2": "access_claim_2_value",
+          "access_claim_3": 1234,
+          "access_claim_4": true,
+          "access_claim_5": [ "access_claim_5_value", 5678, false ]
         },
         "claimsToSuppress": [
           "suppress1",


### PR DESCRIPTION
*Issue #, if available:* #1798 (additional context https://github.com/aws/aws-lambda-dotnet/discussions/1792)

*Description of changes:*
Corrected the data type for `ClaimsToAddOrOverride` property in `IdTokenGeneration` and `AccessTokenGeneration` classes for `CognitoPreTokenGenerationV2Event`.

Per [Pre token generation Lambda trigger](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-token-generation.html), following is the event structure for `V2` event:
```JSON
{
    "request": {
        "userAttributes": {
            "string": "string"
        },
        "scopes": ["string", "string"],
        "groupConfiguration": {
            "groupsToOverride": ["string", "string"],
            "iamRolesToOverride": ["string", "string"],
            "preferredRole": "string"
        },
        "clientMetadata": {
            "string": "string"
        }
    },
    "response": {
        "claimsAndScopeOverrideDetails": {
            "idTokenGeneration": {
                "claimsToAddOrOverride": {
                    "string": [accepted datatype]
                },
                "claimsToSuppress": ["string", "string"]
            },
            "accessTokenGeneration": {
                "claimsToAddOrOverride": {
                    "string": [accepted datatype]
                },
                "claimsToSuppress": ["string", "string"],
                "scopesToAdd": ["string", "string"],
                "scopesToSuppress": ["string", "string"]
            },
            "groupOverrideDetails": {
                "groupsToOverride": ["string", "string"],
                "iamRolesToOverride": ["string", "string"],
                "preferredRole": "string"
            }
        }
    }
}
```
Notice that `claimsToAddOrOverride` for both `idTokenGeneration` and `accessTokenGeneration` has structure `"string": [accepted datatype]`, where **accepted datatype** is one of the following:
- String
- Number
- Boolean
- Array of strings, numbers, booleans, or a combination of any of these
- JSON

**IMPORTANT:** This is a breaking change and should be called out explicitly in CHANGELOG.
___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
