### PR TITLE
fix: greedy variable can be any value

### DIFF
--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Services/ApiGatewayRouteConfigService.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Services/ApiGatewayRouteConfigService.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Amazon.Lambda.TestTool.Models;
 using Amazon.Lambda.TestTool.Services.IO;
 
@@ -142,24 +143,16 @@ public class ApiGatewayRouteConfigService : IApiGatewayRouteConfigService
             return false;
         }
 
-        var occurrences = routeConfig.Path
-            .Split('/')
-            .Where(
-                x => x.StartsWith("{") &&
-                     x.EndsWith("+}"))
-            .ToList();
-        if (occurrences.Count > 1)
+        var segments = routeConfig.Path.Trim('/').Split('/');
+        foreach (var segment in segments)
         {
-            _logger.LogError("The route config {Method} {Path} cannot have multiple greedy variables {{proxy+}}.",
-                routeConfig.HttpMethod, routeConfig.Path);
-            return false;
-        }
-
-        if (occurrences.Count == 1 && !routeConfig.Path.EndsWith($"/{occurrences.Last()}"))
-        {
-            _logger.LogError("The route config {Method} {Path} uses a greedy variable {{proxy+}} but does not end with it.",
-                routeConfig.HttpMethod, routeConfig.Path);
-            return false;
+            var regexPattern = "^(\\{[\\w.:-]+\\+?\\}|[a-zA-Z0-9.:_-]+)$";
+            if (!Regex.IsMatch(segment, regexPattern))
+            {
+                _logger.LogError("One or more path parts appear to be invalid. Parts are validated against this regular expression: {Regex}",
+                    regexPattern);
+                return false;
+            }
         }
 
         return true;

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Services/ApiGatewayRouteConfigServiceTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Services/ApiGatewayRouteConfigServiceTests.cs
@@ -159,8 +159,10 @@ public class ApiGatewayRouteConfigServiceTests
         Assert.Equal("Function2", result2.LambdaResourceName);
     }
 
-    [Fact]
-    public void CatchAllRouteConfig()
+    [Theory]
+    [InlineData("proxy")]
+    [InlineData("anyvalue")]
+    public void CatchAllRouteConfig(string variableName)
     {
         // Arange
         var routeConfigs = new List<ApiGatewayRouteConfig>
@@ -169,7 +171,7 @@ public class ApiGatewayRouteConfigServiceTests
             {
                 LambdaResourceName = "F1",
                 HttpMethod = "ANY",
-                Path = "/{proxy+}"
+                Path = $"/{{{variableName}+}}"
             }
         };
 


### PR DESCRIPTION
*Description of changes:*
* Previously, I hard coded the greedy variable as {proxy+}. In reality, the greedy variable can have any value and not "proxy" explicitly. This PR updates that behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
