### PR TITLE
Adding ASP.NET Core IServer hosting for Websocket APIs

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer.Hosting/Internal/LambdaRuntimeSupportServer.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer.Hosting/Internal/LambdaRuntimeSupportServer.cs
@@ -95,6 +95,47 @@ namespace Amazon.Lambda.AspNetCoreServer.Hosting.Internal
     }
 
     /// <summary>
+    /// IServer for handlying Lambda events from an API Gateway Websocket API.
+    /// </summary>
+    public class APIGatewayWebsocketApiV2LambdaRuntimeSupportServer : LambdaRuntimeSupportServer
+    {
+        /// <summary>
+        /// Create instances
+        /// </summary>
+        /// <param name="serviceProvider">The IServiceProvider created for the ASP.NET Core application</param>
+        public APIGatewayWebsocketApiV2LambdaRuntimeSupportServer(IServiceProvider serviceProvider)
+            : base(serviceProvider)
+        {
+        }
+
+        /// <summary>
+        /// Creates HandlerWrapper for processing events from API Gateway Websocket API
+        /// </summary>
+        /// <param name="serviceProvider"></param>
+        /// <returns></returns>
+        protected override HandlerWrapper CreateHandlerWrapper(IServiceProvider serviceProvider)
+        {
+            var handler = new APIGatewayWebsocketApiV2MinimalApi(serviceProvider).FunctionHandlerAsync;
+            return HandlerWrapper.GetHandlerWrapper(handler, this.Serializer);
+        }
+
+        /// <summary>
+        /// Create the APIGatewayWebsocketApiV2ProxyFunction passing in the ASP.NET Core application's IServiceProvider
+        /// </summary>
+        public class APIGatewayWebsocketApiV2MinimalApi : APIGatewayWebsocketApiV2ProxyFunction
+        {
+            /// <summary>
+            /// Create instances
+            /// </summary>
+            /// <param name="serviceProvider">The IServiceProvider created for the ASP.NET Core application</param>
+            public APIGatewayWebsocketApiV2MinimalApi(IServiceProvider serviceProvider)
+                : base(serviceProvider)
+            {
+            }
+        }
+    }
+
+    /// <summary>
     /// IServer for handlying Lambda events from an API Gateway REST API.
     /// </summary>
     public class APIGatewayRestApiLambdaRuntimeSupportServer : LambdaRuntimeSupportServer

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer.Hosting/ServiceCollectionExtensions.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer.Hosting/ServiceCollectionExtensions.cs
@@ -25,6 +25,11 @@ namespace Microsoft.Extensions.DependencyInjection
         HttpApi, 
 
         /// <summary>
+        /// API Gateway HTTP API
+        /// </summary>
+        WebsocketApi, 
+
+        /// <summary>
         /// ELB Application Load Balancer
         /// </summary>
         ApplicationLoadBalancer
@@ -104,6 +109,7 @@ namespace Microsoft.Extensions.DependencyInjection
             var serverType = eventSource switch
             {
                 LambdaEventSource.HttpApi => typeof(APIGatewayHttpApiV2LambdaRuntimeSupportServer),
+                LambdaEventSource.WebsocketApi => typeof(APIGatewayWebsocketApiV2LambdaRuntimeSupportServer),
                 LambdaEventSource.RestApi => typeof(APIGatewayRestApiLambdaRuntimeSupportServer),
                 LambdaEventSource.ApplicationLoadBalancer => typeof(ApplicationLoadBalancerLambdaRuntimeSupportServer),
                 _ => throw new ArgumentException($"Event source type {eventSource} unknown")

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Security.Claims;
 
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging;
 
@@ -285,6 +286,19 @@ namespace Amazon.Lambda.AspNetCoreServer
         protected virtual string ParseHttpMethod(APIGatewayHttpApiV2ProxyRequest apiGatewayRequest)
         {
             return apiGatewayRequest.RequestContext.Http.Method;
+        }
+
+        /// <summary>
+        /// Add missing headers to request.
+        /// </summary>
+        /// <returns>IHeaderDictionary</returns>
+        protected virtual IHeaderDictionary AddRequestHeaders(APIGatewayHttpApiV2ProxyRequest apiGatewayRequest, IHeaderDictionary headers)
+        {
+            if (!headers.ContainsKey("Host"))
+            {
+                headers["Host"] = apiGatewayRequest.RequestContext.DomainName;
+            }
+            return headers;
         }
     }
 }

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayWebsocketApiV2ProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayWebsocketApiV2ProxyFunction.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+using Microsoft.AspNetCore.Http;
+
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.AspNetCoreServer.Internal;
 
@@ -54,6 +56,15 @@ namespace Amazon.Lambda.AspNetCoreServer
         protected override string ParseHttpMethod(APIGatewayHttpApiV2ProxyRequest apiGatewayRequest)
         {
             return "POST";
+        }
+
+        /// <inheritdoc/>
+        /// <returns>IHeaderDictionary</returns>
+        protected override IHeaderDictionary AddRequestHeaders(APIGatewayHttpApiV2ProxyRequest apiGatewayRequest, IHeaderDictionary headers)
+        {
+            headers = base.AddRequestHeaders(apiGatewayRequest, headers);
+            headers["Content-Type"] = "application/json";
+            return headers;
         }
     }
 }

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayWebsocketApiV2ProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayWebsocketApiV2ProxyFunction.cs
@@ -1,0 +1,59 @@
+﻿using System;
+
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.AspNetCoreServer.Internal;
+
+namespace Amazon.Lambda.AspNetCoreServer
+{
+    /// <summary>
+    /// Base class for ASP.NET Core Lambda functions that are getting request from API Gateway Websocket API V2 payload format.
+    ///
+    /// The http method is fixed as POST. Requests are handled using the RouteKey, so the same lambda should be referenced by multiple API Gateway routes for the ASP.NET Core IServer to successfully route requests.
+    /// </summary>
+    public abstract class APIGatewayWebsocketApiV2ProxyFunction : APIGatewayHttpApiV2ProxyFunction
+    {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        protected APIGatewayWebsocketApiV2ProxyFunction()
+            : base()
+        {
+
+        }
+
+        /// <inheritdoc/>
+        /// <param name="startupMode">Configure when the ASP.NET Core framework will be initialized</param>
+        protected APIGatewayWebsocketApiV2ProxyFunction(StartupMode startupMode)
+            : base(startupMode)
+        {
+
+        }
+
+        /// <summary>
+        /// Constructor used by Amazon.Lambda.AspNetCoreServer.Hosting to support ASP.NET Core projects using the Minimal API style.
+        /// </summary>
+        /// <param name="hostedServices"></param>
+        protected APIGatewayWebsocketApiV2ProxyFunction(IServiceProvider hostedServices)
+            : base(hostedServices)
+        {
+            _hostServices = hostedServices;
+        }
+
+        /// <inheritdoc/>
+        /// <param name="apiGatewayRequest"></param>
+        /// <returns>string</returns>
+        protected override string ParseHttpPath(APIGatewayHttpApiV2ProxyRequest apiGatewayRequest)
+        {
+            var path = "/" + Utilities.DecodeResourcePath(apiGatewayRequest.RequestContext.RouteKey);
+            return path;
+        }
+
+        /// <inheritdoc/>
+        /// <param name="apiGatewayRequest"></param>
+        /// <returns>string</returns>
+        protected override string ParseHttpMethod(APIGatewayHttpApiV2ProxyRequest apiGatewayRequest)
+        {
+            return "POST";
+        }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayWebsocketApiV2ProxyFunction{TStartup}.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayWebsocketApiV2ProxyFunction{TStartup}.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Amazon.Lambda.AspNetCoreServer
+{
+    /// <summary>
+    /// APIGatewayWebsocketApiV2ProxyFunction is the base class that is implemented in a ASP.NET Core Web API. The derived class implements
+    /// the Init method similar to Main function in the ASP.NET Core and provides typed Startup. The function handler for
+    /// the Lambda function will point to this base class FunctionHandlerAsync method.
+    /// </summary>
+    /// <typeparam name ="TStartup">The type containing the startup methods for the application.</typeparam>
+    public abstract class APIGatewayWebsocketApiV2ProxyFunction<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] TStartup> : APIGatewayWebsocketApiV2ProxyFunction where TStartup : class
+    {
+        /// <summary>
+        /// Default Constructor. The ASP.NET Core Framework will be initialized as part of the construction.
+        /// </summary>
+        protected APIGatewayWebsocketApiV2ProxyFunction()
+            : base()
+        {
+
+        }
+
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="startupMode">Configure when the ASP.NET Core framework will be initialized</param>
+        protected APIGatewayWebsocketApiV2ProxyFunction(StartupMode startupMode)
+            : base(startupMode)
+        {
+
+        }
+
+        /// <inheritdoc/>
+        protected override void Init(IWebHostBuilder builder)
+        {
+            builder.UseStartup<TStartup>();
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestApiGatewayWebsocketApiV2Calls.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/TestApiGatewayWebsocketApiV2Calls.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.TestUtilities;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+using TestWebApp;
+
+using Xunit;
+
+
+
+namespace Amazon.Lambda.AspNetCoreServer.Test
+{
+    public class TestApiGatewayWebsocketApiV2Calls
+    {
+        [Fact]
+        public async Task TestPutWithBody()
+        {
+            var response = await this.InvokeAPIGatewayRequest("values-post-withbody-websocketapi-v2-request.json");
+
+            Assert.Equal(200, response.StatusCode);
+            Assert.Equal("Agent, Smith", response.Body);
+            Assert.True(response.Headers.ContainsKey("Content-Type"));
+            Assert.Equal("text/plain; charset=utf-8", response.Headers["Content-Type"]);
+        }
+
+        private async Task<APIGatewayHttpApiV2ProxyResponse> InvokeAPIGatewayRequest(string fileName, bool configureApiToReturnExceptionDetail = false)
+        {
+            return await InvokeAPIGatewayRequestWithContent(new TestLambdaContext(), GetRequestContent(fileName), configureApiToReturnExceptionDetail);
+        }
+
+        private async Task<APIGatewayHttpApiV2ProxyResponse> InvokeAPIGatewayRequest(TestLambdaContext context, string fileName, bool configureApiToReturnExceptionDetail = false)
+        {
+            return await InvokeAPIGatewayRequestWithContent(context, GetRequestContent(fileName), configureApiToReturnExceptionDetail);
+        }
+
+        private async Task<APIGatewayHttpApiV2ProxyResponse> InvokeAPIGatewayRequestWithContent(TestLambdaContext context, string requestContent, bool configureApiToReturnExceptionDetail = false)
+        {
+            var lambdaFunction = new TestWebApp.WebsocketV2LambdaFunction();
+            if (configureApiToReturnExceptionDetail)
+                lambdaFunction.IncludeUnhandledExceptionDetailInResponse = true;
+            var requestStream = new MemoryStream(System.Text.UTF8Encoding.UTF8.GetBytes(requestContent));
+            var request = new Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer().Deserialize<APIGatewayHttpApiV2ProxyRequest>(requestStream);
+
+            return await lambdaFunction.FunctionHandlerAsync(request, context);
+        }
+
+        private string GetRequestContent(string fileName)
+        {
+            var filePath = Path.Combine(Path.GetDirectoryName(this.GetType().GetTypeInfo().Assembly.Location), fileName);
+            var requestStr = File.ReadAllText(filePath);
+            return requestStr;
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-post-withbody-websocketapi-v2-request.json
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/values-post-withbody-websocketapi-v2-request.json
@@ -1,0 +1,22 @@
+﻿{
+  "version": null,
+  "routeKey": null,
+  "rawPath": null,
+  "rawQueryString": null,
+  "headers": null,
+  "requestContext": {
+    "accountId": null,
+    "apiId": "uo9pe23ec6",
+    "domainName": "uo9pe23ec6.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": null,
+    "http": null,
+    "requestId": "J7jk9g-7oAMEJGw=",
+    "routeKey": "$default",
+    "stage": "websocket",
+    "time": null,
+    "timeEpoch": 0
+  },
+  "pathParameters": null,
+  "body": "{\"firstName\":\"Smith\",\"lastName\": \"Agent\"}",
+  "isBase64Encoded": false
+}

--- a/Libraries/test/TestWebApp/Controllers/RouteKeyController.cs
+++ b/Libraries/test/TestWebApp/Controllers/RouteKeyController.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+
+namespace TestWebApp.Controllers
+{
+    [Route("/")]
+    public class RouteKeyController : Controller
+    {
+        [HttpPost("$default")]
+        public string PostBody([FromBody] Person body)
+        {
+            return $"{body.LastName}, {body.FirstName}";
+        }
+
+        public class Person
+        {
+            public string FirstName { get; set; }
+            public string LastName { get; set; }
+        }
+    }
+}

--- a/Libraries/test/TestWebApp/WebsocketApiV2LambdaFunction.cs
+++ b/Libraries/test/TestWebApp/WebsocketApiV2LambdaFunction.cs
@@ -1,0 +1,7 @@
+﻿using Amazon.Lambda.AspNetCoreServer;
+namespace TestWebApp
+{
+    public class WebsocketV2LambdaFunction : APIGatewayWebsocketApiV2ProxyFunction<Startup>
+    {
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
API Gateway Websocket APIs currently error out when using this library to handle requests since the `RequestContext.Http` object is null. This change allows this library to be used with Websocket APIs by setting the `Http.Path` to the `RouteKey` and the `Http.Method` fixed as `POST`. This approach requires the user to reference the same lambda for the `RouteKey`s which they want handled by the lambda server.

The changes to the `APIGatewayHttpApiV2ProxyFunction` class is minimal and adds a `APIGatewayWebsocketApiV2ProxyFunction` class and corresponding changes to the `Amazon.Lambda.AspNetCoreServer.Hosting` project to provide for a Websocket option.

All tests that were passing in the current master branch are passing in the PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
