### PR TITLE
fix dotnet pack command to run on linux too

### DIFF
--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <Target Name="GetRuntimeSupportTargetFrameworks">
-    <Exec Command="dotnet msbuild ..\..\..\..\Libraries\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj --getProperty:TargetFrameworks" ConsoleToMSBuild="true">
+    <Exec Command="dotnet msbuild ../../../../Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj --getProperty:TargetFrameworks" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="RuntimeSupportTargetFrameworks" />
     </Exec>
   </Target>
@@ -44,10 +44,10 @@
                         Condition="'%(Identity)' != 'netstandard2.0'" />
     </ItemGroup>
 
-    <Exec Command="dotnet publish &quot;$(MSBuildThisFileDirectory)..\..\..\..\Libraries\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj&quot; -c $(Configuration) -f %(TargetFrameworks.Identity) /p:ExecutableOutputType=true" />
+    <Exec Command="dotnet publish &quot;$(MSBuildThisFileDirectory)../../../../Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj&quot; -c $(Configuration) -f %(TargetFrameworks.Identity) /p:ExecutableOutputType=true" />
 
     <ItemGroup>
-      <None Include="$(MSBuildThisFileDirectory)..\..\..\..\Libraries\src\Amazon.Lambda.RuntimeSupport\bin\$(Configuration)\%(TargetFrameworks.Identity)\publish\**\*.*">
+      <None Include="$(MSBuildThisFileDirectory)../../../../Libraries/src/Amazon.Lambda.RuntimeSupport/bin/$(Configuration)/%(TargetFrameworks.Identity)/publish/**/*.*">
         <Pack>true</Pack>
         <PackagePath>content\Amazon.Lambda.RuntimeSupport\%(TargetFrameworks.Identity)</PackagePath>
       </None>


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-lambda-dotnet/actions/runs/13013063459/job/36295271057

*Description of changes:* Fix error where it was not able to find csproj file because the pathing was using `\` instead of `/`. I tested on my windows machine and phils linux machine and it passed after doing this change. the CI still fails/hangs because of some other issue it seems, but it appears this issue is fixed


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
