### PR TITLE
chore: add preview label in preparation for release

### DIFF
--- a/.autover/autover.json
+++ b/.autover/autover.json
@@ -138,7 +138,8 @@
     },
     {
       "Name": "Amazon.Lambda.TestTool",
-      "Path": "Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj"
+      "Path": "Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj",
+      "PrereleaseLabel": "preview"
     }
   ],
   "UseCommitsForChangelog": false,

--- a/.autover/changes/ea69e7ec-3ae7-4c7f-bd14-58857aba7bbe.json
+++ b/.autover/changes/ea69e7ec-3ae7-4c7f-bd14-58857aba7bbe.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.TestTool",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Initial preview release"
+      ]
+    }
+  ]
+}

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
 	  <Description>A tool to help debug and test your .NET AWS Lambda functions locally.</Description>
@@ -13,7 +13,7 @@
     <PackAsTool>true</PackAsTool>
     <PackageId>Amazon.Lambda.TestTool</PackageId>
     <ToolCommandName>dotnet-lambda-test-tool</ToolCommandName>
-    <Version>0.0.1-beta.1</Version>
+    <Version>0.0.1-preview</Version>
     <NoWarn>NU5100</NoWarn>
   </PropertyGroup>
 
@@ -40,8 +40,7 @@
     <ItemGroup>
       <TempFrameworks Include="$(RuntimeSupportTargetFrameworks.Split(';'))" />
 
-      <TargetFrameworks Include="@(TempFrameworks)"
-                        Condition="'%(Identity)' != 'netstandard2.0'" />
+      <TargetFrameworks Include="@(TempFrameworks)" Condition="'%(Identity)' != 'netstandard2.0'" />
     </ItemGroup>
 
     <Exec Command="dotnet publish &quot;$(MSBuildThisFileDirectory)../../../../Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj&quot; -c $(Configuration) -f %(TargetFrameworks.Identity) /p:ExecutableOutputType=true" />


### PR DESCRIPTION
*Description of changes:*
* Updated AutoVer config to indicate that TestToolv2 needs a `preview` suffix
* Updated release version to `0.0.1-preview`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
