### PR TITLE
Add null checks before attempting debug response writing

### DIFF
--- a/Libraries/src/Amazon.Lambda.Serialization.Json/Amazon.Lambda.Serialization.Json.csproj
+++ b/Libraries/src/Amazon.Lambda.Serialization.Json/Amazon.Lambda.Serialization.Json.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>Amazon.Lambda.Serialization.Json</AssemblyName>
     <PackageId>Amazon.Lambda.Serialization.Json</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
-    <VersionPrefix>2.2.3</VersionPrefix>
+    <VersionPrefix>2.2.4</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libraries/src/Amazon.Lambda.Serialization.Json/JsonSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.Json/JsonSerializer.cs
@@ -94,7 +94,7 @@ namespace Amazon.Lambda.Serialization.Json
         {
             try
             {
-                if (debug)
+                if (debug && response != null)
                 {
                     using (StringWriter debugWriter = new StringWriter())
                     {

--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/AbstractLambdaJsonSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/AbstractLambdaJsonSerializer.cs
@@ -48,7 +48,7 @@ namespace Amazon.Lambda.Serialization.SystemTextJson
         {
             try
             {
-                if (_debug)
+                if (_debug && response != null)
                 {
                     using (var debugStream = new MemoryStream())
                     using (var utf8Writer = new Utf8JsonWriter(debugStream, WriterOptions))

--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/Amazon.Lambda.Serialization.SystemTextJson.csproj
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/Amazon.Lambda.Serialization.SystemTextJson.csproj
@@ -9,7 +9,7 @@
         <AssemblyName>Amazon.Lambda.Serialization.SystemTextJson</AssemblyName>
         <PackageId>Amazon.Lambda.Serialization.SystemTextJson</PackageId>
         <PackageTags>AWS;Amazon;Lambda</PackageTags>
-        <VersionPrefix>2.4.3</VersionPrefix>
+        <VersionPrefix>2.4.4</VersionPrefix>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 	<ItemGroup>

--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/LambdaJsonSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/LambdaJsonSerializer.cs
@@ -95,7 +95,7 @@ namespace Amazon.Lambda.Serialization.SystemTextJson
         {
             try
             {
-                if (_debug)
+                if (_debug && response != null)
                 {
                     using (var debugWriter = new StringWriter())
                     using (var utf8Writer = new Utf8JsonWriter(responseStream, WriterOptions))


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1328

*Description of changes:*
If the Lambda debug serialization environment variable is set a null pointer exception could be triggered if the Lambda function returned a null. This PR adds the null check to avoid going in the debug logic if the response is null.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
