### PR TITLE
Update PowerShell Lambda blueprints to reference the latest Amazon.Lambda.PowerShellHost and Amazon.Lambda.Core packages.

### DIFF
--- a/PowerShell/Module/AWSLambdaPSCore.psd1
+++ b/PowerShell/Module/AWSLambdaPSCore.psd1
@@ -12,7 +12,7 @@
 RootModule = 'AWSLambdaPSCore.psm1'
 
 # Version number of this module.
-ModuleVersion = '4.0.1.0'
+ModuleVersion = '4.0.2.0'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core'

--- a/PowerShell/Module/Templates/Blueprints/projectfile.csproj.txt
+++ b/PowerShell/Module/Templates/Blueprints/projectfile.csproj.txt
@@ -16,7 +16,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.PowerShell.SDK" Version="POWERSHELL_SDK_VERSION" />
 
-        <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-        <PackageReference Include="Amazon.Lambda.PowerShellHost" Version="3.0.0" />
+        <PackageReference Include="Amazon.Lambda.Core" Version="2.3.0" />
+        <PackageReference Include="Amazon.Lambda.PowerShellHost" Version="3.0.1" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
*Issue #, if available:* #1641

*Description of changes:*
Update PowerShell Lambda blueprints to reference the latest `Amazon.Lambda.PowerShellHost` and `Amazon.Lambda.Core packages`. This would release changes for PR https://github.com/aws/aws-lambda-dotnet/pull/1814.
___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
