### PR TITLE
Version bump libraries to pull in SnapStart versions of Core and RuntimeSupport

### DIFF
--- a/.autover/changes/0051061b-e1cc-4f12-8fb0-852ac35c6b12.json
+++ b/.autover/changes/0051061b-e1cc-4f12-8fb0-852ac35c6b12.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.PowerShellHost",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update to latest version of Amazon.Lambda.Core"
+      ]
+    }
+  ]
+}

--- a/.autover/changes/1b19409c-0e77-4d90-a0f0-fdb9d45ba204.json
+++ b/.autover/changes/1b19409c-0e77-4d90-a0f0-fdb9d45ba204.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Logging.AspNetCore",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update to latest version of Amazon.Lambda.Core"
+      ]
+    }
+  ]
+}

--- a/.autover/changes/2d313695-2697-463b-926f-f9186bb384e8.json
+++ b/.autover/changes/2d313695-2697-463b-926f-f9186bb384e8.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Annotations",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update to latest version of Amazon.Lambda.Core"
+      ]
+    }
+  ]
+}

--- a/.autover/changes/5a533ad1-1760-475b-9ac4-69d53bf9ebf1.json
+++ b/.autover/changes/5a533ad1-1760-475b-9ac4-69d53bf9ebf1.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.AspNetCoreServer.Hosting",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update to latest version of Amazon.Lambda.Core and Amazon.Lambda.RuntimeSupport"
+      ]
+    }
+  ]
+}

--- a/.autover/changes/86fe00ab-010e-42bd-a25b-4fe37a84a798.json
+++ b/.autover/changes/86fe00ab-010e-42bd-a25b-4fe37a84a798.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.AspNetCoreServer",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update to latest version of Amazon.Lambda.Core"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
*Description of changes:*
Version bump all of the packages that have a dependencies on Amazon.Lambda.Core or Amazon.Lambda.RuntimeSupport. That way Lambda functions taking these packages in will pull in the latest Amazon.Lambda.Core or Amazon.Lambda.RuntimeSupport as transitive dependencies enabling SnapStart behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
