### PR TITLE
Yaml LambdaDefaultsConfigFileParser Fix for Environment Variables

### DIFF
--- a/.autover/changes/80695d9a-25c7-4ae6-9db1-6d9d3cc15e49.json
+++ b/.autover/changes/80695d9a-25c7-4ae6-9db1-6d9d3cc15e49.json
@@ -6,13 +6,6 @@
         "ChangelogMessages": [
             "Fixed yaml function-based serverless.template Environment Variable parsing and adding to functioninfo"
         ]
-    },
-    {
-        "Name": "Amazon.Lambda.TestTool",
-        "Type": "Patch",
-        "ChangelogMessages": [
-            "Fixed yaml function-based serverless.template Environment Variable parsing and adding to functioninfo"
-        ]
     }
   ]
 }

--- a/.autover/changes/80695d9a-25c7-4ae6-9db1-6d9d3cc15e49.json
+++ b/.autover/changes/80695d9a-25c7-4ae6-9db1-6d9d3cc15e49.json
@@ -1,0 +1,18 @@
+{
+  "Projects": [
+    {
+        "Name": "Amazon.Lambda.TestTool.BlazorTester",
+        "Type": "Patch",
+        "ChangelogMessages": [
+            "Fixed yaml function-based serverless.template Environment Variable parsing and adding to functioninfo"
+        ]
+    },
+    {
+        "Name": "Amazon.Lambda.TestTool",
+        "Type": "Patch",
+        "ChangelogMessages": [
+            "Fixed yaml function-based serverless.template Environment Variable parsing and adding to functioninfo"
+        ]
+    }
+  ]
+}

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaDefaultsConfigFileParser.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaDefaultsConfigFileParser.cs
@@ -273,7 +273,7 @@ namespace Amazon.Lambda.TestTool.Runtime
                 
                 if (handler == null) continue;
                 if (string.IsNullOrEmpty(handler)) continue;
-
+                
                 
                 var functionInfo = new LambdaFunctionInfo
                 {

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaDefaultsConfigFileParser.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaDefaultsConfigFileParser.cs
@@ -262,40 +262,42 @@ namespace Amazon.Lambda.TestTool.Runtime
         {
             if (resources == null)
                 return;
-
+    
             foreach (var resource in resources.Children)
             {
                 var resourceBody = (YamlMappingNode) resource.Value;
-
+    
                 var handler = resourceBody.Children.ContainsKey("handler")
                     ? ((YamlScalarNode) resourceBody.Children["handler"])?.Value
                     : null;
-                
+    
                 if (handler == null) continue;
                 if (string.IsNullOrEmpty(handler)) continue;
-                
-                
+    
+    
                 var functionInfo = new LambdaFunctionInfo
                 {
                     Name = resource.Key.ToString(),
                     Handler = handler
                 };
-
+    
                 if (resourceBody.Children.TryGetValue("Environment", out var environmentProperty) && environmentProperty is YamlMappingNode)
                 {
-                    if (((YamlMappingNode)environmentProperty).Children.TryGetValue("Environment", out var variableProperty) && variableProperty is YamlMappingNode)
+                    foreach (var kvp in ((YamlMappingNode)environmentProperty).Children)
                     {
-                        foreach(var kvp in ((YamlMappingNode)variableProperty).Children) 
+                        if(kvp.Key is YamlScalarNode keyNode && keyNode.Value != null &&
+    kvp.Value is YamlScalarNode valueNode && valueNode.Value != null)
                         {
-                            if(kvp.Key is YamlScalarNode keyNode && keyNode.Value != null && 
-                                kvp.Value is YamlScalarNode valueNode && valueNode.Value != null)
-                            {
-                                functionInfo.EnvironmentVariables[keyNode.Value] = valueNode.Value;
-                            }
+                            functionInfo.EnvironmentVariables[keyNode.Value] = valueNode.Value;
                         }
                     }
+    
+                    if (functionInfo.EnvironmentVariables.Any())
+                    {
+                        Console.WriteLine($"In total, {functionInfo.EnvironmentVariables.Count()} EnvVars were added to lambda: {functionInfo.Name}");
+                    }
                 }
-
+    
                 configInfo.FunctionInfos.Add(functionInfo);
             }
         }

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaDefaultsConfigFileParser.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaDefaultsConfigFileParser.cs
@@ -262,25 +262,25 @@ namespace Amazon.Lambda.TestTool.Runtime
         {
             if (resources == null)
                 return;
-    
+
             foreach (var resource in resources.Children)
             {
                 var resourceBody = (YamlMappingNode) resource.Value;
-    
+
                 var handler = resourceBody.Children.ContainsKey("handler")
                     ? ((YamlScalarNode) resourceBody.Children["handler"])?.Value
                     : null;
-    
+                
                 if (handler == null) continue;
                 if (string.IsNullOrEmpty(handler)) continue;
-    
-    
+
+                
                 var functionInfo = new LambdaFunctionInfo
                 {
                     Name = resource.Key.ToString(),
                     Handler = handler
                 };
-    
+
                 if (resourceBody.Children.TryGetValue("Environment", out var environmentProperty) && environmentProperty is YamlMappingNode)
                 {
                     foreach (var kvp in ((YamlMappingNode)environmentProperty).Children)
@@ -297,7 +297,7 @@ namespace Amazon.Lambda.TestTool.Runtime
                         Console.WriteLine($"In total, {functionInfo.EnvironmentVariables.Count()} EnvVars were added to lambda: {functionInfo.Name}");
                     }
                 }
-    
+
                 configInfo.FunctionInfos.Add(functionInfo);
             }
         }

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaDefaultsConfigFileParser.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/LambdaDefaultsConfigFileParser.cs
@@ -291,11 +291,6 @@ namespace Amazon.Lambda.TestTool.Runtime
                             functionInfo.EnvironmentVariables[keyNode.Value] = valueNode.Value;
                         }
                     }
-    
-                    if (functionInfo.EnvironmentVariables.Any())
-                    {
-                        Console.WriteLine($"In total, {functionInfo.EnvironmentVariables.Count()} EnvVars were added to lambda: {functionInfo.Name}");
-                    }
                 }
 
                 configInfo.FunctionInfos.Add(functionInfo);


### PR DESCRIPTION
*Issue #, if available:*
Tried finding an issue to attach but did not find it, though saw it listed as a [Known Limitation](https://github.com/aws/aws-lambda-dotnet/tree/master/Tools/LambdaTestTool#known-limitations)

*Description of changes:*

After local debugging I identified that the code was trying to reach one level deeper in the serverless.template yaml funcion-based file, with the proposed changes I was able to modify the environment variables of my lambdas through the serverless.template file by following the format as shown below:
```yaml
functions:
  LambdaTest:
    handler: TestSolution::Path.To.Class::HandlerFunction
    Environment:
        ENV_VAR_OVERRIDE: OverrideApiKey
        DEBUG_KEY: TestResult
  LambdaTest2:
    handler: TestSolution::Path.To.Class::HandlerFunction2
    Environment:
        ENV_VAR_OVERRIDE: OverrideApiKey
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
