### PR TITLE
Hide documentation banner for configuring Lambda functions when tool is hosted by Aspire

### DIFF
--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Components/Pages/Home.razor
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Components/Pages/Home.razor
@@ -3,6 +3,7 @@
 @using Amazon.Lambda.TestTool.Models
 @using Amazon.Lambda.TestTool.SampleRequests
 @using Amazon.Lambda.TestTool.Services
+@using Amazon.Lambda.TestTool.Utilities
 
 <PageTitle>Lambda Function Tester</PageTitle>
 
@@ -26,11 +27,14 @@
     </div>
 </div>
 
-<div class="alert alert-secondary" role="alert">
-    For Lambda functions written as executable assemblies, i.e. custom runtimes functions and top level statement functions, this page can be used for testing the functions locally.
-    Set the <b>AWS_LAMBDA_RUNTIME_API</b> environment variable to <b>@HttpContextAccessor.HttpContext?.Request.Host</b> while debugging executable assembly
-    Lambda function. More information can be found in the <a href="/documentation">documentation</a>.
-</div>
+@if (!Utils.IsAspireHosted)
+{
+    <div class="alert alert-secondary" role="alert">
+        For Lambda functions written as executable assemblies, i.e. custom runtimes functions and top level statement functions, this page can be used for testing the functions locally.
+        Set the <b>AWS_LAMBDA_RUNTIME_API</b> environment variable to <b>@HttpContextAccessor.HttpContext?.Request.Host</b> while debugging executable assembly
+        Lambda function. More information can be found in the <a href="/documentation">documentation</a>.
+    </div>
+}
 
 @if (DataStore == null)
 {

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/Utils.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/Utils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Reflection;
@@ -40,6 +40,14 @@ public static class Utils
         }
 
         return version ?? unknownVersion;
+    }
+
+    /// <summary>
+    /// If true it means the test tool was launched via an Aspire AppHost.
+    /// </summary>
+    internal static bool IsAspireHosted
+    {
+        get { return string.Equals(Environment.GetEnvironmentVariable("ASPIRE_HOSTED"), "true", StringComparison.OrdinalIgnoreCase); }
     }
 
     /// <summary>


### PR DESCRIPTION
*Description of changes:*
The banner on the home page explaining how to set the environment variable for lambda runtime API doesn't make sense when used from Aspire because Aspire takes care of all of that setup. This PR adds a utility method that detects when the tool is hosted by an Aspire and then uses that to hide the banner.

This commit in the Aspire repo is where the environment variable is set. https://github.com/aws/integrations-on-dotnet-aspire-for-aws/pull/18/commits/f12a0a0afdb9f1411b8d8414cb989ce4f0a03eaa

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
