### PR TITLE
Handle error conditions from Lambda function in Runtime API

### DIFF
--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/InvokeResponseExtensions.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/InvokeResponseExtensions.cs
@@ -38,32 +38,48 @@ public static class InvokeResponseExtensions
         }
         catch
         {
-            if (emulatorMode == ApiGatewayEmulatorMode.Rest)
+            return ToApiGatewayErrorResponse(emulatorMode);
+        }
+    }
+
+    /// <summary>
+    /// Creates an API Gateway error response based on the emulator mode.
+    /// </summary>
+    /// <param name="emulatorMode">The API Gateway emulator mode (Rest or Http).</param>
+    /// <returns>An APIGatewayProxyResponse object representing the error response.</returns>
+    /// <remarks>
+    /// This method generates different error responses based on the API Gateway emulator mode:
+    /// - For Rest mode: Returns a response with StatusCode 502 and a generic error message.
+    /// - For Http mode: Returns a response with StatusCode 500 and a generic error message.
+    /// Both responses include a Content-Type header set to application/json.
+    /// </remarks>
+    public static APIGatewayProxyResponse ToApiGatewayErrorResponse(ApiGatewayEmulatorMode emulatorMode)
+    {
+        if (emulatorMode == ApiGatewayEmulatorMode.Rest)
+        {
+            return new APIGatewayProxyResponse
             {
-                return new APIGatewayProxyResponse
-                {
-                    StatusCode = 502,
-                    Body = "{\"message\":\"Internal server error\"}",
-                    Headers = new Dictionary<string, string>
+                StatusCode = 502,
+                Body = "{\"message\":\"Internal server error\"}",
+                Headers = new Dictionary<string, string>
                 {
                     { "Content-Type", "application/json" }
                 },
-                    IsBase64Encoded = false
-                };
-            }
-            else
+                IsBase64Encoded = false
+            };
+        }
+        else
+        {
+            return new APIGatewayProxyResponse
             {
-                return new APIGatewayProxyResponse
-                {
-                    StatusCode = 500,
-                    Body = "{\"message\":\"Internal Server Error\"}",
-                    Headers = new Dictionary<string, string>
+                StatusCode = 500,
+                Body = "{\"message\":\"Internal Server Error\"}",
+                Headers = new Dictionary<string, string>
                 {
                     { "Content-Type", "application/json" }
                 },
-                    IsBase64Encoded = false
-                };
-            }
+                IsBase64Encoded = false
+            };
         }
     }
 
@@ -137,16 +153,7 @@ public static class InvokeResponseExtensions
                 catch
                 {
                     // If deserialization fails, return Internal Server Error
-                    return new APIGatewayHttpApiV2ProxyResponse
-                    {
-                        StatusCode = 500,
-                        Body = "{\"message\":\"Internal Server Error\"}",
-                        Headers = new Dictionary<string, string>
-                    {
-                        { "Content-Type", "application/json" }
-                    },
-                        IsBase64Encoded = false
-                    };
+                    return ToHttpApiV2ErrorResponse();
                 }
             }
 
@@ -173,6 +180,31 @@ public static class InvokeResponseExtensions
         {
             { "Content-Type", "application/json" }
         },
+            IsBase64Encoded = false
+        };
+    }
+
+    /// <summary>
+    /// Creates a standard HTTP API v2 error response.
+    /// </summary>
+    /// <returns>An APIGatewayHttpApiV2ProxyResponse object representing the error response.</returns>
+    /// <remarks>
+    /// This method generates a standard error response for HTTP API v2:
+    /// - StatusCode is set to 500 (Internal Server Error).
+    /// - Body contains a JSON string with a generic error message.
+    /// - Headers include a Content-Type set to application/json.
+    /// - IsBase64Encoded is set to false.
+    /// </remarks>
+    public static APIGatewayHttpApiV2ProxyResponse ToHttpApiV2ErrorResponse()
+    {
+        return new APIGatewayHttpApiV2ProxyResponse
+        {
+            StatusCode = 500,
+            Body = "{\"message\":\"Internal Server Error\"}",
+            Headers = new Dictionary<string, string>
+            {
+                { "Content-Type", "application/json" }
+            },
             IsBase64Encoded = false
         };
     }

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Properties/AssemblyInfo.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Amazon.Lambda.TestTool.UnitTests")]

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Services/LambdaRuntimeAPI.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Services/LambdaRuntimeAPI.cs
@@ -1,12 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Collections.Concurrent;
-using System.Runtime.CompilerServices;
 using System.Text;
 using Amazon.Lambda.TestTool.Models;
 using Microsoft.AspNetCore.Mvc;
-[assembly: InternalsVisibleTo("Amazon.Lambda.TestTool.UnitTests")]
 
 namespace Amazon.Lambda.TestTool.Services;
 

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Services/LambdaRuntimeAPI.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Services/LambdaRuntimeAPI.cs
@@ -63,16 +63,31 @@ public class LambdaRuntimeApi
         if (isRequestResponseMode)
         {
             evnt.WaitForCompletion();
-            var result = Results.Ok(evnt.Response);
-            ctx.Response.StatusCode = 200;
 
-            if (!string.IsNullOrEmpty(evnt.Response))
+            if (evnt.EventStatus == EventContainer.Status.Success)
             {
-                var responseData = Encoding.UTF8.GetBytes(evnt.Response);
-                ctx.Response.Headers.ContentType = "application/json";
-                ctx.Response.Headers.ContentLength = responseData.Length;
+                var result = Results.Ok(evnt.Response);
+                ctx.Response.StatusCode = 200;
 
-                await ctx.Response.Body.WriteAsync(responseData);
+                if (!string.IsNullOrEmpty(evnt.Response))
+                {
+                    var responseData = Encoding.UTF8.GetBytes(evnt.Response);
+                    ctx.Response.Headers.ContentType = "application/json";
+                    ctx.Response.Headers.ContentLength = responseData.Length;
+                    await ctx.Response.Body.WriteAsync(responseData);
+                }
+            }
+            else
+            {
+                ctx.Response.StatusCode = 200;
+                ctx.Response.Headers["X-Amz-Function-Error"] = evnt.ErrorType;
+                if (!string.IsNullOrEmpty(evnt.ErrorResponse))
+                {
+                    var errorData = Encoding.UTF8.GetBytes(evnt.ErrorResponse);
+                    ctx.Response.Headers.ContentType = "application/json";
+                    ctx.Response.Headers.ContentLength = errorData.Length;
+                    await ctx.Response.Body.WriteAsync(errorData);
+                }
             }
             evnt.Dispose();
         }

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Services/LambdaRuntimeAPI.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Services/LambdaRuntimeAPI.cs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Amazon.Lambda.TestTool.Models;
 using Microsoft.AspNetCore.Mvc;
+[assembly: InternalsVisibleTo("Amazon.Lambda.TestTool.UnitTests")]
 
 namespace Amazon.Lambda.TestTool.Services;
 
@@ -15,7 +17,7 @@ public class LambdaRuntimeApi
 
     private readonly IRuntimeApiDataStoreManager _runtimeApiDataStoreManager;
 
-    private LambdaRuntimeApi(WebApplication app)
+    internal LambdaRuntimeApi(WebApplication app)
     {
         _runtimeApiDataStoreManager = app.Services.GetRequiredService<IRuntimeApiDataStoreManager>();
 

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/ApiGatewayEmulatorProcessTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/ApiGatewayEmulatorProcessTests.cs
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net;
+using System.Net.Sockets;
 using System.Text;
 using Amazon.Lambda.TestTool.Commands;
 using Amazon.Lambda.TestTool.Commands.Settings;
@@ -22,6 +24,8 @@ public class ApiGatewayEmulatorProcessTests : IAsyncDisposable
     private readonly Mock<IToolInteractiveService> _mockInteractiveService = new Mock<IToolInteractiveService>();
     private readonly Mock<IRemainingArguments> _mockRemainingArgs = new Mock<IRemainingArguments>();
     private readonly ITestOutputHelper _testOutputHelper;
+    private readonly ConcurrentQueue<string> _logMessages = new ConcurrentQueue<string>();
+    private readonly SemaphoreSlim _logSemaphore = new SemaphoreSlim(1, 1);
     private Process? _lambdaProcess;
 
     public ApiGatewayEmulatorProcessTests(ITestOutputHelper testOutputHelper)
@@ -36,8 +40,8 @@ public class ApiGatewayEmulatorProcessTests : IAsyncDisposable
 #endif
     public async Task TestLambdaToUpperV2()
     {
-        var lambdaPort = 6012;
-        var apiGatewayPort = 6013;
+        var (lambdaPort, apiGatewayPort) = await GetFreePorts();
+
         var testProjectDir = Path.GetFullPath("../../../../../testapps");
         var config = new TestConfig
         {
@@ -75,8 +79,8 @@ public class ApiGatewayEmulatorProcessTests : IAsyncDisposable
 #endif
     public async Task TestLambdaToUpperRest()
     {
-        var lambdaPort = 6010;
-        var apiGatewayPort = 6011;
+        var (lambdaPort, apiGatewayPort) = await GetFreePorts();
+
         var testProjectDir = Path.GetFullPath("../../../../../testapps");
         var config = new TestConfig
         {
@@ -114,8 +118,9 @@ public class ApiGatewayEmulatorProcessTests : IAsyncDisposable
 #endif
     public async Task TestLambdaToUpperV1()
     {
-        var lambdaPort = 6008;
-        var apiGatewayPort = 6009;
+        var (lambdaPort, apiGatewayPort) = await GetFreePorts();
+
+
         var testProjectDir = Path.GetFullPath("../../../../../testapps");
         var config = new TestConfig
         {
@@ -153,8 +158,9 @@ public class ApiGatewayEmulatorProcessTests : IAsyncDisposable
 #endif
     public async Task TestLambdaBinaryResponse()
     {
-        var lambdaPort = 6006;
-        var apiGatewayPort = 6007;
+        var (lambdaPort, apiGatewayPort) = await GetFreePorts();
+
+
         var testProjectDir = Path.GetFullPath("../../../../../testapps");
         var config = new TestConfig
         {
@@ -198,8 +204,8 @@ public class ApiGatewayEmulatorProcessTests : IAsyncDisposable
 #endif
     public async Task TestLambdaReturnString()
     {
-        var lambdaPort = 6004;
-        var apiGatewayPort = 6005;
+        var (lambdaPort, apiGatewayPort) = await GetFreePorts();
+
         var testProjectDir = Path.GetFullPath("../../../../../testapps");
         var config = new TestConfig
         {
@@ -251,8 +257,8 @@ public class ApiGatewayEmulatorProcessTests : IAsyncDisposable
 
         try
         {
-            const int lambdaPort = 5060;
-            const int apiGatewayPort = 5061;
+            var (lambdaPort, apiGatewayPort) = await GetFreePorts();
+
             StartTestToolProcessWithNullEndpoint(ApiGatewayEmulatorMode.HttpV2, lambdaPort, apiGatewayPort, config, cancellationTokenSource);
             await WaitForGatewayHealthCheck(apiGatewayPort);
             await StartLambdaProcess(config, lambdaPort);
@@ -326,6 +332,34 @@ public class ApiGatewayEmulatorProcessTests : IAsyncDisposable
         _ = command.ExecuteAsync(context, settings, cancellationTokenSource);
     }
 
+    private async Task<(int lambdaPort, int apiGatewayPort)> GetFreePorts()
+    {
+        // Get two different ports
+        var lambdaPort = GetFreePort();
+        int apiGatewayPort;
+        do
+        {
+            apiGatewayPort = GetFreePort();
+        } while (apiGatewayPort == lambdaPort);
+
+        return (lambdaPort, apiGatewayPort);
+    }
+
+    private int GetFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        try
+        {
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            return port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
     private async Task StartLambdaProcess(TestConfig config, int lambdaPort)
     {
         // Build the project
@@ -363,13 +397,13 @@ public class ApiGatewayEmulatorProcessTests : IAsyncDisposable
 
     private void ConfigureProcessLogging(Process process, string prefix)
     {
-        process.OutputDataReceived += (_, e) =>
+        process.OutputDataReceived += async (_, e) =>
         {
-            if (e.Data != null) LogMessage($"{prefix}: {e.Data}");
+            if (e.Data != null) await LogMessage($"{prefix}: {e.Data}");
         };
-        process.ErrorDataReceived += (_, e) =>
+        process.ErrorDataReceived += async (_, e) =>
         {
-            if (e.Data != null) LogMessage($"{prefix} Error: {e.Data}");
+            if (e.Data != null) await LogMessage($"{prefix} Error: {e.Data}");
         };
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();
@@ -430,10 +464,18 @@ public class ApiGatewayEmulatorProcessTests : IAsyncDisposable
         throw new TimeoutException("API Gateway failed to start within timeout period");
     }
 
-    private void LogMessage(string message)
+    private async Task LogMessage(string message)
     {
-        Console.WriteLine(message);
-        _testOutputHelper.WriteLine(message);
+        await _logSemaphore.WaitAsync();
+        try
+        {
+            Console.WriteLine(message); // Still write to console for debugging
+            _logMessages.Enqueue(message);
+        }
+        finally
+        {
+            _logSemaphore.Release();
+        }
     }
 
     private async Task CleanupProcesses()
@@ -459,6 +501,13 @@ public class ApiGatewayEmulatorProcessTests : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        // Write all queued messages before disposing
+        while (_logMessages.TryDequeue(out var message))
+        {
+            _testOutputHelper.WriteLine(message);
+        }
+
         await CleanupProcesses();
+        _logSemaphore.Dispose();
     }
 }

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Services/LambdaRuntimeApiTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Services/LambdaRuntimeApiTests.cs
@@ -1,0 +1,270 @@
+using System.Text;
+using Amazon.Lambda.TestTool.Models;
+using Amazon.Lambda.TestTool.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Amazon.Lambda.TestTool.UnitTests.Services;
+
+public class LambdaRuntimeApiTests
+{
+    private readonly Mock<IRuntimeApiDataStore> _mockRuntimeDataStore;
+    private readonly WebApplication _app;
+    private readonly Mock<RuntimeApiDataStore> _mockRuntimeApiDataStore;
+
+    public LambdaRuntimeApiTests()
+    {
+        Mock<IRuntimeApiDataStoreManager> mockDataStoreManager = new();
+        _mockRuntimeDataStore = new Mock<IRuntimeApiDataStore>();
+        _mockRuntimeApiDataStore = new Mock<RuntimeApiDataStore>();
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddSingleton(mockDataStoreManager.Object);
+        _app = builder.Build();
+
+        mockDataStoreManager
+            .Setup(x => x.GetLambdaRuntimeDataStore(It.IsAny<string>()))
+            .Returns(_mockRuntimeDataStore.Object);
+
+        LambdaRuntimeApi.SetupLambdaRuntimeApiEndpoints(_app);
+    }
+
+    [Fact]
+    public async Task PostEvent_RequestResponse_Success()
+    {
+        // Arrange
+        var functionName = "testFunction";
+        var testEvent = "{\"key\":\"value\"}";
+        var response = "{\"result\":\"success\"}";
+
+        var eventContainer = new EventContainer(_mockRuntimeApiDataStore.Object, 1, testEvent, true);
+        eventContainer.ReportSuccessResponse(response);
+
+        _mockRuntimeDataStore
+            .Setup(x => x.QueueEvent(testEvent, true))
+            .Returns(eventContainer);
+
+        var context = new DefaultHttpContext();
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(testEvent));
+        context.Response.Body = new MemoryStream();
+
+        // Act
+        await new LambdaRuntimeApi(_app).PostEvent(context, functionName);
+
+        // Assert
+        Assert.Equal(200, context.Response.StatusCode);
+        Assert.Equal("application/json", context.Response.Headers.ContentType);
+        Assert.Equal(response.Length, context.Response.ContentLength);
+
+        context.Response.Body.Position = 0;
+        var responseBody = await new StreamReader(context.Response.Body).ReadToEndAsync();
+        Assert.Equal(response, responseBody);
+    }
+
+    [Fact]
+    public async Task PostEvent_Event_Async()
+    {
+        // Arrange
+        var functionName = "testFunction";
+        var testEvent = "{\"key\":\"value\"}";
+
+        var context = new DefaultHttpContext();
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(testEvent));
+        context.Request.Headers["X-Amz-Invocation-Type"] = "Event";
+        context.Response.Body = new MemoryStream();
+
+        // Act
+        await new LambdaRuntimeApi(_app).PostEvent(context, functionName);
+
+        // Assert
+        Assert.Equal(202, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostEvent_RequestResponse_Error()
+    {
+        // Arrange
+        var functionName = "testFunction";
+        var testEvent = "{\"key\":\"value\"}";
+        var errorType = "Function.Error";
+        var errorResponse = "{\"errorMessage\":\"Something went wrong\"}";
+
+        var eventContainer = new EventContainer(_mockRuntimeApiDataStore.Object, 1, testEvent, true);
+        eventContainer.ReportErrorResponse(errorType, errorResponse);
+
+        _mockRuntimeDataStore
+            .Setup(x => x.QueueEvent(testEvent, true))
+            .Returns(eventContainer);
+
+        var context = new DefaultHttpContext();
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(testEvent));
+        context.Response.Body = new MemoryStream();
+
+        // Act
+        await new LambdaRuntimeApi(_app).PostEvent(context, functionName);
+
+        // Assert
+        Assert.Equal(200, context.Response.StatusCode);
+        Assert.Equal(errorType, context.Response.Headers["X-Amz-Function-Error"]);
+        Assert.Equal("application/json", context.Response.Headers.ContentType);
+        Assert.Equal(errorResponse.Length, context.Response.ContentLength);
+
+        context.Response.Body.Position = 0;
+        var responseBody = await new StreamReader(context.Response.Body).ReadToEndAsync();
+        Assert.Equal(errorResponse, responseBody);
+    }
+
+    [Fact]
+    public async Task PostEvent_RequestResponse_ErrorWithoutBody()
+    {
+        // Arrange
+        var functionName = "testFunction";
+        var testEvent = "{\"key\":\"value\"}";
+        var errorType = "Function.Error";
+        string? errorResponse = null;
+
+        var eventContainer = new EventContainer(_mockRuntimeApiDataStore.Object, 1, testEvent, true);
+        eventContainer.ReportErrorResponse(errorType, errorResponse);
+
+        _mockRuntimeDataStore
+            .Setup(x => x.QueueEvent(testEvent, true))
+            .Returns(eventContainer);
+
+        var context = new DefaultHttpContext();
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(testEvent));
+        context.Response.Body = new MemoryStream();
+
+        // Act
+        await new LambdaRuntimeApi(_app).PostEvent(context, functionName);
+
+        // Assert
+        Assert.Equal(200, context.Response.StatusCode);
+        Assert.Equal(errorType, context.Response.Headers["X-Amz-Function-Error"]);
+        Assert.Equal(0, context.Response.Headers.ContentType.Count);
+        Assert.Null(context.Response.ContentLength);
+
+        context.Response.Body.Position = 0;
+        var responseBody = await new StreamReader(context.Response.Body).ReadToEndAsync();
+        Assert.Empty(responseBody);
+    }
+
+
+
+    [Fact]
+    public async Task GetNextInvocation_Returns_Event()
+    {
+        // Arrange
+        var functionName = "testFunction";
+        var testEvent = "{\"key\":\"value\"}";
+        var eventContainer = new EventContainer(_mockRuntimeApiDataStore.Object, 1, testEvent, true);
+
+        _mockRuntimeDataStore
+            .Setup(x => x.TryActivateEvent(out eventContainer))
+            .Returns(true);
+
+        var context = new DefaultHttpContext();
+        var memoryStream = new NonClosingMemoryStream(); // Using custom non closing memory stream because if we use regular memory stream its closed after GetBextInvocation and we can't read it.
+        context.Response.Body = memoryStream;
+
+        // Act
+        await new LambdaRuntimeApi(_app).GetNextInvocation(context, functionName);
+
+        // Assert
+        Assert.Equal(200, context.Response.StatusCode);
+        Assert.True(context.Response.Headers.ContainsKey("Lambda-Runtime-Aws-Request-Id"));
+        Assert.True(context.Response.Headers.ContainsKey("Lambda-Runtime-Trace-Id"));
+        Assert.True(context.Response.Headers.ContainsKey("Lambda-Runtime-Invoked-Function-Arn"));
+        Assert.Equal("application/json", context.Response.Headers["Content-Type"]);
+
+        memoryStream.Position = 0;
+        using (var reader = new StreamReader(memoryStream, leaveOpen: true))
+        {
+            var responseBody = await reader.ReadToEndAsync();
+            Assert.Equal(testEvent, responseBody);
+        }
+    }
+
+    [Fact]
+    public void PostInitError_Logs_Error()
+    {
+        // Arrange
+        var functionName = "testFunction";
+        var errorType = "InitializationError";
+        var error = "Failed to initialize";
+
+        // Act
+        var result = new LambdaRuntimeApi(_app).PostInitError(functionName, errorType, error);
+
+        // Assert
+        Assert.NotNull(result);
+        var statusResponse = Assert.IsType<StatusResponse>((result as IValueHttpResult)?.Value);
+        Assert.Equal("success", statusResponse.Status);
+    }
+
+    [Fact]
+    public async Task PostInvocationResponse_Reports_Success()
+    {
+        // Arrange
+        var functionName = "testFunction";
+        var awsRequestId = "request123";
+        var response = "{\"result\":\"success\"}";
+
+        var context = new DefaultHttpContext();
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(response));
+        context.Response.Body = new MemoryStream();
+
+        _mockRuntimeDataStore
+            .Setup(x => x.ReportSuccess(awsRequestId, response));
+
+        // Act
+        var result = await new LambdaRuntimeApi(_app).PostInvocationResponse(context, functionName, awsRequestId);
+
+        // Assert
+        Assert.NotNull(result);
+        var statusResponse = Assert.IsType<StatusResponse>((result as IValueHttpResult)?.Value);
+        Assert.Equal("success", statusResponse.Status);
+
+        _mockRuntimeDataStore.Verify(x => x.ReportSuccess(awsRequestId, response), Times.Once);
+    }
+
+    [Fact]
+    public async Task PostError_Reports_Error()
+    {
+        // Arrange
+        var functionName = "testFunction";
+        var awsRequestId = "request123";
+        var errorType = "HandlerError";
+        var errorBody = "Function execution failed";
+
+        var context = new DefaultHttpContext();
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(errorBody));
+        context.Response.Body = new MemoryStream();
+
+        _mockRuntimeDataStore
+            .Setup(x => x.ReportError(awsRequestId, errorType, errorBody));
+
+        // Act
+        var result = await new LambdaRuntimeApi(_app).PostError(context, functionName, awsRequestId, errorType);
+
+        // Assert
+        Assert.NotNull(result);
+        var statusResponse = Assert.IsType<StatusResponse>((result as IValueHttpResult)?.Value);
+        Assert.Equal("success", statusResponse.Status);
+
+        _mockRuntimeDataStore.Verify(x => x.ReportError(awsRequestId, errorType, errorBody), Times.Once);
+    }
+
+
+
+}
+
+// Helper class to prevent stream from being closed
+public class NonClosingMemoryStream : MemoryStream
+{
+    public override void Close() { }
+    protected override void Dispose(bool disposing) { }
+}
+


### PR DESCRIPTION
*Issue #, if available:* DOTNET-7865

*Description of changes:*
In this PR, we handle error conditions for when the lambda function itself fails. There are 2 main components.

1. Handling the error in the lambda runtime api.
2. Handling the error at the api gateway layer

### Handling the error in the lambda runtime api
For handling the error at the lambda runtime api layer we need to mimic how lambda functions behave when they fail. The behavior is described here https://docs.aws.amazon.com/lambda/latest/api/API_Invoke.html#API_Invoke_ResponseSyntax. The TLDR version is that they will set the status code to 200, populate the payload with the `event.ErrorResponse` object and also set the `X-Amz-Function-Error` header to the `event.ErrorType`.

![image](https://github.com/user-attachments/assets/25f3596e-19a3-41a7-9e8e-854b9c5e2841)


### Handling the lambda error for api gateway
For handling the error at the api gateway layer, it seems that api gateway will just show internal server error when the lambda has an error behind the scenes, so I have done the same.

![image](https://github.com/user-attachments/assets/08027748-136d-48c9-b097-9c5408d481ab)


## Testing/Validation
### Testing lambda runtime api
In order to verify the accuracy of how i am doing the error handling for the lambda runtime api, did the following. I deployed a lambda function that looks like this (it will throw a null pointer exception and fail)
```
exports.handler = async (event) => {
var x;
return x.toUpper()
};
```

I then created a console app to invoke the lambda function directly. 

```
var response = await lambdaClient.InvokeAsync(request);

    // Process the response
    if (response.StatusCode == 200)
    {
        Console.WriteLine("Lambda function invoked successfully.");
        string responsePayload = System.Text.Encoding.UTF8.GetString(response.Payload.ToArray());
        Console.WriteLine($"Response payload: {responsePayload}");
    }
    else
    {
        Console.WriteLine($"Error invoking Lambda function. Status code: {response.StatusCode}");
    }
```

I was able to validate that the response code was `200`,  the responsePayload contained the same  `evnt.ErrorResponse` object that i populate in my code, and that the X-Amz-Function-Error was the same to the one that i populate in my code. (sample fiddler response below)

```
HTTP/1.1 200 OK
Date: Wed, 29 Jan 2025 16:53:47 GMT
Content-Type: application/json
Content-Length: 308
Connection: keep-alive

X-Amz-Function-Error: Unhandled

{"errorType":"TypeError","errorMessage":"Cannot read properties of undefined (reading 'toUpper')","trace":["TypeError: Cannot read properties of undefined (reading 'toUpper')","    at exports.handler (/var/task/index.js:3:10)","    at Runtime.handleOnceNonStreaming (file:///var/runtime/index.mjs:1173:29)"]}
```

### Testing api gateway for handling errors
1. For api gateway, i did similar. I used the same lambda function as above and just hooked up an api gateway and then went to the api gateway url and found that it just returned `Internal Server Error`. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
