### PR TITLE
feat: update invalid route handling based on emulator mode

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -202,7 +202,7 @@ dotnet_code_quality.ca2208.api_surface=public
 dotnet_diagnostic.ca1822.severity=none
 
 # License header
-file_header_template= Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r\nSPDX-License-Identifier: Apache-2.0
+file_header_template= Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\nSPDX-License-Identifier: Apache-2.0
 
 # ReSharper properties
 resharper_braces_for_for=required

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/ResultExtensions.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/ResultExtensions.cs
@@ -13,6 +13,9 @@ public static class ApiGatewayResults
     /// <summary>
     /// Returns a 'Not Found' for HTTP API Gateway mode and 'Missing Authentication Token' for Rest.
     /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> to update.</param>
+    /// <param name="emulatorMode">The API Gateway Emulator mode.</param>
+    /// <returns></returns>
     public static IResult RouteNotFound(HttpContext context, ApiGatewayEmulatorMode emulatorMode)
     {
         if (emulatorMode == ApiGatewayEmulatorMode.Rest)

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/ResultExtensions.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/ResultExtensions.cs
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Lambda.TestTool.Models;
+
+namespace Amazon.Lambda.TestTool.Extensions;
+
+/// <summary>
+/// A class for common API Gateway responses.
+/// </summary>
+public static class ApiGatewayResults
+{
+    /// <summary>
+    /// Returns a 'Not Found' for HTTP API Gateway mode and 'Missing Authentication Token' for Rest.
+    /// </summary>
+    public static IResult RouteNotFound(HttpContext context, ApiGatewayEmulatorMode emulatorMode)
+    {
+        if (emulatorMode == ApiGatewayEmulatorMode.Rest)
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            context.Response.Headers.Append("x-amzn-errortype", "MissingAuthenticationTokenException");
+            return Results.Json(new { message = "Missing Authentication Token" });
+        }
+        else
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Results.Json(new { message = "Not Found" });
+        }
+    }
+}

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Models/Exceptions.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Models/Exceptions.cs
@@ -10,3 +10,9 @@ namespace Amazon.Lambda.TestTool.Models;
 /// <param name="innerException"></param>
 public abstract class TestToolException(string message, Exception? innerException = null)
     : Exception(message, innerException);
+
+/// <summary>
+/// Thrown if the API Gateway Emulator mode was not provided,
+/// </summary>
+public class InvalidApiGatewayModeException(string message, Exception? innerException = null)
+    : TestToolException(message, innerException);

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Models/Exceptions.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Models/Exceptions.cs
@@ -6,13 +6,15 @@ namespace Amazon.Lambda.TestTool.Models;
 /// <summary>
 /// Represents a base exception that is thrown by the test tool.
 /// </summary>
-/// <param name="message"></param>
-/// <param name="innerException"></param>
+/// <param name="message">The message used in the exception.</param>
+/// <param name="innerException">The inner exception, if any.</param>
 public abstract class TestToolException(string message, Exception? innerException = null)
     : Exception(message, innerException);
 
 /// <summary>
 /// Thrown if the API Gateway Emulator mode was not provided,
 /// </summary>
+/// <param name="message">The message used in the exception.</param>
+/// <param name="innerException">The inner exception, if any.</param>
 public class InvalidApiGatewayModeException(string message, Exception? innerException = null)
     : TestToolException(message, innerException);

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/ApiGatewayEmulatorProcess.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/ApiGatewayEmulatorProcess.cs
@@ -33,6 +33,11 @@ public class ApiGatewayEmulatorProcess
     /// </summary>
     public static ApiGatewayEmulatorProcess Startup(RunCommandSettings settings, CancellationToken cancellationToken = default)
     {
+        if (settings.ApiGatewayEmulatorMode is null)
+        {
+            throw new InvalidApiGatewayModeException("The API Gateway emulator mode was not provided.");
+        }
+
         var builder = WebApplication.CreateBuilder();
 
         builder.Services.AddApiGatewayEmulatorServices();
@@ -61,9 +66,7 @@ public class ApiGatewayEmulatorProcess
             {
                 app.Logger.LogInformation("Unable to find a configured Lambda route for the specified method and path: {Method} {Path}",
                     context.Request.Method, context.Request.Path);
-                context.Response.StatusCode = StatusCodes.Status403Forbidden;
-                context.Response.Headers.Append("x-amzn-errortype", "MissingAuthenticationTokenException");
-                return Results.Json(new { message = "Missing Authentication Token" });
+                return ApiGatewayResults.RouteNotFound(context, (ApiGatewayEmulatorMode) settings.ApiGatewayEmulatorMode);
             }
 
             if (settings.ApiGatewayEmulatorMode.Equals(ApiGatewayEmulatorMode.HttpV2))

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Helpers/TestHelpers.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Helpers/TestHelpers.cs
@@ -31,6 +31,14 @@ internal static class TestHelpers
         }
     }
 
+    internal static async Task<HttpResponseMessage> SendRequest(string url)
+    {
+        using (var client = new HttpClient())
+        {
+            return await client.GetAsync(url);
+        }
+    }
+
     internal static async Task CancelAndWaitAsync(Task executeTask)
     {
         await Task.Delay(1000);

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Processes/ApiGatewayEmulatorProcessTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Processes/ApiGatewayEmulatorProcessTests.cs
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Net;
+using Amazon.Lambda.TestTool.Commands.Settings;
+using Amazon.Lambda.TestTool.Models;
+using Amazon.Lambda.TestTool.Processes;
+using Amazon.Lambda.TestTool.UnitTests.Helpers;
+
+namespace Amazon.Lambda.TestTool.UnitTests.Processes;
+
+public class ApiGatewayEmulatorProcessTests
+{
+    [Theory]
+    [InlineData(ApiGatewayEmulatorMode.Rest, HttpStatusCode.Forbidden, "{\"message\":\"Missing Authentication Token\"}")]
+    [InlineData(ApiGatewayEmulatorMode.HttpV1, HttpStatusCode.NotFound, "{\"message\":\"Not Found\"}")]
+    [InlineData(ApiGatewayEmulatorMode.HttpV2, HttpStatusCode.NotFound, "{\"message\":\"Not Found\"}")]
+    public async Task RouteNotFound(ApiGatewayEmulatorMode mode, HttpStatusCode statusCode, string body)
+    {
+        // Arrange
+        var cancellationSource = new CancellationTokenSource();
+        cancellationSource.CancelAfter(5000);
+        var settings = new RunCommandSettings { ApiGatewayEmulatorPort = 9003,  ApiGatewayEmulatorMode = mode, NoLaunchWindow = true};
+        var apiUrl = $"http://{settings.Host}:{settings.ApiGatewayEmulatorPort}/__lambda_test_tool_apigateway_health__";
+
+        // Act
+        var process = ApiGatewayEmulatorProcess.Startup(settings, cancellationSource.Token);
+        var isApiRunning = await TestHelpers.WaitForApiToStartAsync(apiUrl);
+        var response = await TestHelpers.SendRequest($"{process.ServiceUrl}/invalid");
+        await cancellationSource.CancelAsync();
+
+        // Assert
+        await process.RunningTask;
+        Assert.True(isApiRunning);
+        Assert.Equal(statusCode, response.StatusCode);
+        Assert.Equal(body, await response.Content.ReadAsStringAsync());
+    }
+}


### PR DESCRIPTION
*Description of changes:*
* When a route is not found, API Gateway handles it differently for Rest APIs and Http APIs. This PR updates the behavior to return 404 or 403 based on the current emulator mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
