### PR TITLE
Aspire tweaks for test tool

### DIFF
--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/Settings/RunCommandSettings.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/Settings/RunCommandSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using Amazon.Lambda.TestTool.Models;
@@ -23,12 +23,11 @@ public sealed class RunCommandSettings : CommandSettings
     public string LambdaEmulatorHost { get; set; } = Constants.DefaultLambdaEmulatorHost;
 
     /// <summary>
-    /// The port number used for the test tool's web interface.
+    /// The port number used for the test tool's web interface. If a port is specified the Lambda emulator will be started.
     /// </summary>
     [CommandOption("-p|--lambda-emulator-port <PORT>")]
     [Description("The port number used for the test tool's web interface.")]
-    [DefaultValue(Constants.DefaultLambdaEmulatorPort)]
-    public int LambdaEmulatorPort { get; set; } = Constants.DefaultLambdaEmulatorPort;
+    public int? LambdaEmulatorPort { get; set; }
 
     /// <summary>
     /// Disable auto launching the test tool's web interface in a browser.
@@ -58,17 +57,16 @@ public sealed class RunCommandSettings : CommandSettings
     /// and how API Gateway interprets the response from Lambda.
     /// The available modes are: Rest, HttpV1, HttpV2.
     /// </summary>
-    [CommandOption("--api-gateway-emulator <MODE>")]
+    [CommandOption("--api-gateway-emulator-mode <MODE>")]
     [Description(
         "The API Gateway Emulator Mode specifies the format of the event that API Gateway sends to a Lambda integration, and how API Gateway interprets the response from Lambda. " +
         "The available modes are: Rest, HttpV1, HttpV2.")]
     public ApiGatewayEmulatorMode? ApiGatewayEmulatorMode { get; set; }
 
     /// <summary>
-    /// The port number used for the test tool's API Gateway emulator.
+    /// The port number used for the test tool's API Gateway emulator. If a port is specified the API Gateway emulator will be started. The --api-gateway-mode muse also be set when setting the API Gateway emulator port.
     /// </summary>
     [CommandOption("--api-gateway-emulator-port <PORT>")]
     [Description("The port number used for the test tool's API Gateway emulator.")]
-    [DefaultValue(Constants.DefaultApiGatewayEmulatorPort)]
-    public int? ApiGatewayEmulatorPort { get; set; } = Constants.DefaultApiGatewayEmulatorPort;
+    public int? ApiGatewayEmulatorPort { get; set; }
 }

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Constants.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Constants.cs
@@ -16,16 +16,6 @@ public abstract class Constants
     public const string ToolName = "dotnet-lambda-test-tool";
 
     /// <summary>
-    /// The default port used by the Lambda Test Tool for the Lambda Runtime API and the Web Interface.
-    /// </summary>
-    public const int DefaultLambdaEmulatorPort = 5050;
-
-    /// <summary>
-    /// The default port used by the API Gateway Emulator.
-    /// </summary>
-    public const int DefaultApiGatewayEmulatorPort = 5051;
-
-    /// <summary>
     /// The default hostname used for the Lambda Test Tool.
     /// </summary>
     public const string DefaultLambdaEmulatorHost = "localhost";

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/ApiGatewayEmulatorProcessTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/ApiGatewayEmulatorProcessTests.cs
@@ -245,7 +245,7 @@ public class ApiGatewayEmulatorProcessTests : IAsyncDisposable
             ""HttpMethod"": ""{config.HttpMethod}"",
             ""Path"": ""/{config.RouteName}""
         }}");
-        cancellationTokenSource.CancelAfter(5000);
+        cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(60));
         var settings = new RunCommandSettings { LambdaEmulatorPort = lambdaPort, NoLaunchWindow = true, ApiGatewayEmulatorMode = apiGatewayMode,ApiGatewayEmulatorPort = apiGatewayPort};
         var command = new RunCommand(_mockInteractiveService.Object, _mockEnvironmentManager.Object);
         var context = new CommandContext(new List<string>(), _mockRemainingArgs.Object, "run", null);

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Commands/RunCommandTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Commands/RunCommandTests.cs
@@ -50,7 +50,7 @@ public class RunCommandTests
         Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
         var cancellationSource = new CancellationTokenSource();
         cancellationSource.CancelAfter(5000);
-        var settings = new RunCommandSettings { LambdaEmulatorPort = 9002,  ApiGatewayEmulatorMode = ApiGatewayEmulatorMode.HttpV2, NoLaunchWindow = true};
+        var settings = new RunCommandSettings { LambdaEmulatorPort = 9002, ApiGatewayEmulatorPort = 9003, ApiGatewayEmulatorMode = ApiGatewayEmulatorMode.HttpV2, NoLaunchWindow = true};
         var command = new RunCommand(_mockInteractiveService.Object, _mockEnvironmentManager.Object);
         var context = new CommandContext(new List<string>(), _mockRemainingArgs.Object, "run", null);
         var apiUrl = $"http://{settings.LambdaEmulatorHost}:{settings.ApiGatewayEmulatorPort}/__lambda_test_tool_apigateway_health__";

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Commands/Settings/RunCommandSettingsTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Commands/Settings/RunCommandSettingsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using Amazon.Lambda.TestTool.Commands.Settings;
@@ -16,26 +16,6 @@ public class RunCommandSettingsTests
 
         // Assert
         Assert.Equal(Constants.DefaultLambdaEmulatorHost, settings.LambdaEmulatorHost);
-    }
-
-    [Fact]
-    public void DefaultPort_IsSetToConstantsDefaultPort()
-    {
-        // Arrange
-        var settings = new RunCommandSettings();
-
-        // Assert
-        Assert.Equal(Constants.DefaultLambdaEmulatorPort, settings.LambdaEmulatorPort);
-    }
-
-    [Fact]
-    public void ApiGatewayEmulatorPort_IsSetToConstantsDefaultApiGatewayEmulatorPort()
-    {
-        // Arrange
-        var settings = new RunCommandSettings();
-
-        // Assert
-        Assert.Equal(Constants.DefaultApiGatewayEmulatorPort, settings.ApiGatewayEmulatorPort);
     }
 
     [Fact]


### PR DESCRIPTION
*Description of changes:*
Some tweaks to the test tool for the Aspire integrations:
* Make starting Lambda runtime an opt-in by setting port
* Change the opt-in mechanism for API Gateway emulator to be triggered by port for consistency
* Add a query string parameter on the UI home page to allow preselecting a function in the drop down box
* Rename `--api-gateway-emulator` to `--api-gateway-emulator-mode` because `--api-gateway-emulator` doesn't give a sense what it is for.
* Remove the default ports. In the future we might consider an auto port mode for the Lambda port.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
