### PR TITLE
chore: enable NativeAOT test

### DIFF
--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/NativeAOTTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/NativeAOTTests.cs
@@ -19,9 +19,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             _output = output;
         }
 
-#if DEBUG // Only running this test right now in local environment because CI system doesn't have Native AOT prereqs installed.
         [Fact]
-#endif
         public void EnsureNoTrimWarningsDuringPublish()
         {
             var projectDirectory = FindProject("NativeAOTFunction");


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7730

*Description of changes:*
* Enabled NativeAOT test which was failing due to missing dependencies in the build environment. The build environment has been updated and this test can now be enabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
