### PR TITLE
Update default log level 

### DIFF
--- a/.autover/changes/1c4eb3ce-e61b-4119-ac8d-d431f7b426cb.json
+++ b/.autover/changes/1c4eb3ce-e61b-4119-ac8d-d431f7b426cb.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.TestTool",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update default log level"
+      ]
+    }
+  ]
+}

--- a/.autover/changes/1c4eb3ce-e61b-4119-ac8d-d431f7b426cb.json
+++ b/.autover/changes/1c4eb3ce-e61b-4119-ac8d-d431f7b426cb.json
@@ -4,7 +4,7 @@
       "Name": "Amazon.Lambda.TestTool",
       "Type": "Patch",
       "ChangelogMessages": [
-        "Update default log level"
+        "Update default log level to be ERROR in production and INFORMATION in debug mode."
       ]
     }
   ]

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -64,5 +64,5 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  
+
 </Project>

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -56,4 +56,13 @@
   <ItemGroup>
 	  <EmbeddedResource Include="Resources\**" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.Development.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  
 </Project>

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Configuration/ConfigurationSetup.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Configuration/ConfigurationSetup.cs
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace Amazon.Lambda.TestTool.Configuration;
+
+/// <summary>
+/// Provides configuration setup functionality for the Lambda Test Tool.
+/// </summary>
+public static class ConfigurationSetup
+{
+    /// <summary>
+    /// Configures essential services for the application, including logging and configuration.
+    /// </summary>
+    /// <param name="services">The service collection to configure services in.</param>
+    /// <remarks>
+    /// This method:
+    /// 1. Retrieves the configuration from appsettings files
+    /// 2. Sets up logging with console provider
+    /// 3. Registers the configuration as a singleton service
+    /// </remarks>
+    public static void ConfigureServices(IServiceCollection services)
+    {
+        var configuration = GetConfiguration();
+
+        services.AddLogging(builder =>
+        {
+            builder.ClearProviders();
+            builder.AddConfiguration(configuration.GetSection("Logging"));
+            builder.AddConsole();
+        });
+
+        services.AddSingleton<IConfiguration>(configuration);
+    }
+
+    /// <summary>
+    /// Builds and returns the application configuration from JSON files.
+    /// </summary>
+    /// <returns>An IConfiguration instance containing application settings.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when unable to determine the assembly location.</exception>
+    /// <remarks>
+    /// The configuration is built using:
+    /// 1. Base settings from appsettings.json
+    /// 2. Environment-specific settings from appsettings.{environment}.json
+    ///
+    /// The environment is determined by the ASPNETCORE_ENVIRONMENT environment variable,
+    /// defaulting to "Production" if not set.
+    /// </remarks>
+    private static IConfiguration GetConfiguration()
+    {
+        // Get the directory where your package DLL is located
+        var assemblyLocation = typeof(ConfigurationSetup).Assembly.Location;
+        var packageDirectory = Path.GetDirectoryName(assemblyLocation);
+
+        if (string.IsNullOrEmpty(packageDirectory))
+        {
+            throw new InvalidOperationException("Unable to determine assembly location");
+        }
+
+        // Determine environment
+        var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
+                          ?? "Production";
+
+        // Build configuration
+        var builder = new ConfigurationBuilder()
+            .SetBasePath(packageDirectory)
+            .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+            .AddJsonFile($"appsettings.{environment}.json", optional: true, reloadOnChange: true);
+
+        return builder.Build();
+    }
+}

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Configuration/ConfigurationSetup.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Configuration/ConfigurationSetup.cs
@@ -1,48 +1,34 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Reflection;
+
 namespace Amazon.Lambda.TestTool.Configuration;
 
 /// <summary>
-/// Provides functionality to set up and retrieve configuration settings for the Lambda Test Tool.
+/// Handles the configuration setup for the Lambda Test Tool by loading settings from JSON files.
 /// </summary>
 /// <remarks>
-/// This class handles the configuration setup by loading settings from JSON files located in the assembly's directory.
-/// It supports both base configuration (appsettings.json) and environment-specific configuration files.
+/// This class uses dependency injection to receive an Assembly instance, allowing for better testability
+/// and flexibility in determining the configuration file locations.
 /// </remarks>
-public static class ConfigurationSetup
+public class ConfigurationSetup(Assembly assembly)
 {
     /// <summary>
     /// Retrieves the application configuration by loading settings from JSON configuration files.
     /// </summary>
-    /// <returns>An <see cref="IConfiguration"/> instance containing the application settings.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when unable to determine the assembly's location.</exception>
+    /// <returns>An IConfiguration instance containing the application settings.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when unable to determine the assembly location.</exception>
     /// <remarks>
-    /// The method performs the following:
-    /// <list type="bullet">
-    /// <item>
-    ///     <description>Locates the directory containing the assembly</description>
-    /// </item>
-    /// <item>
-    ///     <description>Loads the base configuration from appsettings.json</description>
-    /// </item>
-    /// <item>
-    ///     <description>Loads environment-specific configuration from appsettings.{environment}.json if available</description>
-    /// </item>
-    /// </list>
-    /// The environment is determined by the ASPNETCORE_ENVIRONMENT environment variable, defaulting to "Production" if not set.
+    /// The method performs the following steps:
+    /// 1. Locates the directory containing the assembly
+    /// 2. Loads the base configuration from appsettings.json
+    /// 3. Loads environment-specific configuration from appsettings.{environment}.json if available
     /// </remarks>
-    /// <example>
-    /// Usage example:
-    /// <code>
-    /// IConfiguration configuration = ConfigurationSetup.GetConfiguration();
-    /// var setting = configuration["SectionName:SettingName"];
-    /// </code>
-    /// </example>
-    public static IConfiguration GetConfiguration()
+    public IConfiguration GetConfiguration()
     {
         // Get the directory where the assembly is located
-        var assemblyLocation = typeof(ConfigurationSetup).Assembly.Location;
+        var assemblyLocation = assembly.Location;
         var packageDirectory = Path.GetDirectoryName(assemblyLocation)
                                ?? throw new InvalidOperationException("Unable to determine assembly location");
 

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/ServiceCollectionExtensions.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Reflection;
+using Amazon.Lambda.TestTool.Configuration;
 using Amazon.Lambda.TestTool.Services;
 using Amazon.Lambda.TestTool.Services.IO;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/ApiGatewayEmulatorProcess.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/ApiGatewayEmulatorProcess.cs
@@ -9,6 +9,7 @@ using Amazon.Lambda.TestTool.Models;
 using Amazon.Lambda.TestTool.Services;
 
 using System.Text.Json;
+using Amazon.Lambda.TestTool.Configuration;
 
 namespace Amazon.Lambda.TestTool.Processes;
 
@@ -45,6 +46,13 @@ public class ApiGatewayEmulatorProcess
         }
 
         var builder = WebApplication.CreateBuilder();
+
+        var configuration = ConfigurationSetup.GetConfiguration();
+        builder.Configuration.AddConfiguration(configuration);
+
+        builder.Logging.ClearProviders();
+        builder.Logging.AddConfiguration(configuration.GetSection("Logging"));
+        builder.Logging.AddConsole();
 
         builder.Services.AddApiGatewayEmulatorServices();
 

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/ApiGatewayEmulatorProcess.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/ApiGatewayEmulatorProcess.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Reflection;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.Model;
 using Amazon.Lambda.TestTool.Commands.Settings;
@@ -47,7 +48,11 @@ public class ApiGatewayEmulatorProcess
 
         var builder = WebApplication.CreateBuilder();
 
-        var configuration = ConfigurationSetup.GetConfiguration();
+        builder.Services.AddSingleton(typeof(Assembly), typeof(ConfigurationSetup).Assembly);
+        builder.Services.AddSingleton<ConfigurationSetup>();
+
+        var configSetup = builder.Services.BuildServiceProvider().GetRequiredService<ConfigurationSetup>();
+        var configuration = configSetup.GetConfiguration();
         builder.Configuration.AddConfiguration(configuration);
 
         builder.Logging.ClearProviders();

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/ApiGatewayEmulatorProcess.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/ApiGatewayEmulatorProcess.cs
@@ -11,6 +11,7 @@ using Amazon.Lambda.TestTool.Services;
 
 using System.Text.Json;
 using Amazon.Lambda.TestTool.Configuration;
+using Amazon.Lambda.TestTool.Utilities;
 
 namespace Amazon.Lambda.TestTool.Processes;
 
@@ -48,16 +49,7 @@ public class ApiGatewayEmulatorProcess
 
         var builder = WebApplication.CreateBuilder();
 
-        builder.Services.AddSingleton(typeof(Assembly), typeof(ConfigurationSetup).Assembly);
-        builder.Services.AddSingleton<ConfigurationSetup>();
-
-        var configSetup = builder.Services.BuildServiceProvider().GetRequiredService<ConfigurationSetup>();
-        var configuration = configSetup.GetConfiguration();
-        builder.Configuration.AddConfiguration(configuration);
-
-        builder.Logging.ClearProviders();
-        builder.Logging.AddConfiguration(configuration.GetSection("Logging"));
-        builder.Logging.AddConsole();
+        Utils.ConfigureWebApplicationBuilder(builder);
 
         builder.Services.AddApiGatewayEmulatorServices();
 

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/TestToolProcess.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/TestToolProcess.cs
@@ -7,6 +7,7 @@ using Amazon.Lambda.TestTool.Components;
 using Amazon.Lambda.TestTool.Configuration;
 using Amazon.Lambda.TestTool.Services;
 using Amazon.Lambda.TestTool.Services.IO;
+using Amazon.Lambda.TestTool.Utilities;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 
@@ -39,16 +40,7 @@ public class TestToolProcess
     {
         var builder = WebApplication.CreateBuilder();
 
-        builder.Services.AddSingleton(typeof(Assembly), typeof(ConfigurationSetup).Assembly);
-        builder.Services.AddSingleton<ConfigurationSetup>();
-
-        var configSetup = builder.Services.BuildServiceProvider().GetRequiredService<ConfigurationSetup>();
-        var configuration = configSetup.GetConfiguration();
-        builder.Configuration.AddConfiguration(configuration);
-
-        builder.Logging.ClearProviders();
-        builder.Logging.AddConfiguration(configuration.GetSection("Logging"));
-        builder.Logging.AddConsole();
+        Utils.ConfigureWebApplicationBuilder(builder);
 
         builder.Services.AddSingleton<IRuntimeApiDataStoreManager, RuntimeApiDataStoreManager>();
         builder.Services.AddSingleton<IThemeService, ThemeService>();

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/TestToolProcess.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/TestToolProcess.cs
@@ -3,6 +3,7 @@
 
 using Amazon.Lambda.TestTool.Commands.Settings;
 using Amazon.Lambda.TestTool.Components;
+using Amazon.Lambda.TestTool.Configuration;
 using Amazon.Lambda.TestTool.Services;
 using Amazon.Lambda.TestTool.Services.IO;
 using Microsoft.Extensions.FileProviders;
@@ -36,6 +37,13 @@ public class TestToolProcess
     public static TestToolProcess Startup(RunCommandSettings settings, CancellationToken cancellationToken = default)
     {
         var builder = WebApplication.CreateBuilder();
+
+        var configuration = ConfigurationSetup.GetConfiguration();
+        builder.Configuration.AddConfiguration(configuration);
+
+        builder.Logging.ClearProviders();
+        builder.Logging.AddConfiguration(configuration.GetSection("Logging"));
+        builder.Logging.AddConsole();
 
         builder.Services.AddSingleton<IRuntimeApiDataStoreManager, RuntimeApiDataStoreManager>();
         builder.Services.AddSingleton<IThemeService, ThemeService>();

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/TestToolProcess.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/TestToolProcess.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Reflection;
 using Amazon.Lambda.TestTool.Commands.Settings;
 using Amazon.Lambda.TestTool.Components;
 using Amazon.Lambda.TestTool.Configuration;
@@ -38,7 +39,11 @@ public class TestToolProcess
     {
         var builder = WebApplication.CreateBuilder();
 
-        var configuration = ConfigurationSetup.GetConfiguration();
+        builder.Services.AddSingleton(typeof(Assembly), typeof(ConfigurationSetup).Assembly);
+        builder.Services.AddSingleton<ConfigurationSetup>();
+
+        var configSetup = builder.Services.BuildServiceProvider().GetRequiredService<ConfigurationSetup>();
+        var configuration = configSetup.GetConfiguration();
         builder.Configuration.AddConfiguration(configuration);
 
         builder.Logging.ClearProviders();

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Program.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Program.cs
@@ -3,14 +3,11 @@
 
 using Amazon.Lambda.TestTool;
 using Amazon.Lambda.TestTool.Commands;
-using Amazon.Lambda.TestTool.Configuration;
 using Amazon.Lambda.TestTool.Extensions;
 using Amazon.Lambda.TestTool.Services;
 using Spectre.Console.Cli;
 
 var serviceCollection = new ServiceCollection();
-
-ConfigurationSetup.ConfigureServices(serviceCollection);
 
 serviceCollection.AddCustomServices();
 

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Program.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Program.cs
@@ -3,11 +3,14 @@
 
 using Amazon.Lambda.TestTool;
 using Amazon.Lambda.TestTool.Commands;
+using Amazon.Lambda.TestTool.Configuration;
 using Amazon.Lambda.TestTool.Extensions;
 using Amazon.Lambda.TestTool.Services;
 using Spectre.Console.Cli;
 
 var serviceCollection = new ServiceCollection();
+
+ConfigurationSetup.ConfigureServices(serviceCollection);
 
 serviceCollection.AddCustomServices();
 

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/Utils.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Utilities/Utils.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using System.Text.Json;
+using Amazon.Lambda.TestTool.Configuration;
 
 namespace Amazon.Lambda.TestTool.Utilities;
 
@@ -73,5 +74,33 @@ public static class Utils
         {
             return data ?? string.Empty;
         }
+    }
+
+    /// <summary>
+    /// Configures the web application builder with necessary services, configuration, and logging setup.
+    /// </summary>
+    /// <param name="builder">The WebApplicationBuilder instance to be configured</param>
+    /// <remarks>
+    /// This method performs the following configurations:
+    /// 1. Registers the current assembly as a singleton service
+    /// 2. Registers ConfigurationSetup as a singleton service
+    /// 3. Builds and applies custom configuration
+    /// 4. Sets up logging providers with console output
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when ConfigurationSetup service cannot be resolved from the service provider
+    /// </exception>
+    public static void ConfigureWebApplicationBuilder(WebApplicationBuilder builder)
+    {
+        builder.Services.AddSingleton(typeof(Assembly), typeof(ConfigurationSetup).Assembly);
+        builder.Services.AddSingleton<ConfigurationSetup>();
+
+        var configSetup = builder.Services.BuildServiceProvider().GetRequiredService<ConfigurationSetup>();
+        var configuration = configSetup.GetConfiguration();
+        builder.Configuration.AddConfiguration(configuration);
+
+        builder.Logging.ClearProviders();
+        builder.Logging.AddConfiguration(configuration.GetSection("Logging"));
+        builder.Logging.AddConsole();
     }
 }

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/appsettings.Development.json
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/appsettings.Development.json
@@ -1,8 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Trace",
-      "Microsoft.AspNetCore": "Trace"
+      "Default": "Information"
     }
   },
   "DetailedErrors": true

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/appsettings.json
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/appsettings.json
@@ -1,9 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Trace",
-      "Microsoft": "Trace",
-      "Microsoft.AspNetCore": "Trace"
+      "Default": "Error"
     }
   },
   "AllowedHosts": "*"

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Configuration/ConfigurationSetupTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Configuration/ConfigurationSetupTests.cs
@@ -1,0 +1,113 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Reflection;
+using Amazon.Lambda.TestTool.Configuration;
+using Moq;
+using Xunit;
+
+namespace Amazon.Lambda.TestTool.UnitTests.Configuration;
+
+public class ConfigurationSetupTests
+{
+    [Fact]
+    public void GetConfiguration_WithValidAssemblyLocation_ReturnsConfiguration()
+    {
+        // Arrange
+        var mockAssembly = new Mock<Assembly>();
+        var testDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(testDirectory);
+
+        try
+        {
+            // Create test appsettings.json
+            File.WriteAllText(
+                Path.Combine(testDirectory, "appsettings.json"),
+                @"{""TestSetting"": ""TestValue""}"
+            );
+
+            mockAssembly
+                .Setup(x => x.Location)
+                .Returns(Path.Combine(testDirectory, "dummy.dll"));
+
+            var configSetup = new ConfigurationSetup(mockAssembly.Object);
+
+            // Act
+            var configuration = configSetup.GetConfiguration();
+
+            // Assert
+            Assert.NotNull(configuration);
+            Assert.Equal("TestValue", configuration["TestSetting"]);
+        }
+        finally
+        {
+            // Cleanup
+            Directory.Delete(testDirectory, true);
+        }
+    }
+
+    [Fact]
+    public void GetConfiguration_WithEnvironmentSpecificConfig_LoadsBothConfigs()
+    {
+        // Arrange
+        var mockAssembly = new Mock<Assembly>();
+        var testDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(testDirectory);
+
+        try
+        {
+            // Create test appsettings.json
+            File.WriteAllText(
+                Path.Combine(testDirectory, "appsettings.json"),
+                @"{""TestSetting"": ""BaseValue"", ""CommonSetting"": ""BaseValue""}"
+            );
+
+            // Create test appsettings.Development.json
+            File.WriteAllText(
+                Path.Combine(testDirectory, "appsettings.Development.json"),
+                @"{""TestSetting"": ""DevValue""}"
+            );
+
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
+
+            mockAssembly
+                .Setup(x => x.Location)
+                .Returns(Path.Combine(testDirectory, "dummy.dll"));
+
+            var configSetup = new ConfigurationSetup(mockAssembly.Object);
+
+            // Act
+            var configuration = configSetup.GetConfiguration();
+
+            // Assert
+            Assert.NotNull(configuration);
+            Assert.Equal("DevValue", configuration["TestSetting"]); // Overridden value
+            Assert.Equal("BaseValue", configuration["CommonSetting"]); // Base value
+        }
+        finally
+        {
+            // Cleanup
+            Directory.Delete(testDirectory, true);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", null);
+        }
+    }
+
+    [Fact]
+    public void GetConfiguration_WithInvalidAssemblyLocation_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var mockAssembly = new Mock<Assembly>();
+        mockAssembly
+            .Setup(x => x.Location)
+            .Returns(string.Empty);
+
+        var configSetup = new ConfigurationSetup(mockAssembly.Object);
+
+        // Act & Assert
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => configSetup.GetConfiguration()
+        );
+        Assert.Equal("Unable to determine assembly location", exception.Message);
+    }
+}
+


### PR DESCRIPTION
*Issue #, if available:* DOTNET-7954

*Description of changes:*
1. Change default log level in production to ERROR
2. Change default log level when debugging to INFORMATION

*Testing*
1. I ran in debug mode and verified that I only see INFO logs and no longer see the debug logs from Microsoft ASP Core.
2. I ran the built dll/nuget and ran it from aspire and verified that i only see ERROR and console.writeline,console.error.writelien logs

![image](https://github.com/user-attachments/assets/9003bae5-d630-46cc-93e7-4465414ba1c4)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
