### PR TITLE
ci: run test tool v2 tests in PR checks

### DIFF
--- a/buildtools/build.proj
+++ b/buildtools/build.proj
@@ -197,10 +197,12 @@
         <Exec Command="dotnet test -c $(Configuration)" WorkingDirectory="..\Libraries\test\SnapshotRestore.Registry.Tests"/>
         <Exec Command="dotnet test -c $(Configuration)" WorkingDirectory="..\Libraries\test\Amazon.Lambda.RuntimeSupport.Tests\Amazon.Lambda.RuntimeSupport.UnitTests"/>
         <Exec Command="dotnet test -c $(Configuration)" WorkingDirectory="..\Libraries\test\Amazon.Lambda.Annotations.SourceGenerators.Tests"/>
+        <Exec Command="dotnet test -c $(Configuration)" WorkingDirectory="..\Tools\LambdaTestTool-v2\tests\Amazon.Lambda.TestTool.UnitTests"/>
     </Target>
     <Target Name="run-integ-tests">
         <Exec Command="dotnet test -c $(Configuration) --logger &quot;console;verbosity=detailed&quot;" WorkingDirectory="..\Libraries\test\Amazon.Lambda.RuntimeSupport.Tests\Amazon.Lambda.RuntimeSupport.IntegrationTests"/>
         <Exec Command="dotnet test -c $(Configuration) --logger &quot;console;verbosity=detailed&quot;" WorkingDirectory="..\Libraries\test\TestServerlessApp.IntegrationTests"/>
+        <Exec Command="dotnet test -c $(Configuration) --logger &quot;console;verbosity=detailed&quot;" WorkingDirectory="..\Tools\LambdaTestTool-v2\tests\Amazon.Lambda.TestTool.IntegrationTests"/>
     </Target>
     <Target Name="create-nuget-packages-cicd" DependsOnTargets="build-project-packages">
         <Exec Command="$(PackCommand)" WorkingDirectory="..\Libraries\src\%(LibraryName.FileName)"/>


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7863

*Description of changes:*
* Add the Test Tool v2 unit and integ test projects to the build.proj so that they are run as part of the PR checks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
