### PR TITLE
fix: Removed unnecessary reference to global variable $Name in _packageProject private PowerShell function.

### DIFF
--- a/PowerShell/Module/AWSLambdaPSCore.psd1
+++ b/PowerShell/Module/AWSLambdaPSCore.psd1
@@ -12,7 +12,7 @@
 RootModule = 'AWSLambdaPSCore.psm1'
 
 # Version number of this module.
-ModuleVersion = '4.0.3.0'
+ModuleVersion = '4.0.4.0'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core'

--- a/PowerShell/Module/Private/_DeploymentFunctions.ps1
+++ b/PowerShell/Module/Private/_DeploymentFunctions.ps1
@@ -262,8 +262,7 @@ function _packageProject
     }
     try
     {
-        $arguments = $Name
-        $arguments += " --configuration Release --framework $AwsPowerShellTargetFramework --function-runtime $AwsPowerShellLambdaRuntime"
+        $arguments = " --configuration Release --framework $AwsPowerShellTargetFramework --function-runtime $AwsPowerShellLambdaRuntime"
 
         if (($OutputPackage))
         {


### PR DESCRIPTION
*Issue #, if available:* #1173

*Description of changes:*
Removed unnecessary reference to global variable` $Name` in `_packageProject` private PowerShell function.
Command `dotnet lambda package` doesn't have argument `--name`. Refer below output of `dotnet lambda package --help`:
```
Amazon Lambda Tools for .NET Core applications (5.11.0)
Project Home: https://github.com/aws/aws-extensions-for-dotnet-cli, https://github.com/aws/aws-lambda-dotnet

package:
   Command to package a Lambda project either into a zip file or docker image if --package-type is set to "image". The output can later be deployed to Lambda with either deploy-function command or with another tool.

   dotnet lambda package [arguments] [options]
   Arguments:
      <ZIP-FILE> The name of the zip file to package the project into
   Options:
      --disable-interactive                   When set to true missing required parameters will not be prompted for.
      --region                                The region to connect to AWS services, if not set region will be detected from the environment.
      --profile                               Profile to use to look up AWS credentials, if not set environment credentials will be used.
      --profile-location                      Optional override to the search location for Profiles, points at a shared credentials file.
      --aws-access-key-id                     The AWS access key id. Used when setting credentials explicitly instead of using --profile.
      --aws-secret-key                        The AWS secret key. Used when setting credentials explicitly instead of using --profile.
      --aws-session-token                     The AWS session token. Used when setting credentials explicitly instead of using --profile.
      -pl    | --project-location             The location of the project, if not set the current directory will be assumed.
      -cfg   | --config-file                  Configuration file storing default values for command line arguments.
      -pcfg  | --persist-config-file          If true the arguments used for a successful deployment are persisted to a config file.
      -c     | --configuration                Configuration to build with, for example Release or Debug.
      -f     | --framework                    Target framework to compile, for example netcoreapp3.1.
      -farch | --function-architecture        The architecture of the Lambda function. Valid values: x86_64 or arm64. Default is x86_64
      --msbuild-parameters                    Additional msbuild parameters passed to the 'dotnet publish' command. Add quotes around the value if the value contains spaces.
      -fl    | --function-layers              Comma delimited list of Lambda layer version arns
      -o     | --output-package               The zip file that will be created with compiled and packaged Lambda function.
      -dvc   | --disable-version-check        Disable the .NET Core version check. Only for advanced usage.
      -pt    | --package-type                 The deployment package type for Lambda function. Valid values: image, zip
      -it    | --image-tag                    Docker image name and tag in the 'name:tag' format.
      -df    | --dockerfile                   The docker file used to build the image. Default value is "Dockerfile".
      -dbo   | --docker-build-options         Additional options passed to the "docker build" command.
      -dbwd  | --docker-build-working-dir     The directory to execute the "docker build" command from.
      --docker-host-build-output-dir          If set a "dotnet publish" command is executed on the host machine before executing "docker build". The output can be copied into image being built.
      -ucfb  | --use-container-for-build      Use a local container to build the Lambda binary. A default image will be provided if none is supplied.
      -cifb  | --container-image-for-build    The container image tag (with version) to be used for building the Lambda binary.
      -cmd   | --code-mount-directory         Path to the directory to mount to the build container. Otherwise, look upward for a solution folder.
```

`_packageProject` PS function is perhaps mapping `$Name` global value to **dotnet lambda package** `<ZIP-FILE>` argument. However, this value is not necessary, since:
- In [PackageCommand](https://github.com/aws/aws-extensions-for-dotnet-cli/blob/2e5f84b59dfdb05eae42c76d7cb56b197549a6cc/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs#L100), 
  - `<ZIP-FILE>` argument value is used for `OutputPackageFileName`.
  - `OutputPackageFileName` is set to different value [here](https://github.com/aws/aws-extensions-for-dotnet-cli/blob/2e5f84b59dfdb05eae42c76d7cb56b197549a6cc/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs#L109) if [LambdaDefinedCommandOptions.ARGUMENT_OUTPUT_PACKAGE](https://github.com/aws/aws-extensions-for-dotnet-cli/blob/2e5f84b59dfdb05eae42c76d7cb56b197549a6cc/src/Amazon.Lambda.Tools/LambdaDefinedCommandOptions.cs#L320) (`--output-package`) is set.
- `$OutputPackage` parameter is mandatory
  - In `_packageProject` function [here]((https://github.com/aws/aws-lambda-dotnet/blob/a7b44f7fb65873d7264acde988f1426037fee198/PowerShell/Module/Private/_DeploymentFunctions.ps1#L248C17-L248C31))
  - In `New-AWSPowerShellLambdaPackage` function [here](https://github.com/aws/aws-lambda-dotnet/blob/a7b44f7fb65873d7264acde988f1426037fee198/PowerShell/Module/Public/New-AWSPowerShellLambdaPackage.ps1#L86).
 ___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
