### PR TITLE
Revert behavior for non SnapShot scenario to throw an exception when initialize fails

### DIFF
--- a/.autover/changes/cd8cd757-830a-4abd-b01f-92176e837b07.json
+++ b/.autover/changes/cd8cd757-830a-4abd-b01f-92176e837b07.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.RuntimeSupport",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Revert behavior for non SnapShot scenario to throw an exception when initialization fails"
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
@@ -219,8 +219,8 @@ namespace Amazon.Lambda.RuntimeSupport
                     System.Environment.Exit(1); // This needs to be non-zero for Lambda Sandbox to know that Runtime client encountered an exception
                 }
 #endif
+                throw;
             }
-            return false;
         }
 
         internal async Task InvokeOnceAsync(CancellationToken cancellationToken = default)

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaBootstrapTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaBootstrapTests.cs
@@ -83,14 +83,23 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
         }
 
         [Fact]
-        public async Task InitializerHandlesExceptionsGracefully()
+        public async Task InitializerHandlesExceptions()
         {
+            bool exceptionThrown = false;
             using (var bootstrap = new LambdaBootstrap(_testFunction.BaseHandlerAsync, _testInitializer.InitializeThrowAsync))
             {
                 bootstrap.Client = _testRuntimeApiClient;
-                await bootstrap.RunAsync();
+                try
+                {
+                    await bootstrap.RunAsync();
+                }
+                catch
+                {
+                    exceptionThrown = true;
+                }
             }
 
+            Assert.True(exceptionThrown);
             Assert.True(_testRuntimeApiClient.ReportInitializationErrorAsyncExceptionCalled);
             Assert.True(_testInitializer.InitializerWasCalled);
             Assert.False(_testFunction.HandlerWasCalled);


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1881

*Description of changes:*
As part of the work for SnapStart we need to force an exit quickly if there was a initialization error. That ensured the Lambda service picked up the logs to put in CloudWatch logs. This triggered a refactor that changed the behavior for non SnapStart case to not get an Exception when Lambda functions started the LambdaBootstrap themselves. This PR reverts the behavior for non SnapStart case to ensure the exception is bubbled up to the caller of LambdaBootstrap.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
