### PR TITLE
Add version to test tool

### DIFF
--- a/.autover/changes/efa829ed-59af-46eb-a5e5-ef471698c82d.json
+++ b/.autover/changes/efa829ed-59af-46eb-a5e5-ef471698c82d.json
@@ -4,7 +4,8 @@
       "Name": "Amazon.Lambda.TestTool",
       "Type": "Patch",
       "ChangelogMessages": [
-        "Add --version switch to allow integrators to check what version is installed"
+        "Breaking change: Switch to use commands to invoke the tool. For example to run the Lambda emulator use the command 'dotnet lambda-test-tool start --lambda-emulator-port 5050'",
+		"Add new info command to get metadata about the tool. For example getting the version number of the tool."
       ]
     }
   ]

--- a/.autover/changes/efa829ed-59af-46eb-a5e5-ef471698c82d.json
+++ b/.autover/changes/efa829ed-59af-46eb-a5e5-ef471698c82d.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.TestTool",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add --version switch to allow integrators to check what version is installed"
+      ]
+    }
+  ]
+}

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/RunCommand.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/RunCommand.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using System.Text.Json;
 using Amazon.Lambda.TestTool.Commands.Settings;
 using Amazon.Lambda.TestTool.Extensions;
 using Amazon.Lambda.TestTool.Models;
@@ -28,6 +29,12 @@ public sealed class RunCommand(
     {
         try
         {
+            if (settings.PrintVersionInfo)
+            {
+                PrintVersionInfo();
+                return CommandReturnCodes.Success;
+            }
+
             EvaluateEnvironmentVariables(settings);
 
             if (!settings.LambdaEmulatorPort.HasValue && !settings.ApiGatewayEmulatorPort.HasValue)
@@ -99,6 +106,15 @@ public sealed class RunCommand(
         {
             await cancellationTokenSource.CancelAsync();
         }
+    }
+
+    private void PrintVersionInfo()
+    {
+        Utf8JsonWriter utf8JsonWriter = new Utf8JsonWriter(Console.OpenStandardOutput());
+        utf8JsonWriter.WriteStartObject();
+        utf8JsonWriter.WriteString("version", Utilities.Utils.DetermineToolVersion());
+        utf8JsonWriter.WriteEndObject();
+        utf8JsonWriter.Flush();
     }
 
     private void EvaluateEnvironmentVariables(RunCommandSettings settings)

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/RunCommand.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/RunCommand.cs
@@ -110,11 +110,7 @@ public sealed class RunCommand(
 
     private void PrintVersionInfo()
     {
-        Utf8JsonWriter utf8JsonWriter = new Utf8JsonWriter(Console.OpenStandardOutput());
-        utf8JsonWriter.WriteStartObject();
-        utf8JsonWriter.WriteString("version", Utilities.Utils.DetermineToolVersion());
-        utf8JsonWriter.WriteEndObject();
-        utf8JsonWriter.Flush();
+        toolInteractiveService.WriteLine(Utilities.Utils.GenerateVersionJson());
     }
 
     private void EvaluateEnvironmentVariables(RunCommandSettings settings)

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/RunCommand.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/RunCommand.cs
@@ -29,9 +29,9 @@ public sealed class RunCommand(
     {
         try
         {
-            if (settings.PrintVersionInfo)
+            if (settings.PrintToolInfo)
             {
-                PrintVersionInfo();
+                PrintToolInfo();
                 return CommandReturnCodes.Success;
             }
 
@@ -108,9 +108,9 @@ public sealed class RunCommand(
         }
     }
 
-    private void PrintVersionInfo()
+    private void PrintToolInfo()
     {
-        toolInteractiveService.WriteLine(Utilities.Utils.GenerateVersionJson());
+        toolInteractiveService.WriteLine(Utilities.Utils.GenerateToolInfoJson());
     }
 
     private void EvaluateEnvironmentVariables(RunCommandSettings settings)

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/RunCommand.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/RunCommand.cs
@@ -29,12 +29,6 @@ public sealed class RunCommand(
     {
         try
         {
-            if (settings.PrintToolInfo)
-            {
-                PrintToolInfo();
-                return CommandReturnCodes.Success;
-            }
-
             EvaluateEnvironmentVariables(settings);
 
             if (!settings.LambdaEmulatorPort.HasValue && !settings.ApiGatewayEmulatorPort.HasValue)
@@ -106,11 +100,6 @@ public sealed class RunCommand(
         {
             await cancellationTokenSource.CancelAsync();
         }
-    }
-
-    private void PrintToolInfo()
-    {
-        toolInteractiveService.WriteLine(Utilities.Utils.GenerateToolInfoJson());
     }
 
     private void EvaluateEnvironmentVariables(RunCommandSettings settings)

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/Settings/RunCommandSettings.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/Settings/RunCommandSettings.cs
@@ -71,9 +71,9 @@ public sealed class RunCommandSettings : CommandSettings
     public int? ApiGatewayEmulatorPort { get; set; }
 
     /// <summary>
-    /// When set the tool prints version information as a JSON document and then exits.
+    /// When set the tool prints metadata for the including the version number as a JSON document and then exits.
     /// </summary>
-    [CommandOption("--version")]
-    [Description("When set the tool prints version information as a JSON document and then exits.")]
-    public bool PrintVersionInfo { get; set; }
+    [CommandOption("--tool-info")]
+    [Description("When set the tool prints metadata for the including the version number as a JSON document and then exits.")]
+    public bool PrintToolInfo { get; set; }
 }

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/Settings/RunCommandSettings.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/Settings/RunCommandSettings.cs
@@ -8,7 +8,7 @@ using System.ComponentModel;
 namespace Amazon.Lambda.TestTool.Commands.Settings;
 
 /// <summary>
-/// Represents the settings for configuring the <see cref="RunCommand"/>, which is the default command.
+/// Represents the settings for configuring the <see cref="RunCommand"/>.
 /// </summary>
 public sealed class RunCommandSettings : CommandSettings
 {
@@ -37,22 +37,6 @@ public sealed class RunCommandSettings : CommandSettings
     public bool NoLaunchWindow { get; set; }
 
     /// <summary>
-    /// If set to true the test tool will pause waiting for a key input before exiting.
-    /// The is useful when executing from an IDE so you can avoid having the output window immediately disappear after executing the Lambda code.
-    /// The default value is true.
-    /// </summary>
-    [CommandOption("--pause-exit")]
-    [Description("If set to true the test tool will pause waiting for a key input before exiting. The is useful when executing from an IDE so you can avoid having the output window immediately disappear after executing the Lambda code. The default value is true.")]
-    public bool PauseExit { get; set; }
-
-    /// <summary>
-    /// Disables logging in the application
-    /// </summary>
-    [CommandOption("--disable-logs")]
-    [Description("Disables logging in the application")]
-    public bool DisableLogs { get; set; }
-
-    /// <summary>
     /// The API Gateway Emulator Mode specifies the format of the event that API Gateway sends to a Lambda integration,
     /// and how API Gateway interprets the response from Lambda.
     /// The available modes are: Rest, HttpV1, HttpV2.
@@ -69,11 +53,4 @@ public sealed class RunCommandSettings : CommandSettings
     [CommandOption("--api-gateway-emulator-port <PORT>")]
     [Description("The port number used for the test tool's API Gateway emulator.")]
     public int? ApiGatewayEmulatorPort { get; set; }
-
-    /// <summary>
-    /// When set the tool prints metadata for the including the version number as a JSON document and then exits.
-    /// </summary>
-    [CommandOption("--tool-info")]
-    [Description("When set the tool prints metadata for the including the version number as a JSON document and then exits.")]
-    public bool PrintToolInfo { get; set; }
 }

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/Settings/RunCommandSettings.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/Settings/RunCommandSettings.cs
@@ -69,4 +69,11 @@ public sealed class RunCommandSettings : CommandSettings
     [CommandOption("--api-gateway-emulator-port <PORT>")]
     [Description("The port number used for the test tool's API Gateway emulator.")]
     public int? ApiGatewayEmulatorPort { get; set; }
+
+    /// <summary>
+    /// When set the tool prints version information as a JSON document and then exits.
+    /// </summary>
+    [CommandOption("--version")]
+    [Description("When set the tool prints version information as a JSON document and then exits.")]
+    public bool PrintVersionInfo { get; set; }
 }

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/Settings/ToolInfoCommandSettings.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/Settings/ToolInfoCommandSettings.cs
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Lambda.TestTool.Models;
+using Spectre.Console.Cli;
+using System.ComponentModel;
+
+namespace Amazon.Lambda.TestTool.Commands.Settings;
+
+/// <summary>
+/// Represents the settings for configuring the <see cref="ToolInfoCommand"/>.
+/// </summary>
+public sealed class ToolInfoCommandSettings : CommandSettings
+{
+    public enum InfoFormat 
+    {
+        Text,
+        Json
+    }
+
+    /// <summary>
+    /// The format the info is displayed as.
+    /// The available formats are: Text, Json.
+    /// </summary>
+    [CommandOption("--format <FORMAT>")]
+    [Description(
+        "The format the info is displayed as. " +
+        "The available formats are: Text, Json.")]
+    public InfoFormat? Format { get; set; }
+}

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/ToolInfoCommand.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/ToolInfoCommand.cs
@@ -1,0 +1,81 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text;
+using System.Text.Json;
+using Amazon.Lambda.TestTool.Commands.Settings;
+using Amazon.Lambda.TestTool.Models;
+using Amazon.Lambda.TestTool.Services;
+using Amazon.Lambda.TestTool.Utilities;
+using Spectre.Console.Cli;
+
+namespace Amazon.Lambda.TestTool.Commands;
+
+/// <summary>
+/// Command to display tool information like the version of the tool.
+/// </summary>
+/// <param name="toolInteractiveService"></param>
+public class ToolInfoCommand(IToolInteractiveService toolInteractiveService)
+    : Command<ToolInfoCommandSettings>
+{
+    /// <summary>
+    /// The method responsible for executing the <see cref="RunCommand"/>.
+    /// </summary>
+    public override int Execute(CommandContext context, ToolInfoCommandSettings settings)
+    {
+        var info = CollectInformation();
+
+        var formattedInfo = settings.Format switch
+        {
+            ToolInfoCommandSettings.InfoFormat.Text => GenerateToolInfoText(info),
+            ToolInfoCommandSettings.InfoFormat.Json => GenerateToolInfoJson(info),
+            _ => GenerateToolInfoText(info)
+        };
+
+        toolInteractiveService.WriteLine(formattedInfo);
+        return CommandReturnCodes.Success;
+    }
+
+    private string GenerateToolInfoText(IDictionary<string, string> info)
+    {
+        var stringBuilder = new StringBuilder();
+        foreach(var kvp in info)
+        {
+            stringBuilder.AppendLine($"{kvp.Key}: {kvp.Value}");
+        }
+
+        return stringBuilder.ToString();
+    }
+
+    private string GenerateToolInfoJson(IDictionary<string, string> info)
+    {
+        var stream = new MemoryStream();
+        Utf8JsonWriter utf8JsonWriter = new Utf8JsonWriter(stream, options: new JsonWriterOptions()
+        {
+            Indented = false
+        });
+
+        utf8JsonWriter.WriteStartObject();
+
+        foreach (var kvp in info)
+        {
+            utf8JsonWriter.WriteString(kvp.Key, kvp.Value);
+        }
+
+        utf8JsonWriter.WriteEndObject();
+        utf8JsonWriter.Flush();
+
+        stream.Position = 0;
+        return new StreamReader(stream).ReadToEnd();
+    }
+
+    private Dictionary<string, string> CollectInformation()
+    {
+        var info = new Dictionary<string, string>();
+        info["Version"] = Utils.DetermineToolVersion();
+        info["InstallPath"] = GetInstallPath();
+        return info;
+    }
+
+    private string GetInstallPath() => Directory.GetParent(typeof(Utils).Assembly.Location)!.FullName;
+}

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Program.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Program.cs
@@ -13,9 +13,14 @@ serviceCollection.AddCustomServices();
 
 var registrar = new TypeRegistrar(serviceCollection);
 
-var app = new CommandApp<RunCommand>(registrar);
+var app = new CommandApp(registrar);
 app.Configure(config =>
 {
+    config.AddCommand<RunCommand>("start")
+        .WithDescription("Start the Lambda and/or API Gateway emulator.");
+    config.AddCommand<ToolInfoCommand>("info")
+        .WithDescription("Display information about the tool including the version number.");
+
     config.SetApplicationName(Constants.ToolName);
 });
 

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/Utils.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/Utils.cs
@@ -21,7 +21,7 @@ public static class Utils
         AssemblyInformationalVersionAttribute? attribute = null;
         try
         {
-            var assembly = Assembly.GetEntryAssembly();
+            var assembly = typeof(Utils).Assembly;
             if (assembly == null)
                 return unknownVersion;
             attribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
@@ -40,6 +40,22 @@ public static class Utils
         }
 
         return version ?? unknownVersion;
+    }
+
+    public static string GenerateVersionJson()
+    {
+        var stream = new MemoryStream();
+        Utf8JsonWriter utf8JsonWriter = new Utf8JsonWriter(stream, options: new JsonWriterOptions()
+        {
+            Indented = false
+        });
+        utf8JsonWriter.WriteStartObject();
+        utf8JsonWriter.WriteString("version", Utilities.Utils.DetermineToolVersion());
+        utf8JsonWriter.WriteEndObject();
+        utf8JsonWriter.Flush();
+
+        stream.Position = 0;
+        return new StreamReader(stream).ReadToEnd();
     }
 
     /// <summary>

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/Utils.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/Utils.cs
@@ -42,7 +42,7 @@ public static class Utils
         return version ?? unknownVersion;
     }
 
-    public static string GenerateVersionJson()
+    public static string GenerateToolInfoJson()
     {
         var stream = new MemoryStream();
         Utf8JsonWriter utf8JsonWriter = new Utf8JsonWriter(stream, options: new JsonWriterOptions()
@@ -51,6 +51,7 @@ public static class Utils
         });
         utf8JsonWriter.WriteStartObject();
         utf8JsonWriter.WriteString("version", Utilities.Utils.DetermineToolVersion());
+        utf8JsonWriter.WriteString("install-path", Directory.GetParent(typeof(Utils).Assembly.Location)!.FullName);
         utf8JsonWriter.WriteEndObject();
         utf8JsonWriter.Flush();
 

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/Utils.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/Utils.cs
@@ -42,23 +42,6 @@ public static class Utils
         return version ?? unknownVersion;
     }
 
-    public static string GenerateToolInfoJson()
-    {
-        var stream = new MemoryStream();
-        Utf8JsonWriter utf8JsonWriter = new Utf8JsonWriter(stream, options: new JsonWriterOptions()
-        {
-            Indented = false
-        });
-        utf8JsonWriter.WriteStartObject();
-        utf8JsonWriter.WriteString("version", Utilities.Utils.DetermineToolVersion());
-        utf8JsonWriter.WriteString("install-path", Directory.GetParent(typeof(Utils).Assembly.Location)!.FullName);
-        utf8JsonWriter.WriteEndObject();
-        utf8JsonWriter.Flush();
-
-        stream.Position = 0;
-        return new StreamReader(stream).ReadToEnd();
-    }
-
     /// <summary>
     /// If true it means the test tool was launched via an Aspire AppHost.
     /// </summary>

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Commands/RunCommandTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Commands/RunCommandTests.cs
@@ -103,7 +103,7 @@ public class RunCommandTests
     }
 
     [Fact]
-    public async Task VerifyVersionInfo()
+    public async Task VerifyToolInfo()
     {
         var writeCalls = 0;
         string? versionInfo = null;
@@ -116,7 +116,7 @@ public class RunCommandTests
             });
 
         var cancellationSource = new CancellationTokenSource();
-        var settings = new RunCommandSettings { PrintVersionInfo = true };
+        var settings = new RunCommandSettings { PrintToolInfo = true };
         var command = new RunCommand(mockInteractiveService.Object, _mockEnvironmentManager.Object);
         var context = new CommandContext(new List<string>(), _mockRemainingArgs.Object, "run", null);
         await command.ExecuteAsync(context, settings, cancellationSource);
@@ -133,5 +133,10 @@ public class RunCommandTests
         // The Version.TryParse does not like the preview suffix
         version = version.Replace("-preview", "");
         Assert.True(Version.TryParse(version, out var _));
+
+        var installPath = jsonNode["install-path"]?.ToString();
+        Assert.NotNull(installPath);
+        Assert.True(Directory.Exists(installPath));
+        Assert.True(Path.IsPathFullyQualified(installPath));
     }
 }

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Commands/RunCommandTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Commands/RunCommandTests.cs
@@ -103,7 +103,7 @@ public class RunCommandTests
     }
 
     [Fact]
-    public async Task VerifyToolInfo()
+    public void VerifyToolInfo()
     {
         var writeCalls = 0;
         string? versionInfo = null;
@@ -115,11 +115,10 @@ public class RunCommandTests
                 versionInfo = message;
             });
 
-        var cancellationSource = new CancellationTokenSource();
-        var settings = new RunCommandSettings { PrintToolInfo = true };
-        var command = new RunCommand(mockInteractiveService.Object, _mockEnvironmentManager.Object);
+        var settings = new ToolInfoCommandSettings { Format = ToolInfoCommandSettings.InfoFormat.Json };
+        var command = new ToolInfoCommand(mockInteractiveService.Object);
         var context = new CommandContext(new List<string>(), _mockRemainingArgs.Object, "run", null);
-        await command.ExecuteAsync(context, settings, cancellationSource);
+        command.Execute(context, settings);
 
         Assert.Equal(1, writeCalls);
         Assert.True(!string.IsNullOrEmpty(versionInfo));
@@ -127,14 +126,14 @@ public class RunCommandTests
         JsonNode? jsonNode = JsonNode.Parse(versionInfo);
         Assert.NotNull(jsonNode);
 
-        var version = jsonNode["version"]?.ToString();
+        var version = jsonNode["Version"]?.ToString();
         Assert.NotNull(version);
 
         // The Version.TryParse does not like the preview suffix
         version = version.Replace("-preview", "");
         Assert.True(Version.TryParse(version, out var _));
 
-        var installPath = jsonNode["install-path"]?.ToString();
+        var installPath = jsonNode["InstallPath"]?.ToString();
         Assert.NotNull(installPath);
         Assert.True(Directory.Exists(installPath));
         Assert.True(Path.IsPathFullyQualified(installPath));

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Commands/RunCommandTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Commands/RunCommandTests.cs
@@ -11,6 +11,7 @@ using Amazon.Lambda.TestTool.UnitTests.Helpers;
 using Xunit;
 using Amazon.Lambda.TestTool.Services.IO;
 using Amazon.Lambda.TestTool.Utilities;
+using System.Text.Json.Nodes;
 
 namespace Amazon.Lambda.TestTool.UnitTests.Commands;
 
@@ -99,5 +100,38 @@ public class RunCommandTests
         var result = await runningTask;
         Assert.Equal(CommandReturnCodes.Success, result);
         Assert.True(isApiRunning);
+    }
+
+    [Fact]
+    public async Task VerifyVersionInfo()
+    {
+        var writeCalls = 0;
+        string? versionInfo = null;
+        Mock<IToolInteractiveService> mockInteractiveService = new Mock<IToolInteractiveService>();
+        mockInteractiveService.Setup(i => i.WriteLine(It.IsAny<string>()))
+            .Callback((string message) =>
+            {
+                writeCalls++;
+                versionInfo = message;
+            });
+
+        var cancellationSource = new CancellationTokenSource();
+        var settings = new RunCommandSettings { PrintVersionInfo = true };
+        var command = new RunCommand(mockInteractiveService.Object, _mockEnvironmentManager.Object);
+        var context = new CommandContext(new List<string>(), _mockRemainingArgs.Object, "run", null);
+        await command.ExecuteAsync(context, settings, cancellationSource);
+
+        Assert.Equal(1, writeCalls);
+        Assert.True(!string.IsNullOrEmpty(versionInfo));
+
+        JsonNode? jsonNode = JsonNode.Parse(versionInfo);
+        Assert.NotNull(jsonNode);
+
+        var version = jsonNode["version"]?.ToString();
+        Assert.NotNull(version);
+
+        // The Version.TryParse does not like the preview suffix
+        version = version.Replace("-preview", "");
+        Assert.True(Version.TryParse(version, out var _));
     }
 }

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Commands/Settings/RunCommandSettingsTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Commands/Settings/RunCommandSettingsTests.cs
@@ -29,26 +29,6 @@ public class RunCommandSettingsTests
     }
 
     [Fact]
-    public void DisableLogs_DefaultsToFalse()
-    {
-        // Arrange
-        var settings = new RunCommandSettings();
-
-        // Assert
-        Assert.False(settings.DisableLogs);
-    }
-
-    [Fact]
-    public void PauseExit_DefaultsToFalse()
-    {
-        // Arrange
-        var settings = new RunCommandSettings();
-
-        // Assert
-        Assert.False(settings.PauseExit);
-    }
-
-    [Fact]
     public void ApiGatewayEmulatorMode_DefaultsToNull()
     {
         // Arrange


### PR DESCRIPTION
*Description of changes:*
Add a `--version` switch that if set prints the tool's version as a JSON document. This allows other tooling like the Aspire integration to shell out to the command and programmatically check the installed version. JSON document was chosen to allow the possibility of expanding on the info returned.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
