### PR TITLE
Add ApiGatewayHttpApiV2ProxyRequestTranslator and ApiGatewayProxyRequestTranslator

### DIFF
--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/ApiGatewayResponseExtensions.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/ApiGatewayResponseExtensions.cs
@@ -3,6 +3,7 @@
 
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.TestTool.Models;
+using Amazon.Lambda.TestTool.Utilities;
 using Microsoft.Extensions.Primitives;
 using System.Text;
 
@@ -102,47 +103,16 @@ public static class ApiGatewayResponseExtensions
         {
             case ApiGatewayEmulatorMode.Rest:
                 headers.Add("x-amzn-RequestId", Guid.NewGuid().ToString("D"));
-                headers.Add("x-amz-apigw-id", GenerateRequestId());
-                headers.Add("X-Amzn-Trace-Id", GenerateTraceId());
+                headers.Add("x-amz-apigw-id", HttpRequestUtility.GenerateRequestId());
+                headers.Add("X-Amzn-Trace-Id", HttpRequestUtility.GenerateTraceId());
                 break;
             case ApiGatewayEmulatorMode.HttpV1:
             case ApiGatewayEmulatorMode.HttpV2:
-                headers.Add("Apigw-Requestid", GenerateRequestId());
+                headers.Add("Apigw-Requestid", HttpRequestUtility.GenerateRequestId());
                 break;
         }
 
         return headers;
-    }
-
-    /// <summary>
-    /// Generates a random X-Amzn-Trace-Id for REST API mode.
-    /// </summary>
-    /// <returns>A string representing a random X-Amzn-Trace-Id in the format used by API Gateway for REST APIs.</returns>
-    /// <remarks>
-    /// The generated trace ID includes:
-    /// - A root ID with a timestamp and two partial GUIDs
-    /// - A parent ID
-    /// - A sampling decision (always set to 0 in this implementation)
-    /// - A lineage identifier
-    /// </remarks>
-    private static string GenerateTraceId()
-    {
-        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString("x");
-        var guid1 = Guid.NewGuid().ToString("N");
-        var guid2 = Guid.NewGuid().ToString("N");
-        return $"Root=1-{timestamp}-{guid1.Substring(0, 12)}{guid2.Substring(0, 12)};Parent={Guid.NewGuid().ToString("N").Substring(0, 16)};Sampled=0;Lineage=1:{Guid.NewGuid().ToString("N").Substring(0, 8)}:0";
-    }
-
-    /// <summary>
-    /// Generates a random API Gateway request ID for HTTP API v1 and v2.
-    /// </summary>
-    /// <returns>A string representing a random request ID in the format used by API Gateway for HTTP APIs.</returns>
-    /// <remarks>
-    /// The generated ID is a 15-character string consisting of lowercase letters and numbers, followed by an equals sign.
-    /// </remarks>
-    private static string GenerateRequestId()
-    {
-        return Guid.NewGuid().ToString("N").Substring(0, 8) + Guid.NewGuid().ToString("N").Substring(0, 7) + "=";
     }
 
     /// <summary>

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/HttpContextExtensions.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/HttpContextExtensions.cs
@@ -1,0 +1,196 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace Amazon.Lambda.TestTool.Extensions;
+
+using System.Web;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.TestTool.Models;
+using Amazon.Lambda.TestTool.Utilities;
+using static Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyRequest;
+
+/// <summary>
+/// Provides extension methods to translate an <see cref="HttpContext"/> to different types of API Gateway requests.
+/// </summary>
+public static class HttpContextExtensions
+{
+    /// <summary>
+    /// Translates an <see cref="HttpContext"/> to an <see cref="APIGatewayHttpApiV2ProxyRequest"/>.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> to be translated.</param>
+    /// <param name="apiGatewayRouteConfig">The configuration of the API Gateway route, including the HTTP method, path, and other metadata.</param>
+    /// <returns>An <see cref="APIGatewayHttpApiV2ProxyRequest"/> object representing the translated request.</returns>
+    public static APIGatewayHttpApiV2ProxyRequest ToApiGatewayHttpV2Request(
+        this HttpContext context,
+        ApiGatewayRouteConfig apiGatewayRouteConfig)
+    {
+        var request = context.Request;
+        var currentTime = DateTimeOffset.UtcNow;
+        var body = HttpRequestUtility.ReadRequestBody(request);
+        var contentLength = HttpRequestUtility.CalculateContentLength(request, body);
+
+        var pathParameters = RouteTemplateUtility.ExtractPathParameters(apiGatewayRouteConfig.Path, request.Path);
+
+        // Format 2.0 doesn't have multiValueHeaders or multiValueQueryStringParameters fields. Duplicate headers are combined with commas and included in the headers field.
+        var (_, allHeaders) = HttpRequestUtility.ExtractHeaders(request.Headers);
+        var headers = allHeaders.ToDictionary(
+            kvp => kvp.Key,
+            kvp => string.Join(", ", kvp.Value)
+        );
+
+        // Duplicate query strings are combined with commas and included in the queryStringParameters field.
+        var (_, allQueryParams) = HttpRequestUtility.ExtractQueryStringParameters(request.Query);
+        var queryStringParameters = allQueryParams.ToDictionary(
+            kvp => kvp.Key,
+            kvp => string.Join(",", kvp.Value)
+        );
+
+        string userAgent = request.Headers.UserAgent.ToString();
+
+        if (!headers.ContainsKey("content-length"))
+        {
+            headers["content-length"] = contentLength.ToString();
+        }
+
+        if (!headers.ContainsKey("content-type"))
+        {
+            headers["content-type"] = "text/plain; charset=utf-8";
+        }
+
+        var httpApiV2ProxyRequest = new APIGatewayHttpApiV2ProxyRequest
+        {
+            RouteKey = $"{request.Method} {apiGatewayRouteConfig.Path}",
+            RawPath = request.Path.Value, // this should be decoded value
+            Body = body,
+            IsBase64Encoded = false,
+            RequestContext = new ProxyRequestContext
+            {
+                Http = new HttpDescription
+                {
+                    Method = request.Method,
+                    Path = request.Path.Value, // this should be decoded value
+                    Protocol = !string.IsNullOrEmpty(request.Protocol) ? request.Protocol : "HTTP/1.1", // defaults to http 1.1 if not provided
+                    UserAgent = userAgent
+                },
+                Time = currentTime.ToString("dd/MMM/yyyy:HH:mm:ss") + " +0000",
+                TimeEpoch = currentTime.ToUnixTimeMilliseconds(),
+                RequestId = HttpRequestUtility.GenerateRequestId(),
+                RouteKey = $"{request.Method} {apiGatewayRouteConfig.Path}",
+            },
+            Version = "2.0"
+        };
+
+        if (request.Cookies.Any())
+        {
+            httpApiV2ProxyRequest.Cookies = request.Cookies.Select(c => $"{c.Key}={c.Value}").ToArray();
+        }
+
+        if (headers.Any())
+        {
+            httpApiV2ProxyRequest.Headers = headers;
+        }
+
+        httpApiV2ProxyRequest.RawQueryString = string.Empty; // default is empty string
+        if (queryStringParameters.Any())
+        {
+            // this should be decoded value
+            httpApiV2ProxyRequest.QueryStringParameters = queryStringParameters;
+
+            // this should be the url encoded value and not include the "?"
+            // e.g. key=%2b%2b%2b
+            httpApiV2ProxyRequest.RawQueryString = HttpUtility.UrlPathEncode(request.QueryString.Value?.Substring(1));
+
+        }
+
+        if (pathParameters.Any())
+        {
+            // this should be decoded value
+            httpApiV2ProxyRequest.PathParameters = pathParameters;
+        }
+
+        if (HttpRequestUtility.IsBinaryContent(request.ContentType))
+        {
+            // we already converted it when we read the body so we dont need to re-convert it
+            httpApiV2ProxyRequest.IsBase64Encoded = true;
+        }
+
+        return httpApiV2ProxyRequest;
+    }
+
+    /// <summary>
+    /// Translates an <see cref="HttpContext"/> to an <see cref="APIGatewayProxyRequest"/>.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> to be translated.</param>
+    /// <param name="apiGatewayRouteConfig">The configuration of the API Gateway route, including the HTTP method, path, and other metadata.</param>
+    /// <returns>An <see cref="APIGatewayProxyRequest"/> object representing the translated request.</returns>
+    public static APIGatewayProxyRequest ToApiGatewayRequest(
+        this HttpContext context,
+        ApiGatewayRouteConfig apiGatewayRouteConfig)
+    {
+        var request = context.Request;
+        var body = HttpRequestUtility.ReadRequestBody(request);
+        var contentLength = HttpRequestUtility.CalculateContentLength(request, body);
+
+        var pathParameters = RouteTemplateUtility.ExtractPathParameters(apiGatewayRouteConfig.Path, request.Path);
+
+        var (headers, multiValueHeaders) = HttpRequestUtility.ExtractHeaders(request.Headers);
+        var (queryStringParameters, multiValueQueryStringParameters) = HttpRequestUtility.ExtractQueryStringParameters(request.Query);
+
+        if (!headers.ContainsKey("content-length"))
+        {
+            headers["content-length"] = contentLength.ToString();
+            multiValueHeaders["content-length"] = new List<string> { contentLength.ToString() };
+        }
+
+        if (!headers.ContainsKey("content-type"))
+        {
+            headers["content-type"] = "text/plain; charset=utf-8";
+            multiValueHeaders["content-type"] = new List<string> { "text/plain; charset=utf-8" };
+        }
+
+        var proxyRequest = new APIGatewayProxyRequest
+        {
+            Resource = apiGatewayRouteConfig.Path,
+            Path = request.Path.Value,
+            HttpMethod = request.Method,
+            Body = body,
+            IsBase64Encoded = false
+        };
+
+        if (headers.Any())
+        {
+            proxyRequest.Headers = headers;
+        }
+
+        if (multiValueHeaders.Any())
+        {
+            proxyRequest.MultiValueHeaders = multiValueHeaders;
+        }
+
+        if (queryStringParameters.Any())
+        {
+            // this should be decoded value
+            proxyRequest.QueryStringParameters = queryStringParameters;
+        }
+
+        if (multiValueQueryStringParameters.Any())
+        {
+            // this should be decoded value
+            proxyRequest.MultiValueQueryStringParameters = multiValueQueryStringParameters;
+        }
+
+        if (pathParameters.Any())
+        {
+            // this should be decoded value
+            proxyRequest.PathParameters = pathParameters;
+        }
+
+        if (HttpRequestUtility.IsBinaryContent(request.ContentType))
+        {
+            // we already converted it when we read the body so we dont need to re-convert it
+            proxyRequest.IsBase64Encoded = true;
+        }
+
+        return proxyRequest;
+    }
+}

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/HttpRequestUtility.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/HttpRequestUtility.cs
@@ -1,0 +1,178 @@
+﻿using System.Text;
+
+namespace Amazon.Lambda.TestTool.Utilities;
+
+/// <summary>
+/// Utility class for handling HTTP requests in the context of API Gateway emulation.
+/// </summary>
+public static class HttpRequestUtility
+{
+    /// <summary>
+    /// Determines whether the specified content type represents binary content.
+    /// </summary>
+    /// <param name="contentType">The content type to check.</param>
+    /// <returns>True if the content type represents binary content; otherwise, false.</returns>
+    public static bool IsBinaryContent(string? contentType)
+    {
+        if (string.IsNullOrEmpty(contentType))
+            return false;
+
+        return contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase) ||
+               contentType.StartsWith("audio/", StringComparison.OrdinalIgnoreCase) ||
+               contentType.StartsWith("video/", StringComparison.OrdinalIgnoreCase) ||
+               contentType.Equals("application/octet-stream", StringComparison.OrdinalIgnoreCase) ||
+               contentType.Equals("application/zip", StringComparison.OrdinalIgnoreCase) ||
+               contentType.Equals("application/pdf", StringComparison.OrdinalIgnoreCase) ||
+               contentType.Equals("application/wasm", StringComparison.OrdinalIgnoreCase) ||
+               contentType.Equals("application/x-protobuf", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Reads the body of the HTTP request as a string. Returns null if the request body is empty.
+    /// </summary>
+    /// <param name="request">The HTTP request.</param>
+    /// <returns>The body of the request as a string, or null if the body is empty.</returns>
+    public static string? ReadRequestBody(HttpRequest request)
+    {
+        if (request.ContentLength == 0 || request.Body == null || !request.Body.CanRead)
+        {
+            return null;
+        }
+
+        // Check if the content is binary
+        bool isBinary = HttpRequestUtility.IsBinaryContent(request.ContentType);
+
+        request.Body.Position = 0;
+
+        using (var memoryStream = new MemoryStream())
+        {
+            request.Body.CopyTo(memoryStream);
+
+            // If the stream is empty, return null
+            if (memoryStream.Length == 0)
+            {
+                return null;
+            }
+
+            memoryStream.Position = 0;
+
+            if (isBinary)
+            {
+                // For binary data, convert to Base64 string
+                byte[] bytes = memoryStream.ToArray();
+                return Convert.ToBase64String(bytes);
+            }
+            else
+            {
+                // For text data, read as string
+                using (var reader = new StreamReader(memoryStream))
+                {
+                    string content = reader.ReadToEnd();
+                    return string.IsNullOrWhiteSpace(content) ? null : content;
+                }
+            }
+        }
+    }
+
+
+
+    /// <summary>
+    /// Extracts headers from the request, separating them into single-value and multi-value dictionaries.
+    /// </summary>
+    /// <param name="headers">The request headers.</param>
+    /// <returns>A tuple containing single-value and multi-value header dictionaries.</returns>
+    /// <example>
+    /// For headers:
+    /// Accept: text/html
+    /// Accept: application/xhtml+xml
+    /// X-Custom-Header: value1
+    /// 
+    /// The method will return:
+    /// singleValueHeaders: { "Accept": "application/xhtml+xml", "X-Custom-Header": "value1" }
+    /// multiValueHeaders: { "Accept": ["text/html", "application/xhtml+xml"], "X-Custom-Header": ["value1"] }
+    /// </example>
+    public static (IDictionary<string, string>, IDictionary<string, IList<string>>) ExtractHeaders(IHeaderDictionary headers)
+    {
+        var singleValueHeaders = new Dictionary<string, string>();
+        var multiValueHeaders = new Dictionary<string, IList<string>>();
+
+        foreach (var header in headers)
+        {
+            singleValueHeaders[header.Key.ToLower()] = header.Value.Last() ?? "";
+            multiValueHeaders[header.Key.ToLower()] = [.. header.Value];
+        }
+
+        return (singleValueHeaders, multiValueHeaders);
+    }
+
+    /// <summary>
+    /// Extracts query string parameters from the request, separating them into single-value and multi-value dictionaries.
+    /// </summary>
+    /// <param name="query">The query string collection.</param>
+    /// <returns>A tuple containing single-value and multi-value query parameter dictionaries.</returns>
+    /// <example>
+    /// For query string: ?param1=value1&amp;param2=value2&amp;param2=value3
+    /// 
+    /// The method will return:
+    /// singleValueParams: { "param1": "value1", "param2": "value3" }
+    /// multiValueParams: { "param1": ["value1"], "param2": ["value2", "value3"] }
+    /// </example>
+    public static (IDictionary<string, string>, IDictionary<string, IList<string>>) ExtractQueryStringParameters(IQueryCollection query)
+    {
+        var singleValueParams = new Dictionary<string, string>();
+        var multiValueParams = new Dictionary<string, IList<string>>();
+
+        foreach (var param in query)
+        {
+            singleValueParams[param.Key] = param.Value.Last() ?? "";
+            multiValueParams[param.Key] = [.. param.Value];
+        }
+
+        return (singleValueParams, multiValueParams);
+    }
+
+    /// <summary>
+    /// Generates a random API Gateway request ID for HTTP API v1 and v2.
+    /// </summary>
+    /// <returns>A string representing a random request ID in the format used by API Gateway for HTTP APIs.</returns>
+    /// <remarks>
+    /// The generated ID is a 145character string consisting of lowercase letters and numbers, followed by an equals sign.
+    public static string GenerateRequestId()
+    {
+        return Guid.NewGuid().ToString("N").Substring(0, 8) + Guid.NewGuid().ToString("N").Substring(0, 7) + "=";
+    }
+
+    /// <summary>
+    /// Generates a random X-Amzn-Trace-Id for REST API mode.
+    /// </summary>
+    /// <returns>A string representing a random X-Amzn-Trace-Id in the format used by API Gateway for REST APIs.</returns>
+    /// <remarks>
+    /// The generated trace ID includes:
+    /// - A root ID with a timestamp and two partial GUIDs
+    /// - A parent ID
+    /// - A sampling decision (always set to 0 in this implementation)
+    /// - A lineage identifier
+    /// </remarks>
+    public static string GenerateTraceId()
+    {
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString("x");
+        var guid1 = Guid.NewGuid().ToString("N");
+        var guid2 = Guid.NewGuid().ToString("N");
+        return $"Root=1-{timestamp}-{guid1.Substring(0, 12)}{guid2.Substring(0, 12)};Parent={Guid.NewGuid().ToString("N").Substring(0, 16)};Sampled=0;Lineage=1:{Guid.NewGuid().ToString("N").Substring(0, 8)}:0";
+    }
+
+    public static long CalculateContentLength(HttpRequest request, string body)
+    {
+        if (!string.IsNullOrEmpty(body))
+        {
+            return Encoding.UTF8.GetByteCount(body);
+        }
+        else if (request.ContentLength.HasValue)
+        {
+            return request.ContentLength.Value;
+        }
+        return 0;
+    }
+
+
+}

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/RouteTemplateUtility.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/RouteTemplateUtility.cs
@@ -1,0 +1,66 @@
+﻿namespace Amazon.Lambda.TestTool.Utilities;
+
+using Microsoft.AspNetCore.Routing.Template;
+
+/// <summary>
+/// Provides utility methods for working with route templates and extracting path parameters.
+/// </summary>
+public static class RouteTemplateUtility
+{
+    /// <summary>
+    /// Extracts path parameters from an actual path based on a route template.
+    /// </summary>
+    /// <param name="routeTemplate">The route template to match against.</param>
+    /// <param name="actualPath">The actual path to extract parameters from.</param>
+    /// <returns>A dictionary of extracted path parameters and their values.</returns>
+    /// <example>
+    /// Using this method:
+    /// <code>
+    /// var routeTemplate = "/users/{id}/orders/{orderId}";
+    /// var actualPath = "/users/123/orders/456";
+    /// var parameters = RouteTemplateUtility.ExtractPathParameters(routeTemplate, actualPath);
+    /// // parameters will contain: { {"id", "123"}, {"orderId", "456"} }
+    /// </code>
+    /// </example>
+    public static Dictionary<string, string> ExtractPathParameters(string routeTemplate, string actualPath)
+    {
+        var template = TemplateParser.Parse(routeTemplate);
+        var matcher = new TemplateMatcher(template, GetDefaults(template));
+        var routeValues = new RouteValueDictionary();
+
+        if (matcher.TryMatch(actualPath, routeValues))
+        {
+            return routeValues.ToDictionary(rv => rv.Key, rv => rv.Value?.ToString() ?? string.Empty);
+        }
+
+        return new Dictionary<string, string>();
+    }
+
+    /// <summary>
+    /// Gets the default values for parameters in a parsed route template.
+    /// </summary>
+    /// <param name="parsedTemplate">The parsed route template.</param>
+    /// <returns>A dictionary of default values for the template parameters.</returns>
+    /// <example>
+    /// Using this method:
+    /// <code>
+    /// var template = TemplateParser.Parse("/api/{version=v1}/users/{id}");
+    /// var defaults = RouteTemplateUtility.GetDefaults(template);
+    /// // defaults will contain: { {"version", "v1"} }
+    /// </code>
+    /// </example>
+    public static RouteValueDictionary GetDefaults(RouteTemplate parsedTemplate)
+    {
+        var result = new RouteValueDictionary();
+
+        foreach (var parameter in parsedTemplate.Parameters)
+        {
+            if (parameter.DefaultValue != null)
+            {
+                if (parameter.Name != null) result.Add(parameter.Name, parameter.DefaultValue);
+            }
+        }
+
+        return result;
+    }
+}

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/RouteTemplateUtility.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/RouteTemplateUtility.cs
@@ -78,7 +78,10 @@ public static class RouteTemplateUtility
         // Convert AWS-style {proxy+} to ASP.NET Core style {*proxy}
         template = Regex.Replace(template, @"\{(\w+)\+\}", "{*$1}");
 
-        // Handle AWS-style "constraints" by replacing them with temporary parameter names
+        // AWS allows you to name a route as {abc:int}, which gets parsed by AWS as the path
+        // variable abc:int. However, .NET template matcher, thinks {abc:int} means
+        // abc variable with the int constraint. So we are converting variables that have
+        // contstraints to a different name temporarily, so template matcher doesn't think they are constraints.
         return Regex.Replace(template, @"\{([^}]+):([^}]+)\}", match =>
         {
             var paramName = match.Groups[1].Value;

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/ApiGatewayIntegrationTestFixture.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/ApiGatewayIntegrationTestFixture.cs
@@ -16,17 +16,39 @@ namespace Amazon.Lambda.TestTool.IntegrationTests
         public ApiGatewayTestHelper ApiGatewayTestHelper { get; private set; }
 
         public string StackName { get; private set; }
-        public string RestApiId { get; private set; }
-        public string HttpApiV1Id { get; private set; }
-        public string HttpApiV2Id { get; private set; }
-        public string ReturnRawRequestBodyV2Id { get; private set; }
-        public string RestApiUrl { get; private set; }
-        public string HttpApiV1Url { get; private set; }
-        public string HttpApiV2Url { get; private set; }
-        public string ReturnRawRequestBodyHttpApiV2Url { get; private set; }
-        public string BinaryMediaRestApiId { get; private set; }
-        public string BinaryMediaRestApiUrl { get; private set; }
 
+        // ParseAndReturnBody
+        public string ParseAndReturnBodyRestApiId { get; private set; }
+        public string ParseAndReturnBodyHttpApiV1Id { get; private set; }
+        public string ParseAndReturnBodyHttpApiV2Id { get; private set; }
+        public string ParseAndReturnBodyRestApiUrl { get; private set; }
+        public string ParseAndReturnBodyHttpApiV1Url { get; private set; }
+        public string ParseAndReturnBodyHttpApiV2Url { get; private set; }
+
+        // ReturnRawBody
+        public string ReturnRawBodyRestApiId { get; private set; }
+        public string ReturnRawBodyHttpApiV1Id { get; private set; }
+        public string ReturnRawBodyHttpApiV2Id { get; private set; }
+        public string ReturnRawBodyRestApiUrl { get; private set; }
+        public string ReturnRawBodyHttpApiV1Url { get; private set; }
+        public string ReturnRawBodyHttpApiV2Url { get; private set; }
+
+        // ReturnFullEvent
+        public string ReturnFullEventRestApiId { get; private set; }
+        public string ReturnFullEventHttpApiV1Id { get; private set; }
+        public string ReturnFullEventHttpApiV2Id { get; private set; }
+        public string ReturnFullEventRestApiUrl { get; private set; }
+        public string ReturnFullEventHttpApiV1Url { get; private set; }
+        public string ReturnFullEventHttpApiV2Url { get; private set; }
+
+        // ReturnDecodedParseBin
+        public string ReturnDecodedParseBinRestApiId { get; private set; }
+        public string ReturnDecodedParseBinRestApiUrl { get; private set; }
+
+        // Lambda Function ARNs
+        public string ParseAndReturnBodyLambdaFunctionArn { get; private set; }
+        public string ReturnRawBodyLambdaFunctionArn { get; private set; }
+        public string ReturnFullEventLambdaFunctionArn { get; private set; }
 
         public ApiGatewayIntegrationTestFixture()
         {
@@ -37,17 +59,41 @@ namespace Amazon.Lambda.TestTool.IntegrationTests
                 new AmazonApiGatewayV2Client(regionEndpoint)
             );
             ApiGatewayTestHelper = new ApiGatewayTestHelper();
+
             StackName = string.Empty;
-            RestApiId = string.Empty;
-            HttpApiV1Id = string.Empty;
-            HttpApiV2Id = string.Empty;
-            ReturnRawRequestBodyV2Id = string.Empty;
-            RestApiUrl = string.Empty;
-            HttpApiV1Url = string.Empty;
-            HttpApiV2Url = string.Empty;
-            ReturnRawRequestBodyHttpApiV2Url = string.Empty;
-            BinaryMediaRestApiId = string.Empty;
-            BinaryMediaRestApiUrl = string.Empty;
+
+            // ParseAndReturnBody
+            ParseAndReturnBodyRestApiId = string.Empty;
+            ParseAndReturnBodyHttpApiV1Id = string.Empty;
+            ParseAndReturnBodyHttpApiV2Id = string.Empty;
+            ParseAndReturnBodyRestApiUrl = string.Empty;
+            ParseAndReturnBodyHttpApiV1Url = string.Empty;
+            ParseAndReturnBodyHttpApiV2Url = string.Empty;
+
+            // ReturnRawBody
+            ReturnRawBodyRestApiId = string.Empty;
+            ReturnRawBodyHttpApiV1Id = string.Empty;
+            ReturnRawBodyHttpApiV2Id = string.Empty;
+            ReturnRawBodyRestApiUrl = string.Empty;
+            ReturnRawBodyHttpApiV1Url = string.Empty;
+            ReturnRawBodyHttpApiV2Url = string.Empty;
+
+            // ReturnFullEvent
+            ReturnFullEventRestApiId = string.Empty;
+            ReturnFullEventHttpApiV1Id = string.Empty;
+            ReturnFullEventHttpApiV2Id = string.Empty;
+            ReturnFullEventRestApiUrl = string.Empty;
+            ReturnFullEventHttpApiV1Url = string.Empty;
+            ReturnFullEventHttpApiV2Url = string.Empty;
+
+            // ReturnDecodedParseBin
+            ReturnDecodedParseBinRestApiId = string.Empty;
+            ReturnDecodedParseBinRestApiUrl = string.Empty;
+
+            // Lambda Function ARNs
+            ParseAndReturnBodyLambdaFunctionArn = string.Empty;
+            ReturnRawBodyLambdaFunctionArn = string.Empty;
+            ReturnFullEventLambdaFunctionArn = string.Empty;
         }
 
         public async Task InitializeAsync()
@@ -99,29 +145,59 @@ namespace Amazon.Lambda.TestTool.IntegrationTests
 
         private async Task RetrieveStackOutputs()
         {
-            RestApiId = await CloudFormationHelper.GetOutputValueAsync(StackName, "RestApiId");
-            RestApiUrl = await CloudFormationHelper.GetOutputValueAsync(StackName, "RestApiUrl");
+            // ParseAndReturnBody
+            ParseAndReturnBodyRestApiId = await CloudFormationHelper.GetOutputValueAsync(StackName, "ParseAndReturnBodyRestApiId");
+            ParseAndReturnBodyHttpApiV1Id = await CloudFormationHelper.GetOutputValueAsync(StackName, "ParseAndReturnBodyHttpApiV1Id");
+            ParseAndReturnBodyHttpApiV2Id = await CloudFormationHelper.GetOutputValueAsync(StackName, "ParseAndReturnBodyHttpApiV2Id");
+            ParseAndReturnBodyRestApiUrl = await CloudFormationHelper.GetOutputValueAsync(StackName, "ParseAndReturnBodyRestApiUrl");
+            ParseAndReturnBodyHttpApiV1Url = await CloudFormationHelper.GetOutputValueAsync(StackName, "ParseAndReturnBodyHttpApiV1Url");
+            ParseAndReturnBodyHttpApiV2Url = await CloudFormationHelper.GetOutputValueAsync(StackName, "ParseAndReturnBodyHttpApiV2Url");
 
-            HttpApiV1Id = await CloudFormationHelper.GetOutputValueAsync(StackName, "HttpApiV1Id");
-            HttpApiV1Url = await CloudFormationHelper.GetOutputValueAsync(StackName, "HttpApiV1Url");
+            // ReturnRawBody
+            ReturnRawBodyRestApiId = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnRawBodyRestApiId");
+            ReturnRawBodyHttpApiV1Id = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnRawBodyHttpApiV1Id");
+            ReturnRawBodyHttpApiV2Id = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnRawBodyHttpApiV2Id");
+            ReturnRawBodyRestApiUrl = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnRawBodyRestApiUrl");
+            ReturnRawBodyHttpApiV1Url = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnRawBodyHttpApiV1Url");
+            ReturnRawBodyHttpApiV2Url = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnRawBodyHttpApiV2Url");
 
-            HttpApiV2Id = await CloudFormationHelper.GetOutputValueAsync(StackName, "HttpApiV2Id");
-            HttpApiV2Url = await CloudFormationHelper.GetOutputValueAsync(StackName, "HttpApiV2Url");
+            // ReturnFullEvent
+            ReturnFullEventRestApiId = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnFullEventRestApiId");
+            ReturnFullEventHttpApiV1Id = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnFullEventHttpApiV1Id");
+            ReturnFullEventHttpApiV2Id = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnFullEventHttpApiV2Id");
+            ReturnFullEventRestApiUrl = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnFullEventRestApiUrl");
+            ReturnFullEventHttpApiV1Url = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnFullEventHttpApiV1Url");
+            ReturnFullEventHttpApiV2Url = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnFullEventHttpApiV2Url");
 
-            ReturnRawRequestBodyV2Id = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnRawRequestBodyHttpApiId");
-            ReturnRawRequestBodyHttpApiV2Url = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnRawRequestBodyHttpApiUrl");
+            // ReturnDecodedParseBin
+            ReturnDecodedParseBinRestApiId = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnDecodedParseBinRestApiId");
+            ReturnDecodedParseBinRestApiUrl = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnDecodedParseBinRestApiUrl");
 
-            BinaryMediaRestApiId = await CloudFormationHelper.GetOutputValueAsync(StackName, "BinaryMediaRestApiId");
-            BinaryMediaRestApiUrl = await CloudFormationHelper.GetOutputValueAsync(StackName, "BinaryMediaRestApiUrl");
+            // Lambda Function ARNs
+            ParseAndReturnBodyLambdaFunctionArn = await CloudFormationHelper.GetOutputValueAsync(StackName, "ParseAndReturnBodyLambdaFunctionArn");
+            ReturnRawBodyLambdaFunctionArn = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnRawBodyLambdaFunctionArn");
+            ReturnFullEventLambdaFunctionArn = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnFullEventLambdaFunctionArn");
         }
 
         private async Task WaitForApisAvailability()
         {
-            await ApiGatewayHelper.WaitForApiAvailability(RestApiId, RestApiUrl, false);
-            await ApiGatewayHelper.WaitForApiAvailability(HttpApiV1Id, HttpApiV1Url, true);
-            await ApiGatewayHelper.WaitForApiAvailability(HttpApiV2Id, HttpApiV2Url, true);
-            await ApiGatewayHelper.WaitForApiAvailability(ReturnRawRequestBodyV2Id, ReturnRawRequestBodyHttpApiV2Url, true);
-            await ApiGatewayHelper.WaitForApiAvailability(BinaryMediaRestApiId, BinaryMediaRestApiUrl, false);
+            // ParseAndReturnBody
+            await ApiGatewayHelper.WaitForApiAvailability(ParseAndReturnBodyRestApiId, ParseAndReturnBodyRestApiUrl, false);
+            await ApiGatewayHelper.WaitForApiAvailability(ParseAndReturnBodyHttpApiV1Id, ParseAndReturnBodyHttpApiV1Url, true);
+            await ApiGatewayHelper.WaitForApiAvailability(ParseAndReturnBodyHttpApiV2Id, ParseAndReturnBodyHttpApiV2Url, true);
+
+            // ReturnRawBody
+            await ApiGatewayHelper.WaitForApiAvailability(ReturnRawBodyRestApiId, ReturnRawBodyRestApiUrl, false);
+            await ApiGatewayHelper.WaitForApiAvailability(ReturnRawBodyHttpApiV1Id, ReturnRawBodyHttpApiV1Url, true);
+            await ApiGatewayHelper.WaitForApiAvailability(ReturnRawBodyHttpApiV2Id, ReturnRawBodyHttpApiV2Url, true);
+
+            // ReturnFullEvent
+            await ApiGatewayHelper.WaitForApiAvailability(ReturnFullEventRestApiId, ReturnFullEventRestApiUrl, false);
+            await ApiGatewayHelper.WaitForApiAvailability(ReturnFullEventHttpApiV1Id, ReturnFullEventHttpApiV1Url, true);
+            await ApiGatewayHelper.WaitForApiAvailability(ReturnFullEventHttpApiV2Id, ReturnFullEventHttpApiV2Url, true);
+
+            await ApiGatewayHelper.WaitForApiAvailability(ReturnDecodedParseBinRestApiId, ReturnDecodedParseBinRestApiUrl, false);
+
         }
 
         public async Task DisposeAsync()

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/ApiGatewayResponseExtensionsAdditionalTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/ApiGatewayResponseExtensionsAdditionalTests.cs
@@ -54,7 +54,7 @@ namespace Amazon.Lambda.TestTool.IntegrationTests
 
             var httpContext = new DefaultHttpContext();
             testResponse.ToHttpResponse(httpContext, ApiGatewayEmulatorMode.Rest);
-            var actualResponse = await _httpClient.PostAsync(_fixture.BinaryMediaRestApiUrl, new StringContent(JsonSerializer.Serialize(testResponse)));
+            var actualResponse = await _httpClient.PostAsync(_fixture.ReturnDecodedParseBinRestApiUrl, new StringContent(JsonSerializer.Serialize(testResponse)));
             await _fixture.ApiGatewayTestHelper.AssertResponsesEqual(actualResponse, httpContext.Response);
             Assert.Equal(200, (int)actualResponse.StatusCode);
             var content = await actualResponse.Content.ReadAsStringAsync();
@@ -73,7 +73,7 @@ namespace Amazon.Lambda.TestTool.IntegrationTests
 
             var httpContext = new DefaultHttpContext();
             testResponse.ToHttpResponse(httpContext, ApiGatewayEmulatorMode.HttpV1);
-            var actualResponse = await _httpClient.PostAsync(_fixture.HttpApiV1Url, new StringContent(JsonSerializer.Serialize(testResponse)));
+            var actualResponse = await _httpClient.PostAsync(_fixture.ParseAndReturnBodyHttpApiV1Url, new StringContent(JsonSerializer.Serialize(testResponse)));
 
             await _fixture.ApiGatewayTestHelper.AssertResponsesEqual(actualResponse, httpContext.Response);
             Assert.Equal(200, (int)actualResponse.StatusCode);

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/ApiGatewayResponseExtensionsTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/ApiGatewayResponseExtensionsTests.cs
@@ -25,7 +25,7 @@ namespace Amazon.Lambda.TestTool.IntegrationTests
         {
             await RetryHelper.RetryOperation(async () =>
             {
-                await RunV1Test(testCase, _fixture.RestApiUrl, ApiGatewayEmulatorMode.Rest);
+                await RunV1Test(testCase, _fixture.ParseAndReturnBodyRestApiUrl, ApiGatewayEmulatorMode.Rest);
                 return true;
             });
         }
@@ -37,7 +37,7 @@ namespace Amazon.Lambda.TestTool.IntegrationTests
         {
             await RetryHelper.RetryOperation(async () =>
             {
-                await RunV1Test(testCase, _fixture.HttpApiV1Url, ApiGatewayEmulatorMode.HttpV1);
+                await RunV1Test(testCase, _fixture.ParseAndReturnBodyHttpApiV1Url, ApiGatewayEmulatorMode.HttpV1);
                 return true;
             });
         }
@@ -51,7 +51,7 @@ namespace Amazon.Lambda.TestTool.IntegrationTests
             {
                 var testResponse = testCase.Response as APIGatewayHttpApiV2ProxyResponse;
                 Assert.NotNull(testResponse);
-                var (actualResponse, httpTestResponse) = await _fixture.ApiGatewayTestHelper.ExecuteTestRequest(testResponse, _fixture.HttpApiV2Url);
+                var (actualResponse, httpTestResponse) = await _fixture.ApiGatewayTestHelper.ExecuteTestRequest(testResponse, _fixture.ParseAndReturnBodyHttpApiV2Url);
                 await _fixture.ApiGatewayTestHelper.AssertResponsesEqual(actualResponse, httpTestResponse);
                 await testCase.IntegrationAssertions(actualResponse, ApiGatewayEmulatorMode.HttpV2);
                 return true;

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/HttpContextExtensionsTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/HttpContextExtensionsTests.cs
@@ -1,0 +1,278 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Net;
+using System.Text.Json;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.TestTool.Extensions;
+using Amazon.Lambda.TestTool.IntegrationTests.Helpers;
+using Amazon.Lambda.TestTool.Models;
+using Amazon.Lambda.TestTool.UnitTests.Extensions;
+using Microsoft.AspNetCore.Http;
+using static Amazon.Lambda.TestTool.UnitTests.Extensions.HttpContextTestCases;
+
+namespace Amazon.Lambda.TestTool.IntegrationTests
+{
+    [Collection("ApiGateway Integration Tests")]
+    public class HttpContextExtensionsTests
+    {
+        private readonly ApiGatewayIntegrationTestFixture _fixture;
+
+        public HttpContextExtensionsTests(ApiGatewayIntegrationTestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Theory]
+        [MemberData(nameof(HttpContextTestCases.V1TestCases), MemberType = typeof(HttpContextTestCases))]
+        public async Task IntegrationTest_APIGatewayV1_REST(string testName, ApiGatewayTestCaseForRequest testCase)
+        {
+            var route = testCase.ApiGatewayRouteConfig?.Path ?? "/test";
+            await _fixture.ApiGatewayHelper.AddRouteToRestApi(_fixture.ReturnFullEventRestApiId, _fixture.ReturnFullEventLambdaFunctionArn, route);
+            await RunApiGatewayTest<APIGatewayProxyRequest>(testCase, _fixture.ReturnFullEventRestApiUrl,
+                (context, config) => context.ToApiGatewayRequest(config), true);
+        }
+
+        [Theory]
+        [MemberData(nameof(HttpContextTestCases.V1TestCases), MemberType = typeof(HttpContextTestCases))]
+        public async Task IntegrationTest_APIGatewayV1_HTTP(string testName, ApiGatewayTestCaseForRequest testCase)
+        {
+            var route = testCase.ApiGatewayRouteConfig?.Path ?? "/test";
+            var routeKey = testCase.ApiGatewayRouteConfig?.HttpMethod ?? "POST";
+            await _fixture.ApiGatewayHelper.AddRouteToHttpApi(_fixture.ReturnFullEventHttpApiV1Id, _fixture.ReturnFullEventLambdaFunctionArn, "1.0", route, routeKey);
+            await RunApiGatewayTest<APIGatewayProxyRequest>(testCase, _fixture.ReturnFullEventHttpApiV1Url,
+                (context, config) => context.ToApiGatewayRequest(config), false);
+        }
+
+        [Theory]
+        [MemberData(nameof(HttpContextTestCases.V2TestCases), MemberType = typeof(HttpContextTestCases))]
+        public async Task IntegrationTest_APIGatewayV2(string testName, ApiGatewayTestCaseForRequest testCase)
+        {
+            var route = testCase.ApiGatewayRouteConfig?.Path ?? "/test";
+            var routeKey = testCase.ApiGatewayRouteConfig?.HttpMethod ?? "POST";
+            await _fixture.ApiGatewayHelper.AddRouteToHttpApi(_fixture.ReturnFullEventHttpApiV2Id, _fixture.ReturnFullEventLambdaFunctionArn, "2.0", route, routeKey);
+            await RunApiGatewayTest<APIGatewayHttpApiV2ProxyRequest>(testCase, _fixture.ReturnFullEventHttpApiV2Url,
+                (context, config) => context.ToApiGatewayHttpV2Request(config), false);
+        }
+
+        private async Task RunApiGatewayTest<T>(ApiGatewayTestCaseForRequest testCase, string apiUrl, Func<HttpContext, ApiGatewayRouteConfig, T> toApiGatewayRequest, bool isRestAPI)
+            where T : class
+        {
+            var httpClient = new HttpClient();
+
+            var uri = new Uri(apiUrl);
+            var baseUrl = $"{uri.Scheme}://{uri.Authority}";
+            var stageName = isRestAPI ? "/test" : ""; // matching hardcoded test stage name for rest api. TODO update this logic later to not be hardcoded
+            var actualPath = ResolveActualPath(testCase.ApiGatewayRouteConfig.Path, testCase.HttpContext.Request.Path);
+            var fullUrl = baseUrl + stageName + actualPath + testCase.HttpContext.Request.QueryString;
+
+
+            var httpRequest = CreateHttpRequestMessage(testCase.HttpContext, fullUrl);
+
+            var response = await httpClient.SendAsync(httpRequest);
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(200, (int)response.StatusCode);
+            Assert.Equal("application/json", response.Content.Headers.ContentType?.ToString());
+
+            var actualApiGatewayRequest = JsonSerializer.Deserialize<T>(responseContent,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            var expectedApiGatewayRequest = toApiGatewayRequest(testCase.HttpContext, testCase.ApiGatewayRouteConfig);
+
+            CompareApiGatewayRequests(expectedApiGatewayRequest, actualApiGatewayRequest);
+
+            testCase.Assertions(actualApiGatewayRequest);
+
+            await Task.Delay(1000); // Small delay between requests
+        }
+
+        private void CompareApiGatewayRequests<T>(T expected, T actual) where T : class
+        {
+            if (expected is APIGatewayProxyRequest v1Expected && actual is APIGatewayProxyRequest v1Actual)
+            {
+                CompareApiGatewayV1Requests(v1Expected, v1Actual);
+            }
+            else if (expected is APIGatewayHttpApiV2ProxyRequest v2Expected && actual is APIGatewayHttpApiV2ProxyRequest v2Actual)
+            {
+                CompareApiGatewayV2Requests(v2Expected, v2Actual);
+            }
+            else
+            {
+                throw new ArgumentException("Unsupported type for comparison");
+            }
+        }
+
+        private void CompareApiGatewayV1Requests(APIGatewayProxyRequest expected, APIGatewayProxyRequest actual)
+        {
+            Assert.Equal(expected.HttpMethod, actual.HttpMethod);
+            Assert.Equal(expected.Path, actual.Path);
+            Assert.Equal(expected.Resource, actual.Resource);
+            Assert.Equal(expected.Body, actual.Body);
+            Assert.Equal(expected.IsBase64Encoded, actual.IsBase64Encoded);
+
+            CompareHeaders(expected.Headers, actual.Headers);
+            CompareMultiValueHeaders(expected.MultiValueHeaders, actual.MultiValueHeaders);
+            CompareDictionaries(expected.QueryStringParameters, actual.QueryStringParameters);
+            CompareDictionaries(expected.PathParameters, actual.PathParameters);
+            CompareDictionaries(expected.StageVariables, actual.StageVariables);
+            CompareDictionaries(expected.MultiValueQueryStringParameters, actual.MultiValueQueryStringParameters);
+        }
+
+        private void CompareApiGatewayV2Requests(APIGatewayHttpApiV2ProxyRequest expected, APIGatewayHttpApiV2ProxyRequest actual)
+        {
+            Assert.Equal(expected.RouteKey, actual.RouteKey);
+            Assert.Equal(expected.RawPath, actual.RawPath);
+            Assert.Equal(expected.RawQueryString, actual.RawQueryString);
+            Assert.Equal(expected.Body, actual.Body);
+            Assert.Equal(expected.IsBase64Encoded, actual.IsBase64Encoded);
+            Assert.Equal(expected.Version, actual.Version);
+
+            CompareHeaders(expected.Headers, actual.Headers);
+            CompareDictionaries(expected.QueryStringParameters, actual.QueryStringParameters);
+            CompareDictionaries(expected.PathParameters, actual.PathParameters);
+            CompareStringArrays(expected.Cookies, actual.Cookies);
+
+            CompareRequestContexts(expected.RequestContext, actual.RequestContext);
+        }
+
+        private void CompareHeaders(IDictionary<string, string> expected, IDictionary<string, string> actual)
+        {
+            var expectedFiltered = FilterHeaders(expected);
+            var actualFiltered = FilterHeaders(actual);
+
+            Assert.Equal(expectedFiltered.Count, actualFiltered.Count);
+
+            foreach (var kvp in expectedFiltered)
+            {
+                Assert.True(actualFiltered.Keys.Any(k => string.Equals(k, kvp.Key, StringComparison.OrdinalIgnoreCase)),
+                    $"Actual headers do not contain key: {kvp.Key}");
+
+                var actualValue = actualFiltered.First(pair => string.Equals(pair.Key, kvp.Key, StringComparison.OrdinalIgnoreCase)).Value;
+                Assert.Equal(kvp.Value, actualValue);
+            }
+        }
+
+        private void CompareMultiValueHeaders(IDictionary<string, IList<string>> expected, IDictionary<string, IList<string>> actual)
+        {
+            var expectedFiltered = FilterHeaders(expected);
+            var actualFiltered = FilterHeaders(actual);
+
+            Assert.Equal(expectedFiltered.Count, actualFiltered.Count);
+
+            foreach (var kvp in expectedFiltered)
+            {
+                Assert.True(actualFiltered.Keys.Any(k => string.Equals(k, kvp.Key, StringComparison.OrdinalIgnoreCase)),
+                    $"Actual headers do not contain key: {kvp.Key}");
+
+                var actualValue = actualFiltered.First(pair => string.Equals(pair.Key, kvp.Key, StringComparison.OrdinalIgnoreCase)).Value;
+                Assert.Equal(kvp.Value, actualValue);
+            }
+        }
+
+        private IDictionary<TKey, TValue> FilterHeaders<TKey, TValue>(IDictionary<TKey, TValue> headers)
+        {
+            return headers.Where(kvp =>
+                !(kvp.Key.ToString().StartsWith("x-forwarded-", StringComparison.OrdinalIgnoreCase) || // ignore these for now
+                  kvp.Key.ToString().StartsWith("cloudfront-", StringComparison.OrdinalIgnoreCase) || // ignore these for now
+                  kvp.Key.ToString().StartsWith("via-", StringComparison.OrdinalIgnoreCase) || // ignore these for now
+                  kvp.Key.ToString().Equals("x-amzn-trace-id", StringComparison.OrdinalIgnoreCase) || // this is dynamic so ignoring for now
+                  kvp.Key.ToString().Equals("cookie", StringComparison.OrdinalIgnoreCase) || // TODO may have to have api gateway v2 not set this in headers
+                  kvp.Key.ToString().Equals("host", StringComparison.OrdinalIgnoreCase))) // TODO we may want to set this
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        }
+
+
+        private void CompareDictionaries<TKey, TValue>(IDictionary<TKey, TValue> expected, IDictionary<TKey, TValue> actual)
+        {
+            if (expected == null && actual == null) return;
+            Assert.Equal(expected.Count, actual.Count);
+
+            foreach (var kvp in expected)
+            {
+                Assert.True(actual.ContainsKey(kvp.Key), $"Actual does not contain key: {kvp.Key}");
+                Assert.Equal(kvp.Value, actual[kvp.Key]);
+            }
+        }
+
+        private void CompareStringArrays(string[] expected, string[] actual)
+        {
+            Assert.Equal(expected?.Length, actual?.Length);
+            if (expected != null)
+            {
+                Assert.Equal(expected.OrderBy(x => x), actual.OrderBy(x => x));
+            }
+        }
+
+        private void CompareRequestContexts(APIGatewayHttpApiV2ProxyRequest.ProxyRequestContext expected, APIGatewayHttpApiV2ProxyRequest.ProxyRequestContext actual)
+        {
+            Assert.Equal(expected.RouteKey, actual.RouteKey);
+
+            Assert.Equal(expected.Http.Method, actual.Http.Method);
+            Assert.Equal(expected.Http.Path, actual.Http.Path);
+            Assert.Equal(expected.Http.Protocol, actual.Http.Protocol);
+            Assert.Equal(expected.Http.UserAgent, actual.Http.UserAgent);
+        }
+
+        private string ResolveActualPath(string routeWithPlaceholders, string actualPath)
+        {
+            var routeParts = routeWithPlaceholders.Split('/');
+            var actualParts = actualPath.Split('/');
+
+            if (routeParts.Length != actualParts.Length)
+            {
+                throw new ArgumentException("Route and actual path have different number of segments");
+            }
+
+            var resolvedParts = new List<string>();
+            for (int i = 0; i < routeParts.Length; i++)
+            {
+                if (routeParts[i].StartsWith("{") && routeParts[i].EndsWith("}"))
+                {
+                    resolvedParts.Add(actualParts[i]);
+                }
+                else
+                {
+                    resolvedParts.Add(routeParts[i]);
+                }
+            }
+
+            return string.Join("/", resolvedParts);
+        }
+
+        private HttpRequestMessage CreateHttpRequestMessage(HttpContext context, string fullUrl)
+        {
+            var request = context.Request;
+            var httpRequest = new HttpRequestMessage(new HttpMethod(request.Method), fullUrl);
+
+            foreach (var header in request.Headers)
+            {
+                httpRequest.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray());
+            }
+
+            if (request.ContentLength > 0)
+            {
+                var bodyStream = new MemoryStream();
+                request.Body.CopyTo(bodyStream);
+                bodyStream.Position = 0;
+                httpRequest.Content = new StreamContent(bodyStream);
+
+                // Set Content-Type if present in the original request
+                if (request.ContentType != null)
+                {
+                    httpRequest.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(request.ContentType);
+                }
+            }
+            else
+            {
+                httpRequest.Content = new StringContent(string.Empty);
+            }
+
+
+
+            httpRequest.Version = HttpVersion.Version11;
+
+            return httpRequest;
+        }
+    }
+}

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/cloudformation-template-apigateway.yaml
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/cloudformation-template-apigateway.yaml
@@ -82,6 +82,9 @@ Resources:
     Type: 'AWS::ApiGateway::RestApi'
     Properties:
       Name: !Sub '${AWS::StackName}-ParseAndReturnBodyRestAPI'
+      EndpointConfiguration:
+        Types:
+          - REGIONAL
 
   ParseAndReturnBodyRestApiResource:
     Type: 'AWS::ApiGateway::Resource'
@@ -176,6 +179,9 @@ Resources:
     Type: 'AWS::ApiGateway::RestApi'
     Properties:
       Name: !Sub '${AWS::StackName}-ReturnRawBodyRestAPI'
+      EndpointConfiguration:
+        Types:
+          - REGIONAL
 
   ReturnRawBodyRestApiResource:
     Type: 'AWS::ApiGateway::Resource'
@@ -270,6 +276,9 @@ Resources:
     Type: 'AWS::ApiGateway::RestApi'
     Properties:
       Name: !Sub '${AWS::StackName}-ReturnFullEventRestAPI'
+      EndpointConfiguration:
+        Types:
+          - REGIONAL
 
   ReturnFullEventRestApiResource:
     Type: 'AWS::ApiGateway::Resource'
@@ -436,6 +445,9 @@ Resources:
     Type: 'AWS::ApiGateway::RestApi'
     Properties:
       Name: !Sub '${AWS::StackName}-ReturnDecodedParseBinRestAPI'
+      EndpointConfiguration:
+        Types:
+          - REGIONAL
       BinaryMediaTypes:
         - '*/*'
 

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/cloudformation-template-apigateway.yaml
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/cloudformation-template-apigateway.yaml
@@ -3,10 +3,10 @@ Description: 'CloudFormation template for API Gateway and Lambda integration tes
 
 Resources:
 
-  TestLambdaFunction:
+  ParseAndReturnBodyLambdaFunction:
     Type: 'AWS::Lambda::Function'
     Properties:
-      FunctionName: !Sub '${AWS::StackName}-TestFunction'
+      FunctionName: !Sub '${AWS::StackName}-ParseAndReturnBodyFunction'
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Code:
@@ -16,10 +16,10 @@ Resources:
           };
       Runtime: nodejs20.x
 
-  BinaryLambdaFunction:
+  ReturnDecodedParseBinLambdaFunction:
     Type: 'AWS::Lambda::Function'
     Properties:
-      FunctionName: !Sub '${AWS::StackName}-BinaryFunction'
+      FunctionName: !Sub '${AWS::StackName}-ReturnDecodedParseBinFunction'
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Code:
@@ -31,10 +31,10 @@ Resources:
           };
       Runtime: nodejs20.x
 
-  ReturnRawRequestBodyLambdaFunction:
+  ReturnRawBodyLambdaFunction:
     Type: 'AWS::Lambda::Function'
     Properties:
-      FunctionName: !Sub '${AWS::StackName}-ReturnRawRequestBodyFunction'
+      FunctionName: !Sub '${AWS::StackName}-ReturnRawBodyFunction'
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Code:
@@ -42,6 +42,25 @@ Resources:
           exports.handler = async (event, context, callback) => {
             console.log(event);
             callback(null, event.body);
+          };
+      Runtime: nodejs20.x
+
+  ReturnFullEventLambdaFunction:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      FunctionName: !Sub '${AWS::StackName}-ReturnFullEventFunction'
+      Handler: index.handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Code:
+        ZipFile: |
+          exports.handler = async (event) => {
+            return {
+              statusCode: 200,
+              headers: {
+                'Content-Type': 'application/json'
+              },
+              body: JSON.stringify(event)
+            };
           };
       Runtime: nodejs20.x
 
@@ -58,240 +77,491 @@ Resources:
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
 
-  RestApi:
+  # ParseAndReturnBody APIs
+  ParseAndReturnBodyRestApi:
     Type: 'AWS::ApiGateway::RestApi'
     Properties:
-      Name: !Sub '${AWS::StackName}-RestAPI'
+      Name: !Sub '${AWS::StackName}-ParseAndReturnBodyRestAPI'
 
-  RestApiResource:
+  ParseAndReturnBodyRestApiResource:
     Type: 'AWS::ApiGateway::Resource'
     Properties:
-      ParentId: !GetAtt RestApi.RootResourceId
+      ParentId: !GetAtt ParseAndReturnBodyRestApi.RootResourceId
       PathPart: 'test'
-      RestApiId: !Ref RestApi
+      RestApiId: !Ref ParseAndReturnBodyRestApi
 
-  RestApiMethod:
+  ParseAndReturnBodyRestApiMethod:
     Type: 'AWS::ApiGateway::Method'
     Properties:
       HttpMethod: POST
-      ResourceId: !Ref RestApiResource
-      RestApiId: !Ref RestApi
+      ResourceId: !Ref ParseAndReturnBodyRestApiResource
+      RestApiId: !Ref ParseAndReturnBodyRestApi
       AuthorizationType: NONE
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TestLambdaFunction.Arn}/invocations'
+        Uri: !Sub 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParseAndReturnBodyLambdaFunction.Arn}/invocations'
 
-  RestApiDeployment:
+  ParseAndReturnBodyRestApiDeployment:
     Type: 'AWS::ApiGateway::Deployment'
-    DependsOn: RestApiMethod
+    DependsOn: ParseAndReturnBodyRestApiMethod
     Properties:
-      RestApiId: !Ref RestApi
+      RestApiId: !Ref ParseAndReturnBodyRestApi
       StageName: 'test'
 
-  HttpApiV1:
+  ParseAndReturnBodyHttpApiV1:
     Type: 'AWS::ApiGatewayV2::Api'
     Properties:
-      Name: !Sub '${AWS::StackName}-HttpAPIv1'
+      Name: !Sub '${AWS::StackName}-ParseAndReturnBodyHttpAPIv1'
       ProtocolType: HTTP
 
-  HttpApiV1Integration:
+  ParseAndReturnBodyHttpApiV1Integration:
     Type: 'AWS::ApiGatewayV2::Integration'
     Properties:
-      ApiId: !Ref HttpApiV1
+      ApiId: !Ref ParseAndReturnBodyHttpApiV1
       IntegrationType: AWS_PROXY
-      IntegrationUri: !GetAtt TestLambdaFunction.Arn
+      IntegrationUri: !GetAtt ParseAndReturnBodyLambdaFunction.Arn
       PayloadFormatVersion: '1.0'
 
-  HttpApiV1Route:
+  ParseAndReturnBodyHttpApiV1Route:
     Type: 'AWS::ApiGatewayV2::Route'
     Properties:
-      ApiId: !Ref HttpApiV1
+      ApiId: !Ref ParseAndReturnBodyHttpApiV1
       RouteKey: 'POST /test'
       Target: !Join
         - /
         - - integrations
-          - !Ref HttpApiV1Integration
+          - !Ref ParseAndReturnBodyHttpApiV1Integration
 
-  HttpApiV1Stage:
+  ParseAndReturnBodyHttpApiV1Stage:
     Type: 'AWS::ApiGatewayV2::Stage'
     Properties:
-      ApiId: !Ref HttpApiV1
+      ApiId: !Ref ParseAndReturnBodyHttpApiV1
       StageName: '$default'
       AutoDeploy: true
 
-  HttpApiV2:
+  ParseAndReturnBodyHttpApiV2:
     Type: 'AWS::ApiGatewayV2::Api'
     Properties:
-      Name: !Sub '${AWS::StackName}-HttpAPIv2'
+      Name: !Sub '${AWS::StackName}-ParseAndReturnBodyHttpAPIv2'
       ProtocolType: HTTP
 
-  HttpApiV2Integration:
+  ParseAndReturnBodyHttpApiV2Integration:
     Type: 'AWS::ApiGatewayV2::Integration'
     Properties:
-      ApiId: !Ref HttpApiV2
+      ApiId: !Ref ParseAndReturnBodyHttpApiV2
       IntegrationType: AWS_PROXY
-      IntegrationUri: !GetAtt TestLambdaFunction.Arn
+      IntegrationUri: !GetAtt ParseAndReturnBodyLambdaFunction.Arn
       PayloadFormatVersion: '2.0'
 
-  HttpApiV2Route:
+  ParseAndReturnBodyHttpApiV2Route:
     Type: 'AWS::ApiGatewayV2::Route'
     Properties:
-      ApiId: !Ref HttpApiV2
+      ApiId: !Ref ParseAndReturnBodyHttpApiV2
       RouteKey: 'POST /test'
       Target: !Join
         - /
         - - integrations
-          - !Ref HttpApiV2Integration
+          - !Ref ParseAndReturnBodyHttpApiV2Integration
 
-  HttpApiV2Stage:
+  ParseAndReturnBodyHttpApiV2Stage:
     Type: 'AWS::ApiGatewayV2::Stage'
     Properties:
-      ApiId: !Ref HttpApiV2
+      ApiId: !Ref ParseAndReturnBodyHttpApiV2
       StageName: '$default'
       AutoDeploy: true
 
-  ReturnRawRequestBodyHttpApi:
-    Type: 'AWS::ApiGatewayV2::Api'
-    Properties:
-      Name: !Sub '${AWS::StackName}-ReturnRawRequestBodyHttpAPI'
-      ProtocolType: HTTP
-
-  ReturnRawRequestBodyHttpApiIntegration:
-    Type: 'AWS::ApiGatewayV2::Integration'
-    Properties:
-      ApiId: !Ref ReturnRawRequestBodyHttpApi
-      IntegrationType: AWS_PROXY
-      IntegrationUri: !GetAtt ReturnRawRequestBodyLambdaFunction.Arn
-      PayloadFormatVersion: '2.0'
-
-  ReturnRawRequestBodyHttpApiRoute:
-    Type: 'AWS::ApiGatewayV2::Route'
-    Properties:
-      ApiId: !Ref ReturnRawRequestBodyHttpApi
-      RouteKey: 'POST /'
-      Target: !Join
-        - /
-        - - integrations
-          - !Ref ReturnRawRequestBodyHttpApiIntegration
-
-  ReturnRawRequestBodyHttpApiStage:
-    Type: 'AWS::ApiGatewayV2::Stage'
-    Properties:
-      ApiId: !Ref ReturnRawRequestBodyHttpApi
-      StageName: '$default'
-      AutoDeploy: true
-
-  LambdaPermissionRestApi:
-    Type: 'AWS::Lambda::Permission'
-    Properties:
-      Action: 'lambda:InvokeFunction'
-      FunctionName: !GetAtt TestLambdaFunction.Arn
-      Principal: apigateway.amazonaws.com
-      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${RestApi}/*'
-
-  LambdaPermissionHttpApiV1:
-    Type: 'AWS::Lambda::Permission'
-    Properties:
-      Action: 'lambda:InvokeFunction'
-      FunctionName: !GetAtt TestLambdaFunction.Arn
-      Principal: apigateway.amazonaws.com
-      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${HttpApiV1}/*'
-
-  LambdaPermissionHttpApiV2:
-    Type: 'AWS::Lambda::Permission'
-    Properties:
-      Action: 'lambda:InvokeFunction'
-      FunctionName: !GetAtt TestLambdaFunction.Arn
-      Principal: apigateway.amazonaws.com
-      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${HttpApiV2}/*'
-
-  LambdaPermissionReturnRawRequestBodyHttpApi:
-    Type: 'AWS::Lambda::Permission'
-    Properties:
-      Action: 'lambda:InvokeFunction'
-      FunctionName: !GetAtt ReturnRawRequestBodyLambdaFunction.Arn
-      Principal: apigateway.amazonaws.com
-      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ReturnRawRequestBodyHttpApi}/*'
-
-  BinaryMediaRestApi:
+  # ReturnRawBody APIs
+  ReturnRawBodyRestApi:
     Type: 'AWS::ApiGateway::RestApi'
     Properties:
-      Name: !Sub '${AWS::StackName}-BinaryMediaRestAPI'
+      Name: !Sub '${AWS::StackName}-ReturnRawBodyRestAPI'
+
+  ReturnRawBodyRestApiResource:
+    Type: 'AWS::ApiGateway::Resource'
+    Properties:
+      ParentId: !GetAtt ReturnRawBodyRestApi.RootResourceId
+      PathPart: 'test'
+      RestApiId: !Ref ReturnRawBodyRestApi
+
+  ReturnRawBodyRestApiMethod:
+    Type: 'AWS::ApiGateway::Method'
+    Properties:
+      HttpMethod: POST
+      ResourceId: !Ref ReturnRawBodyRestApiResource
+      RestApiId: !Ref ReturnRawBodyRestApi
+      AuthorizationType: NONE
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST
+        Uri: !Sub 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ReturnRawBodyLambdaFunction.Arn}/invocations'
+
+  ReturnRawBodyRestApiDeployment:
+    Type: 'AWS::ApiGateway::Deployment'
+    DependsOn: ReturnRawBodyRestApiMethod
+    Properties:
+      RestApiId: !Ref ReturnRawBodyRestApi
+      StageName: 'test'
+
+  ReturnRawBodyHttpApiV1:
+    Type: 'AWS::ApiGatewayV2::Api'
+    Properties:
+      Name: !Sub '${AWS::StackName}-ReturnRawBodyHttpAPIv1'
+      ProtocolType: HTTP
+
+  ReturnRawBodyHttpApiV1Integration:
+    Type: 'AWS::ApiGatewayV2::Integration'
+    Properties:
+      ApiId: !Ref ReturnRawBodyHttpApiV1
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !GetAtt ReturnRawBodyLambdaFunction.Arn
+      PayloadFormatVersion: '1.0'
+
+  ReturnRawBodyHttpApiV1Route:
+    Type: 'AWS::ApiGatewayV2::Route'
+    Properties:
+      ApiId: !Ref ReturnRawBodyHttpApiV1
+      RouteKey: 'POST /test'
+      Target: !Join
+        - /
+        - - integrations
+          - !Ref ReturnRawBodyHttpApiV1Integration
+
+  ReturnRawBodyHttpApiV1Stage:
+    Type: 'AWS::ApiGatewayV2::Stage'
+    Properties:
+      ApiId: !Ref ReturnRawBodyHttpApiV1
+      StageName: '$default'
+      AutoDeploy: true
+
+  ReturnRawBodyHttpApiV2:
+    Type: 'AWS::ApiGatewayV2::Api'
+    Properties:
+      Name: !Sub '${AWS::StackName}-ReturnRawBodyHttpAPIv2'
+      ProtocolType: HTTP
+
+  ReturnRawBodyHttpApiV2Integration:
+    Type: 'AWS::ApiGatewayV2::Integration'
+    Properties:
+      ApiId: !Ref ReturnRawBodyHttpApiV2
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !GetAtt ReturnRawBodyLambdaFunction.Arn
+      PayloadFormatVersion: '2.0'
+
+  ReturnRawBodyHttpApiV2Route:
+    Type: 'AWS::ApiGatewayV2::Route'
+    Properties:
+      ApiId: !Ref ReturnRawBodyHttpApiV2
+      RouteKey: 'POST /test'
+      Target: !Join
+        - /
+        - - integrations
+          - !Ref ReturnRawBodyHttpApiV2Integration
+
+  ReturnRawBodyHttpApiV2Stage:
+    Type: 'AWS::ApiGatewayV2::Stage'
+    Properties:
+      ApiId: !Ref ReturnRawBodyHttpApiV2
+      StageName: '$default'
+      AutoDeploy: true
+
+  # ReturnFullEvent APIs
+  ReturnFullEventRestApi:
+    Type: 'AWS::ApiGateway::RestApi'
+    Properties:
+      Name: !Sub '${AWS::StackName}-ReturnFullEventRestAPI'
+
+  ReturnFullEventRestApiResource:
+    Type: 'AWS::ApiGateway::Resource'
+    Properties:
+      ParentId: !GetAtt ReturnFullEventRestApi.RootResourceId
+      PathPart: 'test'
+      RestApiId: !Ref ReturnFullEventRestApi
+
+  ReturnFullEventRestApiMethod:
+    Type: 'AWS::ApiGateway::Method'
+    Properties:
+      HttpMethod: POST
+      ResourceId: !Ref ReturnFullEventRestApiResource
+      RestApiId: !Ref ReturnFullEventRestApi
+      AuthorizationType: NONE
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST
+        Uri: !Sub 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ReturnFullEventLambdaFunction.Arn}/invocations'
+
+  ReturnFullEventRestApiDeployment:
+    Type: 'AWS::ApiGateway::Deployment'
+    DependsOn: ReturnFullEventRestApiMethod
+    Properties:
+      RestApiId: !Ref ReturnFullEventRestApi
+      StageName: 'test'
+
+  ReturnFullEventHttpApiV1:
+    Type: 'AWS::ApiGatewayV2::Api'
+    Properties:
+      Name: !Sub '${AWS::StackName}-ReturnFullEventHttpAPIv1'
+      ProtocolType: HTTP
+
+  ReturnFullEventHttpApiV1Integration:
+    Type: 'AWS::ApiGatewayV2::Integration'
+    Properties:
+      ApiId: !Ref ReturnFullEventHttpApiV1
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !GetAtt ReturnFullEventLambdaFunction.Arn
+      PayloadFormatVersion: '1.0'
+
+  ReturnFullEventHttpApiV1Route:
+    Type: 'AWS::ApiGatewayV2::Route'
+    Properties:
+      ApiId: !Ref ReturnFullEventHttpApiV1
+      RouteKey: 'POST /test'
+      Target: !Join
+        - /
+        - - integrations
+          - !Ref ReturnFullEventHttpApiV1Integration
+
+  ReturnFullEventHttpApiV1Stage:
+    Type: 'AWS::ApiGatewayV2::Stage'
+    Properties:
+      ApiId: !Ref ReturnFullEventHttpApiV1
+      StageName: '$default'
+      AutoDeploy: true
+
+  ReturnFullEventHttpApiV2:
+    Type: 'AWS::ApiGatewayV2::Api'
+    Properties:
+      Name: !Sub '${AWS::StackName}-ReturnFullEventHttpAPIv2'
+      ProtocolType: HTTP
+
+  ReturnFullEventHttpApiV2Integration:
+    Type: 'AWS::ApiGatewayV2::Integration'
+    Properties:
+      ApiId: !Ref ReturnFullEventHttpApiV2
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !GetAtt ReturnFullEventLambdaFunction.Arn
+      PayloadFormatVersion: '2.0'
+
+  ReturnFullEventHttpApiV2Route:
+    Type: 'AWS::ApiGatewayV2::Route'
+    Properties:
+      ApiId: !Ref ReturnFullEventHttpApiV2
+      RouteKey: 'POST /test'
+      Target: !Join
+        - /
+        - - integrations
+          - !Ref ReturnFullEventHttpApiV2Integration
+
+  ReturnFullEventHttpApiV2Stage:
+    Type: 'AWS::ApiGatewayV2::Stage'
+    Properties:
+      ApiId: !Ref ReturnFullEventHttpApiV2
+      StageName: '$default'
+      AutoDeploy: true
+
+  # Lambda Permissions
+  LambdaPermissionParseAndReturnBodyRestApi:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !GetAtt ParseAndReturnBodyLambdaFunction.Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ParseAndReturnBodyRestApi}/*'
+
+  LambdaPermissionParseAndReturnBodyHttpApiV1:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !GetAtt ParseAndReturnBodyLambdaFunction.Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ParseAndReturnBodyHttpApiV1}/*'
+
+  LambdaPermissionParseAndReturnBodyHttpApiV2:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !GetAtt ParseAndReturnBodyLambdaFunction.Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ParseAndReturnBodyHttpApiV2}/*'
+
+  LambdaPermissionReturnRawBodyRestApi:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !GetAtt ReturnRawBodyLambdaFunction.Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ReturnRawBodyRestApi}/*'
+
+  LambdaPermissionReturnRawBodyHttpApiV1:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !GetAtt ReturnRawBodyLambdaFunction.Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ReturnRawBodyHttpApiV1}/*'
+
+  LambdaPermissionReturnRawBodyHttpApiV2:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !GetAtt ReturnRawBodyLambdaFunction.Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ReturnRawBodyHttpApiV2}/*'
+
+  LambdaPermissionReturnFullEventRestApi:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !GetAtt ReturnFullEventLambdaFunction.Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ReturnFullEventRestApi}/*'
+
+  LambdaPermissionReturnFullEventHttpApiV1:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !GetAtt ReturnFullEventLambdaFunction.Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ReturnFullEventHttpApiV1}/*'
+
+  LambdaPermissionReturnFullEventHttpApiV2:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !GetAtt ReturnFullEventLambdaFunction.Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ReturnFullEventHttpApiV2}/*'
+
+  ReturnDecodedParseBinRestApi:
+    Type: 'AWS::ApiGateway::RestApi'
+    Properties:
+      Name: !Sub '${AWS::StackName}-ReturnDecodedParseBinRestAPI'
       BinaryMediaTypes:
         - '*/*'
 
-  BinaryMediaRestApiResource:
+  ReturnDecodedParseBinRestApiResource:
     Type: 'AWS::ApiGateway::Resource'
     Properties:
-      ParentId: !GetAtt BinaryMediaRestApi.RootResourceId
+      ParentId: !GetAtt ReturnDecodedParseBinRestApi.RootResourceId
       PathPart: 'test'
-      RestApiId: !Ref BinaryMediaRestApi
+      RestApiId: !Ref ReturnDecodedParseBinRestApi
 
-  BinaryMediaRestApiMethod:
+  ReturnDecodedParseBinRestApiMethod:
     Type: 'AWS::ApiGateway::Method'
     Properties:
       HttpMethod: POST
-      ResourceId: !Ref BinaryMediaRestApiResource
-      RestApiId: !Ref BinaryMediaRestApi
+      ResourceId: !Ref ReturnDecodedParseBinRestApiResource
+      RestApiId: !Ref ReturnDecodedParseBinRestApi
       AuthorizationType: NONE
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BinaryLambdaFunction.Arn}/invocations'
+        Uri: !Sub 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ReturnDecodedParseBinLambdaFunction.Arn}/invocations'
 
-  BinaryMediaRestApiDeployment:
+  ReturnDecodedParseBinRestApiDeployment:
     Type: 'AWS::ApiGateway::Deployment'
-    DependsOn: BinaryMediaRestApiMethod
+    DependsOn: ReturnDecodedParseBinRestApiMethod
     Properties:
-      RestApiId: !Ref BinaryMediaRestApi
+      RestApiId: !Ref ReturnDecodedParseBinRestApi
       StageName: 'test'
 
-  LambdaPermissionBinaryMediaRestApi:
+  LambdaPermissionReturnDecodedParseBinRestApi:
     Type: 'AWS::Lambda::Permission'
     Properties:
       Action: 'lambda:InvokeFunction'
-      FunctionName: !GetAtt BinaryLambdaFunction.Arn
+      FunctionName: !GetAtt ReturnDecodedParseBinLambdaFunction.Arn
       Principal: apigateway.amazonaws.com
-      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${BinaryMediaRestApi}/*'
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ReturnDecodedParseBinRestApi}/*'
 
 Outputs:
-  RestApiId:
-    Description: 'ID of the REST API'
-    Value: !Ref RestApi
+  ParseAndReturnBodyRestApiId:
+    Description: 'ID of the Parse and Return Body REST API'
+    Value: !Ref ParseAndReturnBodyRestApi
 
-  RestApiUrl:
-    Description: 'URL of the REST API'
-    Value: !Sub 'https://${RestApi}.execute-api.${AWS::Region}.amazonaws.com/test/test'
+  ParseAndReturnBodyRestApiUrl:
+    Description: 'URL of the Parse and Return Body REST API'
+    Value: !Sub 'https://${ParseAndReturnBodyRestApi}.execute-api.${AWS::Region}.amazonaws.com/test/test'
 
-  HttpApiV1Id:
-    Description: 'ID of the HTTP API v1'
-    Value: !Ref HttpApiV1
+  ParseAndReturnBodyHttpApiV1Id:
+    Description: 'ID of the Parse and Return Body HTTP API v1'
+    Value: !Ref ParseAndReturnBodyHttpApiV1
 
-  HttpApiV1Url:
-    Description: 'URL of the HTTP API v1'
-    Value: !Sub 'https://${HttpApiV1}.execute-api.${AWS::Region}.amazonaws.com/test'
+  ParseAndReturnBodyHttpApiV1Url:
+    Description: 'URL of the Parse and Return Body HTTP API v1'
+    Value: !Sub 'https://${ParseAndReturnBodyHttpApiV1}.execute-api.${AWS::Region}.amazonaws.com/test'
 
-  HttpApiV2Id:
-    Description: 'ID of the HTTP API v2'
-    Value: !Ref HttpApiV2
+  ParseAndReturnBodyHttpApiV2Id:
+    Description: 'ID of the Parse and Return Body HTTP API v2'
+    Value: !Ref ParseAndReturnBodyHttpApiV2
 
-  HttpApiV2Url:
-    Description: 'URL of the HTTP API v2'
-    Value: !Sub 'https://${HttpApiV2}.execute-api.${AWS::Region}.amazonaws.com/test'
+  ParseAndReturnBodyHttpApiV2Url:
+    Description: 'URL of the Parse and Return Body HTTP API v2'
+    Value: !Sub 'https://${ParseAndReturnBodyHttpApiV2}.execute-api.${AWS::Region}.amazonaws.com/test'
 
-  ReturnRawRequestBodyHttpApiId:
-    Description: 'ID of the JSON Inference HTTP API'
-    Value: !Ref ReturnRawRequestBodyHttpApi
+  ReturnRawBodyRestApiId:
+    Description: 'ID of the Return Raw Body REST API'
+    Value: !Ref ReturnRawBodyRestApi
 
-  ReturnRawRequestBodyHttpApiUrl:
-    Description: 'URL of the JSON Inference HTTP API'
-    Value: !Sub 'https://${ReturnRawRequestBodyHttpApi}.execute-api.${AWS::Region}.amazonaws.com/'
+  ReturnRawBodyRestApiUrl:
+    Description: 'URL of the Return Raw Body REST API'
+    Value: !Sub 'https://${ReturnRawBodyRestApi}.execute-api.${AWS::Region}.amazonaws.com/test/test'
 
-  BinaryMediaRestApiId:
-      Description: 'ID of the Binary Media REST API'
-      Value: !Ref BinaryMediaRestApi
+  ReturnRawBodyHttpApiV1Id:
+    Description: 'ID of the Return Raw Body HTTP API v1'
+    Value: !Ref ReturnRawBodyHttpApiV1
 
-  BinaryMediaRestApiUrl:
-      Description: 'URL of the Binary Media REST API'
-      Value: !Sub 'https://${BinaryMediaRestApi}.execute-api.${AWS::Region}.amazonaws.com/test/test'
+  ReturnRawBodyHttpApiV1Url:
+    Description: 'URL of the Return Raw Body HTTP API v1'
+    Value: !Sub 'https://${ReturnRawBodyHttpApiV1}.execute-api.${AWS::Region}.amazonaws.com/test'
+
+  ReturnRawBodyHttpApiV2Id:
+    Description: 'ID of the Return Raw Body HTTP API v2'
+    Value: !Ref ReturnRawBodyHttpApiV2
+
+  ReturnRawBodyHttpApiV2Url:
+    Description: 'URL of the Return Raw Body HTTP API v2'
+    Value: !Sub 'https://${ReturnRawBodyHttpApiV2}.execute-api.${AWS::Region}.amazonaws.com/test'
+
+  ReturnFullEventRestApiId:
+    Description: 'ID of the Return Full Event REST API'
+    Value: !Ref ReturnFullEventRestApi
+
+  ReturnFullEventRestApiUrl:
+    Description: 'URL of the Return Full Event REST API'
+    Value: !Sub 'https://${ReturnFullEventRestApi}.execute-api.${AWS::Region}.amazonaws.com/test/test'
+
+  ReturnFullEventHttpApiV1Id:
+    Description: 'ID of the Return Full Event HTTP API v1'
+    Value: !Ref ReturnFullEventHttpApiV1
+
+  ReturnFullEventHttpApiV1Url:
+    Description: 'URL of the Return Full Event HTTP API v1'
+    Value: !Sub 'https://${ReturnFullEventHttpApiV1}.execute-api.${AWS::Region}.amazonaws.com/test'
+
+  ReturnFullEventHttpApiV2Id:
+    Description: 'ID of the Return Full Event HTTP API v2'
+    Value: !Ref ReturnFullEventHttpApiV2
+
+  ReturnFullEventHttpApiV2Url:
+    Description: 'URL of the Return Full Event HTTP API v2'
+    Value: !Sub 'https://${ReturnFullEventHttpApiV2}.execute-api.${AWS::Region}.amazonaws.com/test'
+
+  ParseAndReturnBodyLambdaFunctionArn:
+    Description: 'ARN of the Parse and Return Body Lambda Function'
+    Value: !GetAtt ParseAndReturnBodyLambdaFunction.Arn
+
+  ReturnRawBodyLambdaFunctionArn:
+    Description: 'ARN of the Return Raw Body Lambda Function'
+    Value: !GetAtt ReturnRawBodyLambdaFunction.Arn
+
+  ReturnFullEventLambdaFunctionArn:
+    Description: 'ARN of the Return Full Event Lambda Function'
+    Value: !GetAtt ReturnFullEventLambdaFunction.Arn
+
+  ReturnDecodedParseBinRestApiId:
+      Description: 'ID of the ReturnDecodedParseBin Media REST API'
+      Value: !Ref ReturnDecodedParseBinRestApi
+
+  ReturnDecodedParseBinRestApiUrl:
+      Description: 'URL of the ReturnDecodedParseBin Media REST API'
+      Value: !Sub 'https://${ReturnDecodedParseBinRestApi}.execute-api.${AWS::Region}.amazonaws.com/test/test'

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Extensions/HttpContextExtensionsTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Extensions/HttpContextExtensionsTests.cs
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Amazon.Lambda.TestTool.Extensions;
+using Amazon.Lambda.TestTool.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
 using static Amazon.Lambda.TestTool.UnitTests.Extensions.HttpContextTestCases;
 
 namespace Amazon.Lambda.TestTool.UnitTests.Extensions
@@ -10,30 +14,235 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
     {
         [Theory]
         [MemberData(nameof(HttpContextTestCases.V1TestCases), MemberType = typeof(HttpContextTestCases))]
-        public void ToApiGatewayRequest_ConvertsCorrectly(string testName, ApiGatewayTestCaseForRequest testCase)
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1026:Theory methods should use all of their parameters")]
+        public async Task ToApiGatewayRequestRest_ConvertsCorrectly(string testName, HttpContextTestCase testCase)
         {
             // Arrange
             var context = testCase.HttpContext;
 
             // Act
-            var result = context.ToApiGatewayRequest(testCase.ApiGatewayRouteConfig);
+            var result = await context.ToApiGatewayRequest(testCase.ApiGatewayRouteConfig, ApiGatewayEmulatorMode.Rest);
 
             // Assert
-            testCase.Assertions(result);
+            testCase.Assertions(result, ApiGatewayEmulatorMode.Rest);
+        }
+
+        [Theory]
+        [MemberData(nameof(HttpContextTestCases.V1TestCases), MemberType = typeof(HttpContextTestCases))]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1026:Theory methods should use all of their parameters")]
+        public async Task ToApiGatewayRequestV1_ConvertsCorrectly(string testName, HttpContextTestCase testCase)
+        {
+            // Arrange
+            var context = testCase.HttpContext;
+
+            // Act
+            var result = await context.ToApiGatewayRequest(testCase.ApiGatewayRouteConfig, ApiGatewayEmulatorMode.HttpV1);
+
+            // Assert
+            testCase.Assertions(result, ApiGatewayEmulatorMode.HttpV1);
         }
 
         [Theory]
         [MemberData(nameof(HttpContextTestCases.V2TestCases), MemberType = typeof(HttpContextTestCases))]
-        public void ToApiGatewayHttpV2Request_ConvertsCorrectly(string testName, ApiGatewayTestCaseForRequest testCase)
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1026:Theory methods should use all of their parameters")]
+        public async Task ToApiGatewayHttpV2Request_ConvertsCorrectly(string testName, HttpContextTestCase testCase)
         {
             // Arrange
             var context = testCase.HttpContext;
 
             // Act
-            var result = context.ToApiGatewayHttpV2Request(testCase.ApiGatewayRouteConfig);
+            var result = await context.ToApiGatewayHttpV2Request(testCase.ApiGatewayRouteConfig);
 
             // Assert
-            testCase.Assertions(result);
+            testCase.Assertions(result, ApiGatewayEmulatorMode.HttpV2);
+        }
+
+        [Fact]
+        public async Task ToApiGatewayHttpV2Request_EmptyCollections()
+        {
+
+            var httpContext = CreateHttpContext("POST", "/test10/api/notmatchingpath/123/orders");
+            var config = new ApiGatewayRouteConfig
+            {
+                LambdaResourceName = "TestLambdaFunction",
+                Endpoint = "/test10/api/users/{userId}/orders",
+                HttpMethod = "POST",
+                Path = "/test10/api/users/{userId}/orders"
+            };
+
+            // Act
+            var result = await httpContext.ToApiGatewayHttpV2Request(config);
+            Assert.Equal(2, result.Headers.Count);
+            Assert.Equal("0", result.Headers["content-length"]);
+            Assert.Equal("text/plain; charset=utf-8", result.Headers["content-type"]);
+            Assert.Null(result.QueryStringParameters);
+            Assert.Null(result.PathParameters);
+            Assert.Null(result.Cookies);
+        }
+
+        [Fact]
+        public async Task ToApiGatewayHttpV1Request_EmptyCollections()
+        {
+            var httpContext = CreateHttpContext("POST", "/test10/api/notmatchingpath/123/orders");
+            var config = new ApiGatewayRouteConfig
+            {
+                LambdaResourceName = "TestLambdaFunction",
+                Endpoint = "/test10/api/users/{userId}/orders",
+                HttpMethod = "POST",
+                Path = "/test10/api/users/{userId}/orders"
+            };
+
+            // Act
+            var result = await httpContext.ToApiGatewayRequest(config, ApiGatewayEmulatorMode.HttpV1);
+            Assert.Equal(2, result.Headers.Count);
+            Assert.Equal("0", result.Headers["content-length"]);
+            Assert.Equal("text/plain; charset=utf-8", result.Headers["content-type"]);
+            Assert.Equal(new List<string> { "0" }, result.MultiValueHeaders["content-length"]);
+            Assert.Equal(new List<string> { "text/plain; charset=utf-8" }, result.MultiValueHeaders["content-type"]);
+            Assert.Null(result.QueryStringParameters);
+            Assert.Null(result.MultiValueQueryStringParameters);
+            Assert.Null(result.PathParameters);
+        }
+
+        [Theory]
+        [InlineData(ApiGatewayEmulatorMode.Rest)]
+        [InlineData(ApiGatewayEmulatorMode.HttpV1)]
+        public async Task ToApiGateway_MultiValueHeader(ApiGatewayEmulatorMode emulatorMode)
+        {
+            var httpContext = CreateHttpContext("POST", "/test1/api/users/123/orders",
+                new Dictionary<string, StringValues>
+                {
+                    { "Accept", new StringValues(new[] { "text/html", "application/json" }) },
+                });
+            var config = new ApiGatewayRouteConfig
+            {
+                LambdaResourceName = "TestLambdaFunction",
+                Endpoint = "/test1/api/users/{userId}/orders",
+                HttpMethod = "POST",
+                Path = "/test1/api/users/{userId}/orders"
+            };
+
+            var result = await httpContext.ToApiGatewayRequest(config, emulatorMode);
+            Assert.Equal(["text/html", "application/json"], result.MultiValueHeaders["accept"]);
+        }
+
+        
+        [Fact]
+        public async Task ToApiGatewayHttpV1_EncodedAndUnicodeHeader()
+        {
+            var httpContext = CreateHttpContext("POST", "/test1/api/users/123/orders",
+               new Dictionary<string, StringValues>
+                        {
+                            { "X-Encoded-Header", "value%20with%20spaces" },
+                            { "X-Unicode-Header", "☕ Coffee" },
+                            { "X-Mixed-Header", "Hello%2C%20World%21%20☕" },
+                            { "X-Raw-Unicode", "\u2615 Coffee" }
+                        });
+            var config = new ApiGatewayRouteConfig
+            {
+                LambdaResourceName = "TestLambdaFunction",
+                Endpoint = "/test1/api/users/{userId}/orders",
+                HttpMethod = "POST",
+                Path = "/test1/api/users/{userId}/orders"
+            };
+
+            var result = await httpContext.ToApiGatewayRequest(config, ApiGatewayEmulatorMode.HttpV1);
+            Assert.Equal("value%20with%20spaces", result.Headers["X-Encoded-Header"]);
+            Assert.Equal("☕ Coffee", result.Headers["X-Unicode-Header"]);
+            Assert.Equal("Hello%2C%20World%21%20☕", result.Headers["X-Mixed-Header"]);
+            Assert.Equal("\u2615 Coffee", result.Headers["X-Raw-Unicode"]);
+            Assert.Equal(new List<string> { "value%20with%20spaces" }, result.MultiValueHeaders["X-Encoded-Header"]);
+            Assert.Equal(new List<string> { "☕ Coffee" }, result.MultiValueHeaders["X-Unicode-Header"]);
+            Assert.Equal(new List<string> { "Hello%2C%20World%21%20☕" }, result.MultiValueHeaders["X-Mixed-Header"]);
+            Assert.Equal(new List<string> { "\u2615 Coffee" }, result.MultiValueHeaders["X-Raw-Unicode"]);
+        }
+
+
+        // Keeping this commented out for now. We have a backlog item DOTNET-7862 for this
+        //[Fact]
+        //public void ToApiGatewayRest_EncodedAndUnicodeHeader()
+        //{
+        //    var httpContext = CreateHttpContext("POST", "/test1/api/users/123/orders",
+        //       new Dictionary<string, StringValues>
+        //                {
+        //                    { "X-Encoded-Header", "value%20with%20spaces" },
+        //                    { "X-Unicode-Header", "☕ Coffee" },
+        //                    { "X-Mixed-Header", "Hello%2C%20World%21%20☕" },
+        //                    { "X-Raw-Unicode", "\u2615 Coffee" }
+        //                });
+        //    var config = new ApiGatewayRouteConfig
+        //    {
+        //        LambdaResourceName = "TestLambdaFunction",
+        //        Endpoint = "/test1/api/users/{userId}/orders",
+        //        HttpMethod = "POST",
+        //        Path = "/test1/api/users/{userId}/orders"
+        //    };
+
+        //    var result = httpContext.ToApiGatewayRequest(config, ApiGatewayEmulatorMode.Rest);
+        //    Assert.Equal("value%20with%20spaces", result.Headers["X-Encoded-Header"]);
+        //    Assert.Equal("￢ﾘﾕ Coffee", result.Headers["X-Unicode-Header"]);
+        //    Assert.Equal("Hello%2C%20World%21%20￢ﾘﾕ", result.Headers["X-Mixed-Header"]);
+        //    Assert.Equal("\u2615 Coffee", result.Headers["X-Raw-Unicode"]);
+        //    Assert.Equal(new List<string> { "value%20with%20spaces" }, result.MultiValueHeaders["X-Encoded-Header"]);
+        //    Assert.Equal(new List<string> { "￢ﾘﾕ Coffee" }, result.MultiValueHeaders["X-Unicode-Header"]); // in reality this is what rest api thinks it is
+        //    Assert.Equal(new List<string> { "Hello%2C%20World%21%20☕" }, result.MultiValueHeaders["X-Mixed-Header"]);
+        //    Assert.Equal(new List<string> { "\u2615 Coffee" }, result.MultiValueHeaders["X-Raw-Unicode"]);
+        //}
+
+        [Fact]
+        public async Task ToApiGateway_EncodedAndUnicodeHeaderV2()
+        {
+            var httpContext = CreateHttpContext("POST", "/test1/api/users/123/orders",
+               new Dictionary<string, StringValues>
+                        {
+                            { "X-Encoded-Header", "value%20with%20spaces" },
+                            { "X-Unicode-Header", "☕ Coffee" },
+                            { "X-Mixed-Header", "Hello%2C%20World%21%20☕" },
+                            { "X-Raw-Unicode", "\u2615 Coffee" }
+                        });
+            var config = new ApiGatewayRouteConfig
+            {
+                LambdaResourceName = "TestLambdaFunction",
+                Endpoint = "/test1/api/users/{userId}/orders",
+                HttpMethod = "POST",
+                Path = "/test1/api/users/{userId}/orders"
+            };
+
+            var result = await httpContext.ToApiGatewayHttpV2Request(config);
+            Assert.Equal("value%20with%20spaces", result.Headers["x-encoded-header"]);
+            Assert.Equal("☕ Coffee", result.Headers["x-unicode-header"]);
+            Assert.Equal("Hello%2C%20World%21%20☕", result.Headers["x-mixed-header"]);
+            Assert.Equal("\u2615 Coffee", result.Headers["x-raw-unicode"]);
+        }
+
+        [Theory]
+        [InlineData(ApiGatewayEmulatorMode.Rest)]
+        [InlineData(ApiGatewayEmulatorMode.HttpV1)]
+        public async Task BinaryContentHttpV1(ApiGatewayEmulatorMode emulatorMode)
+        {
+            // Arrange
+            var httpContext = CreateHttpContext("POST", "/test3/api/users/123/avatar",
+                new Dictionary<string, StringValues> { { "Content-Type", "application/octet-stream" } },
+                body: new byte[] { 1, 2, 3, 4, 5 });
+
+            var config = new ApiGatewayRouteConfig
+            {
+                LambdaResourceName = "UploadAvatarFunction",
+                Endpoint = "/test3/api/users/{userId}/avatar",
+                HttpMethod = "POST",
+                Path = "/test3/api/users/{userId}/avatar"
+            };
+
+            // Act
+            var result = await httpContext.ToApiGatewayRequest(config, emulatorMode);
+
+            // Assert
+            Assert.True(result.IsBase64Encoded);
+            Assert.Equal(Convert.ToBase64String(new byte[] { 1, 2, 3, 4, 5 }), result.Body);
+            Assert.Equal("123", result.PathParameters["userId"]);
+            Assert.Equal("/test3/api/users/{userId}/avatar", result.Resource);
+            Assert.Equal("POST", result.HttpMethod);
+            Assert.Equal("application/octet-stream", result.Headers["Content-Type"]);
         }
     }
 }

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Extensions/HttpContextExtensionsTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Extensions/HttpContextExtensionsTests.cs
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Lambda.TestTool.Extensions;
+using static Amazon.Lambda.TestTool.UnitTests.Extensions.HttpContextTestCases;
+
+namespace Amazon.Lambda.TestTool.UnitTests.Extensions
+{
+    public class HttpContextExtensionsTests
+    {
+        [Theory]
+        [MemberData(nameof(HttpContextTestCases.V1TestCases), MemberType = typeof(HttpContextTestCases))]
+        public void ToApiGatewayRequest_ConvertsCorrectly(string testName, ApiGatewayTestCaseForRequest testCase)
+        {
+            // Arrange
+            var context = testCase.HttpContext;
+
+            // Act
+            var result = context.ToApiGatewayRequest(testCase.ApiGatewayRouteConfig);
+
+            // Assert
+            testCase.Assertions(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(HttpContextTestCases.V2TestCases), MemberType = typeof(HttpContextTestCases))]
+        public void ToApiGatewayHttpV2Request_ConvertsCorrectly(string testName, ApiGatewayTestCaseForRequest testCase)
+        {
+            // Arrange
+            var context = testCase.HttpContext;
+
+            // Act
+            var result = context.ToApiGatewayHttpV2Request(testCase.ApiGatewayRouteConfig);
+
+            // Assert
+            testCase.Assertions(result);
+        }
+    }
+}

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Extensions/HttpContextTestCases.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Extensions/HttpContextTestCases.cs
@@ -1,0 +1,512 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.TestTool.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+
+namespace Amazon.Lambda.TestTool.UnitTests.Extensions
+{
+    public static class HttpContextTestCases
+    {
+        public static IEnumerable<object[]> V1TestCases()
+        {
+            yield return new object[]
+            {
+                "V1_SimpleGetRequest",
+                new ApiGatewayTestCaseForRequest
+                {
+                    HttpContext = CreateHttpContext("POST", "/test1/api/users/123/orders",
+                        new Dictionary<string, StringValues>
+                        {
+                            { "User-Agent", "TestAgent" },
+                            { "Accept", new StringValues(new[] { "text/html", "application/json" }) },
+                            { "Cookie", "session=abc123; theme=dark" },
+                            { "X-Custom-Header", "value1" }
+                        },
+                        queryString: "?status=pending&tag=important&tag=urgent"),
+                    ApiGatewayRouteConfig = new ApiGatewayRouteConfig
+                    {
+                        LambdaResourceName = "TestLambdaFunction",
+                        Endpoint = "/test1/api/users/{userId}/orders",
+                        HttpMethod = "POST",
+                        Path = "/test1/api/users/{userId}/orders"
+                    },
+                    Assertions = (result) =>
+                    {
+                        var v1Result = Assert.IsType<APIGatewayProxyRequest>(result);
+                        Assert.Equal("/test1/api/users/{userId}/orders", v1Result.Resource);
+                        Assert.Equal("/test1/api/users/123/orders", v1Result.Path);
+                        Assert.Equal("POST", v1Result.HttpMethod);
+                        Assert.Equal("TestAgent", v1Result.Headers["user-agent"]);
+                        Assert.Equal("application/json", v1Result.Headers["accept"]);
+                        Assert.Equal(new List<string> { "text/html", "application/json" }, v1Result.MultiValueHeaders["accept"]);                        Assert.Equal("session=abc123; theme=dark", v1Result.Headers["cookie"]);
+                        Assert.Equal("value1", v1Result.Headers["x-custom-header"]);
+                        Assert.Equal(new List<string> { "TestAgent" }, v1Result.MultiValueHeaders["user-agent"]);
+                        Assert.Equal(new List<string> { "text/html", "application/json" }, v1Result.MultiValueHeaders["accept"]);
+                        Assert.Equal(new List<string> { "session=abc123; theme=dark" }, v1Result.MultiValueHeaders["cookie"]);
+                        Assert.Equal(new List<string> { "value1" }, v1Result.MultiValueHeaders["x-custom-header"]);
+                        Assert.Equal("pending", v1Result.QueryStringParameters["status"]);
+                        Assert.Equal("urgent", v1Result.QueryStringParameters["tag"]);
+                        Assert.Equal(new List<string> { "pending" }, v1Result.MultiValueQueryStringParameters["status"]);
+                        Assert.Equal(new List<string> { "important", "urgent" }, v1Result.MultiValueQueryStringParameters["tag"]);
+                        Assert.Equal("123", v1Result.PathParameters["userId"]);
+                        Assert.Null(v1Result.Body);
+                        Assert.False(v1Result.IsBase64Encoded);
+                    }
+                }
+            };
+
+            yield return new object[]
+            {
+                "V1_EmptyCollections",
+                new ApiGatewayTestCaseForRequest
+                {
+                    HttpContext = CreateHttpContext("POST", "/test2/api/notmatchingpath/123/orders"),
+                    ApiGatewayRouteConfig = new ApiGatewayRouteConfig
+                    {
+                        LambdaResourceName = "TestLambdaFunction",
+                        Endpoint = "/test2/api/users/{userId}/orders",
+                        HttpMethod = "POST",
+                        Path = "/test2/api/users/{userId}/orders"
+                    },
+                    Assertions = (result) =>
+                    {
+                        var v1Result = Assert.IsType<APIGatewayProxyRequest>(result);
+                        Assert.Equal(2, v1Result.Headers.Count);
+                        Assert.Equal("0", v1Result.Headers["content-length"]);
+                        Assert.Equal("text/plain; charset=utf-8", v1Result.Headers["content-type"]);
+                        Assert.Equal(new List<string> { "0" }, v1Result.MultiValueHeaders["content-length"]);
+                        Assert.Equal(new List<string> { "text/plain; charset=utf-8" }, v1Result.MultiValueHeaders["content-type"]);
+                        Assert.Null(v1Result.QueryStringParameters);
+                        Assert.Null(v1Result.MultiValueQueryStringParameters);
+                        Assert.Null(v1Result.PathParameters);
+                    }
+                }
+            };
+
+            yield return new object[]
+            {
+                "V1_BinaryContent",
+                new ApiGatewayTestCaseForRequest
+                {
+                    HttpContext = CreateHttpContext("POST", "/test3/api/users/123/avatar",
+                        new Dictionary<string, StringValues> { { "Content-Type", "application/octet-stream" } },
+                        body: new byte[] { 1, 2, 3, 4, 5 }),
+                    ApiGatewayRouteConfig = new ApiGatewayRouteConfig
+                    {
+                        LambdaResourceName = "UploadAvatarFunction",
+                        Endpoint = "/test3/api/users/{userId}/avatar",
+                        HttpMethod = "POST",
+                        Path = "/test3/api/users/{userId}/avatar"
+                    },
+                    Assertions = (result) =>
+                    {
+                        var v1Result = Assert.IsType<APIGatewayProxyRequest>(result);
+                        Assert.True(v1Result.IsBase64Encoded);
+                        Assert.Equal(Convert.ToBase64String(new byte[] { 1, 2, 3, 4, 5 }), v1Result.Body);
+                        Assert.Equal("123", v1Result.PathParameters["userId"]);
+                        Assert.Equal("/test3/api/users/{userId}/avatar", v1Result.Resource);
+                        Assert.Equal("POST", v1Result.HttpMethod);
+                    }
+                }
+            };
+
+            yield return new object[]
+            {
+                "V1_UrlEncodedQueryString",
+                new ApiGatewayTestCaseForRequest
+                {
+                    HttpContext = CreateHttpContext("POST", "/test4/api/search",
+                        queryString: "?q=Hello%20World&tag=C%23%20Programming&tag=.NET%20Core"),
+                    ApiGatewayRouteConfig = new ApiGatewayRouteConfig
+                    {
+                        LambdaResourceName = "SearchFunction",
+                        Endpoint = "/test4/api/search",
+                        HttpMethod = "POST",
+                        Path = "/test4/api/search"
+                    },
+                    Assertions = (result) =>
+                    {
+                        var v1Result = Assert.IsType<APIGatewayProxyRequest>(result);
+                        Assert.Equal("Hello World", v1Result.QueryStringParameters["q"]);
+                        Assert.Equal(".NET Core", v1Result.QueryStringParameters["tag"]);
+                        Assert.Equal(new List<string> { "Hello World" }, v1Result.MultiValueQueryStringParameters["q"]);
+                        Assert.Equal(new List<string> { "C# Programming", ".NET Core" }, v1Result.MultiValueQueryStringParameters["tag"]);
+                    }
+                }
+            };
+
+            yield return new object[]
+            {
+                "V1_SpecialCharactersInPath",
+                new ApiGatewayTestCaseForRequest
+                {
+                    HttpContext = CreateHttpContext("POST", "/test5/api/users/****%20Doe/orders/Summer%20Sale%202023"),
+                    ApiGatewayRouteConfig = new ApiGatewayRouteConfig
+                    {
+                        LambdaResourceName = "UserOrdersFunction",
+                        Endpoint = "/test5/api/users/{username}/orders/{orderName}",
+                        HttpMethod = "POST",
+                        Path = "/test5/api/users/{username}/orders/{orderName}"
+                    },
+                    Assertions = (result) =>
+                    {
+                        var v1Result = Assert.IsType<APIGatewayProxyRequest>(result);
+                        Assert.Equal("/test5/api/users/**** Doe/orders/Summer Sale 2023", v1Result.Path);
+                        Assert.Equal("**** Doe", v1Result.PathParameters["username"]);
+                        Assert.Equal("Summer Sale 2023", v1Result.PathParameters["orderName"]);
+                    }
+                }
+            };
+
+            yield return new object[]
+            {
+                "V1_UnicodeCharactersInPath",
+                new ApiGatewayTestCaseForRequest
+                {
+                    HttpContext = CreateHttpContext("POST", "/test6/api/products/%E2%98%95%20Coffee/reviews/%F0%9F%98%8A%20Happy"),
+                    ApiGatewayRouteConfig = new ApiGatewayRouteConfig
+                    {
+                        LambdaResourceName = "ProductReviewsFunction",
+                        Endpoint = "/test6/api/products/{productName}/reviews/{reviewTitle}",
+                        HttpMethod = "POST",
+                        Path = "/test6/api/products/{productName}/reviews/{reviewTitle}"
+                    },
+                    Assertions = (result) =>
+                    {
+                        var v1Result = Assert.IsType<APIGatewayProxyRequest>(result);
+                        Assert.Equal("/test6/api/products/☕ Coffee/reviews/😊 Happy", v1Result.Path);
+                        Assert.Equal("☕ Coffee", v1Result.PathParameters["productName"]);
+                        Assert.Equal("😊 Happy", v1Result.PathParameters["reviewTitle"]);
+                    }
+                }
+            };
+
+            yield return new object[]
+            {
+                "V1_EncodedAndUnicodeHeaders",
+                new ApiGatewayTestCaseForRequest
+                {
+                    HttpContext = CreateHttpContext("POST", "/test7/api/test",
+                        new Dictionary<string, StringValues>
+                        {
+                            { "X-Encoded-Header", "value%20with%20spaces" },
+                            { "X-Unicode-Header", "☕ Coffee" },
+                            { "X-Mixed-Header", "Hello%2C%20World%21%20☕" },
+                            { "X-Raw-Unicode", "\u2615 Coffee" }
+                        }),
+                    ApiGatewayRouteConfig = new ApiGatewayRouteConfig
+                    {
+                        LambdaResourceName = "TestFunction",
+                        Endpoint = "/test7/api/test",
+                        HttpMethod = "POST",
+                        Path = "/test7/api/test"
+                    },
+                    Assertions = (result) =>
+                    {
+                        var v1Result = Assert.IsType<APIGatewayProxyRequest>(result);
+                        Assert.Equal("value%20with%20spaces", v1Result.Headers["x-encoded-header"]);
+                        Assert.Equal("☕ Coffee", v1Result.Headers["x-unicode-header"]);
+                        Assert.Equal("Hello%2C%20World%21%20☕", v1Result.Headers["x-mixed-header"]);
+                        Assert.Equal("\u2615 Coffee", v1Result.Headers["x-raw-unicode"]);
+                        Assert.Equal(new List<string> { "value%20with%20spaces" }, v1Result.MultiValueHeaders["x-encoded-header"]);
+                        Assert.Equal(new List<string> { "☕ Coffee" }, v1Result.MultiValueHeaders["x-unicode-header"]);
+                        Assert.Equal(new List<string> { "Hello%2C%20World%21%20☕" }, v1Result.MultiValueHeaders["x-mixed-header"]);
+                        Assert.Equal(new List<string> { "\u2615 Coffee" }, v1Result.MultiValueHeaders["x-raw-unicode"]);
+                    }
+                }
+            };
+
+            yield return new object[]
+            {
+                "V1_MultipleHeaderValuesWithUnicode",
+                new ApiGatewayTestCaseForRequest
+                {
+                    HttpContext = CreateHttpContext("POST", "/test8/api/test",
+                        new Dictionary<string, StringValues>
+                        {
+                            { "X-Multi-Value", new StringValues(new[] { "value1", "value2%20with%20spaces", "☕ Coffee", "value4%20☕" }) }
+                        }),
+                    ApiGatewayRouteConfig = new ApiGatewayRouteConfig
+                    {
+                        LambdaResourceName = "TestFunction",
+                        Endpoint = "/test8/api/test",
+                        HttpMethod = "POST",
+                        Path = "/test8/api/test"
+                    },
+                    Assertions = (result) =>
+                    {
+                        var v1Result = Assert.IsType<APIGatewayProxyRequest>(result);
+                        Assert.Equal("value4%20☕", v1Result.Headers["x-multi-value"]);
+                        Assert.Equal(
+                            new List<string> { "value1", "value2%20with%20spaces", "☕ Coffee", "value4%20☕" },
+                            v1Result.MultiValueHeaders["x-multi-value"]
+                        );
+                    }
+                }
+            };
+        }
+
+        public static IEnumerable<object[]> V2TestCases()
+        {
+            yield return new object[]
+            {
+        "V2_SimpleGetRequest",
+        new ApiGatewayTestCaseForRequest
+        {
+            HttpContext = CreateHttpContext("POST", "/test9/api/users/123/orders",
+                new Dictionary<string, StringValues>
+                {
+                    { "user-agent", "TestAgent" },
+                    { "accept", new StringValues(new[] { "text/html", "application/json" }) },
+                    { "cookie", "session=abc123; theme=dark" },
+                    { "x-custom-Header", "value1" }
+                },
+                queryString: "?status=pending&tag=important&tag=urgent"),
+            ApiGatewayRouteConfig = new ApiGatewayRouteConfig
+            {
+                LambdaResourceName = "TestLambdaFunction",
+                Endpoint = "/test9/api/users/{userId}/orders",
+                HttpMethod = "POST",
+                Path = "/test9/api/users/{userId}/orders"
+            },
+            Assertions = (result) =>
+            {
+                var v2Result = Assert.IsType<APIGatewayHttpApiV2ProxyRequest>(result);
+                Assert.Equal("POST /test9/api/users/{userId}/orders", v2Result.RouteKey);
+                Assert.Equal("/test9/api/users/123/orders", v2Result.RawPath);
+                Assert.Equal("status=pending&tag=important&tag=urgent", v2Result.RawQueryString);
+                Assert.Equal("TestAgent", v2Result.Headers["user-agent"]);
+                Assert.Equal("text/html, application/json", v2Result.Headers["accept"]);
+                //Assert.Equal("session=abc123; theme=dark", v2Result.Headers["cookie"]);
+                Assert.Equal("value1", v2Result.Headers["x-custom-header"]);
+                Assert.Equal("pending", v2Result.QueryStringParameters["status"]);
+                Assert.Equal("important,urgent", v2Result.QueryStringParameters["tag"]);
+                Assert.Equal("123", v2Result.PathParameters["userId"]);
+                Assert.Equal(new[] { "session=abc123", "theme=dark" }, v2Result.Cookies);
+                Assert.Equal("POST", v2Result.RequestContext.Http.Method);
+                Assert.Equal("/test9/api/users/123/orders", v2Result.RequestContext.Http.Path);
+                Assert.Equal("HTTP/1.1", v2Result.RequestContext.Http.Protocol);
+            }
+        }
+            };
+
+            yield return new object[]
+            {
+            "V2_EmptyCollections",
+            new ApiGatewayTestCaseForRequest
+            {
+                HttpContext = CreateHttpContext("POST", "/test10/api/notmatchingpath/123/orders"),
+                ApiGatewayRouteConfig = new ApiGatewayRouteConfig
+                {
+                    LambdaResourceName = "TestLambdaFunction",
+                    Endpoint = "/test10/api/users/{userId}/orders",
+                    HttpMethod = "POST",
+                    Path = "/test10/api/users/{userId}/orders"
+                },
+                Assertions = (result) =>
+                {
+                    var v2Result = Assert.IsType<APIGatewayHttpApiV2ProxyRequest>(result);
+                    Assert.Equal(2, v2Result.Headers.Count);
+                    Assert.Equal("0", v2Result.Headers["content-length"]);
+                    Assert.Equal("text/plain; charset=utf-8", v2Result.Headers["content-type"]);
+                    Assert.Null(v2Result.QueryStringParameters);
+                    Assert.Null(v2Result.PathParameters);
+                    Assert.Null(v2Result.Cookies);
+                }
+            }
+            };
+
+            yield return new object[]
+            {
+            "V2_BinaryContent",
+            new ApiGatewayTestCaseForRequest
+            {
+                HttpContext = CreateHttpContext("POST", "/test11/api/users/123/avatar",
+                    new Dictionary<string, StringValues> { { "Content-Type", "application/octet-stream" } },
+                    body: new byte[] { 1, 2, 3, 4, 5 }),
+                ApiGatewayRouteConfig = new ApiGatewayRouteConfig
+                {
+                    LambdaResourceName = "UploadAvatarFunction",
+                    Endpoint = "/test11/api/users/{userId}/avatar",
+                    HttpMethod = "POST",
+                    Path = "/test11/api/users/{userId}/avatar"
+                },
+                Assertions = (result) =>
+                {
+                    var v2Result = Assert.IsType<APIGatewayHttpApiV2ProxyRequest>(result);
+                    Assert.True(v2Result.IsBase64Encoded);
+                    Assert.Equal(Convert.ToBase64String(new byte[] { 1, 2, 3, 4, 5 }), v2Result.Body);
+                    Assert.Equal("123", v2Result.PathParameters["userId"]);
+                    Assert.Equal("POST /test11/api/users/{userId}/avatar", v2Result.RouteKey);
+                    Assert.Equal("POST", v2Result.RequestContext.Http.Method);
+                }
+            }
+            };
+
+            yield return new object[]
+            {
+            "V2_UrlEncodedQueryString",
+            new ApiGatewayTestCaseForRequest
+            {
+                HttpContext = CreateHttpContext("POST", "/test12/api/search",
+                    queryString: "?q=Hello%20World&tag=C%23%20Programming&tag=.NET%20Core"),
+                ApiGatewayRouteConfig = new ApiGatewayRouteConfig
+                {
+                    LambdaResourceName = "SearchFunction",
+                    Endpoint = "/test12/api/search",
+                    HttpMethod = "POST",
+                    Path = "/test12/api/search"
+                },
+                Assertions = (result) =>
+                {
+                    var v2Result = Assert.IsType<APIGatewayHttpApiV2ProxyRequest>(result);
+                    Assert.Equal("q=Hello%20World&tag=C%23%20Programming&tag=.NET%20Core", v2Result.RawQueryString);
+                    Assert.Equal("Hello World", v2Result.QueryStringParameters["q"]);
+                    Assert.Equal("C# Programming,.NET Core", v2Result.QueryStringParameters["tag"]);
+                }
+            }
+            };
+
+            yield return new object[]
+            {
+            "V2_SpecialCharactersInPath",
+            new ApiGatewayTestCaseForRequest
+            {
+                HttpContext = CreateHttpContext("POST", "/test13/api/users/****%20Doe/orders/Summer%20Sale%202023"),
+                ApiGatewayRouteConfig = new ApiGatewayRouteConfig
+                {
+                    LambdaResourceName = "UserOrdersFunction",
+                    Endpoint = "/test13/api/users/{username}/orders/{orderName}",
+                    HttpMethod = "POST",
+                    Path = "/test13/api/users/{username}/orders/{orderName}"
+                },
+                Assertions = (result) =>
+                {
+                    var v2Result = Assert.IsType<APIGatewayHttpApiV2ProxyRequest>(result);
+                    Assert.Equal("/test13/api/users/**** Doe/orders/Summer Sale 2023", v2Result.RawPath);
+                    Assert.Equal("/test13/api/users/**** Doe/orders/Summer Sale 2023", v2Result.RequestContext.Http.Path);
+                    Assert.Equal("**** Doe", v2Result.PathParameters["username"]);
+                    Assert.Equal("Summer Sale 2023", v2Result.PathParameters["orderName"]);
+                }
+            }
+            };
+
+            yield return new object[]
+            {
+            "V2_UnicodeCharactersInPath",
+            new ApiGatewayTestCaseForRequest
+            {
+                HttpContext = CreateHttpContext("POST", "/test14/api/products/%E2%98%95%20Coffee/reviews/%F0%9F%98%8A%20Happy"),
+                ApiGatewayRouteConfig = new ApiGatewayRouteConfig
+                {
+                    LambdaResourceName = "ProductReviewsFunction",
+                    Endpoint = "/test14/api/products/{productName}/reviews/{reviewTitle}",
+                    HttpMethod = "POST",
+                    Path = "/test14/api/products/{productName}/reviews/{reviewTitle}"
+                },
+                Assertions = (result) =>
+                {
+                    var v2Result = Assert.IsType<APIGatewayHttpApiV2ProxyRequest>(result);
+                    Assert.Equal("/test14/api/products/☕ Coffee/reviews/😊 Happy", v2Result.RawPath);
+                    Assert.Equal("/test14/api/products/☕ Coffee/reviews/😊 Happy", v2Result.RequestContext.Http.Path);
+                    Assert.Equal("☕ Coffee", v2Result.PathParameters["productName"]);
+                    Assert.Equal("😊 Happy", v2Result.PathParameters["reviewTitle"]);
+                }
+            }
+            };
+
+            yield return new object[]
+            {
+            "V2_EncodedAndUnicodeHeaders",
+            new ApiGatewayTestCaseForRequest
+            {
+                HttpContext = CreateHttpContext("POST", "/test15/api/test",
+                    new Dictionary<string, StringValues>
+                    {
+                        { "X-Encoded-Header", "value%20with%20spaces" },
+                        { "X-Unicode-Header", "☕ Coffee" },
+                        { "X-Mixed-Header", "Hello%2C%20World%21%20☕" },
+                        { "X-Raw-Unicode", "\u2615 Coffee" }
+                    }),
+                ApiGatewayRouteConfig = new ApiGatewayRouteConfig
+                {
+                    LambdaResourceName = "TestFunction",
+                    Endpoint = "/test15/api/test",
+                    HttpMethod = "POST",
+                    Path = "/test15/api/test"
+                },
+                Assertions = (result) =>
+                {
+                    var v2Result = Assert.IsType<APIGatewayHttpApiV2ProxyRequest>(result);
+                    Assert.Equal("value%20with%20spaces", v2Result.Headers["x-encoded-header"]);
+                    Assert.Equal("☕ Coffee", v2Result.Headers["x-unicode-header"]);
+                    Assert.Equal("Hello%2C%20World%21%20☕", v2Result.Headers["x-mixed-header"]);
+                    Assert.Equal("\u2615 Coffee", v2Result.Headers["x-raw-unicode"]);
+                }
+            }
+            };
+
+            yield return new object[]
+            {
+            "V2_MultipleHeaderValuesWithUnicode",
+            new ApiGatewayTestCaseForRequest
+            {
+                HttpContext = CreateHttpContext("POST", "/test16/api/test",
+                    new Dictionary<string, StringValues>
+                    {
+                        { "X-Multi-Value", new StringValues(new[] { "value1", "value2%20with%20spaces", "☕ Coffee", "value4%20☕" }) }
+                    }),
+                ApiGatewayRouteConfig = new ApiGatewayRouteConfig
+                {
+                    LambdaResourceName = "TestFunction",
+                    Endpoint = "/test16/api/test",
+                    HttpMethod = "POST",
+                    Path = "/test16/api/test"
+                },
+                Assertions = (result) =>
+                {
+                    var v2Result = Assert.IsType<APIGatewayHttpApiV2ProxyRequest>(result);
+                    Assert.Equal("value1, value2%20with%20spaces, ☕ Coffee, value4%20☕", v2Result.Headers["x-multi-value"]);
+                }
+            }
+            };
+        }
+
+        private static DefaultHttpContext CreateHttpContext(string method, string path,
+            Dictionary<string, StringValues>? headers = null, string? queryString = null, byte[]? body = null)
+        {
+            var context = new DefaultHttpContext();
+            var request = context.Request;
+            request.Method = method;
+            request.Path = path;
+            if (headers != null)
+            {
+                foreach (var header in headers)
+                {
+                    request.Headers[header.Key] = new StringValues(header.Value.ToArray());
+                }
+            }
+            if (queryString != null)
+            {
+                request.QueryString = new QueryString(queryString);
+            }
+            if (body != null)
+            {
+                request.Body = new MemoryStream(body);
+                request.ContentLength = body.Length;
+            }
+            return context;
+        }
+
+
+        public class ApiGatewayTestCaseForRequest
+        {
+            public required DefaultHttpContext HttpContext { get; set; }
+            public required ApiGatewayRouteConfig ApiGatewayRouteConfig { get; set; }
+            public required Action<object> Assertions { get; set; }
+        }
+    }
+}

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Extensions/HttpContextTestCases.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Extensions/HttpContextTestCases.cs
@@ -15,13 +15,12 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
             yield return new object[]
             {
                 "V1_SimpleGetRequest",
-                new ApiGatewayTestCaseForRequest
+                new HttpContextTestCase
                 {
                     HttpContext = CreateHttpContext("POST", "/test1/api/users/123/orders",
                         new Dictionary<string, StringValues>
                         {
                             { "User-Agent", "TestAgent" },
-                            { "Accept", new StringValues(new[] { "text/html", "application/json" }) },
                             { "Cookie", "session=abc123; theme=dark" },
                             { "X-Custom-Header", "value1" }
                         },
@@ -33,20 +32,18 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
                         HttpMethod = "POST",
                         Path = "/test1/api/users/{userId}/orders"
                     },
-                    Assertions = (result) =>
+                    Assertions = (result, emulatorMode) =>
                     {
                         var v1Result = Assert.IsType<APIGatewayProxyRequest>(result);
                         Assert.Equal("/test1/api/users/{userId}/orders", v1Result.Resource);
                         Assert.Equal("/test1/api/users/123/orders", v1Result.Path);
                         Assert.Equal("POST", v1Result.HttpMethod);
-                        Assert.Equal("TestAgent", v1Result.Headers["user-agent"]);
-                        Assert.Equal("application/json", v1Result.Headers["accept"]);
-                        Assert.Equal(new List<string> { "text/html", "application/json" }, v1Result.MultiValueHeaders["accept"]);                        Assert.Equal("session=abc123; theme=dark", v1Result.Headers["cookie"]);
-                        Assert.Equal("value1", v1Result.Headers["x-custom-header"]);
-                        Assert.Equal(new List<string> { "TestAgent" }, v1Result.MultiValueHeaders["user-agent"]);
-                        Assert.Equal(new List<string> { "text/html", "application/json" }, v1Result.MultiValueHeaders["accept"]);
-                        Assert.Equal(new List<string> { "session=abc123; theme=dark" }, v1Result.MultiValueHeaders["cookie"]);
-                        Assert.Equal(new List<string> { "value1" }, v1Result.MultiValueHeaders["x-custom-header"]);
+                        Assert.Equal("TestAgent", v1Result.Headers["User-Agent"]);
+                        Assert.Equal("session=abc123; theme=dark", v1Result.Headers["Cookie"]);
+                        Assert.Equal("value1", v1Result.Headers["X-Custom-Header"]);
+                        Assert.Equal(new List<string> { "TestAgent" }, v1Result.MultiValueHeaders["User-Agent"]);
+                        Assert.Equal(new List<string> { "session=abc123; theme=dark" }, v1Result.MultiValueHeaders["Cookie"]);
+                        Assert.Equal(new List<string> { "value1" }, v1Result.MultiValueHeaders["X-Custom-Header"]);
                         Assert.Equal("pending", v1Result.QueryStringParameters["status"]);
                         Assert.Equal("urgent", v1Result.QueryStringParameters["tag"]);
                         Assert.Equal(new List<string> { "pending" }, v1Result.MultiValueQueryStringParameters["status"]);
@@ -60,63 +57,8 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
 
             yield return new object[]
             {
-                "V1_EmptyCollections",
-                new ApiGatewayTestCaseForRequest
-                {
-                    HttpContext = CreateHttpContext("POST", "/test2/api/notmatchingpath/123/orders"),
-                    ApiGatewayRouteConfig = new ApiGatewayRouteConfig
-                    {
-                        LambdaResourceName = "TestLambdaFunction",
-                        Endpoint = "/test2/api/users/{userId}/orders",
-                        HttpMethod = "POST",
-                        Path = "/test2/api/users/{userId}/orders"
-                    },
-                    Assertions = (result) =>
-                    {
-                        var v1Result = Assert.IsType<APIGatewayProxyRequest>(result);
-                        Assert.Equal(2, v1Result.Headers.Count);
-                        Assert.Equal("0", v1Result.Headers["content-length"]);
-                        Assert.Equal("text/plain; charset=utf-8", v1Result.Headers["content-type"]);
-                        Assert.Equal(new List<string> { "0" }, v1Result.MultiValueHeaders["content-length"]);
-                        Assert.Equal(new List<string> { "text/plain; charset=utf-8" }, v1Result.MultiValueHeaders["content-type"]);
-                        Assert.Null(v1Result.QueryStringParameters);
-                        Assert.Null(v1Result.MultiValueQueryStringParameters);
-                        Assert.Null(v1Result.PathParameters);
-                    }
-                }
-            };
-
-            yield return new object[]
-            {
-                "V1_BinaryContent",
-                new ApiGatewayTestCaseForRequest
-                {
-                    HttpContext = CreateHttpContext("POST", "/test3/api/users/123/avatar",
-                        new Dictionary<string, StringValues> { { "Content-Type", "application/octet-stream" } },
-                        body: new byte[] { 1, 2, 3, 4, 5 }),
-                    ApiGatewayRouteConfig = new ApiGatewayRouteConfig
-                    {
-                        LambdaResourceName = "UploadAvatarFunction",
-                        Endpoint = "/test3/api/users/{userId}/avatar",
-                        HttpMethod = "POST",
-                        Path = "/test3/api/users/{userId}/avatar"
-                    },
-                    Assertions = (result) =>
-                    {
-                        var v1Result = Assert.IsType<APIGatewayProxyRequest>(result);
-                        Assert.True(v1Result.IsBase64Encoded);
-                        Assert.Equal(Convert.ToBase64String(new byte[] { 1, 2, 3, 4, 5 }), v1Result.Body);
-                        Assert.Equal("123", v1Result.PathParameters["userId"]);
-                        Assert.Equal("/test3/api/users/{userId}/avatar", v1Result.Resource);
-                        Assert.Equal("POST", v1Result.HttpMethod);
-                    }
-                }
-            };
-
-            yield return new object[]
-            {
                 "V1_UrlEncodedQueryString",
-                new ApiGatewayTestCaseForRequest
+                new HttpContextTestCase
                 {
                     HttpContext = CreateHttpContext("POST", "/test4/api/search",
                         queryString: "?q=Hello%20World&tag=C%23%20Programming&tag=.NET%20Core"),
@@ -127,7 +69,7 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
                         HttpMethod = "POST",
                         Path = "/test4/api/search"
                     },
-                    Assertions = (result) =>
+                    Assertions = (result, emulatorMode) =>
                     {
                         var v1Result = Assert.IsType<APIGatewayProxyRequest>(result);
                         Assert.Equal("Hello World", v1Result.QueryStringParameters["q"]);
@@ -141,7 +83,7 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
             yield return new object[]
             {
                 "V1_SpecialCharactersInPath",
-                new ApiGatewayTestCaseForRequest
+                new HttpContextTestCase
                 {
                     HttpContext = CreateHttpContext("POST", "/test5/api/users/****%20Doe/orders/Summer%20Sale%202023"),
                     ApiGatewayRouteConfig = new ApiGatewayRouteConfig
@@ -151,12 +93,22 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
                         HttpMethod = "POST",
                         Path = "/test5/api/users/{username}/orders/{orderName}"
                     },
-                    Assertions = (result) =>
+                    Assertions = (result, emulatorMode) =>
                     {
                         var v1Result = Assert.IsType<APIGatewayProxyRequest>(result);
-                        Assert.Equal("/test5/api/users/**** Doe/orders/Summer Sale 2023", v1Result.Path);
-                        Assert.Equal("**** Doe", v1Result.PathParameters["username"]);
-                        Assert.Equal("Summer Sale 2023", v1Result.PathParameters["orderName"]);
+
+                        if (emulatorMode == ApiGatewayEmulatorMode.HttpV1)
+                        {
+                            Assert.Equal("/test5/api/users/****%20Doe/orders/Summer%20Sale%202023", v1Result.Path);
+                            Assert.Equal("**** Doe", v1Result.PathParameters["username"]);
+                            Assert.Equal("Summer Sale 2023", v1Result.PathParameters["orderName"]);
+                        }
+                        else
+                        {
+                            Assert.Equal("/test5/api/users/****%20Doe/orders/Summer%20Sale%202023", v1Result.Path);
+                            Assert.Equal("****%20Doe", v1Result.PathParameters["username"]);
+                            Assert.Equal("Summer%20Sale%202023", v1Result.PathParameters["orderName"]);
+                        }
                     }
                 }
             };
@@ -164,7 +116,7 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
             yield return new object[]
             {
                 "V1_UnicodeCharactersInPath",
-                new ApiGatewayTestCaseForRequest
+                new HttpContextTestCase
                 {
                     HttpContext = CreateHttpContext("POST", "/test6/api/products/%E2%98%95%20Coffee/reviews/%F0%9F%98%8A%20Happy"),
                     ApiGatewayRouteConfig = new ApiGatewayRouteConfig
@@ -174,76 +126,22 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
                         HttpMethod = "POST",
                         Path = "/test6/api/products/{productName}/reviews/{reviewTitle}"
                     },
-                    Assertions = (result) =>
+                    Assertions = (result, emulatorMode) =>
                     {
                         var v1Result = Assert.IsType<APIGatewayProxyRequest>(result);
-                        Assert.Equal("/test6/api/products/☕ Coffee/reviews/😊 Happy", v1Result.Path);
-                        Assert.Equal("☕ Coffee", v1Result.PathParameters["productName"]);
-                        Assert.Equal("😊 Happy", v1Result.PathParameters["reviewTitle"]);
-                    }
-                }
-            };
 
-            yield return new object[]
-            {
-                "V1_EncodedAndUnicodeHeaders",
-                new ApiGatewayTestCaseForRequest
-                {
-                    HttpContext = CreateHttpContext("POST", "/test7/api/test",
-                        new Dictionary<string, StringValues>
+                        if (emulatorMode == ApiGatewayEmulatorMode.HttpV1)
                         {
-                            { "X-Encoded-Header", "value%20with%20spaces" },
-                            { "X-Unicode-Header", "☕ Coffee" },
-                            { "X-Mixed-Header", "Hello%2C%20World%21%20☕" },
-                            { "X-Raw-Unicode", "\u2615 Coffee" }
-                        }),
-                    ApiGatewayRouteConfig = new ApiGatewayRouteConfig
-                    {
-                        LambdaResourceName = "TestFunction",
-                        Endpoint = "/test7/api/test",
-                        HttpMethod = "POST",
-                        Path = "/test7/api/test"
-                    },
-                    Assertions = (result) =>
-                    {
-                        var v1Result = Assert.IsType<APIGatewayProxyRequest>(result);
-                        Assert.Equal("value%20with%20spaces", v1Result.Headers["x-encoded-header"]);
-                        Assert.Equal("☕ Coffee", v1Result.Headers["x-unicode-header"]);
-                        Assert.Equal("Hello%2C%20World%21%20☕", v1Result.Headers["x-mixed-header"]);
-                        Assert.Equal("\u2615 Coffee", v1Result.Headers["x-raw-unicode"]);
-                        Assert.Equal(new List<string> { "value%20with%20spaces" }, v1Result.MultiValueHeaders["x-encoded-header"]);
-                        Assert.Equal(new List<string> { "☕ Coffee" }, v1Result.MultiValueHeaders["x-unicode-header"]);
-                        Assert.Equal(new List<string> { "Hello%2C%20World%21%20☕" }, v1Result.MultiValueHeaders["x-mixed-header"]);
-                        Assert.Equal(new List<string> { "\u2615 Coffee" }, v1Result.MultiValueHeaders["x-raw-unicode"]);
-                    }
-                }
-            };
-
-            yield return new object[]
-            {
-                "V1_MultipleHeaderValuesWithUnicode",
-                new ApiGatewayTestCaseForRequest
-                {
-                    HttpContext = CreateHttpContext("POST", "/test8/api/test",
-                        new Dictionary<string, StringValues>
+                            Assert.Equal("/test6/api/products/%E2%98%95%20Coffee/reviews/%F0%9F%98%8A%20Happy", v1Result.Path);
+                            Assert.Equal("☕ Coffee", v1Result.PathParameters["productName"]);
+                            Assert.Equal("😊 Happy", v1Result.PathParameters["reviewTitle"]);
+                        }
+                        else
                         {
-                            { "X-Multi-Value", new StringValues(new[] { "value1", "value2%20with%20spaces", "☕ Coffee", "value4%20☕" }) }
-                        }),
-                    ApiGatewayRouteConfig = new ApiGatewayRouteConfig
-                    {
-                        LambdaResourceName = "TestFunction",
-                        Endpoint = "/test8/api/test",
-                        HttpMethod = "POST",
-                        Path = "/test8/api/test"
-                    },
-                    Assertions = (result) =>
-                    {
-                        var v1Result = Assert.IsType<APIGatewayProxyRequest>(result);
-                        Assert.Equal("value4%20☕", v1Result.Headers["x-multi-value"]);
-                        Assert.Equal(
-                            new List<string> { "value1", "value2%20with%20spaces", "☕ Coffee", "value4%20☕" },
-                            v1Result.MultiValueHeaders["x-multi-value"]
-                        );
+                            Assert.Equal("/test6/api/products/%E2%98%95%20Coffee/reviews/%F0%9F%98%8A%20Happy", v1Result.Path);
+                            Assert.Equal("%E2%98%95%20Coffee", v1Result.PathParameters["productName"]);
+                            Assert.Equal("%F0%9F%98%8A%20Happy", v1Result.PathParameters["reviewTitle"]);
+                        }
                     }
                 }
             };
@@ -254,7 +152,7 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
             yield return new object[]
             {
         "V2_SimpleGetRequest",
-        new ApiGatewayTestCaseForRequest
+        new HttpContextTestCase
         {
             HttpContext = CreateHttpContext("POST", "/test9/api/users/123/orders",
                 new Dictionary<string, StringValues>
@@ -272,7 +170,7 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
                 HttpMethod = "POST",
                 Path = "/test9/api/users/{userId}/orders"
             },
-            Assertions = (result) =>
+            Assertions = (result, emulatorMode) =>
             {
                 var v2Result = Assert.IsType<APIGatewayHttpApiV2ProxyRequest>(result);
                 Assert.Equal("POST /test9/api/users/{userId}/orders", v2Result.RouteKey);
@@ -280,7 +178,6 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
                 Assert.Equal("status=pending&tag=important&tag=urgent", v2Result.RawQueryString);
                 Assert.Equal("TestAgent", v2Result.Headers["user-agent"]);
                 Assert.Equal("text/html, application/json", v2Result.Headers["accept"]);
-                //Assert.Equal("session=abc123; theme=dark", v2Result.Headers["cookie"]);
                 Assert.Equal("value1", v2Result.Headers["x-custom-header"]);
                 Assert.Equal("pending", v2Result.QueryStringParameters["status"]);
                 Assert.Equal("important,urgent", v2Result.QueryStringParameters["tag"]);
@@ -295,34 +192,8 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
 
             yield return new object[]
             {
-            "V2_EmptyCollections",
-            new ApiGatewayTestCaseForRequest
-            {
-                HttpContext = CreateHttpContext("POST", "/test10/api/notmatchingpath/123/orders"),
-                ApiGatewayRouteConfig = new ApiGatewayRouteConfig
-                {
-                    LambdaResourceName = "TestLambdaFunction",
-                    Endpoint = "/test10/api/users/{userId}/orders",
-                    HttpMethod = "POST",
-                    Path = "/test10/api/users/{userId}/orders"
-                },
-                Assertions = (result) =>
-                {
-                    var v2Result = Assert.IsType<APIGatewayHttpApiV2ProxyRequest>(result);
-                    Assert.Equal(2, v2Result.Headers.Count);
-                    Assert.Equal("0", v2Result.Headers["content-length"]);
-                    Assert.Equal("text/plain; charset=utf-8", v2Result.Headers["content-type"]);
-                    Assert.Null(v2Result.QueryStringParameters);
-                    Assert.Null(v2Result.PathParameters);
-                    Assert.Null(v2Result.Cookies);
-                }
-            }
-            };
-
-            yield return new object[]
-            {
             "V2_BinaryContent",
-            new ApiGatewayTestCaseForRequest
+            new HttpContextTestCase
             {
                 HttpContext = CreateHttpContext("POST", "/test11/api/users/123/avatar",
                     new Dictionary<string, StringValues> { { "Content-Type", "application/octet-stream" } },
@@ -334,7 +205,7 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
                     HttpMethod = "POST",
                     Path = "/test11/api/users/{userId}/avatar"
                 },
-                Assertions = (result) =>
+                Assertions = (result, emulatorMode) =>
                 {
                     var v2Result = Assert.IsType<APIGatewayHttpApiV2ProxyRequest>(result);
                     Assert.True(v2Result.IsBase64Encoded);
@@ -349,7 +220,7 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
             yield return new object[]
             {
             "V2_UrlEncodedQueryString",
-            new ApiGatewayTestCaseForRequest
+            new HttpContextTestCase
             {
                 HttpContext = CreateHttpContext("POST", "/test12/api/search",
                     queryString: "?q=Hello%20World&tag=C%23%20Programming&tag=.NET%20Core"),
@@ -360,7 +231,7 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
                     HttpMethod = "POST",
                     Path = "/test12/api/search"
                 },
-                Assertions = (result) =>
+                Assertions = (result, emulatorMode) =>
                 {
                     var v2Result = Assert.IsType<APIGatewayHttpApiV2ProxyRequest>(result);
                     Assert.Equal("q=Hello%20World&tag=C%23%20Programming&tag=.NET%20Core", v2Result.RawQueryString);
@@ -373,7 +244,7 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
             yield return new object[]
             {
             "V2_SpecialCharactersInPath",
-            new ApiGatewayTestCaseForRequest
+            new HttpContextTestCase
             {
                 HttpContext = CreateHttpContext("POST", "/test13/api/users/****%20Doe/orders/Summer%20Sale%202023"),
                 ApiGatewayRouteConfig = new ApiGatewayRouteConfig
@@ -383,7 +254,7 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
                     HttpMethod = "POST",
                     Path = "/test13/api/users/{username}/orders/{orderName}"
                 },
-                Assertions = (result) =>
+                Assertions = (result, emulatorMode) =>
                 {
                     var v2Result = Assert.IsType<APIGatewayHttpApiV2ProxyRequest>(result);
                     Assert.Equal("/test13/api/users/**** Doe/orders/Summer Sale 2023", v2Result.RawPath);
@@ -397,7 +268,7 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
             yield return new object[]
             {
             "V2_UnicodeCharactersInPath",
-            new ApiGatewayTestCaseForRequest
+            new HttpContextTestCase
             {
                 HttpContext = CreateHttpContext("POST", "/test14/api/products/%E2%98%95%20Coffee/reviews/%F0%9F%98%8A%20Happy"),
                 ApiGatewayRouteConfig = new ApiGatewayRouteConfig
@@ -407,7 +278,7 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
                     HttpMethod = "POST",
                     Path = "/test14/api/products/{productName}/reviews/{reviewTitle}"
                 },
-                Assertions = (result) =>
+                Assertions = (result, emulatorMode) =>
                 {
                     var v2Result = Assert.IsType<APIGatewayHttpApiV2ProxyRequest>(result);
                     Assert.Equal("/test14/api/products/☕ Coffee/reviews/😊 Happy", v2Result.RawPath);
@@ -417,65 +288,9 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
                 }
             }
             };
-
-            yield return new object[]
-            {
-            "V2_EncodedAndUnicodeHeaders",
-            new ApiGatewayTestCaseForRequest
-            {
-                HttpContext = CreateHttpContext("POST", "/test15/api/test",
-                    new Dictionary<string, StringValues>
-                    {
-                        { "X-Encoded-Header", "value%20with%20spaces" },
-                        { "X-Unicode-Header", "☕ Coffee" },
-                        { "X-Mixed-Header", "Hello%2C%20World%21%20☕" },
-                        { "X-Raw-Unicode", "\u2615 Coffee" }
-                    }),
-                ApiGatewayRouteConfig = new ApiGatewayRouteConfig
-                {
-                    LambdaResourceName = "TestFunction",
-                    Endpoint = "/test15/api/test",
-                    HttpMethod = "POST",
-                    Path = "/test15/api/test"
-                },
-                Assertions = (result) =>
-                {
-                    var v2Result = Assert.IsType<APIGatewayHttpApiV2ProxyRequest>(result);
-                    Assert.Equal("value%20with%20spaces", v2Result.Headers["x-encoded-header"]);
-                    Assert.Equal("☕ Coffee", v2Result.Headers["x-unicode-header"]);
-                    Assert.Equal("Hello%2C%20World%21%20☕", v2Result.Headers["x-mixed-header"]);
-                    Assert.Equal("\u2615 Coffee", v2Result.Headers["x-raw-unicode"]);
-                }
-            }
-            };
-
-            yield return new object[]
-            {
-            "V2_MultipleHeaderValuesWithUnicode",
-            new ApiGatewayTestCaseForRequest
-            {
-                HttpContext = CreateHttpContext("POST", "/test16/api/test",
-                    new Dictionary<string, StringValues>
-                    {
-                        { "X-Multi-Value", new StringValues(new[] { "value1", "value2%20with%20spaces", "☕ Coffee", "value4%20☕" }) }
-                    }),
-                ApiGatewayRouteConfig = new ApiGatewayRouteConfig
-                {
-                    LambdaResourceName = "TestFunction",
-                    Endpoint = "/test16/api/test",
-                    HttpMethod = "POST",
-                    Path = "/test16/api/test"
-                },
-                Assertions = (result) =>
-                {
-                    var v2Result = Assert.IsType<APIGatewayHttpApiV2ProxyRequest>(result);
-                    Assert.Equal("value1, value2%20with%20spaces, ☕ Coffee, value4%20☕", v2Result.Headers["x-multi-value"]);
-                }
-            }
-            };
         }
 
-        private static DefaultHttpContext CreateHttpContext(string method, string path,
+        public static DefaultHttpContext CreateHttpContext(string method, string path,
             Dictionary<string, StringValues>? headers = null, string? queryString = null, byte[]? body = null)
         {
             var context = new DefaultHttpContext();
@@ -502,11 +317,11 @@ namespace Amazon.Lambda.TestTool.UnitTests.Extensions
         }
 
 
-        public class ApiGatewayTestCaseForRequest
+        public class HttpContextTestCase
         {
             public required DefaultHttpContext HttpContext { get; set; }
             public required ApiGatewayRouteConfig ApiGatewayRouteConfig { get; set; }
-            public required Action<object> Assertions { get; set; }
+            public required Action<object, ApiGatewayEmulatorMode> Assertions { get; set; }
         }
     }
 }

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Utilities/HttpRequestUtilityTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Utilities/HttpRequestUtilityTests.cs
@@ -25,21 +25,21 @@ public class HttpRequestUtilityTests
     [InlineData("application/json", false)]
     [InlineData(null, false)]
     [InlineData("", false)]
-    public void IsBinaryContent_ReturnsExpectedResult(string contentType, bool expected)
+    public void IsBinaryContent_ReturnsExpectedResult(string? contentType, bool expected)
     {
         var result = HttpRequestUtility.IsBinaryContent(contentType);
         Assert.Equal(expected, result);
     }
 
     [Fact]
-    public void ReadRequestBody_ReturnsCorrectContent()
+    public async Task ReadRequestBody_ReturnsCorrectContent()
     {
         var content = "Test body content";
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
         var request = new Mock<HttpRequest>();
         request.Setup(r => r.Body).Returns(stream);
 
-        var result = HttpRequestUtility.ReadRequestBody(request.Object);
+        var result = await HttpRequestUtility.ReadRequestBody(request.Object);
 
         Assert.Equal(content, result);
     }

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Utilities/HttpRequestUtilityTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Utilities/HttpRequestUtilityTests.cs
@@ -1,0 +1,84 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace Amazon.Lambda.TestTool.UnitTests.Utilities;
+
+using System.Collections.Generic;
+using System.Text;
+using Amazon.Lambda.TestTool.Utilities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Moq;
+
+public class HttpRequestUtilityTests
+{
+    [Theory]
+    [InlineData("image/jpeg", true)]
+    [InlineData("audio/mpeg", true)]
+    [InlineData("video/mp4", true)]
+    [InlineData("application/octet-stream", true)]
+    [InlineData("application/zip", true)]
+    [InlineData("application/pdf", true)]
+    [InlineData("application/x-protobuf", true)]
+    [InlineData("application/wasm", true)]
+    [InlineData("text/plain", false)]
+    [InlineData("application/json", false)]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    public void IsBinaryContent_ReturnsExpectedResult(string contentType, bool expected)
+    {
+        var result = HttpRequestUtility.IsBinaryContent(contentType);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ReadRequestBody_ReturnsCorrectContent()
+    {
+        var content = "Test body content";
+        var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+        var request = new Mock<HttpRequest>();
+        request.Setup(r => r.Body).Returns(stream);
+
+        var result = HttpRequestUtility.ReadRequestBody(request.Object);
+
+        Assert.Equal(content, result);
+    }
+
+    [Fact]
+    public void ExtractHeaders_ReturnsCorrectDictionaries()
+    {
+        var headers = new HeaderDictionary
+        {
+            { "Single", new StringValues("Value") },
+            { "Multi", new StringValues(new[] { "Value1", "Value2" }) }
+        };
+
+        var (singleValueHeaders, multiValueHeaders) = HttpRequestUtility.ExtractHeaders(headers);
+
+        Assert.Equal(2, singleValueHeaders.Count);
+        Assert.Equal(2, multiValueHeaders.Count);
+        Assert.Equal("Value", singleValueHeaders["single"]);
+        Assert.Equal("Value2", singleValueHeaders["multi"]);
+        Assert.Equal(new List<string> { "Value" }, multiValueHeaders["single"]);
+        Assert.Equal(new List<string> { "Value1", "Value2" }, multiValueHeaders["multi"]);
+    }
+
+    [Fact]
+    public void ExtractQueryStringParameters_ReturnsCorrectDictionaries()
+    {
+        var query = new QueryCollection(new Dictionary<string, StringValues>
+        {
+            { "Single", new StringValues("Value") },
+            { "Multi", new StringValues(new[] { "Value1", "Value2" }) }
+        });
+
+        var (singleValueParams, multiValueParams) = HttpRequestUtility.ExtractQueryStringParameters(query);
+
+        Assert.Equal(2, singleValueParams.Count);
+        Assert.Equal(2, multiValueParams.Count);
+        Assert.Equal("Value", singleValueParams["Single"]);
+        Assert.Equal("Value2", singleValueParams["Multi"]);
+        Assert.Equal(new List<string> { "Value" }, multiValueParams["Single"]);
+        Assert.Equal(new List<string> { "Value1", "Value2" }, multiValueParams["Multi"]);
+    }
+}

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Utilities/RouteTemplateUtilityTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Utilities/RouteTemplateUtilityTests.cs
@@ -1,0 +1,92 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace Amazon.Lambda.TestTool.UnitTests.Utilities;
+
+using Amazon.Lambda.TestTool.Utilities;
+using Microsoft.AspNetCore.Routing.Template;
+using Xunit;
+
+public class RouteTemplateUtilityTests
+{
+    [Theory]
+    [InlineData("/users/{id}", "/users/123", "id", "123")]
+    [InlineData("/users/{id}/orders/{orderId}", "/users/123/orders/456", "id", "123", "orderId", "456")]
+    [InlineData("/products/{category}/{id}", "/products/electronics/laptop-123", "category", "electronics", "id", "laptop-123")]
+    [InlineData("/api/{version}/users/{userId}", "/api/v1/users/abc-xyz", "version", "v1", "userId", "abc-xyz")]
+    public void ExtractPathParameters_ShouldExtractCorrectly(string routeTemplate, string actualPath, params string[] expectedKeyValuePairs)
+    {
+        // Arrange
+        var expected = new Dictionary<string, string>();
+        for (int i = 0; i < expectedKeyValuePairs.Length; i += 2)
+        {
+            expected[expectedKeyValuePairs[i]] = expectedKeyValuePairs[i + 1];
+        }
+
+        // Act
+        var result = RouteTemplateUtility.ExtractPathParameters(routeTemplate, actualPath);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("/users/{id}", "/products/123")]
+    [InlineData("/api/{version}/users", "/api/v1/products")]
+    [InlineData("/products/{category}/{id}", "/products/electronics")]
+    public void ExtractPathParameters_ShouldReturnEmptyDictionary_WhenNoMatch(string routeTemplate, string actualPath)
+    {
+        // Act
+        var result = RouteTemplateUtility.ExtractPathParameters(routeTemplate, actualPath);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Theory]
+    [InlineData("/users/{id:int}", "/users/123", "id", "123")]
+    [InlineData("/users/{id:guid}", "/users/550e8400-e29b-41d4-a716-446655440000", "id", "550e8400-e29b-41d4-a716-446655440000")]
+    [InlineData("/api/{version:regex(^v[0-9]+$)}/users/{userId}", "/api/v1/users/abc-xyz", "version", "v1", "userId", "abc-xyz")]
+    public void ExtractPathParameters_ShouldHandleConstraints(string routeTemplate, string actualPath, params string[] expectedKeyValuePairs)
+    {
+        // Arrange
+        var expected = new Dictionary<string, string>();
+        for (int i = 0; i < expectedKeyValuePairs.Length; i += 2)
+        {
+            expected[expectedKeyValuePairs[i]] = expectedKeyValuePairs[i + 1];
+        }
+
+        // Act
+        var result = RouteTemplateUtility.ExtractPathParameters(routeTemplate, actualPath);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetDefaults_ShouldReturnCorrectDefaults()
+    {
+        // Arrange
+        var template = TemplateParser.Parse("/api/{version=v1}/users/{id}");
+
+        // Act
+        var result = RouteTemplateUtility.GetDefaults(template);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("v1", result["version"]);
+    }
+
+    [Fact]
+    public void GetDefaults_ShouldReturnEmptyDictionary_WhenNoDefaults()
+    {
+        // Arrange
+        var template = TemplateParser.Parse("/api/{version}/users/{id}");
+
+        // Act
+        var result = RouteTemplateUtility.GetDefaults(template);
+
+        // Assert
+        Assert.Empty(result);
+    }
+}


### PR DESCRIPTION
DOTNET-7838

*Description of changes:*
1. Add functions to translate httpcontext into APIGatewayHttpApiV2ProxyRequest and APIGatewayProxyRequest 
2. Add unit tests for above classes

*Testing details*
1. Wrote unit tests
2. integration tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
