### PR TITLE
Add port environment variables for Aspire integration

### DIFF
--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
 	  <Description>A tool to help debug and test your .NET AWS Lambda functions locally.</Description>
@@ -16,7 +16,7 @@
     <Version>0.0.1-beta.1</Version>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="$(Configuration) == 'Release'">
     <None Include="$(OutputPath)\publish\wwwroot\" Pack="true" PackagePath="tools\net8.0\any\wwwroot" Visible="false" />
   </ItemGroup>
 

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/HttpContextExtensions.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/HttpContextExtensions.cs
@@ -168,9 +168,11 @@ public static class HttpContextExtensions
 
         if (emulatorMode == ApiGatewayEmulatorMode.Rest) // rest uses encoded value for the path params
         {
+#pragma warning disable SYSLIB0013 // Type or member is obsolete
             var encodedPathParameters = pathParameters.ToDictionary(
                     kvp => kvp.Key,
-                    kvp => Uri.EscapeUriString(kvp.Value)); // intentionally using EscapeURiString over EscapeDataString since EscapeURiString correctly handles reserved characters :/?#[]@!$&'()*+,;= in this case
+                    kvp => Uri.EscapeUriString(kvp.Value)); // intentionally using EscapeUriString over EscapeDataString since EscapeUriString correctly handles reserved characters :/?#[]@!$&'()*+,;= in this case
+#pragma warning restore SYSLIB0013 // Type or member is obsolete
             pathParameters = encodedPathParameters;
         }
 

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/InvokeResponseExtensions.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/InvokeResponseExtensions.cs
@@ -34,7 +34,7 @@ public static class InvokeResponseExtensions
         string responseJson = reader.ReadToEnd();
         try
         {
-            return JsonSerializer.Deserialize<APIGatewayProxyResponse>(responseJson);
+            return JsonSerializer.Deserialize<APIGatewayProxyResponse>(responseJson)!;
         }
         catch
         {
@@ -132,7 +132,7 @@ public static class InvokeResponseExtensions
                 // It has a statusCode property, so try to deserialize as full response
                 try
                 {
-                    return JsonSerializer.Deserialize<APIGatewayHttpApiV2ProxyResponse>(response);
+                    return JsonSerializer.Deserialize<APIGatewayHttpApiV2ProxyResponse>(response)!;
                 }
                 catch
                 {
@@ -155,7 +155,7 @@ public static class InvokeResponseExtensions
             // return "test", it actually comes as "\"test\"" to response. So we need to get the raw string which is what api gateway does.
             if (jsonElement.ValueKind == JsonValueKind.String)
             {
-                response = jsonElement.GetString();
+                response = jsonElement.GetString()!;
             }
 
         }

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/ServiceCollectionExtensions.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/ServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ public static class ServiceCollectionExtensions
     {
         serviceCollection.TryAdd(new ServiceDescriptor(typeof(IToolInteractiveService), typeof(ConsoleInteractiveService), lifetime));
         serviceCollection.TryAdd(new ServiceDescriptor(typeof(IDirectoryManager), typeof(DirectoryManager), lifetime));
+        serviceCollection.TryAdd(new ServiceDescriptor(typeof(IEnvironmentManager), typeof(EnvironmentManager), lifetime));
     }
 
     /// <summary>

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Program.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Program.cs
@@ -19,17 +19,4 @@ app.Configure(config =>
     config.SetApplicationName(Constants.ToolName);
 });
 
-var arguments = new List<string>(args);
-
-if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("LAMBDA_RUNTIME_API_PORT")))
-{
-    arguments.Add("--port");
-    arguments.Add(Environment.GetEnvironmentVariable("LAMBDA_RUNTIME_API_PORT")!);
-}
-if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("API_GATEWAY_EMULATOR_PORT")))
-{
-    arguments.Add("--api-gateway-emulator-port");
-    arguments.Add(Environment.GetEnvironmentVariable("API_GATEWAY_EMULATOR_PORT")!);
-}
-
-return await app.RunAsync(arguments);
+return await app.RunAsync(args);

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Program.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Program.cs
@@ -19,4 +19,17 @@ app.Configure(config =>
     config.SetApplicationName(Constants.ToolName);
 });
 
-return await app.RunAsync(args);
+var arguments = new List<string>(args);
+
+if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("LAMBDA_RUNTIME_API_PORT")))
+{
+    arguments.Add("--port");
+    arguments.Add(Environment.GetEnvironmentVariable("LAMBDA_RUNTIME_API_PORT")!);
+}
+if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("API_GATEWAY_EMULATOR_PORT")))
+{
+    arguments.Add("--api-gateway-emulator-port");
+    arguments.Add(Environment.GetEnvironmentVariable("API_GATEWAY_EMULATOR_PORT")!);
+}
+
+return await app.RunAsync(arguments);

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Services/ApiGatewayRouteConfigService.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Services/ApiGatewayRouteConfigService.cs
@@ -14,7 +14,7 @@ public class ApiGatewayRouteConfigService : IApiGatewayRouteConfigService
 {
     private readonly ILogger<ApiGatewayRouteConfigService> _logger;
     private readonly IEnvironmentManager _environmentManager;
-    private List<ApiGatewayRouteConfig> _routeConfigs = new();
+    private readonly List<ApiGatewayRouteConfig> _routeConfigs = new();
 
     /// <summary>
     /// Constructs an instance of <see cref="ApiGatewayRouteConfigService"/>.

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/HttpRequestUtility.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/HttpRequestUtility.cs
@@ -107,7 +107,7 @@ public static class HttpRequestUtility
         {
             var key = lowerCaseKeyName ? header.Key.ToLower() : header.Key;
             singleValueHeaders[key] = header.Value.Last() ?? "";
-            multiValueHeaders[key] = [.. header.Value];
+            multiValueHeaders[key] = [.. header.Value!];
         }
 
         return (singleValueHeaders, multiValueHeaders);
@@ -133,7 +133,7 @@ public static class HttpRequestUtility
         foreach (var param in query)
         {
             singleValueParams[param.Key] = param.Value.Last() ?? "";
-            multiValueParams[param.Key] = [.. param.Value];
+            multiValueParams[param.Key] = [.. param.Value!];
         }
 
         return (singleValueParams, multiValueParams);

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/LocalEnvironmentManager.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/LocalEnvironmentManager.cs
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections;
+using Amazon.Lambda.TestTool.Services.IO;
+
+namespace Amazon.Lambda.TestTool.Utilities;
+
+public class LocalEnvironmentManager(IDictionary environmentManager) : IEnvironmentManager
+{
+    public IDictionary GetEnvironmentVariables() => environmentManager;
+}

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/RouteTemplateUtility.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/RouteTemplateUtility.cs
@@ -40,7 +40,7 @@ public static class RouteTemplateUtility
 
             foreach (var param in template.Parameters)
             {
-                if (routeValues.TryGetValue(param.Name, out var value))
+                if (routeValues.TryGetValue(param.Name!, out var value))
                 {
                     var stringValue = value?.ToString() ?? string.Empty;
 
@@ -51,7 +51,7 @@ public static class RouteTemplateUtility
                     }
 
                     // Restore original parameter name
-                    var originalParamName = RestoreOriginalParamName(param.Name);
+                    var originalParamName = RestoreOriginalParamName(param.Name!);
                     result[originalParamName] = stringValue;
                 }
             }

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/ApiGatewayEmulatorProcessTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/ApiGatewayEmulatorProcessTests.cs
@@ -8,6 +8,7 @@ using Amazon.Lambda.TestTool.Commands;
 using Amazon.Lambda.TestTool.Commands.Settings;
 using Amazon.Lambda.TestTool.Models;
 using Amazon.Lambda.TestTool.Services;
+using Amazon.Lambda.TestTool.Services.IO;
 using Moq;
 using Spectre.Console.Cli;
 using Xunit;
@@ -17,6 +18,7 @@ namespace Amazon.Lambda.TestTool.IntegrationTests;
 
 public class ApiGatewayEmulatorProcessTests : IAsyncDisposable
 {
+    private readonly Mock<IEnvironmentManager> _mockEnvironmentManager = new Mock<IEnvironmentManager>();
     private readonly Mock<IToolInteractiveService> _mockInteractiveService = new Mock<IToolInteractiveService>();
     private readonly Mock<IRemainingArguments> _mockRemainingArgs = new Mock<IRemainingArguments>();
     private readonly ITestOutputHelper _testOutputHelper;
@@ -245,7 +247,7 @@ public class ApiGatewayEmulatorProcessTests : IAsyncDisposable
         }}");
         cancellationTokenSource.CancelAfter(5000);
         var settings = new RunCommandSettings { Port = lambdaPort, NoLaunchWindow = true, ApiGatewayEmulatorMode = apiGatewayMode,ApiGatewayEmulatorPort = apiGatewayPort};
-        var command = new RunCommand(_mockInteractiveService.Object);
+        var command = new RunCommand(_mockInteractiveService.Object, _mockEnvironmentManager.Object);
         var context = new CommandContext(new List<string>(), _mockRemainingArgs.Object, "run", null);
 
         // Act

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Commands/RunCommandTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Commands/RunCommandTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using Amazon.Lambda.TestTool.Commands.Settings;
@@ -9,11 +9,14 @@ using Spectre.Console.Cli;
 using Moq;
 using Amazon.Lambda.TestTool.UnitTests.Helpers;
 using Xunit;
+using Amazon.Lambda.TestTool.Services.IO;
+using Amazon.Lambda.TestTool.Utilities;
 
 namespace Amazon.Lambda.TestTool.UnitTests.Commands;
 
 public class RunCommandTests
 {
+    private readonly Mock<IEnvironmentManager> _mockEnvironmentManager = new Mock<IEnvironmentManager>();
     private readonly Mock<IToolInteractiveService> _mockInteractiveService = new Mock<IToolInteractiveService>();
     private readonly Mock<IRemainingArguments> _mockRemainingArgs = new Mock<IRemainingArguments>();
 
@@ -25,7 +28,7 @@ public class RunCommandTests
         var cancellationSource = new CancellationTokenSource();
         cancellationSource.CancelAfter(5000);
         var settings = new RunCommandSettings { Port = 9001, NoLaunchWindow = true };
-        var command = new RunCommand(_mockInteractiveService.Object);
+        var command = new RunCommand(_mockInteractiveService.Object, _mockEnvironmentManager.Object);
         var context = new CommandContext(new List<string>(), _mockRemainingArgs.Object, "run", null);
         var apiUrl = $"http://{settings.Host}:{settings.Port}";
 
@@ -48,9 +51,38 @@ public class RunCommandTests
         var cancellationSource = new CancellationTokenSource();
         cancellationSource.CancelAfter(5000);
         var settings = new RunCommandSettings { Port = 9002,  ApiGatewayEmulatorMode = ApiGatewayEmulatorMode.HttpV2, NoLaunchWindow = true};
-        var command = new RunCommand(_mockInteractiveService.Object);
+        var command = new RunCommand(_mockInteractiveService.Object, _mockEnvironmentManager.Object);
         var context = new CommandContext(new List<string>(), _mockRemainingArgs.Object, "run", null);
         var apiUrl = $"http://{settings.Host}:{settings.ApiGatewayEmulatorPort}/__lambda_test_tool_apigateway_health__";
+
+        // Act
+        var runningTask = command.ExecuteAsync(context, settings, cancellationSource);
+        var isApiRunning = await TestHelpers.WaitForApiToStartAsync(apiUrl);
+        await cancellationSource.CancelAsync();
+
+        // Assert
+        var result = await runningTask;
+        Assert.Equal(CommandReturnCodes.Success, result);
+        Assert.True(isApiRunning);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EnvPorts_SuccessfulLaunch()
+    {
+        var environmentManager = new LocalEnvironmentManager(new Dictionary<string, string>
+        {
+            { RunCommand.LAMBDA_RUNTIME_API_PORT, "9432" },
+            { RunCommand.API_GATEWAY_EMULATOR_PORT, "9765" }
+        });
+
+        // Arrange
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
+        var cancellationSource = new CancellationTokenSource();
+        cancellationSource.CancelAfter(5000);
+        var settings = new RunCommandSettings { ApiGatewayEmulatorMode = ApiGatewayEmulatorMode.HttpV2, NoLaunchWindow = true };
+        var command = new RunCommand(_mockInteractiveService.Object, environmentManager);
+        var context = new CommandContext(new List<string>(), _mockRemainingArgs.Object, "run", null);
+        var apiUrl = $"http://{settings.Host}:9765/__lambda_test_tool_apigateway_health__";
 
         // Act
         var runningTask = command.ExecuteAsync(context, settings, cancellationSource);


### PR DESCRIPTION
*Description of changes:*
In Aspire we don't know the ports that it will allocate for the test tool till after the command line parameters have been set for the executable. To work around this I added environment variables that can be set by Aspire for the executable to pick up and use for ports.

I had trouble loading the test tool project for debugging due to the recent commit adding the wwwroot folder for packaging. To get around that I have the property only be set in Release mode allowing the project to be loaded in visual studio and `dotnet pack` which is run in release mode to find the static content. Not a perfect solution because it means VS will have issues in release mode. Unblocks for now but open to better solution.

I also addressed the remaining warnings in the project.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
