### PR TITLE
Fix issue with not correctly detecting "warning" log level.

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/ConsoleLoggerWriter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/ConsoleLoggerWriter.cs
@@ -324,6 +324,10 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
                     {
                         _minmumLogLevel = LogLevel.Critical;
                     }
+                    else if (string.Equals(envLogLevel, "warn", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        _minmumLogLevel = LogLevel.Warning;
+                    }
                     else if (Enum.TryParse<LogLevel>(envLogLevel, true, out var result))
                     {
                         _minmumLogLevel = result;

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/Amazon.Lambda.RuntimeSupport.IntegrationTests.csproj
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/Amazon.Lambda.RuntimeSupport.IntegrationTests.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.100.98" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.7.105.17" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.402.7" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.7.402.3" />
     <PackageReference Include="AWSSDK.S3" Version="3.7.103.34" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
@@ -32,7 +32,7 @@
     <PackageReference Include="xunit" Version="2.4.2" />
 
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.32" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.400.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/CustomRuntimeTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/CustomRuntimeTests.cs
@@ -102,8 +102,21 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
                     await RunTestExceptionAsync(lambdaClient, "ExceptionNonAsciiCharacterUnwrappedAsync", "", "Exception", "Unhandled exception with non ASCII character: ♂");
                     await RunTestSuccessAsync(lambdaClient, "UnintendedDisposeTest", "not-used", "UnintendedDisposeTest-SUCCESS");
                     await RunTestSuccessAsync(lambdaClient, "LoggingStressTest", "not-used", "LoggingStressTest-success");
-                    await RunLoggingTestAsync(lambdaClient, "LoggingTest", null);
-                    await RunLoggingTestAsync(lambdaClient, "LoggingTest", "debug");
+
+                    await RunLoggingTestAsync(lambdaClient, "LoggingTest", RuntimeLogLevel.Trace, LogConfigSource.LambdaAPI);
+                    await RunLoggingTestAsync(lambdaClient, "LoggingTest", RuntimeLogLevel.Debug, LogConfigSource.LambdaAPI);
+                    await RunLoggingTestAsync(lambdaClient, "LoggingTest", RuntimeLogLevel.Information, LogConfigSource.LambdaAPI);
+                    await RunLoggingTestAsync(lambdaClient, "LoggingTest", RuntimeLogLevel.Warning, LogConfigSource.LambdaAPI);
+                    await RunLoggingTestAsync(lambdaClient, "LoggingTest", RuntimeLogLevel.Error, LogConfigSource.LambdaAPI);
+                    await RunLoggingTestAsync(lambdaClient, "LoggingTest", RuntimeLogLevel.Critical, LogConfigSource.LambdaAPI);
+                    await RunLoggingTestAsync(lambdaClient, "LoggingTest", RuntimeLogLevel.Trace, LogConfigSource.DotnetEnvironment);
+                    await RunLoggingTestAsync(lambdaClient, "LoggingTest", RuntimeLogLevel.Debug, LogConfigSource.DotnetEnvironment);
+                    await RunLoggingTestAsync(lambdaClient, "LoggingTest", RuntimeLogLevel.Information, LogConfigSource.DotnetEnvironment);
+                    await RunLoggingTestAsync(lambdaClient, "LoggingTest", RuntimeLogLevel.Warning, LogConfigSource.DotnetEnvironment);
+                    await RunLoggingTestAsync(lambdaClient, "LoggingTest", RuntimeLogLevel.Error, LogConfigSource.DotnetEnvironment);
+                    await RunLoggingTestAsync(lambdaClient, "LoggingTest", RuntimeLogLevel.Critical, LogConfigSource.DotnetEnvironment);
+
+
                     await RunUnformattedLoggingTestAsync(lambdaClient, "LoggingTest");
 
                     await RunTestSuccessAsync(lambdaClient, "ToUpperAsync", "message", "ToUpperAsync-MESSAGE");
@@ -207,14 +220,17 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
             }
         }
 
-        private async Task RunLoggingTestAsync(AmazonLambdaClient lambdaClient, string handler, string logLevel)
+        // The .NET Lambda runtime has a legacy environment variable for configuring the log level. This enum is used in the test to choose
+        // whether the legacy environment variable should be set or use the new properties in the update configuration api for setting log level.
+        enum LogConfigSource { LambdaAPI, DotnetEnvironment}
+        private async Task RunLoggingTestAsync(AmazonLambdaClient lambdaClient, string handler, RuntimeLogLevel? runtimeLogLevel, LogConfigSource configSource)
         {
             var environmentVariables = new Dictionary<string, string>();
-            if(!string.IsNullOrEmpty(logLevel))
+            if(runtimeLogLevel.HasValue && configSource == LogConfigSource.DotnetEnvironment)
             {
-                environmentVariables["AWS_LAMBDA_HANDLER_LOG_LEVEL"] = logLevel;
+                environmentVariables["AWS_LAMBDA_HANDLER_LOG_LEVEL"] = runtimeLogLevel.Value.ToString().ToLowerInvariant();
             }
-            await UpdateHandlerAsync(lambdaClient, handler, environmentVariables);
+            await UpdateHandlerAsync(lambdaClient, handler, environmentVariables, configSource == LogConfigSource.LambdaAPI ? runtimeLogLevel : null); 
 
             var invokeResponse = await InvokeFunctionAsync(lambdaClient, JsonConvert.SerializeObject(""));
             Assert.True(invokeResponse.HttpStatusCode == System.Net.HttpStatusCode.OK);
@@ -222,22 +238,65 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
 
             var log = System.Text.UTF8Encoding.UTF8.GetString(Convert.FromBase64String(invokeResponse.LogResult));
 
-            Assert.Contains("info\tA information log", log);
-            Assert.Contains("warn\tA warning log", log);
-            Assert.Contains("fail\tA error log", log);
-            Assert.Contains("crit\tA critical log", log);
+            if (!runtimeLogLevel.HasValue)
+                runtimeLogLevel = RuntimeLogLevel.Information;
 
-            Assert.Contains("info\tA stdout info message", log);
-
-            Assert.Contains("fail\tA stderror error message", log);
-
-            if (string.IsNullOrEmpty(logLevel))
+            if (runtimeLogLevel <= RuntimeLogLevel.Trace)
             {
-                Assert.DoesNotContain($"a {logLevel} log".ToLower(), log.ToLower());
+                Assert.Contains("A trace log", log);
             }
             else
             {
-                Assert.Contains($"a {logLevel} log".ToLower(), log.ToLower());
+                Assert.DoesNotContain("A trace log", log);
+            }
+
+            if (runtimeLogLevel <= RuntimeLogLevel.Debug)
+            {
+                Assert.Contains("A debug log", log);
+            }
+            else
+            {
+                Assert.DoesNotContain("A debug log", log);
+            }
+
+            if (runtimeLogLevel <= RuntimeLogLevel.Information)
+            {
+                Assert.Contains("A information log", log);
+                Assert.Contains("A stdout info message", log);
+            }
+            else
+            {
+                Assert.DoesNotContain("A information log", log);
+                Assert.DoesNotContain("A stdout info message", log);
+            }
+
+            if (runtimeLogLevel <= RuntimeLogLevel.Warning)
+            {
+                Assert.Contains("A warning log", log);
+            }
+            else
+            {
+                Assert.DoesNotContain("A warning log", log);
+            }
+
+            if (runtimeLogLevel <= RuntimeLogLevel.Error)
+            {
+                Assert.Contains("A error log", log);
+                Assert.Contains("A stderror error message", log);
+            }
+            else
+            {
+                Assert.DoesNotContain("A error log", log);
+                Assert.DoesNotContain("A stderror error message", log);
+            }
+
+            if (runtimeLogLevel <= RuntimeLogLevel.Critical)
+            {
+                Assert.Contains("A critical log", log);
+            }
+            else
+            {
+                Assert.DoesNotContain("A critical log", log);
             }
         }
 

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/CustomRuntimeFunctionTest/CustomRuntimeFunction.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/CustomRuntimeFunctionTest/CustomRuntimeFunction.cs
@@ -98,6 +98,10 @@ namespace CustomRuntimeFunctionTest
                     case nameof(GetTimezoneNameAsync):
                         bootstrap = new LambdaBootstrap(GetTimezoneNameAsync);
                         break;
+                    case nameof(ThrowUnhandledApplicationException):
+                        handlerWrapper = HandlerWrapper.GetHandlerWrapper((Action)ThrowUnhandledApplicationException);
+                        bootstrap = new LambdaBootstrap(handlerWrapper);
+                        break;
                     default:
                         throw new Exception($"Handler {handler} is not supported.");
                 }
@@ -372,6 +376,11 @@ namespace CustomRuntimeFunctionTest
         private static void AggregateExceptionNotUnwrapped()
         {
             throw new AggregateException("AggregateException thrown from a synchronous handler.");
+        }
+
+        private static void ThrowUnhandledApplicationException()
+        {
+            throw new ApplicationException("Function fail");
         }
 
         private static Task<InvocationResponse> TooLargeResponseBodyAsync(InvocationRequest invocation)


### PR DESCRIPTION
*Description of changes:*
When the log level is set to warning it sets the logging environment variable to `warn` instead of `warning` which is what the .NET Lambda runtime was using. This PR adds the special case for `warn` to translate to .NET's `warning` and reworks the integration tests to test the log level through both the legacy .NET environment variable and the Lambda logging configuration properties.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
