### PR TITLE
Fix compiler warnings for unit and integration test project

### DIFF
--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/HttpContextExtensionsTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/HttpContextExtensionsTests.cs
@@ -172,13 +172,13 @@ namespace Amazon.Lambda.TestTool.IntegrationTests
 
             CompareApiGatewayRequests(expectedApiGatewayRequest, actualApiGatewayRequest);
 
-            testCase.Assertions(actualApiGatewayRequest, emulatorMode);
+            testCase.Assertions(actualApiGatewayRequest!, emulatorMode);
 
             await Task.Delay(1000); // Small delay between requests
         }
 
 
-        private void CompareApiGatewayRequests<T>(T expected, T actual) where T : class
+        private void CompareApiGatewayRequests<T>(T expected, T actual) where T : class?
         {
             if (expected is APIGatewayProxyRequest v1Expected && actual is APIGatewayProxyRequest v1Actual)
             {
@@ -261,23 +261,25 @@ namespace Amazon.Lambda.TestTool.IntegrationTests
             }
         }
 
-        private IDictionary<TKey, TValue> FilterHeaders<TKey, TValue>(IDictionary<TKey, TValue> headers)
+        private IDictionary<TKey, TValue> FilterHeaders<TKey, TValue>(IDictionary<TKey, TValue> headers) where TKey : notnull
         {
             return headers.Where(kvp =>
-                !(kvp.Key.ToString().StartsWith("x-forwarded-", StringComparison.OrdinalIgnoreCase) || // ignore these for now
-                  kvp.Key.ToString().StartsWith("cloudfront-", StringComparison.OrdinalIgnoreCase) || // ignore these for now
-                  kvp.Key.ToString().StartsWith("via-", StringComparison.OrdinalIgnoreCase) || // ignore these for now
-                  kvp.Key.ToString().Equals("x-amzn-trace-id", StringComparison.OrdinalIgnoreCase) || // this is dynamic so ignoring for now
-                  kvp.Key.ToString().Equals("cookie", StringComparison.OrdinalIgnoreCase) || // TODO may have to have api gateway v2 not set this in headers
-                  kvp.Key.ToString().Equals("host", StringComparison.OrdinalIgnoreCase))) // TODO we may want to set this
+                !(kvp.Key.ToString()!.StartsWith("x-forwarded-", StringComparison.OrdinalIgnoreCase) || // ignore these for now
+                  kvp.Key.ToString()!.StartsWith("cloudfront-", StringComparison.OrdinalIgnoreCase) || // ignore these for now
+                  kvp.Key.ToString()!.StartsWith("via-", StringComparison.OrdinalIgnoreCase) || // ignore these for now
+                  kvp.Key.ToString()!.Equals("x-amzn-trace-id", StringComparison.OrdinalIgnoreCase) || // this is dynamic so ignoring for now
+                  kvp.Key.ToString()!.Equals("cookie", StringComparison.OrdinalIgnoreCase) || // TODO may have to have api gateway v2 not set this in headers
+                  kvp.Key.ToString()!.Equals("host", StringComparison.OrdinalIgnoreCase))) // TODO we may want to set this
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 
 
-        private void CompareDictionaries<TKey, TValue>(IDictionary<TKey, TValue> expected, IDictionary<TKey, TValue> actual)
+        private void CompareDictionaries<TKey, TValue>(IDictionary<TKey, TValue>? expected, IDictionary<TKey, TValue>? actual)
         {
             if (expected == null && actual == null) return;
-            Assert.Equal(expected.Count, actual.Count);
+            if (expected == null && actual != null) Assert.Fail();
+            if (expected != null && actual == null) Assert.Fail();
+            Assert.Equal(expected!.Count, actual!.Count);
 
             foreach (var kvp in expected)
             {
@@ -291,7 +293,7 @@ namespace Amazon.Lambda.TestTool.IntegrationTests
             Assert.Equal(expected?.Length, actual?.Length);
             if (expected != null)
             {
-                Assert.Equal(expected.OrderBy(x => x), actual.OrderBy(x => x));
+                Assert.Equal(expected.OrderBy(x => x), actual?.OrderBy(x => x));
             }
         }
 

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/PackagingTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/PackagingTests.cs
@@ -94,7 +94,7 @@ public class PackagingTests : IDisposable
 
         Assert.Equal(0, packProcess.ExitCode);
 
-        var packageDir = Path.Combine(Path.GetDirectoryName(projectPath), "bin", "Release");
+        var packageDir = Path.Combine(Path.GetDirectoryName(projectPath)!, "bin", "Release");
         _output.WriteLine($"Looking for package in: {packageDir}");
 
         var packageFiles = Directory.GetFiles(packageDir, "*.nupkg", SearchOption.AllDirectories);
@@ -143,7 +143,7 @@ public class PackagingTests : IDisposable
     private string FindSolutionRoot()
     {
         Console.WriteLine("Looking for solution root...");
-        string currentDirectory = Directory.GetCurrentDirectory();
+        string? currentDirectory = Directory.GetCurrentDirectory();
         while (currentDirectory != null)
         {
             // Look for the aws-lambda-dotnet directory specifically


### PR DESCRIPTION
*Issue #, if available:* DOTNET-7935

*Description of changes:* Fix compiler warnings in integration test and regular project. Most of them are due to null checks.

*Testing*. I ran all unit tests and integration tests locally on my machine and they pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
