### PR TITLE
chore: remove testtool preview label

### DIFF
--- a/.autover/autover.json
+++ b/.autover/autover.json
@@ -138,8 +138,7 @@
     },
     {
       "Name": "Amazon.Lambda.TestTool",
-      "Path": "Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj",
-      "PrereleaseLabel": "preview"
+      "Path": "Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj"
     }
   ],
   "UseCommitsForChangelog": false,


### PR DESCRIPTION
*Description of changes:*
Remove the "preview" suffix for the Test Tool

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
