### PR TITLE
ci: fix release workflow to not fail if no Lambda annotations changes

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -75,7 +75,12 @@ jobs:
         run: |
           dotnet build Libraries/Libraries.sln -c Release
           git add "*.template"
-          git commit -m "Update test app CloudFormation templates"
+          
+          if git diff --cached --quiet; then
+            echo "No .template files were staged; skipping commit."
+          else
+            git commit -m "Update test app CloudFormation templates"
+          fi
       # Update the changelog based on the change files
       - name: Update Changelog
         run: autover changelog


### PR DESCRIPTION
*Description of changes:*
Update workflow to skip committing `*.template` files if non were updated. This would happen if `Amazon.Lambda.Annotation` was not being updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
