### PR TITLE
fix: add NET 9 to fix Lambda custom runtime image

### DIFF
--- a/.autover/autover.json
+++ b/.autover/autover.json
@@ -131,6 +131,10 @@
     {
       "Name": "Amazon.Lambda.Templates",
       "Path": "Blueprints/BlueprintDefinitions/vs2022/Templates.csproj"
+    },
+    {
+      "Name": "SnapshotRestore.Registry",
+      "Path": "Libraries/src/SnapshotRestore.Registry/SnapshotRestore.Registry.csproj"
     }
   ],
   "UseCommitsForChangelog": false,

--- a/.autover/changes/2685eba0-7e2e-4bb7-aa6c-4a237434d388.json
+++ b/.autover/changes/2685eba0-7e2e-4bb7-aa6c-4a237434d388.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "SnapshotRestore.Registry",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Added License URL to project"
+      ]
+    }
+  ]
+}

--- a/.autover/changes/27878e75-1d65-4334-b3cc-fb79a84f9456.json
+++ b/.autover/changes/27878e75-1d65-4334-b3cc-fb79a84f9456.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.RuntimeSupport",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Updated project to support building the .NET 9 Lambda custom runtime image"
+      ]
+    }
+  ]
+}

--- a/.autover/changes/40379e2a-29d6-4e86-a7c8-af98eacf5dd9.json
+++ b/.autover/changes/40379e2a-29d6-4e86-a7c8-af98eacf5dd9.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Annotations",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Added License URL to project"
+      ]
+    }
+  ]
+}

--- a/.autover/changes/b9c57497-1ab4-4d26-8cc6-6aa945f7ac96.json
+++ b/.autover/changes/b9c57497-1ab4-4d26-8cc6-6aa945f7ac96.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "SnapshotRestore.Registry",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Updated project to support building the .NET 9 Lambda custom runtime image"
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Amazon.Lambda.Annotations.SourceGenerator.csproj
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Amazon.Lambda.Annotations.SourceGenerator.csproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://github.com/aws/aws-lambda-dotnet</PackageProjectUrl>
     <PackageIcon>images\icon.png</PackageIcon>
     <PackageReadmeFile>docs\README.md</PackageReadmeFile>
-    <PackageLicenseUrl>https://aws.amazon.com/apache2.0/</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     
     <!--This assembly needs to access internal methods inside the Amazon.Lambda.Annotations assembly.
     Both these assemblies need to be strongly signed for the InternalsVisibleTo attribute to take effect.-->

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Amazon.Lambda.Annotations.SourceGenerator.csproj
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Amazon.Lambda.Annotations.SourceGenerator.csproj
@@ -9,6 +9,7 @@
     <PackageProjectUrl>https://github.com/aws/aws-lambda-dotnet</PackageProjectUrl>
     <PackageIcon>images\icon.png</PackageIcon>
     <PackageReadmeFile>docs\README.md</PackageReadmeFile>
+    <PackageLicenseUrl>https://aws.amazon.com/apache2.0/</PackageLicenseUrl>
     
     <!--This assembly needs to access internal methods inside the Amazon.Lambda.Annotations assembly.
     Both these assemblies need to be strongly signed for the InternalsVisibleTo attribute to take effect.-->

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\..\buildtools\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0</TargetFrameworks>
     <Version>1.12.1</Version>
     <Description>Provides a bootstrap and Lambda Runtime API Client to help you to develop custom .NET Core Lambda Runtimes.</Description>
     <AssemblyTitle>Amazon.Lambda.RuntimeSupport</AssemblyTitle>
@@ -20,7 +20,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 	
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0'">
     <WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
@@ -41,7 +41,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Amazon.Lambda.Core\Amazon.Lambda.Core.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0'">
     <ProjectReference Include="..\SnapshotRestore.Registry\SnapshotRestore.Registry.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/Libraries/src/SnapshotRestore.Registry/SnapshotRestore.Registry.csproj
+++ b/Libraries/src/SnapshotRestore.Registry/SnapshotRestore.Registry.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Description>Provides a Restore Hooks library to help you register before snapshot and after restore hooks.</Description>
     <AssemblyTitle>SnapshotRestore.Registry</AssemblyTitle>

--- a/Libraries/src/SnapshotRestore.Registry/SnapshotRestore.Registry.csproj
+++ b/Libraries/src/SnapshotRestore.Registry/SnapshotRestore.Registry.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\..\..\buildtools\common.props" />
+
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <VersionPrefix>1.0.0</VersionPrefix>

--- a/buildtools/common.props
+++ b/buildtools/common.props
@@ -13,7 +13,7 @@
 	
     <PackageIconUrl>https://sdk-for-net.amazonwebservices.com/images/AWSLogo128x128.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/aws/aws-lambda-dotnet</PackageProjectUrl>
-    <PackageLicenseUrl>http://aws.amazon.com/apache2.0/</PackageLicenseUrl>
+    <PackageLicenseUrl>https://aws.amazon.com/apache2.0/</PackageLicenseUrl>
 
 
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/buildtools/common.props
+++ b/buildtools/common.props
@@ -13,7 +13,7 @@
 	
     <PackageIconUrl>https://sdk-for-net.amazonwebservices.com/images/AWSLogo128x128.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/aws/aws-lambda-dotnet</PackageProjectUrl>
-    <PackageLicenseUrl>https://aws.amazon.com/apache2.0/</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 
 
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>


### PR DESCRIPTION
*Description of changes:*
* Added .NET9 targets to RuntimeSupport and SnapshotRestore to fix issue building .NET 9 Lambda custom runtime image
* Added SnapshotRestore.Registry to AutoVer
* Added License URL to the projects that don't have it

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
