### PR TITLE
chore: improve RuntimeSupport integration test performance

### DIFF
--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/Amazon.Lambda.RuntimeSupport.IntegrationTests.csproj
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/Amazon.Lambda.RuntimeSupport.IntegrationTests.csproj
@@ -23,13 +23,13 @@
     <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.402.7" />
     <PackageReference Include="AWSSDK.Lambda" Version="3.7.402.3" />
     <PackageReference Include="AWSSDK.S3" Version="3.7.103.34" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit" Version="2.9.2" />
 
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.400.13" />
@@ -38,25 +38,5 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Amazon.Lambda.APIGatewayEvents\Amazon.Lambda.APIGatewayEvents.csproj" />
   </ItemGroup>
-
-  <Target Name="PackageTestFunction" BeforeTargets="BeforeBuild">
-    <Exec Command="dotnet tool install -g Amazon.Lambda.Tools" IgnoreExitCode="true" />
-
-	<Exec WorkingDirectory="..\CustomRuntimeFunctionTest" Command="dotnet restore" />
-    <Exec WorkingDirectory="..\CustomRuntimeFunctionTest" Condition="'$(Architecture)'=='' or '$(Architecture)'=='x86'" Command="dotnet lambda package -c Release --framework net6.0" />
-    <Exec WorkingDirectory="..\CustomRuntimeFunctionTest" Condition="'$(Architecture)'=='arm64'" Command="dotnet lambda package -c Release --framework net6.0 --function-architecture arm64" />
-	  
-	<Exec WorkingDirectory="..\CustomRuntimeFunctionTest" Command="dotnet restore" />
-    <Exec WorkingDirectory="..\CustomRuntimeFunctionTest" Condition="'$(Architecture)'=='' or '$(Architecture)'=='x86'" Command="dotnet lambda package -c Release --framework net8.0" />
-    <Exec WorkingDirectory="..\CustomRuntimeFunctionTest" Condition="'$(Architecture)'=='arm64'" Command="dotnet lambda package -c Release --framework net8.0 --function-architecture arm64" />	  
-
-	<Exec WorkingDirectory="..\CustomRuntimeAspNetCoreMinimalApiTest" Command="dotnet restore" />
-	<Exec WorkingDirectory="..\CustomRuntimeAspNetCoreMinimalApiTest" Condition="'$(Architecture)'=='' or '$(Architecture)'=='x86'" Command="dotnet lambda package -c Release --framework net6.0" />
-	<Exec WorkingDirectory="..\CustomRuntimeAspNetCoreMinimalApiTest" Condition="'$(Architecture)'=='arm64'" Command="dotnet lambda package -c Release --framework net6.0 --function-architecture arm64" />
-
-	<Exec WorkingDirectory="..\CustomRuntimeAspNetCoreMinimalApiCustomSerializerTest" Command="dotnet restore" />
-	<Exec WorkingDirectory="..\CustomRuntimeAspNetCoreMinimalApiCustomSerializerTest" Condition="'$(Architecture)'=='' or '$(Architecture)'=='x86'" Command="dotnet lambda package -c Release --framework net6.0" />
-	<Exec WorkingDirectory="..\CustomRuntimeAspNetCoreMinimalApiCustomSerializerTest" Condition="'$(Architecture)'=='arm64'" Command="dotnet lambda package -c Release --framework net6.0 --function-architecture arm64" />	  
-  </Target>
 
 </Project>

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/CustomRuntimeAspNetCoreMinimalApiCustomSerializerTest.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/CustomRuntimeAspNetCoreMinimalApiCustomSerializerTest.cs
@@ -14,15 +14,34 @@ using System.Threading.Tasks;
 using Xunit;
 using Amazon.Lambda.APIGatewayEvents;
 using System.Text.Json;
+using Amazon.Lambda.RuntimeSupport.IntegrationTests.Helpers;
+using Xunit.Abstractions;
 
 
 namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
 {
     public class CustomRuntimeAspNetCoreMinimalApiCustomSerializerTest : BaseCustomRuntimeTest
     {
-        public CustomRuntimeAspNetCoreMinimalApiCustomSerializerTest()
+        public CustomRuntimeAspNetCoreMinimalApiCustomSerializerTest(
+            ITestOutputHelper output)
             : base("CustomRuntimeMinimalApiCustomSerializerTest-" + DateTime.Now.Ticks, "CustomRuntimeAspNetCoreMinimalApiCustomSerializerTest.zip", @"CustomRuntimeAspNetCoreMinimalApiCustomSerializerTest\bin\Release\net6.0\CustomRuntimeAspNetCoreMinimalApiCustomSerializerTest.zip", "bootstrap")
         {
+            string testAppPath = null;
+            string toolPath = null;
+            try
+            {
+                testAppPath = LambdaToolsHelper.GetTempTestAppDirectory(
+                    "../../../../../../..",
+                    "Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/CustomRuntimeAspNetCoreMinimalApiCustomSerializerTest");
+                toolPath = LambdaToolsHelper.InstallLambdaTools(output);
+                LambdaToolsHelper.DotnetRestore(testAppPath, output);
+                LambdaToolsHelper.LambdaPackage(toolPath, "net6.0", testAppPath, output);
+            }
+            finally
+            {
+                LambdaToolsHelper.CleanUp(testAppPath);
+                LambdaToolsHelper.CleanUp(toolPath);
+            }
         }
 
 

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/CustomRuntimeAspNetCoreMinimalApiTest.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/CustomRuntimeAspNetCoreMinimalApiTest.cs
@@ -14,15 +14,34 @@ using System.Threading.Tasks;
 using Xunit;
 using Amazon.Lambda.APIGatewayEvents;
 using System.Text.Json;
+using Amazon.Lambda.RuntimeSupport.IntegrationTests.Helpers;
+using Xunit.Abstractions;
 
 
 namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
 {
     public class CustomRuntimeAspNetCoreMinimalApiTest : BaseCustomRuntimeTest
     {
-        public CustomRuntimeAspNetCoreMinimalApiTest()
+        public CustomRuntimeAspNetCoreMinimalApiTest(
+            ITestOutputHelper output)
             : base("CustomRuntimeAspNetCoreMinimalApiTest-" + DateTime.Now.Ticks, "CustomRuntimeAspNetCoreMinimalApiTest.zip", @"CustomRuntimeAspNetCoreMinimalApiTest\bin\Release\net6.0\CustomRuntimeAspNetCoreMinimalApiTest.zip", "bootstrap")
         {
+            string testAppPath = null;
+            string toolPath = null;
+            try
+            {
+                testAppPath = LambdaToolsHelper.GetTempTestAppDirectory(
+                    "../../../../../../..",
+                    "Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/CustomRuntimeAspNetCoreMinimalApiTest");
+                toolPath = LambdaToolsHelper.InstallLambdaTools(output);
+                LambdaToolsHelper.DotnetRestore(testAppPath, output);
+                LambdaToolsHelper.LambdaPackage(toolPath, "net6.0", testAppPath, output);
+            }
+            finally
+            {
+                LambdaToolsHelper.CleanUp(testAppPath);
+                LambdaToolsHelper.CleanUp(toolPath);
+            }
         }
 
 

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/Helpers/CommandLineWrapper.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/Helpers/CommandLineWrapper.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Amazon.Lambda.RuntimeSupport.IntegrationTests.Helpers;
+
+public static class CommandLineWrapper
+{
+    public static void Run(string command, string arguments, string workingDirectory, ITestOutputHelper outputHelper)
+    {
+        string tempOutputFile = Path.GetTempFileName();
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = GetSystemShell(),
+            Arguments = 
+                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 
+                    $"/c {command} {arguments} > \"{tempOutputFile}\" 2>&1" : 
+                    $"-c \"{command} {arguments} > '{tempOutputFile}' 2>&1\"",
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = true,
+            CreateNoWindow = true
+        };
+            
+        using (var process = Process.Start(startInfo))
+        {
+            if (process == null)
+                throw new Exception($"Unable to start process: {command} {arguments}");
+            
+            process.WaitForExit();
+
+            string output = File.ReadAllText(tempOutputFile);
+            outputHelper.WriteLine(output);
+                
+            Assert.True(process.ExitCode == 0, $"Command '{command} {arguments}' failed.");
+        }
+        File.Delete(tempOutputFile);
+    }
+
+    private static string GetSystemShell()
+    {
+        if (TryGetEnvironmentVariable("COMSPEC", out var comspec))
+            return comspec!;
+
+        if (TryGetEnvironmentVariable("SHELL", out var shell))
+            return shell!;
+
+        // fall back to defaults
+        return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "cmd.exe" : "bash";
+    }
+
+    private static bool TryGetEnvironmentVariable(string variable, out string value)
+    {
+        value = Environment.GetEnvironmentVariable(variable);
+
+        return !string.IsNullOrEmpty(value);
+    }
+}

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/Helpers/LambdaToolsHelper.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/Helpers/LambdaToolsHelper.cs
@@ -1,0 +1,89 @@
+using System.IO;
+using System.Runtime.InteropServices;
+using Xunit.Abstractions;
+
+namespace Amazon.Lambda.RuntimeSupport.IntegrationTests.Helpers;
+
+public static class LambdaToolsHelper
+{
+    private static readonly string FunctionArchitecture = RuntimeInformation.OSArchitecture == System.Runtime.InteropServices.Architecture.Arm64 ? "arm64" : "x86_64";
+
+    public static string GetTempTestAppDirectory(string workingDirectory, string testAppPath)
+    {
+        var customTestAppPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(customTestAppPath);
+
+        var currentDir = new DirectoryInfo(workingDirectory);
+        CopyDirectory(currentDir, customTestAppPath);
+
+        return Path.Combine(customTestAppPath, testAppPath);
+    }
+    
+    public static string InstallLambdaTools(ITestOutputHelper output)
+    {
+        var customToolPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(customToolPath);
+        CommandLineWrapper.Run(
+            "dotnet", 
+            $"tool install Amazon.Lambda.Tools --tool-path {customToolPath}",
+            Directory.GetCurrentDirectory(),
+            output);
+        return customToolPath;
+    }
+
+    public static void DotnetRestore(string workingDirectory, ITestOutputHelper output)
+    {
+        CommandLineWrapper.Run(
+            "dotnet", 
+            "restore", 
+            workingDirectory,
+            output);
+    }
+
+    public static void LambdaPackage(string toolPath, string framework, string workingDirectory, ITestOutputHelper output)
+    {
+        string lambdaToolPath = Path.Combine(toolPath, "dotnet-lambda");
+        CommandLineWrapper.Run(
+            lambdaToolPath, 
+            $"package -c Release --framework {framework} --function-architecture {FunctionArchitecture}", 
+            workingDirectory,
+            output);
+    }
+
+    public static void CleanUp(string toolPath)
+    {
+        if (!string.IsNullOrEmpty(toolPath) && Directory.Exists(toolPath))
+        {
+            Directory.Delete(toolPath, true);
+        }
+    }
+
+    /// <summary>
+    /// <see cref="https://docs.microsoft.com/en-us/dotnet/standard/io/how-to-copy-directories"/>
+    /// </summary>
+    private static void CopyDirectory(DirectoryInfo dir, string destDirName)
+    {
+        if (!dir.Exists)
+        {
+            throw new DirectoryNotFoundException($"Source directory does not exist or could not be found: {dir.FullName}");
+        }
+
+        var dirs = dir.GetDirectories();
+
+        Directory.CreateDirectory(destDirName);
+
+        var files = dir.GetFiles();
+        foreach (var file in files)
+        {
+            var tempPath = Path.Combine(destDirName, file.Name);
+            file.CopyTo(tempPath, false);
+        }
+
+        foreach (var subdir in dirs)
+        {
+            var tempPath = Path.Combine(destDirName, subdir.Name);
+            var subDir = new DirectoryInfo(subdir.FullName);
+            CopyDirectory(subDir, tempPath);
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp.IntegrationTests/TestServerlessApp.IntegrationTests.csproj
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/TestServerlessApp.IntegrationTests.csproj
@@ -12,9 +12,9 @@
         <PackageReference Include="AWSSDK.S3" Version="3.7.4.1" />
         <!-- AWSSDK.SecurityToken is needed at runtime for environments which uses assume-role operation for credentials -->
         <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.99" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/buildtools/build.proj
+++ b/buildtools/build.proj
@@ -194,12 +194,12 @@
         <Exec Command="dotnet msbuild -restore /p:Configuration=$(Configuration) /p:AssemblyOriginatorKeyFile=$(AssemblyOriginatorKeyFile) /p:SignAssembly=$(SignAssembly)" WorkingDirectory="..\Libraries\src\%(LibraryName.FileName)"/>
     </Target>
     <Target Name="run-unit-tests">
-        <Exec Command="dotnet test -c $(Configuration)" WorkingDirectory="..\Libraries\test\Amazon.Lambda.RuntimeSupport.Tests\Amazon.Lambda.RuntimeSupport.UnitTests"/>
-        <Exec Command="dotnet test -c $(Configuration)" WorkingDirectory="..\Libraries\test\Amazon.Lambda.Annotations.SourceGenerators.Tests"/>
+        <Exec Command="dotnet test -c $(Configuration) --logger &quot;console;verbosity=detailed&quot;" WorkingDirectory="..\Libraries\test\Amazon.Lambda.RuntimeSupport.Tests\Amazon.Lambda.RuntimeSupport.UnitTests"/>
+        <Exec Command="dotnet test -c $(Configuration) --logger &quot;console;verbosity=detailed&quot;" WorkingDirectory="..\Libraries\test\Amazon.Lambda.Annotations.SourceGenerators.Tests"/>
     </Target>
     <Target Name="run-integ-tests">
-        <Exec Command="dotnet test -c $(Configuration)" WorkingDirectory="..\Libraries\test\Amazon.Lambda.RuntimeSupport.Tests\Amazon.Lambda.RuntimeSupport.IntegrationTests"/>
-        <Exec Command="dotnet test -c $(Configuration)" WorkingDirectory="..\Libraries\test\TestServerlessApp.IntegrationTests"/>
+        <Exec Command="dotnet test -c $(Configuration) --logger &quot;console;verbosity=detailed&quot;" WorkingDirectory="..\Libraries\test\Amazon.Lambda.RuntimeSupport.Tests\Amazon.Lambda.RuntimeSupport.IntegrationTests"/>
+        <Exec Command="dotnet test -c $(Configuration) --logger &quot;console;verbosity=detailed&quot;" WorkingDirectory="..\Libraries\test\TestServerlessApp.IntegrationTests"/>
     </Target>
     <Target Name="create-nuget-packages-cicd" DependsOnTargets="build-project-packages">
         <Exec Command="$(PackCommand)" WorkingDirectory="..\Libraries\src\%(LibraryName.FileName)"/>


### PR DESCRIPTION
*Description of changes:*
This PR improves the runtime of the integration tests when ran through the CI/CD pipeline. It brings down the runtime from over 2 hours to less than an hour. I have consistently seen 2 different runtimes of the tests after the update. Sometimes the tests run in ~21 minutes and other times in ~51 minutes. In any case, they are now way faster than they were before. I have also updated them to run in isolation of one another which prevents parallel runs to conflict with each other. This means we are now able to run X86 and ARM tests in parallel with no issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
