### PR TITLE
Replace reference of LogLevel enum from Core to RuntimeSupport version

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
@@ -254,7 +254,7 @@ namespace Amazon.Lambda.RuntimeSupport
         private void WriteUnhandledExceptionToLog(Exception exception)
         {
 #if NET6_0_OR_GREATER
-            Client.ConsoleLogger.FormattedWriteLine(LogLevel.Error.ToString(), exception, null);
+            Client.ConsoleLogger.FormattedWriteLine(Amazon.Lambda.RuntimeSupport.Helpers.LogLevelLoggerWriter.LogLevel.Error.ToString(), exception, null);
 #else
             Console.Error.WriteLine(exception);
 #endif


### PR DESCRIPTION
*Description of changes:*
While building the OCI images that include the new structured logging support the smoke tests failed due to the fact that the smoke test function had an old reference of `Amazon.Lambda.Core` that didn't have the `LogLevel` enum defined. The RuntimeSupport package had an unintended reference to the `LogLevel` enum that caused an undefined enum exception when an unhandled exception. This PR updates the `LogLevel` reference to the version defined in RuntimeSupport.

This only affects when deploying functions as a class library because the executable programming model will have a version of `Amazon.Lambda.Core` that matches with `Amazon.Lambda.RuntimeSupport` expects. So we don't need to patch the NuGet package and just need to get master updated which the OCI image builders use.


## Testing
After change all OCI smoke tests pass. The test function is still referencing the old version of `Amazon.Lambda.Core` to exercise this corner case.
