### PR TITLE
fix: use sln instead of slnx to fix pipeline issue

### DIFF
--- a/buildtools/build.proj
+++ b/buildtools/build.proj
@@ -195,7 +195,7 @@
     </Target>
     <Target Name="testtoolv2-tests" DependsOnTargets="testtoolv2-unit-tests;testtoolv2-integ-tests"></Target>
     <Target Name="testtoolv2-build">
-        <Exec Command="dotnet build -c $(Configuration) Amazon.Lambda.TestTool.slnx" WorkingDirectory="..\Tools\LambdaTestTool-v2" ConsoleToMSBuild="true"/>
+        <Exec Command="dotnet build -c $(Configuration) Amazon.Lambda.TestTool.sln" WorkingDirectory="..\Tools\LambdaTestTool-v2" ConsoleToMSBuild="true"/>
     </Target>
     <Target Name="testtoolv2-unit-tests" DependsOnTargets="testtoolv2-build">
         <Exec Command="dotnet test -c $(Configuration) --logger &quot;console;verbosity=detailed&quot; 2>&amp;1" 


### PR DESCRIPTION
*Description of changes:*
Use sln instead of slnx to fix pipeline issue which does not yet support slnx format.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
