### PR TITLE
add packaging of runtime

### DIFF
--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -15,9 +15,14 @@
   </PropertyGroup>
 	
   <ItemGroup>
+      <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.11.0" />
       <PackageReference Include="Blazored.Modal" Version="7.3.1" />
 	  <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.11" /> 
-  </ItemGroup>	
+  </ItemGroup>
+
+  <ItemGroup>
+	  <None Include="$(OutputPath)Amazon.Lambda.RuntimeSupport.dll" Pack="true" PackagePath="content" />
+  </ItemGroup>
 	
   <ItemGroup>
     <EmbeddedResource Include="wwwroot\**" />

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/PackagingTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/PackagingTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using Xunit;
+
+namespace Amazon.Lambda.TestTool.UnitTests;
+
+public class PackagingTests
+{
+    [Fact]
+    public void VerifyPackageContentsHasRuntimeSupport()
+    {
+        string projectPath = Path.Combine(FindSolutionRoot(), "src", "Amazon.Lambda.TestTool", "Amazon.Lambda.TestTool.csproj");
+
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = $"pack {projectPath} -c Release",
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            }
+        };
+
+        process.Start();
+        string output = process.StandardOutput.ReadToEnd();
+        process.WaitForExit();
+
+        Assert.Equal(0, process.ExitCode);
+
+        string packagePath = Directory.GetFiles(Path.GetDirectoryName(projectPath), "*.nupkg", SearchOption.AllDirectories)[0];
+
+        using (var archive = ZipFile.OpenRead(packagePath))
+        {
+            var runtimeSupportDllEntry = archive.GetEntry("content/Amazon.Lambda.RuntimeSupport.dll");
+            Assert.NotNull(runtimeSupportDllEntry);
+        }
+    }
+
+    private string FindSolutionRoot()
+    {
+        string currentDirectory = Directory.GetCurrentDirectory();
+        while (currentDirectory != null)
+        {
+            string[] solutionFiles = Directory.GetFiles(currentDirectory, "*.sln");
+            if (solutionFiles.Length > 0)
+            {
+                return currentDirectory;
+            }
+            currentDirectory = Directory.GetParent(currentDirectory)?.FullName;
+        }
+        throw new Exception("Could not find the solution root directory.");
+    }
+
+
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Add Amazon.Lambda.RuntimeSupport dll to the output nuget package
![Screenshot 2024-12-04 154218](https://github.com/user-attachments/assets/8f2f35a1-cc36-4512-9371-d2450e67cc73)
2. Add test to verify dll is inside the content folder.

*Testing*
1. So far only tested via checking that the files are in the nuget package manually. I still need to test that this dll works by running with the aspire proof of concept.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
