### PR TITLE
feat: update lambda container images and test tool to .NET9

### DIFF
--- a/.autover/autover.json
+++ b/.autover/autover.json
@@ -124,8 +124,8 @@
       "Paths": [
         "Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj",
         "Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester60-pack.csproj",
-        "Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester70-pack.csproj",
-        "Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester80-pack.csproj"
+        "Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester80-pack.csproj",
+        "Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester90-pack.csproj"
       ]
     }
   ],

--- a/.autover/changes/5f868ca3-fd40-4adc-8f0b-3b492276cc77.json
+++ b/.autover/changes/5f868ca3-fd40-4adc-8f0b-3b492276cc77.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.TestTool.BlazorTester",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Update Lambda Test Tool to add a .NET9 target"
+      ]
+    }
+  ]
+}

--- a/LambdaRuntimeDockerfiles/Images/net9/amd64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net9/amd64/Dockerfile
@@ -1,21 +1,23 @@
 # Based on Docker image from: https://github.com/dotnet/dotnet-docker/
 
-ARG ASPNET_VERSION=7.0.20
-ARG ASPNET_SHA512=62ed9743972043a72e48d5aa2f7fdf3483cf684a32b051315004d1c778e9712bf66e5e7a97a5a53993fa8e92daf5bacaf2cdb3eae44bb9a9e25532b9a80f4f70
+ARG ASPNET_VERSION=9.0.0-rc.2.24474.3
+ARG ASPNET_SHA512=9370c26174cd7f1b2fef58e0a53041c94b7d5412f15ea5865fbc653a65b148b1f92e7992f147610a6ca2e92011ff28c43480ab26a6e7f8cd56f2189af0610be8
 
-ARG LAMBDA_RUNTIME_NAME=dotnet7
-ARG AMAZON_LINUX=public.ecr.aws/lambda/provided:al2
+ARG LAMBDA_RUNTIME_NAME=dotnet9
+ARG AMAZON_LINUX=public.ecr.aws/lambda/provided:al2023
 
 FROM $AMAZON_LINUX AS base
 
-FROM base AS builder-net7
+RUN dnf install libicu-67.1-7.amzn2023.0.3.x86_64 --assumeyes
+
+FROM base AS builder-net9
 ARG ASPNET_VERSION
 ARG ASPNET_SHA512
 
 WORKDIR /dotnet
 
 # Install tar and gzip for unarchiving downloaded tar.gz
-RUN yum install tar gzip --assumeyes
+RUN dnf install tar gzip --assumeyes
 
 # Install the ASP.NET Core shared framework
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-x64.tar.gz \
@@ -25,22 +27,23 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
     && rm aspnetcore.tar.gz
 
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim AS builder
+FROM mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim AS builder
 WORKDIR /src
 COPY ["Libraries/src/Amazon.Lambda.RuntimeSupport", "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/"]
 COPY ["Libraries/src/Amazon.Lambda.Core", "Repo/Libraries/src/Amazon.Lambda.Core/"]
 COPY ["buildtools/", "Repo/buildtools/"]
-RUN dotnet restore "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj" /p:TargetFrameworks=net7.0
+RUN dotnet restore "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj" /p:TargetFrameworks=net9.0
 WORKDIR "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport"
-RUN dotnet build "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net7.0 --runtime linux-x64 -c Release -o /app/build
+RUN dotnet build "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net9.0 --runtime linux-x64 -c Release -o /app/build
 
 
 FROM builder AS publish
-RUN dotnet publish "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net7.0 -f net7.0 --runtime linux-x64 --self-contained false -p:PublishReadyToRun=true -c Release -o /app/publish
+RUN dotnet publish "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net9.0 -f net9.0 --runtime linux-x64 --self-contained false -p:PublishReadyToRun=true -c Release -o /app/publish
 RUN apt-get update && apt-get install -y dos2unix
-RUN dos2unix /app/publish/bootstrap.sh && \
-    mv /app/publish/bootstrap.sh /app/publish/bootstrap && \
+RUN dos2unix /app/publish/bootstrap-al2023.sh && \
+    mv /app/publish/bootstrap-al2023.sh /app/publish/bootstrap && \
     chmod +x /app/publish/bootstrap
+RUN touch /app/publish/empty-certificates.crt
 
 
 FROM base
@@ -60,7 +63,7 @@ ENV \
     # Disable Microsoft's telemetry collection
     DOTNET_CLI_TELEMETRY_OPTOUT=true
 
-COPY --from=builder-net7    /dotnet         ${DOTNET_ROOT}
+COPY --from=builder-net9    /dotnet         ${DOTNET_ROOT}
 COPY --from=publish         /app/publish    ${LAMBDA_RUNTIME_DIR}
 
 # Generate runtime-release file

--- a/LambdaRuntimeDockerfiles/Images/net9/arm64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net9/arm64/Dockerfile
@@ -1,51 +1,23 @@
 # Based on Docker image from: https://github.com/dotnet/dotnet-docker/
 
-ARG ASPNET_VERSION=7.0.20
-ARG ASPNET_SHA512=dfb1c1bef4d826defd3d995599a5c03e1bf1a64c65d98b675d6c05dbb7380d98233953e68d53fc5ebec60ad4ef75417073fb1fb3256a0176bb964f0e01161f6c
+ARG ASPNET_VERSION=9.0.0-rc.2.24474.3
+ARG ASPNET_SHA512=b6de668ce8714476be78ae00ed66027f3a5b06d95c6768ad6b3eca4d0f396c91843267c0e8c03160b709a7acdcbc2b09047f1ec8d46309d40c3d31f849cc981f
 
-ARG ICU_VERSION=68.1
-ARG ICU_MD5=6a99b541ea01f271257b121a4433c7c0
-
-ARG LAMBDA_RUNTIME_NAME=dotnet7
-ARG AMAZON_LINUX=public.ecr.aws/lambda/provided:al2
+ARG LAMBDA_RUNTIME_NAME=dotnet9
+ARG AMAZON_LINUX=public.ecr.aws/lambda/provided:al2023
 
 FROM $AMAZON_LINUX AS base
 
-FROM base AS builder-libicu
-WORKDIR /
+RUN dnf install libicu-67.1-7.amzn2023.0.3.aarch64 --assumeyes
 
-# Install depedencies to extract and build ICU library
-RUN yum install -d1 -y \
-    tar \
-    gzip \
-    make \
-    gcc-c++
-
-# Download, validate and extract ICU library
-# https://github.com/unicode-org/icu/releases/tag/release-68-1
-ARG ICU_VERSION
-ARG ICU_MD5
-RUN curl -SL https://github.com/unicode-org/icu/releases/download/release-${ICU_VERSION//./-}/icu4c-${ICU_VERSION//./_}-src.tgz -o icu-src.tgz \
-    && echo "$ICU_MD5  icu-src.tgz" | md5sum -c - \
-    && tar -xzf icu-src.tgz \
-    && rm icu-src.tgz
-
-# Build ICU library
-RUN mkdir /libicu
-WORKDIR /icu/source/
-RUN ./configure --prefix=/libicu \
-    && make \
-    && make install
-
-
-FROM base AS builder-net7
+FROM base AS builder-net9
 ARG ASPNET_VERSION
 ARG ASPNET_SHA512
 
 WORKDIR /dotnet
 
 # Install tar and gzip for unarchiving downloaded tar.gz
-RUN yum install tar gzip --assumeyes
+RUN dnf install tar gzip --assumeyes
 
 # Install the ASP.NET Core shared framework
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-arm64.tar.gz \
@@ -55,25 +27,23 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
     && rm aspnetcore.tar.gz
 
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim AS builder
+FROM mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim AS builder
 WORKDIR /src
 COPY ["Libraries/src/Amazon.Lambda.RuntimeSupport", "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/"]
 COPY ["Libraries/src/Amazon.Lambda.Core", "Repo/Libraries/src/Amazon.Lambda.Core/"]
 COPY ["buildtools/", "Repo/buildtools/"]
-RUN dotnet restore "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj" /p:TargetFrameworks=net7.0
+RUN dotnet restore "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj" /p:TargetFrameworks=net9.0
 WORKDIR "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport"
-RUN dotnet build "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net7.0 --runtime linux-arm64 -c Release -o /app/build
+RUN dotnet build "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net9.0 --runtime linux-arm64 -c Release -o /app/build
 
 
 FROM builder AS publish
-RUN dotnet publish "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net7.0 -f net7.0 --runtime linux-arm64 --self-contained false -p:PublishReadyToRun=true -c Release -o /app/publish
+RUN dotnet publish "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net9.0 -f net9.0 --runtime linux-arm64 --self-contained false -p:PublishReadyToRun=true -c Release -o /app/publish
 RUN apt-get update && apt-get install -y dos2unix
-RUN dos2unix /app/publish/bootstrap.sh && \
-    mv /app/publish/bootstrap.sh /app/publish/bootstrap && \
+RUN dos2unix /app/publish/bootstrap-al2023.sh && \
+    mv /app/publish/bootstrap-al2023.sh /app/publish/bootstrap && \
     chmod +x /app/publish/bootstrap
-
-# Copy native dependencies
-COPY --from=builder-libicu  /libicu         /app/publish
+RUN touch /app/publish/empty-certificates.crt
 
 
 FROM base
@@ -93,7 +63,7 @@ ENV \
     # Disable Microsoft's telemetry collection
     DOTNET_CLI_TELEMETRY_OPTOUT=true
 
-COPY --from=builder-net7    /dotnet         ${DOTNET_ROOT}
+COPY --from=builder-net9    /dotnet         ${DOTNET_ROOT}
 COPY --from=publish         /app/publish    ${LAMBDA_RUNTIME_DIR}
 
 # Generate runtime-release file

--- a/LambdaRuntimeDockerfiles/Infrastructure/README.md
+++ b/LambdaRuntimeDockerfiles/Infrastructure/README.md
@@ -8,7 +8,7 @@ Infrastructure project allows to create pipeline to build and push .NET Lambda R
 2. [AWS Account and User](https://portal.aws.amazon.com/billing/signup)
 3. [Node.js](https://nodejs.org/)
 4. [AWS CDK Toolkit](https://www.npmjs.com/package/aws-cdk)
-5. [.NET Core 3.1 SDK or above](https://dotnet.microsoft.com/download)
+5. [.NET 8 SDK or above](https://dotnet.microsoft.com/download)
 
 ### Bootstrap
 
@@ -17,28 +17,24 @@ Infrastructure project allows to create pipeline to build and push .NET Lambda R
 ```powershell
 .\bootstrap.ps1 `
 -PipelineAccountId "AccountId" `
--CodeCommitAccountId "CodeCommitAccountId" `
--Profile "AccountProfile" `
--CodeCommitAccountProfile "CodeCommitAccountProfile" `
 -Region "AwsRegion" `
--SourceRepositoryArn "arn:aws:codecommit:us-west-2:CodeCommitAccountId:aws-lambda-dotnet" `
--SourceBranchName "main" `
+-GitHubTokenSecretName "SecretName" `
+-GitHubTokenSecretKey "Key" `
+-GitHubRepoOwner "GitHubOwner" `
+-GitHubRepoName "GitHubRepo" `
+-GitHubRepoBranch "GitHubBranch" `
 -StageEcr "AccountId.dkr.ecr.us-west-2.amazonaws.com" `
 -BetaEcrs "AccountId.dkr.ecr.us-west-2.amazonaws.com;AccountId.dkr.ecr.us-west-2.amazonaws.com" `
 -ProdEcrs "AccountId.dkr.ecr.us-west-2.amazonaws.com;AccountId.dkr.ecr.us-west-2.amazonaws.com" `
--EcrRepositoryName "awslambda/dotnet6.0-runtime;awslambda/dotnet7-runtime;awslambda/dotnet8-runtime" `
--TargetFramework "net6;net7;net8" `
--DotnetChannel "6.0;7.0;8.0"
+-EcrRepositoryName "awslambda/dotnet6.0-runtime;awslambda/dotnet8-runtime;awslambda/dotnet9-runtime" `
+-TargetFramework "net6;net8;net9" `
+-DotnetChannel "6.0;8.0;9.0"
 ```
 
 #### Notes
  - AWS Profiles used to execute `bootstrap.ps1` must have administrator access.
  - All resources used to bootstrap the pipeline must already exist.
  - `AccountId` is AWS AccountId used for deploying CDK App.
- - `CodeCommitAccountId` is AWS AccountId that contains source repository.
- - If the CodeCommit repository is in the same account, use the same account Id for `PipelineAccountId` and `CodeCommitAccountId`.
- - When doing a cross-account deployment, you need to have AWS Profiles for both accounts.
- - `bootstrap.ps1` will run 2 `cdk bootstrap` commands for the cross account deployments to establish a trust relationships between the accounts. This way, we do not require a separate IAM role to be created manually.
 
 ## Useful commands
 * `npx cdk bootstrap --cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess` bootstrap this app
@@ -46,4 +42,3 @@ Infrastructure project allows to create pipeline to build and push .NET Lambda R
 * `cdk deploy`       deploy this stack to your default AWS account/region
 * `cdk diff`         compare deployed stack with current state
 * `cdk synth`        emits the synthesized CloudFormation template
-

--- a/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/Configuration.cs
+++ b/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/Configuration.cs
@@ -16,41 +16,38 @@
 using System;
 using System.Collections.Generic;
 
-namespace Infrastructure
+namespace Infrastructure;
+
+internal class Configuration
 {
-    internal class Configuration
-    {
-        public string AccountId { get; } = Environment.GetEnvironmentVariable("AWS_LAMBDA_PIPELINE_ACCOUNT_ID");
-        public string CodeCommitAccountId { get; } = Environment.GetEnvironmentVariable("AWS_LAMBDA_PIPELINE_CODECOMMIT_ACCOUNT_ID");
-        public string Region { get; } = Environment.GetEnvironmentVariable("AWS_LAMBDA_PIPELINE_REGION");
+    public string AccountId { get; } = Environment.GetEnvironmentVariable("AWS_LAMBDA_PIPELINE_ACCOUNT_ID");
+    public string Region { get; } = Environment.GetEnvironmentVariable("AWS_LAMBDA_PIPELINE_REGION");
 
-        public Source Source { get; } = new Source();
-        public Ecrs Ecrs { get; } = new Ecrs();
-        public readonly string[] EcrRepositoryNames = Environment.GetEnvironmentVariable("AWS_LAMBDA_ECR_REPOSITORY_NAME")?.Split(";");
-        public const string ProjectRoot = "LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure";
-        public const string ProjectName = "aws-lambda-container-images";
-        public readonly string[] DockerARM64Images = new string[] { "net6", "net7", "net8" };
-        // DotnetSdkVersions is used to specify a specific version of the .NET SDK to be installed on the CodeBuild image
-        // The default behavior is to specify a channel and that installs the latest version in that channel
-        // By specifying a specific .NET SDK version, you override the default channel behavior
-        public readonly Dictionary<string, string> DotnetSdkVersions = new Dictionary<string, string> { };
-        public readonly Dictionary<string, string> DockerBuildImages = new Dictionary<string, string> { {"net6", "6.0-bullseye-slim"}, {"net7", "7.0-bullseye-slim"}, {"net8", "8.0-bookworm-slim"} };
-        public readonly Dictionary<string, string> BaseImageAMD64Tags = new Dictionary<string, string> { { "net6", "contributed-base-image-x86_64" }, { "net7", "contributed-base-image-x86_64" }, { "net8", "contributed-base-image-x86_64" } };
-        public readonly Dictionary<string, string> BaseImageARM64Tags = new Dictionary<string, string> { { "net6", "contributed-base-image-arm64" }, { "net7", "contributed-base-image-arm64" }, { "net8", "contributed-base-image-arm64" } };
-        public readonly string[] Frameworks = Environment.GetEnvironmentVariable("AWS_LAMBDA_DOTNET_FRAMEWORK_VERSION")?.Split(";");
-        public readonly string[] Channels = Environment.GetEnvironmentVariable("AWS_LAMBDA_DOTNET_FRAMEWORK_CHANNEL")?.Split(";");
-    }
+    public string GitHubTokenSecretName { get; } = Environment.GetEnvironmentVariable("AWS_LAMBDA_GITHUB_TOKEN_SECRET_NAME");
 
-    internal class Source
-    {
-        public string RepositoryArn { get; } = Environment.GetEnvironmentVariable("AWS_LAMBDA_SOURCE_REPOSITORY_ARN");
-        public string BranchName { get; } = Environment.GetEnvironmentVariable("AWS_LAMBDA_SOURCE_BRANCH_NAME");
-    }
+    public string GitHubTokenSecretKey { get; } = Environment.GetEnvironmentVariable("AWS_LAMBDA_GITHUB_TOKEN_SECRET_KEY");
+    public string GitHubOwner { get; } = Environment.GetEnvironmentVariable("AWS_LAMBDA_GITHUB_REPO_OWNER");
+    public string GitHubRepository { get; } = Environment.GetEnvironmentVariable("AWS_LAMBDA_GITHUB_REPO_NAME");
+    public string GitHubBranch { get; } = Environment.GetEnvironmentVariable("AWS_LAMBDA_GITHUB_REPO_BRANCH");
+    public Ecrs Ecrs { get; } = new Ecrs();
+    public readonly string[] EcrRepositoryNames = Environment.GetEnvironmentVariable("AWS_LAMBDA_ECR_REPOSITORY_NAME")?.Split(";");
+    public const string ProjectRoot = "LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure";
+    public static readonly string ProjectName = $"aws-lambda-container-images{Environment.GetEnvironmentVariable("AWS_LAMBDA_PIPELINE_NAME_SUFFIX")}";
+    public readonly string[] DockerArm64Images = new string[] { "net6", "net8", "net9" };
+    // DotnetSdkVersions is used to specify a specific version of the .NET SDK to be installed on the CodeBuild image
+    // The default behavior is to specify a channel and that installs the latest version in that channel
+    // By specifying a specific .NET SDK version, you override the default channel behavior
+    public readonly Dictionary<string, string> DotnetSdkVersions = new Dictionary<string, string> { };
+    public readonly Dictionary<string, string> DockerBuildImages = new Dictionary<string, string> { {"net6", "6.0-bullseye-slim"}, {"net8", "8.0-bookworm-slim"}, {"net9", "9.0-bookworm-slim"} };
+    public readonly Dictionary<string, string> BaseImageAmd64Tags = new Dictionary<string, string> { { "net6", "contributed-base-image-x86_64" }, { "net8", "contributed-base-image-x86_64" }, { "net9", "contributed-base-image-x86_64" } };
+    public readonly Dictionary<string, string> BaseImageArm64Tags = new Dictionary<string, string> { { "net6", "contributed-base-image-arm64" }, { "net8", "contributed-base-image-arm64" }, { "net9", "contributed-base-image-arm64" } };
+    public readonly string[] Frameworks = Environment.GetEnvironmentVariable("AWS_LAMBDA_DOTNET_FRAMEWORK_VERSION")?.Split(";");
+    public readonly string[] Channels = Environment.GetEnvironmentVariable("AWS_LAMBDA_DOTNET_FRAMEWORK_CHANNEL")?.Split(";");
+}
 
-    internal class Ecrs
-    {
-        public string Stage { get; } = Environment.GetEnvironmentVariable("AWS_LAMBDA_STAGE_ECR");
-        public string Beta { get; } = Environment.GetEnvironmentVariable("AWS_LAMBDA_BETA_ECRS");
-        public string Prod { get; } = Environment.GetEnvironmentVariable("AWS_LAMBDA_PROD_ECRS");
-    }
+internal class Ecrs
+{
+    public string Stage { get; } = Environment.GetEnvironmentVariable("AWS_LAMBDA_STAGE_ECR");
+    public string Beta { get; } = Environment.GetEnvironmentVariable("AWS_LAMBDA_BETA_ECRS");
+    public string Prod { get; } = Environment.GetEnvironmentVariable("AWS_LAMBDA_PROD_ECRS");
 }

--- a/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/DockerBuild/build.ps1
+++ b/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/DockerBuild/build.ps1
@@ -28,6 +28,16 @@ if (!$?)
 
 $SourceNameTagPair = "aws-lambda-${Framework}:latest"
 
+# Check if the repository exists
+aws ecr describe-repositories --repository-names $EcrRepositoryName --region $StageRegion
+if (!$?) {
+    Write-Output "Repository '$EcrRepositoryName' does not exist. Creating it..."
+    aws ecr create-repository --repository-name $EcrRepositoryName --region $StageRegion
+}
+else {
+    Write-Output "Repository '$EcrRepositoryName' exists."
+}
+
 # Build runtime docker image
 try
 {

--- a/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/DockerBuild/buildspec.yml
+++ b/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/DockerBuild/buildspec.yml
@@ -2,6 +2,8 @@ version: 0.2
 phases:
   pre_build:
     commands:
+      # Find and delete the global.json files that were added by CodeBuild. This causes issues when multiple SDKs are installed.
+      - find / -type f -name 'global.json' -delete
       - |
         if [ "$AWS_LAMBDA_DOTNET_SDK_VERSION" = "" ]; then
           curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel $AWS_LAMBDA_DOTNET_FRAMEWORK_CHANNEL
@@ -11,7 +13,7 @@ phases:
       - export PATH="$PATH:$HOME/.dotnet"
       - export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
       - rm -rf /usr/bin/pwsh
-      - curl -sSL https://raw.githubusercontent.com/PowerShell/PowerShell/master/docker/InstallTarballPackage.sh | bash /dev/stdin $AWS_LAMBDA_POWERSHELL_VERSION
+      - dotnet tool install --global PowerShell --version $AWS_LAMBDA_POWERSHELL_VERSION
   build:
     commands:
       - pwsh LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/DockerBuild/build.ps1

--- a/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/Infrastructure.csproj
+++ b/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/Infrastructure.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
     <!-- Roll forward to future major versions of the netcoreapp as needed -->
     <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-	<PackageReference Include="Amazon.CDK.Lib" Version="2.44.0" />
+	<PackageReference Include="Amazon.CDK.Lib" Version="2.165.0" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />

--- a/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/Program.cs
+++ b/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/Program.cs
@@ -16,22 +16,29 @@
 using System;
 using Amazon.CDK;
 
-namespace Infrastructure
-{
-    sealed class Program
-    {
-        public static void Main(string[] args)
-        {
-            var configuration = new Configuration();
-            var app = new App();
-            if (configuration.EcrRepositoryNames.Length != configuration.Frameworks.Length &&
-                configuration.EcrRepositoryNames.Length != configuration.Channels.Length)
-                throw new ArgumentException(
-                    "There is a mismatch between the number of ECR Repositories, .NET Versions and .NET Channels.");
+namespace Infrastructure;
 
-            for (var i = 0; i < configuration.Frameworks.Length; i++)
-            {
-                new PipelineStack(app, $"{Configuration.ProjectName}-{configuration.Frameworks[i]}", configuration.EcrRepositoryNames[i], configuration.Frameworks[i], configuration.Channels[i], configuration.DockerBuildImages[configuration.Frameworks[i]], configuration, new StackProps
+sealed class Program
+{
+    public static void Main(string[] args)
+    {
+        var configuration = new Configuration();
+        var app = new App();
+        if (configuration.EcrRepositoryNames.Length != configuration.Frameworks.Length &&
+            configuration.EcrRepositoryNames.Length != configuration.Channels.Length)
+            throw new ArgumentException(
+                "There is a mismatch between the number of ECR Repositories, .NET Versions and .NET Channels.");
+
+        for (var i = 0; i < configuration.Frameworks.Length; i++)
+        {
+            new PipelineStack(app, 
+                $"{Configuration.ProjectName}-{configuration.Frameworks[i]}", 
+                configuration.EcrRepositoryNames[i], 
+                configuration.Frameworks[i], 
+                configuration.Channels[i], 
+                configuration.DockerBuildImages[configuration.Frameworks[i]], 
+                configuration, 
+                new StackProps
                 {
                     TerminationProtection = true,
                     Env = new Amazon.CDK.Environment
@@ -39,10 +46,10 @@ namespace Infrastructure
                         Account = configuration.AccountId,
                         Region = configuration.Region
                     }
-                });
-            }
-
-            app.Synth();
+                }
+            );
         }
+
+        app.Synth();
     }
 }

--- a/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/SmokeTests/buildspec.yml
+++ b/LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/SmokeTests/buildspec.yml
@@ -2,6 +2,8 @@ version: 0.2
 phases:
   pre_build:
     commands:
+      # Find and delete the global.json files that were added by CodeBuild. This causes issues when multiple SDKs are installed.
+      - find / -type f -name 'global.json' -delete
       - |
         if [ "$AWS_LAMBDA_DOTNET_SDK_VERSION" = "" ]; then
           curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel $AWS_LAMBDA_DOTNET_FRAMEWORK_CHANNEL
@@ -11,7 +13,7 @@ phases:
       - export PATH="$PATH:$HOME/.dotnet"
       - export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
       - rm -rf /usr/bin/pwsh
-      - curl -sSL https://raw.githubusercontent.com/PowerShell/PowerShell/master/docker/InstallTarballPackage.sh | bash /dev/stdin $AWS_LAMBDA_POWERSHELL_VERSION
+      - dotnet tool install --global PowerShell --version $AWS_LAMBDA_POWERSHELL_VERSION
   build:
     commands:
       - pwsh LambdaRuntimeDockerfiles/Infrastructure/src/Infrastructure/SmokeTests/build.ps1

--- a/LambdaRuntimeDockerfiles/SmokeTests/test/ImageFunction.SmokeTests/ImageFunction.SmokeTests.csproj
+++ b/LambdaRuntimeDockerfiles/SmokeTests/test/ImageFunction.SmokeTests/ImageFunction.SmokeTests.csproj
@@ -7,11 +7,11 @@
   <PropertyGroup Condition=" '$(Framework)'=='net6.0' ">
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Framework)'=='net7.0' ">
-    <TargetFramework>net7.0</TargetFramework>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Framework)'=='net8.0' ">
     <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)'=='net9.0' ">
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LambdaRuntimeDockerfiles/SmokeTests/test/ImageFunction/ImageFunction.csproj
+++ b/LambdaRuntimeDockerfiles/SmokeTests/test/ImageFunction/ImageFunction.csproj
@@ -7,11 +7,11 @@
   <PropertyGroup Condition=" '$(Framework)'=='net6.0' ">
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Framework)'=='net7.0' ">
-    <TargetFramework>net7.0</TargetFramework>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Framework)'=='net8.0' ">
     <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)'=='net9.0' ">
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />

--- a/LambdaRuntimeDockerfiles/build.ps1
+++ b/LambdaRuntimeDockerfiles/build.ps1
@@ -2,7 +2,7 @@ param(
     [ValidateSet('amd64','arm64')]
     [string]$Architecture = "amd64",
 
-    [ValidateSet('net6','net7','net8')]
+    [ValidateSet('net6', 'net8', 'net9')]
     [string]$TargetFramework = "net6"
 )
 
@@ -25,22 +25,7 @@ try
 
     if (Test-Path -Path (Join-Path $PWD -ChildPath '.\LambdaRuntimeDockerfiles\Images\' | Join-Path -ChildPath $TargetFramework | Join-Path -ChildPath  $Architecture | Join-Path -ChildPath 'Dockerfile') -PathType Leaf)
     {
-		if ($TargetFramework -eq "net8")
-		{
-			$Tag = "dotnet8-runtime:base-image-$Architecture"
-		}
-		elseif($TargetFramework -eq "net7")
-		{
-			$Tag = "dotnet7-runtime:base-image-$Architecture"
-		}
-		elseif($TargetFramework -eq "net6")
-		{
-			$Tag = "dotnet6-runtime:base-image-$Architecture"
-		}
-		else
-		{
-			throw "Unable to determine tag for target framework $TargetFramework" 
-		}
+		$Tag = "dot$TargetFramework-runtime:base-image-$Architecture"
 
         Write-Status "Building $TargetFramework base image: $Tag"
         docker build -f (Join-Path $PWD -ChildPath '.\LambdaRuntimeDockerfiles\Images\' | Join-Path -ChildPath $TargetFramework | Join-Path -ChildPath  $Architecture | Join-Path -ChildPath 'Dockerfile') -t $Tag .

--- a/Tools/LambdaTestTool/README.md
+++ b/Tools/LambdaTestTool/README.md
@@ -34,8 +34,9 @@ that the Lambda function will be run in. Below is the list of published versions
 | .NET Core 3.1 (Deprecated) | Amazon.Lambda.TestTool-3.1 | dotnet-lambda-test-tool-3.1.exe |
 | .NET 5.0 (Deprecated) | Amazon.Lambda.TestTool-5.0 | dotnet-lambda-test-tool-5.0.exe |
 | .NET 6.0 | Amazon.Lambda.TestTool-6.0 | dotnet-lambda-test-tool-6.0.exe |
-| .NET 7.0 | Amazon.Lambda.TestTool-7.0 | dotnet-lambda-test-tool-7.0.exe |
+| .NET 7.0 (Deprecated) | Amazon.Lambda.TestTool-7.0 | dotnet-lambda-test-tool-7.0.exe |
 | .NET 8.0 | Amazon.Lambda.TestTool-8.0 | dotnet-lambda-test-tool-8.0.exe |
+| .NET 9.0 | Amazon.Lambda.TestTool-9.0 | dotnet-lambda-test-tool-9.0.exe |
 
 ## AWS Credentials
 

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester.csproj
@@ -12,20 +12,20 @@
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
     <NoWarn>1701;1702;1591;1587;3021;NU5100;CS1591</NoWarn>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
-	<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+	  <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>  
 	
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.0" />
-    </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.35" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.10" />
+  </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.0" />
-    </ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.0-rc.2.23480.2" />
-	</ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.0-rc.2.24474.3" />
+  </ItemGroup>
 
 	<ItemGroup>
 	  <PackageReference Include="Blazored.Modal" Version="3.1.2" />

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester60-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester60-pack.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
       <PackageReference Include="Blazored.Modal" Version="3.1.2" />
-	  <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.0" /> 
+	  <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.35" /> 
 	  <ProjectReference Include="..\Amazon.Lambda.TestTool\Amazon.Lambda.TestTool.csproj" />
   </ItemGroup>
 

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester80-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester80-pack.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
       <PackageReference Include="Blazored.Modal" Version="3.1.2" />
-	  <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.0-rc.2.23480.2" /> 
+	  <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.10" /> 
 	  <ProjectReference Include="..\Amazon.Lambda.TestTool\Amazon.Lambda.TestTool.csproj" />
   </ItemGroup>
 

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester90-pack.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Amazon.Lambda.TestTool.BlazorTester90-pack.csproj
@@ -4,16 +4,16 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <Description>A tool to help debug and test your .NET 7.0 AWS Lambda functions locally.</Description>
+    <Description>A tool to help debug and test your .NET 9.0 AWS Lambda functions locally.</Description>
     <Version>0.15.3</Version>
     <Product>AWS .NET Lambda Test Tool</Product>
     <Copyright>Apache 2</Copyright>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
-    <TargetFramework>net7.0</TargetFramework>
-    <ToolCommandName>dotnet-lambda-test-tool-7.0</ToolCommandName>	
+    <TargetFramework>net9.0</TargetFramework>
+    <ToolCommandName>dotnet-lambda-test-tool-9.0</ToolCommandName>	
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
-    <PackageId>Amazon.Lambda.TestTool-7.0</PackageId>
+    <PackageId>Amazon.Lambda.TestTool-9.0</PackageId>
 	<AssemblyName>Amazon.Lambda.TestTool.BlazorTester</AssemblyName>
 	<RootNamespace>Amazon.Lambda.TestTool.BlazorTester</RootNamespace>	
 	<GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
@@ -22,7 +22,7 @@
 
   <ItemGroup>
       <PackageReference Include="Blazored.Modal" Version="3.1.2" />
-	  <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.0" /> 
+	  <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.0-rc.2.24474.3" /> 
 	  <ProjectReference Include="..\Amazon.Lambda.TestTool\Amazon.Lambda.TestTool.csproj" />
   </ItemGroup>
 

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Constants.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool.BlazorTester/Constants.cs
@@ -7,10 +7,10 @@ namespace Amazon.Lambda.TestTool.BlazorTester
 
 #if NET6_0
         public const string PRODUCT_NAME = "AWS .NET 6.0 Mock Lambda Test Tool";
-#elif NET7_0
-        public const string PRODUCT_NAME = "AWS .NET 7.0 Mock Lambda Test Tool";
 #elif NET8_0
         public const string PRODUCT_NAME = "AWS .NET 8.0 Mock Lambda Test Tool";
+#elif NET9_0
+        public const string PRODUCT_NAME = "AWS .NET 9.0 Mock Lambda Test Tool";
 #else
         Update for new target framework!!!
 #endif

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\..\..\buildtools\common.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
     <Description>Common code for the AWS .NET Core Lambda Mock Test Tool.</Description>
     <NoWarn>1701;1702;1591;1587;3021;NU5100;CS1591</NoWarn>
   </PropertyGroup>
@@ -22,26 +22,26 @@
 	
   <PropertyGroup Condition=" '$(Configuration)' == 'PackNET60' ">
     <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>  	
-  
-  <PropertyGroup Condition=" '$(Configuration)' == 'PackNET70' ">
-    <TargetFramework>net7.0</TargetFramework>
-  </PropertyGroup> 
-
+  </PropertyGroup>
+	
   <PropertyGroup Condition=" '$(Configuration)' == 'PackNET80' ">
     <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup> 
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'PackNET90' ">
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>   
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.1" />
 	</ItemGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
 	</ItemGroup>
 	
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0-rc.2.23479.6" />
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="9.0.0-rc.2.24473.5" />
 	</ItemGroup>	
 
 	<ItemGroup>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/TestToolStartup.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/TestToolStartup.cs
@@ -57,10 +57,10 @@ namespace Amazon.Lambda.TestTool
 
 #if NET6_0
                 var targetFramework = "net6.0";
-#elif NET7_0
-                var targetFramework = "net7.0";
 #elif NET8_0
                 var targetFramework = "net8.0";
+#elif NET9_0
+                var targetFramework = "net9.0";
 #endif
 
                 // If running in the project directory select the build directory so the deps.json file can be found.

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -2,17 +2,26 @@ param (
     [Parameter(Mandatory = $true, HelpMessage = "Pipeline Account ID.")]
     [string] $PipelineAccountId,
 
-    [Parameter(Mandatory = $true, HelpMessage = "Code Commit Account ID.")]
-    [string] $CodeCommitAccountId,
+    [Parameter(Mandatory = $false, HelpMessage = "Pipeline name suffix.")]
+    [string] $PipelineNameSuffix,
 
     [Parameter(Mandatory = $true, HelpMessage = "Region.")]
     [string] $Region,
 
-    [Parameter(Mandatory = $true, HelpMessage = "Source repository ARN.")]
-    [string] $SourceRepositoryArn,
+    [Parameter(Mandatory = $true, HelpMessage = "The name of the secret in Secret Manager that contains the GitHub Access Token.")]
+    [string] $GitHubTokenSecretName,
 
-    [Parameter(Mandatory = $true, HelpMessage = "Source branch name.")]
-    [string] $SourceBranchName,
+    [Parameter(Mandatory = $true, HelpMessage = "The secret key in Secret Manager that contains the GitHub Access Token.")]
+    [string] $GitHubTokenSecretKey,
+
+    [Parameter(Mandatory = $true, HelpMessage = "GitHub repository owner name.")]
+    [string] $GitHubRepoOwner,
+
+    [Parameter(Mandatory = $true, HelpMessage = "GitHub repository name.")]
+    [string] $GitHubRepoName,
+
+    [Parameter(Mandatory = $true, HelpMessage = "GitHub repository branch name.")]
+    [string] $GitHubRepoBranch,
 
     [Parameter(Mandatory = $false, HelpMessage = "ECR URI to store Stage images.")]
     [string] $StageEcr,
@@ -26,12 +35,6 @@ param (
     [Parameter(Mandatory = $true, HelpMessage = "ECR repository name for Stage, Beta and Prod images.")]
     [string] $EcrRepositoryName,
 
-    [Parameter(Mandatory = $true, HelpMessage = "AWS Profile used to created resources.")]
-    [string] $Profile,
-
-    [Parameter(Mandatory = $true, HelpMessage = "AWS Profile for the CodeCommmit AWS account.")]
-    [string] $CodeCommitAccountProfile,
-
     [Parameter(Mandatory = $true, HelpMessage = "The target .NET framework to create a pipeline for.")]
     [string] $TargetFramework,
 
@@ -40,11 +43,15 @@ param (
 )
 
 $env:AWS_LAMBDA_PIPELINE_ACCOUNT_ID = $PipelineAccountId
-$env:AWS_LAMBDA_PIPELINE_CODECOMMIT_ACCOUNT_ID = $CodeCommitAccountId
 $env:AWS_LAMBDA_PIPELINE_REGION = $Region
+$env:AWS_LAMBDA_PIPELINE_NAME_SUFFIX = $PipelineNameSuffix
 
-$env:AWS_LAMBDA_SOURCE_REPOSITORY_ARN = $SourceRepositoryArn
-$env:AWS_LAMBDA_SOURCE_BRANCH_NAME = $SourceBranchName
+$env:AWS_LAMBDA_GITHUB_TOKEN_SECRET_NAME = $GitHubTokenSecretName
+$env:AWS_LAMBDA_GITHUB_TOKEN_SECRET_KEY = $GitHubTokenSecretKey
+
+$env:AWS_LAMBDA_GITHUB_REPO_OWNER = $GitHubRepoOwner
+$env:AWS_LAMBDA_GITHUB_REPO_NAME = $GitHubRepoName
+$env:AWS_LAMBDA_GITHUB_REPO_BRANCH = $GitHubRepoBranch
 
 $env:AWS_LAMBDA_STAGE_ECR = $StageEcr
 $env:AWS_LAMBDA_BETA_ECRS = $BetaEcrs
@@ -55,6 +62,5 @@ $env:AWS_LAMBDA_ECR_REPOSITORY_NAME = $EcrRepositoryName
 $env:AWS_LAMBDA_DOTNET_FRAMEWORK_VERSION = $TargetFramework
 $env:AWS_LAMBDA_DOTNET_FRAMEWORK_CHANNEL = $DotnetChannel
 
-npx cdk bootstrap --cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess aws://$PipelineAccountId/$Region --profile $Profile
-npx cdk bootstrap --cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess --trust $PipelineAccountId aws://$CodeCommitAccountId/$Region --profile $CodeCommitAccountProfile
-npx cdk deploy --require-approval never --all --profile $Profile
+npx cdk bootstrap --cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess aws://$PipelineAccountId/$Region
+npx cdk deploy --require-approval never --all

--- a/buildtools/ci.buildspec.yml
+++ b/buildtools/ci.buildspec.yml
@@ -5,8 +5,11 @@ phases:
     runtime-versions:
       dotnet: 8.x
     commands:
-      # The tests need .NET 3.1, 6 and 8. .NET6 is installed by default. .NET8 is added in the runtime-versions. .NET 3.1 is installed manually.
+      # Find and delete the global.json files that were added by CodeBuild. This causes issues when multiple SDKs are installed.
+      - find / -type f -name 'global.json' -delete
+      # The tests need .NET 3.1, 6, 8 and 9. .NET6 is installed by default. .NET8 is added in the runtime-versions. .NET 3.1 and 9 are installed manually.
       - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 3.1
+      - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 9.0
   build:
     commands:
       - dotnet msbuild buildtools/build.proj /t:unit-tests /p:Cicd=true 


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7790

*Description of changes:*
* Added .NET9 target for Lambda Container Images and Test Tool
* Dropped .NET7 since it is already out of support
* Updated the CodePipeline to V2 and dropped CodeCommit support
* Updated build script in Lambda Container Images pipeline to create an ECR registry if ones doesn't exist.

Note: The pipelines were deployed to my dev account and ran to completion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
