### PR TITLE
Fixes an issue where Write-Debug doesn't log debug messages to CloudWatch for a Lambda PowerShell function.

### DIFF
--- a/Libraries/src/Amazon.Lambda.PowerShellHost/Amazon.Lambda.PowerShellHost.csproj
+++ b/Libraries/src/Amazon.Lambda.PowerShellHost/Amazon.Lambda.PowerShellHost.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <Description>AWS Lambda PowerShell Host.</Description>
     <AssemblyTitle>Amazon.Lambda.PowerShellHost</AssemblyTitle>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.0.1</VersionPrefix>
     <AssemblyName>Amazon.Lambda.PowerShellHost</AssemblyName>
     <PackageId>Amazon.Lambda.PowerShellHost</PackageId>
     <PackageTags>AWS;Amazon;Lambda;PowerShell</PackageTags>

--- a/Libraries/src/Amazon.Lambda.PowerShellHost/PowerShellFunctionHost.cs
+++ b/Libraries/src/Amazon.Lambda.PowerShellHost/PowerShellFunctionHost.cs
@@ -148,6 +148,9 @@ namespace Amazon.Lambda.PowerShellHost
             // Clear all previous PowerShell executions, variables and outputs
             this._ps.Commands?.Clear();
             this._ps.Streams.Verbose?.Clear();
+            this._ps.Streams.Debug?.Clear();
+            this._ps.Streams.Information?.Clear();
+            this._ps.Streams.Warning?.Clear();
             this._ps.Streams.Error?.Clear();
             this._ps.Runspace?.ResetRunspaceState();
             this._output.Clear();
@@ -292,6 +295,7 @@ ConvertTo-Json $Response
             };
 
             this._ps.Streams.Verbose.DataAdding += _loggerFactory("Verbose");
+            this._ps.Streams.Debug.DataAdding += _loggerFactory("Debug");
             this._ps.Streams.Information.DataAdding += _loggerFactory("Information");
             this._ps.Streams.Warning.DataAdding += _loggerFactory("Warning");
             this._ps.Streams.Error.DataAdding += _loggerFactory("Error");


### PR DESCRIPTION
*Issue #, if available:* #1641

*Description of changes:*
Fixes an issue where `Write-Debug` doesn't log debug messages to CloudWatch for a Lambda PowerShell function. Refer [PSDataStreams](https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.psdatastreams?view=powershellsdk-7.4.0) for more information about various buffers.

___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
