### PR TITLE
Add Integration test for verifying ApiGatewayProxyRequest format for binary content for REST api

### DIFF
--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/HttpContextExtensions.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/HttpContextExtensions.cs
@@ -3,7 +3,6 @@
 
 namespace Amazon.Lambda.TestTool.Extensions;
 
-using System.Text;
 using System.Web;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.TestTool.Models;
@@ -150,6 +149,13 @@ public static class HttpContextExtensions
         {
             headers["content-type"] = "text/plain; charset=utf-8";
             multiValueHeaders["content-type"] = ["text/plain; charset=utf-8"];
+        }
+
+
+        if (HttpRequestUtility.IsBinaryContent(request.ContentType) && emulatorMode == ApiGatewayEmulatorMode.Rest) // Rest mode with binary content never sends content length
+        {
+            headers.Remove("content-length");
+            multiValueHeaders.Remove("content-length");
         }
 
         // This is the decoded value

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/ApiGatewayIntegrationTestFixture.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/ApiGatewayIntegrationTestFixture.cs
@@ -42,8 +42,8 @@ namespace Amazon.Lambda.TestTool.IntegrationTests
         public string ReturnFullEventHttpApiV2Url { get; private set; }
 
         // ReturnDecodedParseBin
-        public string ReturnDecodedParseBinRestApiId { get; private set; }
-        public string ReturnDecodedParseBinRestApiUrl { get; private set; }
+        public string BinaryMediaTypeRestApiId { get; private set; }
+        public string BinaryMediaTypeRestApiUrl { get; private set; }
 
         // Lambda Function ARNs
         public string ParseAndReturnBodyLambdaFunctionArn { get; private set; }
@@ -86,9 +86,9 @@ namespace Amazon.Lambda.TestTool.IntegrationTests
             ReturnFullEventHttpApiV1Url = string.Empty;
             ReturnFullEventHttpApiV2Url = string.Empty;
 
-            // ReturnDecodedParseBin
-            ReturnDecodedParseBinRestApiId = string.Empty;
-            ReturnDecodedParseBinRestApiUrl = string.Empty;
+            // BinaryMediaTypeRestApiId
+            BinaryMediaTypeRestApiId = string.Empty;
+            BinaryMediaTypeRestApiUrl = string.Empty;
 
             // Lambda Function ARNs
             ParseAndReturnBodyLambdaFunctionArn = string.Empty;
@@ -170,8 +170,8 @@ namespace Amazon.Lambda.TestTool.IntegrationTests
             ReturnFullEventHttpApiV2Url = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnFullEventHttpApiV2Url");
 
             // ReturnDecodedParseBin
-            ReturnDecodedParseBinRestApiId = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnDecodedParseBinRestApiId");
-            ReturnDecodedParseBinRestApiUrl = await CloudFormationHelper.GetOutputValueAsync(StackName, "ReturnDecodedParseBinRestApiUrl");
+            BinaryMediaTypeRestApiId = await CloudFormationHelper.GetOutputValueAsync(StackName, "BinaryMediaTypeRestApiId");
+            BinaryMediaTypeRestApiUrl = await CloudFormationHelper.GetOutputValueAsync(StackName, "BinaryMediaTypeRestApiUrl");
 
             // Lambda Function ARNs
             ParseAndReturnBodyLambdaFunctionArn = await CloudFormationHelper.GetOutputValueAsync(StackName, "ParseAndReturnBodyLambdaFunctionArn");
@@ -196,7 +196,7 @@ namespace Amazon.Lambda.TestTool.IntegrationTests
             await ApiGatewayHelper.WaitForApiAvailability(ReturnFullEventHttpApiV1Id, ReturnFullEventHttpApiV1Url, true);
             await ApiGatewayHelper.WaitForApiAvailability(ReturnFullEventHttpApiV2Id, ReturnFullEventHttpApiV2Url, true);
 
-            await ApiGatewayHelper.WaitForApiAvailability(ReturnDecodedParseBinRestApiId, ReturnDecodedParseBinRestApiUrl, false);
+            await ApiGatewayHelper.WaitForApiAvailability(BinaryMediaTypeRestApiId, BinaryMediaTypeRestApiUrl, false);
 
         }
 

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/ApiGatewayResponseExtensionsAdditionalTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/ApiGatewayResponseExtensionsAdditionalTests.cs
@@ -54,7 +54,7 @@ namespace Amazon.Lambda.TestTool.IntegrationTests
 
             var httpContext = new DefaultHttpContext();
             testResponse.ToHttpResponse(httpContext, ApiGatewayEmulatorMode.Rest);
-            var actualResponse = await _httpClient.PostAsync(_fixture.ReturnDecodedParseBinRestApiUrl, new StringContent(JsonSerializer.Serialize(testResponse)));
+            var actualResponse = await _httpClient.PostAsync(_fixture.BinaryMediaTypeRestApiUrl, new StringContent(JsonSerializer.Serialize(testResponse)));
             await _fixture.ApiGatewayTestHelper.AssertResponsesEqual(actualResponse, httpContext.Response);
             Assert.Equal(200, (int)actualResponse.StatusCode);
             var content = await actualResponse.Content.ReadAsStringAsync();

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/cloudformation-template-apigateway.yaml
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/cloudformation-template-apigateway.yaml
@@ -441,49 +441,57 @@ Resources:
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ReturnFullEventHttpApiV2}/*'
 
-  ReturnDecodedParseBinRestApi:
+  BinaryMediaTypeRestApi:
     Type: 'AWS::ApiGateway::RestApi'
     Properties:
-      Name: !Sub '${AWS::StackName}-ReturnDecodedParseBinRestAPI'
+      Name: !Sub '${AWS::StackName}-BinaryMediaTypeRestApi'
       EndpointConfiguration:
         Types:
           - REGIONAL
       BinaryMediaTypes:
         - '*/*'
 
-  ReturnDecodedParseBinRestApiResource:
+  BinaryMediaTypeRestApiResource:
     Type: 'AWS::ApiGateway::Resource'
     Properties:
-      ParentId: !GetAtt ReturnDecodedParseBinRestApi.RootResourceId
+      ParentId: !GetAtt BinaryMediaTypeRestApi.RootResourceId
       PathPart: 'test'
-      RestApiId: !Ref ReturnDecodedParseBinRestApi
+      RestApiId: !Ref BinaryMediaTypeRestApi
 
-  ReturnDecodedParseBinRestApiMethod:
+  BinaryMediaTypeRestApiMethod:
     Type: 'AWS::ApiGateway::Method'
     Properties:
       HttpMethod: POST
-      ResourceId: !Ref ReturnDecodedParseBinRestApiResource
-      RestApiId: !Ref ReturnDecodedParseBinRestApi
+      ResourceId: !Ref BinaryMediaTypeRestApiResource
+      RestApiId: !Ref BinaryMediaTypeRestApi
       AuthorizationType: NONE
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
         Uri: !Sub 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ReturnDecodedParseBinLambdaFunction.Arn}/invocations'
 
-  ReturnDecodedParseBinRestApiDeployment:
+  BinaryMediaTypeRestApiDeployment:
     Type: 'AWS::ApiGateway::Deployment'
-    DependsOn: ReturnDecodedParseBinRestApiMethod
+    DependsOn: BinaryMediaTypeRestApiMethod
     Properties:
-      RestApiId: !Ref ReturnDecodedParseBinRestApi
+      RestApiId: !Ref BinaryMediaTypeRestApi
       StageName: 'test'
 
-  LambdaPermissionReturnDecodedParseBinRestApi:
+  LambdaPermissionBinaryMediaTypeRestApi:
     Type: 'AWS::Lambda::Permission'
     Properties:
       Action: 'lambda:InvokeFunction'
       FunctionName: !GetAtt ReturnDecodedParseBinLambdaFunction.Arn
       Principal: apigateway.amazonaws.com
-      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ReturnDecodedParseBinRestApi}/*'
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${BinaryMediaTypeRestApi}/*'
+
+  LambdaPermissionBinaryMediaTypeRestApi2:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !GetAtt ReturnFullEventLambdaFunction.Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${BinaryMediaTypeRestApi}/*'
 
 Outputs:
   ParseAndReturnBodyRestApiId:
@@ -570,10 +578,10 @@ Outputs:
     Description: 'ARN of the Return Full Event Lambda Function'
     Value: !GetAtt ReturnFullEventLambdaFunction.Arn
 
-  ReturnDecodedParseBinRestApiId:
-      Description: 'ID of the ReturnDecodedParseBin Media REST API'
-      Value: !Ref ReturnDecodedParseBinRestApi
+  BinaryMediaTypeRestApiId:
+      Description: 'ID of the BinaryMediaTypeRest Media REST API'
+      Value: !Ref BinaryMediaTypeRestApi
 
-  ReturnDecodedParseBinRestApiUrl:
-      Description: 'URL of the ReturnDecodedParseBin Media REST API'
-      Value: !Sub 'https://${ReturnDecodedParseBinRestApi}.execute-api.${AWS::Region}.amazonaws.com/test/test'
+  BinaryMediaTypeRestApiUrl:
+      Description: 'URL of the BinaryMediaTypeRest Media REST API'
+      Value: !Sub 'https://${BinaryMediaTypeRestApi}.execute-api.${AWS::Region}.amazonaws.com/test/test'


### PR DESCRIPTION
*Issue #, if available:* DOTNET-7866

*Description of changes:*
- Add integration test to verify that http request to APIGatewayProxyRequest works as expected. This is done by attaching the existing REST api that is configured to the existing lambda function which returns the input `event` object. We then compare the expected `event` object with the actual object. 
- By adding this test, I have found that for REST apis with binary content, the `content-length` header is not in the `APIGatewayProxyRequest ` object, so i have updated our logic to handle it.
- I have renamed `ReturnDecodedParseBinRestApi` to `BinaryMediaTypeRestApi ` since this API can be reused by multiple scenarios involving binary media with rest apis. 
    - Note: In the future, I think we should probably do similar for our other api gateways in cloudformation, where we just have an api gateway for httpv1, v2, rest, and rest with binary, and then attach routes/lambdas as needed. This would reduce the amount of gateways we have.
- I have ran all of the unit tests and integration tests after making this change and they pass.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
