### PR TITLE
Update Lambda Test Tool to support version 2.4.0 of Amazon.Lambda.Core

### DIFF
--- a/.autover/changes/a6ea8820-2eb2-4ce7-ba06-a1141e740a9b.json
+++ b/.autover/changes/a6ea8820-2eb2-4ce7-ba06-a1141e740a9b.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.TestTool.BlazorTester",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fixed issue supporting parameterized logging APIs added to Amazon.Lambda.Core in version 2.4.0"
+      ]
+    }
+  ]
+}

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.4.0" />
     <PackageReference Include="AWSSDK.SSO" Version="3.7.300.80" />
     <PackageReference Include="AWSSDK.SSOOIDC" Version="3.7.301.75" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaMocks/LocalLambdaLogger.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaMocks/LocalLambdaLogger.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 using Amazon.Lambda.Core;
 
 namespace Amazon.Lambda.TestTool.Runtime.LambdaMocks
@@ -6,7 +7,33 @@ namespace Amazon.Lambda.TestTool.Runtime.LambdaMocks
     public class LocalLambdaLogger : ILambdaLogger
     {
         private StringBuilder _buffer = new StringBuilder();
-        
+
+        public void Log(string level, string message)
+        {
+            _buffer.AppendLine($"Level = {level}, Message = {message}");
+        }
+
+        public void Log(string level, string message, params object[] args)
+        {
+            _buffer.Append($"Level = {level}, Message = {message}");
+            if (args?.Length > 0)
+                _buffer.AppendLine($", Arguments = {string.Join(',', args)}");
+            else
+                _buffer.AppendLine();
+        }
+
+        public void Log(string level, Exception exception, string message, params object[] args)
+        {
+
+            _buffer.Append($"Level = {level}, Message = {message}");
+            if (args?.Length > 0)
+                _buffer.AppendLine($", Arguments = {string.Join(',', args)}");
+            else
+                _buffer.AppendLine();
+
+            _buffer.AppendLine(exception.ToString());
+        }
+
         public void Log(string message)
         {
             _buffer.Append(message);

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests/ConsoleCaptureTests.cs
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests/ConsoleCaptureTests.cs
@@ -37,5 +37,22 @@ namespace Amazon.Lambda.TestTool.Tests
             Assert.DoesNotContain("NOT_CAPTURED", logger.Buffer);
         }
 
+
+        [Fact]
+        public void CallParameterizedLoggingMethods()
+        {
+            var logger = new LocalLambdaLogger();
+
+            logger.Log("INFO", "TheMessage");
+            logger.Log("WARN", "TheMessage {argument}", "TheArgument");
+            logger.Log("ERROR", new ApplicationException("TheApplicationException"), "TheMessageWithException");
+            logger.Log("ERROR", new ApplicationException("TheApplicationException"), "TheMessageWithException {argument}", "TheExceptionArgument");
+
+            Assert.Contains("Level = INFO, Message = TheMessage", logger.Buffer);
+            Assert.Contains("Level = WARN, Message = TheMessage {argument}, Arguments = TheArgument", logger.Buffer);
+            Assert.Contains("Level = ERROR, Message = TheMessageWithException", logger.Buffer);
+            Assert.Contains("System.ApplicationException: TheApplicationException", logger.Buffer);
+            Assert.Contains("Level = ERROR, Message = TheMessageWithException {argument}, Arguments = TheExceptionArgument", logger.Buffer);
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1869

*Description of changes:*
Update the Lambda Test tool to support Amazon.Lambda.Core 2.4.0 new parameterized logging APIs. Currently it doesn't format the parameterized logging messages the same as RuntimeSupport but all of the information is available. We will need to figure out long term how would we share all of the formatting logic in Amazon.Lambda.RuntimeSupport with the test tool.

### Testing
Added new unit tests and did manual confirmation using the test tool with a Lambda function using the parameterized logging APIs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
