### PR TITLE
Add DynamoDBEvents SDK Convertor package

### DIFF
--- a/.autover/autover.json
+++ b/.autover/autover.json
@@ -50,6 +50,10 @@
     {
       "Name": "Amazon.Lambda.DynamoDBEvents",
       "Path": "Libraries/src/Amazon.Lambda.DynamoDBEvents/Amazon.Lambda.DynamoDBEvents.csproj"
+    },    
+    {
+      "Name": "Amazon.Lambda.DynamoDBEvents.SDK.Convertor",
+      "Path": "Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/Amazon.Lambda.DynamoDBEvents.SDK.Convertor.csproj"
     },
     {
       "Name": "Amazon.Lambda.KafkaEvents",

--- a/.autover/d9aeb53a-0808-4514-bdd1-e276ac532059.json
+++ b/.autover/d9aeb53a-0808-4514-bdd1-e276ac532059.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.DynamoDBEvents.SDK.Convertor",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Implement DynamoDBEvents SDK Convertor package for DynamoDBEvent images to DynamoDBv2.Document"
+      ]
+    }
+  ]
+}

--- a/.autover/d9aeb53a-0808-4514-bdd1-e276ac532059.json
+++ b/.autover/d9aeb53a-0808-4514-bdd1-e276ac532059.json
@@ -2,7 +2,7 @@
   "Projects": [
     {
       "Name": "Amazon.Lambda.DynamoDBEvents.SDK.Convertor",
-      "Type": "Patch",
+      "Type": "Major",
       "ChangelogMessages": [
         "Implement DynamoDBEvents SDK Convertor package for DynamoDBEvent images to DynamoDBv2.Document"
       ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,7 @@ The available projects are:
 * Amazon.Lambda.ConnectEvents
 * Amazon.Lambda.Core
 * Amazon.Lambda.DynamoDBEvents
+* Amazon.Lambda.DynamoDBEvents.SDK.Convertor
 * Amazon.Lambda.KafkaEvents
 * Amazon.Lambda.KinesisAnalyticsEvents
 * Amazon.Lambda.KinesisEvents

--- a/Libraries/Libraries.sln
+++ b/Libraries/Libraries.sln
@@ -135,6 +135,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SnapshotRestore.Registry", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SnapshotRestore.Registry.Tests", "test\SnapshotRestore.Registry.Tests\SnapshotRestore.Registry.Tests.csproj", "{A699E183-D0D4-4F26-A0A7-88DA5607F455}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.Lambda.DynamoDBEvents.SDK.Convertor", "src\Amazon.Lambda.DynamoDBEvents.SDK.Convertor\Amazon.Lambda.DynamoDBEvents.SDK.Convertor.csproj", "{3400F4E9-BA12-4D3D-9BA1-2798AA8D0AFC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.Lambda.DynamoDBEvents.SDK.Convertor.Tests", "test\Amazon.Lambda.DynamoDBEvents.SDK.Convertor.Tests\Amazon.Lambda.DynamoDBEvents.SDK.Convertor.Tests.csproj", "{074DB940-82BA-47D4-B888-C213D4220A82}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -369,6 +373,14 @@ Global
 		{A699E183-D0D4-4F26-A0A7-88DA5607F455}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A699E183-D0D4-4F26-A0A7-88DA5607F455}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A699E183-D0D4-4F26-A0A7-88DA5607F455}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3400F4E9-BA12-4D3D-9BA1-2798AA8D0AFC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3400F4E9-BA12-4D3D-9BA1-2798AA8D0AFC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3400F4E9-BA12-4D3D-9BA1-2798AA8D0AFC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3400F4E9-BA12-4D3D-9BA1-2798AA8D0AFC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{074DB940-82BA-47D4-B888-C213D4220A82}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{074DB940-82BA-47D4-B888-C213D4220A82}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{074DB940-82BA-47D4-B888-C213D4220A82}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{074DB940-82BA-47D4-B888-C213D4220A82}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -435,6 +447,8 @@ Global
 		{7300983D-8FCE-42EA-9B9E-B1C5347D15D8} = {1DE4EE60-45BA-4EF7-BE00-B9EB861E4C69}
 		{7261A438-8C1D-47AD-98B0-7678F72E4382} = {AAB54E74-20B1-42ED-BC3D-CE9F7BC7FD12}
 		{A699E183-D0D4-4F26-A0A7-88DA5607F455} = {1DE4EE60-45BA-4EF7-BE00-B9EB861E4C69}
+		{3400F4E9-BA12-4D3D-9BA1-2798AA8D0AFC} = {AAB54E74-20B1-42ED-BC3D-CE9F7BC7FD12}
+		{074DB940-82BA-47D4-B888-C213D4220A82} = {1DE4EE60-45BA-4EF7-BE00-B9EB861E4C69}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {503678A4-B8D1-4486-8915-405A3E9CF0EB}

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/Amazon.Lambda.DynamoDBEvents.SDK.Convertor.csproj
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/Amazon.Lambda.DynamoDBEvents.SDK.Convertor.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>Amazon Lambda .NET Core support -  DynamoDBEvents SDK Convertor package.</Description>
-    <TargetFrameworks>netcoreapp3.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.DynamoDBEvents.SDK.Convertor</AssemblyTitle>
     <AssemblyName>Amazon.Lambda.DynamoDBEvents.SDK.Convertor</AssemblyName>
     <PackageId>Amazon.Lambda.DynamoDBEvents.SDK.Convertor</PackageId>

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/Amazon.Lambda.DynamoDBEvents.SDK.Convertor.csproj
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/Amazon.Lambda.DynamoDBEvents.SDK.Convertor.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\..\buildtools\common.props" />
+
+  <PropertyGroup>
+    <Description>Amazon Lambda .NET Core support -  DynamoDBEvents SDK Convertor package.</Description>
+    <TargetFrameworks>netcoreapp3.1;net8.0</TargetFrameworks>
+    <AssemblyTitle>Amazon.Lambda.DynamoDBEvents.SDK.Convertor</AssemblyTitle>
+    <AssemblyName>Amazon.Lambda.DynamoDBEvents.SDK.Convertor</AssemblyName>
+    <PackageId>Amazon.Lambda.DynamoDBEvents.SDK.Convertor</PackageId>
+    <PackageTags>AWS;Amazon;Lambda</PackageTags>
+    <Version>1.0.0</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.405.23" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Amazon.Lambda.DynamoDBEvents\Amazon.Lambda.DynamoDBEvents.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/Amazon.Lambda.DynamoDBEvents.SDK.Convertor.csproj
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/Amazon.Lambda.DynamoDBEvents.SDK.Convertor.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>Amazon.Lambda.DynamoDBEvents.SDK.Convertor</AssemblyName>
     <PackageId>Amazon.Lambda.DynamoDBEvents.SDK.Convertor</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
-    <Version>1.0.0</Version>
+    <Version>0.0.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/DynamodbAttributeValueConvertor.cs
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/DynamodbAttributeValueConvertor.cs
@@ -1,0 +1,101 @@
+namespace Amazon.Lambda.DynamoDBEvents.SDK.Convertor
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Convert DynamoDB Event AttributeValue to SDK AttributeValue
+    /// </summary>
+    public static class DynamodbAttributeValueConvertor
+    {
+        /// <summary>
+        /// Convert Lambda AttributeValue to SDK AttributeValue
+        /// </summary>
+        /// <param name="lambdaAttribute">The Lambda AttributeValue to convert.</param>
+        /// <returns>The converted SDK AttributeValue.</returns>
+        public static Amazon.DynamoDBv2.Model.AttributeValue ConvertToSdkAttribute(this
+            DynamoDBEvent.AttributeValue lambdaAttribute)
+        {
+            if (lambdaAttribute == null)
+                return null;
+
+            var sdkAttribute = new Amazon.DynamoDBv2.Model.AttributeValue();
+
+            // String
+            if (!string.IsNullOrEmpty(lambdaAttribute.S))
+                sdkAttribute.S = lambdaAttribute.S;
+
+            // Number
+            else if (!string.IsNullOrEmpty(lambdaAttribute.N))
+                sdkAttribute.N = lambdaAttribute.N;
+
+            // Boolean
+            else if (lambdaAttribute.BOOL.HasValue)
+            {
+                sdkAttribute.BOOL = lambdaAttribute.BOOL.Value;
+            }
+
+            // Null
+            else if (lambdaAttribute.NULL.HasValue)
+                sdkAttribute.NULL = lambdaAttribute.NULL.Value;
+
+            // Binary
+            else if (lambdaAttribute.B != null)
+                sdkAttribute.B = lambdaAttribute.B;
+
+            // String Set
+            else if (lambdaAttribute.SS != null && lambdaAttribute.SS.Count > 0)
+                sdkAttribute.SS = new List<string>(lambdaAttribute.SS);
+
+            // Number Set
+            else if (lambdaAttribute.NS != null && lambdaAttribute.NS.Count > 0)
+                sdkAttribute.NS = new List<string>(lambdaAttribute.NS);
+
+            // Binary Set
+            else if (lambdaAttribute.BS != null && lambdaAttribute.BS.Count > 0)
+                sdkAttribute.BS = lambdaAttribute.BS;
+
+            // List
+            else if (lambdaAttribute.L != null && lambdaAttribute.L.Count > 0)
+            {
+                sdkAttribute.L = new List<Amazon.DynamoDBv2.Model.AttributeValue>();
+                foreach (var item in lambdaAttribute.L)
+                {
+                    sdkAttribute.L.Add(item.ConvertToSdkAttribute());
+                }
+            }
+
+            // Map
+            else if (lambdaAttribute.M != null && lambdaAttribute.M.Count > 0)
+            {
+                sdkAttribute.M = new Dictionary<string, Amazon.DynamoDBv2.Model.AttributeValue>();
+                foreach (var kvp in lambdaAttribute.M)
+                {
+                    sdkAttribute.M[kvp.Key] = kvp.Value.ConvertToSdkAttribute();
+                }
+            }
+
+            return sdkAttribute;
+        }
+
+        /// <summary>
+        /// Convert Dictionary of Lambda AttributeValue to SDK Dictionary of AttributeValue
+        /// </summary>
+        /// <param name="lambdaAttributes">The dictionary of Lambda AttributeValue to convert.</param>
+        /// <returns>The converted dictionary of SDK AttributeValue.</returns>
+        public static Dictionary<string, Amazon.DynamoDBv2.Model.AttributeValue> ConvertToSdkAttributeValueDictionary(
+           this Dictionary<string, DynamoDBEvent.AttributeValue> lambdaAttributes)
+        {
+            var sdkDictionary = new Dictionary<string, Amazon.DynamoDBv2.Model.AttributeValue>();
+
+            if (lambdaAttributes == null)
+                return sdkDictionary;
+
+            foreach (var kvp in lambdaAttributes)
+            {
+                sdkDictionary[kvp.Key] = ConvertToSdkAttribute(kvp.Value);
+            }
+
+            return sdkDictionary;
+        }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/DynamodbAttributeValueConvertor.cs
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/DynamodbAttributeValueConvertor.cs
@@ -43,19 +43,19 @@ namespace Amazon.Lambda.DynamoDBEvents.SDK.Convertor
                 sdkAttribute.B = lambdaAttribute.B;
 
             // String Set
-            else if (lambdaAttribute.SS != null && lambdaAttribute.SS.Count > 0)
+            else if (lambdaAttribute.SS != null)
                 sdkAttribute.SS = new List<string>(lambdaAttribute.SS);
 
             // Number Set
-            else if (lambdaAttribute.NS != null && lambdaAttribute.NS.Count > 0)
+            else if (lambdaAttribute.NS != null)
                 sdkAttribute.NS = new List<string>(lambdaAttribute.NS);
 
             // Binary Set
-            else if (lambdaAttribute.BS != null && lambdaAttribute.BS.Count > 0)
+            else if (lambdaAttribute.BS != null)
                 sdkAttribute.BS = lambdaAttribute.BS;
 
             // List
-            else if (lambdaAttribute.L != null && lambdaAttribute.L.Count > 0)
+            else if (lambdaAttribute.L != null)
             {
                 sdkAttribute.L = new List<Amazon.DynamoDBv2.Model.AttributeValue>();
                 foreach (var item in lambdaAttribute.L)
@@ -65,7 +65,7 @@ namespace Amazon.Lambda.DynamoDBEvents.SDK.Convertor
             }
 
             // Map
-            else if (lambdaAttribute.M != null && lambdaAttribute.M.Count > 0)
+            else if (lambdaAttribute.M != null)
             {
                 sdkAttribute.M = new Dictionary<string, Amazon.DynamoDBv2.Model.AttributeValue>();
                 foreach (var kvp in lambdaAttribute.M)

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/DynamodbIdentityConvertor.cs
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/DynamodbIdentityConvertor.cs
@@ -1,0 +1,28 @@
+namespace Amazon.Lambda.DynamoDBEvents.SDK.Convertor
+{
+
+    /// <summary>
+    /// Convert DynamoDB Event Identity to SDK Identity
+    /// </summary>
+    public static class DynamodbIdentityConvertor
+    {
+        /// <summary>
+        /// Convert Lambda Identity to SDK Identity
+        /// </summary>
+        /// <param name="lambdaIdentity">The Lambda Identity to convert.</param>
+        /// <returns>The converted SDK Identity.</returns>
+        public static Amazon.DynamoDBv2.Model.Identity ConvertToSdkIdentity(this DynamoDBEvent.Identity lambdaIdentity)
+        {
+            if (lambdaIdentity == null)
+                return null;
+
+            var sdkIdentity = new Amazon.DynamoDBv2.Model.Identity
+            {
+                PrincipalId = lambdaIdentity.PrincipalId,
+                Type = lambdaIdentity.Type
+            };
+
+            return sdkIdentity;
+        }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/DynamodbStreamRecordConvertor.cs
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/DynamodbStreamRecordConvertor.cs
@@ -1,0 +1,34 @@
+namespace Amazon.Lambda.DynamoDBEvents.SDK.Convertor
+{
+    /// <summary>
+    /// Convert DynamoDB Event StreamRecord to SDK StreamRecord
+    /// </summary>
+    public static class DynamodbStreamRecordConvertor
+    {
+
+        /// <summary>
+        /// Convert Lambda StreamRecord to SDK StreamRecord
+        /// </summary>
+        /// <param name="lambdaStreamRecord">The Lambda StreamRecord to convert.</param>
+        /// <returns>The converted SDK StreamRecord.</returns>
+        public static Amazon.DynamoDBv2.Model.StreamRecord ConvertToSdkStreamRecord(this DynamoDBEvent.StreamRecord lambdaStreamRecord)
+        {
+            if (lambdaStreamRecord == null)
+                return null;
+
+            var sdkStreamRecord = new Amazon.DynamoDBv2.Model.StreamRecord
+            {
+                ApproximateCreationDateTime = lambdaStreamRecord.ApproximateCreationDateTime,
+                Keys = lambdaStreamRecord.Keys?.ConvertToSdkAttributeValueDictionary(),
+                NewImage = lambdaStreamRecord.NewImage?.ConvertToSdkAttributeValueDictionary(),
+                OldImage = lambdaStreamRecord.OldImage?.ConvertToSdkAttributeValueDictionary(),
+                SequenceNumber = lambdaStreamRecord.SequenceNumber,
+                SizeBytes = lambdaStreamRecord.SizeBytes,
+                StreamViewType = lambdaStreamRecord.StreamViewType
+            };
+
+            return sdkStreamRecord;
+        }
+
+    }
+}

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/README.md
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/README.md
@@ -1,0 +1,70 @@
+# Amazon.Lambda.DynamoDBEvents.SDK.Convertor
+
+This package provides helper extension methods to use alongside Amazon.Lambda.DynamoDBEvents in order to transform Lambda input event model objects into SDK-compatible output model objects (eg. DynamodbEvent to a List of records writable back to DynamoDB through the AWS DynamoDB SDK for .NET).
+
+## Overview
+
+The `DynamodbAttributeValueConvertor` and `DynamodbStreamRecordConvertor` classes provide methods to convert DynamoDB event data from the Lambda format to the SDK format. This is useful when you need to process DynamoDB events in a Lambda function and interact with the AWS SDK for .NET.
+
+## Usage
+
+### Converting AttributeValue
+
+The following example demonstrates how to convert a `DynamoDBEvent.AttributeValue` to an `Amazon.DynamoDBv2.Model.AttributeValue`:
+
+
+The following is a sample class and Lambda function that receives Amazon DynamoDB event record data as an input and writes some of the incoming event data to CloudWatch Logs. (Note that by default anything written to Console will be logged as CloudWatch Logs events.)
+
+```csharp
+public class Function
+{
+    public void Handler(DynamoDBEvent ddbEvent)
+    {
+        foreach (var record in ddbEvent.Records)
+        {
+            var ddbRecord = record.Dynamodb;
+            var sdkAttributeValue = ddbRecord.NewImage["exampleKey"].ConvertToSdkAttribute();
+            Console.WriteLine($"Converted AttributeValue: {sdkAttributeValue.S}");
+        }
+    }
+}
+```
+
+
+### Converting StreamRecord
+
+The following example demonstrates how to convert a `DynamoDBEvent.StreamRecord` to an `Amazon.DynamoDBv2.Model.StreamRecord`:
+
+```csharp
+
+public class Function
+{
+    public void Handler(DynamoDBEvent ddbEvent)
+    {
+        foreach (var record in ddbEvent.Records)
+        {
+            var sdkStreamRecord = record.Dynamodb.ConvertToSdkStreamRecord();
+            Console.WriteLine($"Converted StreamRecord: {sdkStreamRecord.SequenceNumber}");
+        }
+    }
+}
+```
+
+### Converting Identity
+
+The following example demonstrates how to convert a `DynamoDBEvent.Identity` to an `Amazon.DynamoDBv2.Model.Identity`:
+
+```csharp
+public class Function
+{
+    public void Handler(DynamoDBEvent ddbEvent)
+    {
+        foreach (var record in ddbEvent.Records)
+        {
+            var sdkIdentity = record.UserIdentity.ConvertToSdkIdentity();
+            Console.WriteLine($"Converted Identity: {sdkIdentity.PrincipalId}");
+        }
+  }
+}
+```
+

--- a/Libraries/test/Amazon.Lambda.DynamoDBEvents.SDK.Convertor.Tests/Amazon.Lambda.DynamoDBEvents.SDK.Convertor.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.DynamoDBEvents.SDK.Convertor.Tests/Amazon.Lambda.DynamoDBEvents.SDK.Convertor.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Amazon.Lambda.DynamoDBEvents.SDK.Convertor\Amazon.Lambda.DynamoDBEvents.SDK.Convertor.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DynamoDBEvents.SDK.Convertor.Tests/DynamodbAttributeValueConvertorTests.cs
+++ b/Libraries/test/Amazon.Lambda.DynamoDBEvents.SDK.Convertor.Tests/DynamodbAttributeValueConvertorTests.cs
@@ -1,0 +1,129 @@
+namespace Amazon.Lambda.DynamoDBEvents.SDK.Convertor.Tests
+{
+    public class DynamodbAttributeValueConvertorTests
+    {
+        [Fact]
+        public void ConvertToSdkAttribute_StringValue_ReturnsSdkAttribute()
+        {
+            var lambdaAttribute = new DynamoDBEvent.AttributeValue { S = "TestString" };
+            var sdkAttribute = lambdaAttribute.ConvertToSdkAttribute();
+
+            Assert.NotNull(sdkAttribute);
+            Assert.Equal("TestString", sdkAttribute.S);
+        }
+
+        [Fact]
+        public void ConvertToSdkAttribute_NumberValue_ReturnsSdkAttribute()
+        {
+            var lambdaAttribute = new DynamoDBEvent.AttributeValue { N = "123" };
+            var sdkAttribute = lambdaAttribute.ConvertToSdkAttribute();
+
+            Assert.NotNull(sdkAttribute);
+            Assert.Equal("123", sdkAttribute.N);
+        }
+
+        [Fact]
+        public void ConvertToSdkAttribute_BoolValue_ReturnsSdkAttribute()
+        {
+            var lambdaAttribute = new DynamoDBEvent.AttributeValue { BOOL = true };
+            var sdkAttribute = lambdaAttribute.ConvertToSdkAttribute();
+
+            Assert.NotNull(sdkAttribute);
+            Assert.True(sdkAttribute.BOOL);
+        }
+
+        [Fact]
+        public void ConvertToSdkAttribute_NullValue_ReturnsSdkAttribute()
+        {
+            var lambdaAttribute = new DynamoDBEvent.AttributeValue { NULL = true };
+            var sdkAttribute = lambdaAttribute.ConvertToSdkAttribute();
+
+            Assert.NotNull(sdkAttribute);
+            Assert.True(sdkAttribute.NULL);
+        }
+
+        [Fact]
+        public void ConvertToSdkAttribute_StringSetValue_ReturnsSdkAttribute()
+        {
+            var lambdaAttribute = new DynamoDBEvent.AttributeValue { SS = new List<string> { "A", "B" } };
+            var sdkAttribute = lambdaAttribute.ConvertToSdkAttribute();
+
+            Assert.NotNull(sdkAttribute);
+            Assert.Equal(new List<string> { "A", "B" }, sdkAttribute.SS);
+        }
+
+        [Fact]
+        public void ConvertToSdkAttribute_NumberSetValue_ReturnsSdkAttribute()
+        {
+            var lambdaAttribute = new DynamoDBEvent.AttributeValue { NS = new List<string> { "1", "2" } };
+            var sdkAttribute = lambdaAttribute.ConvertToSdkAttribute();
+
+            Assert.NotNull(sdkAttribute);
+            Assert.Equal(new List<string> { "1", "2" }, sdkAttribute.NS);
+        }
+
+        [Fact]
+        public void ConvertToSdkAttribute_ListValue_ReturnsSdkAttribute()
+        {
+            var lambdaAttribute = new DynamoDBEvent.AttributeValue
+            {
+                L = new List<DynamoDBEvent.AttributeValue>
+                {
+                    new() { S = "Item1" },
+                    new() { N = "2" }
+                }
+            };
+            var sdkAttribute = lambdaAttribute.ConvertToSdkAttribute();
+
+            Assert.NotNull(sdkAttribute);
+            Assert.Equal(2, sdkAttribute.L.Count);
+            Assert.Equal("Item1", sdkAttribute.L[0].S);
+            Assert.Equal("2", sdkAttribute.L[1].N);
+        }
+
+        [Fact]
+        public void ConvertToSdkAttribute_MapValue_ReturnsSdkAttribute()
+        {
+            var lambdaAttribute = new DynamoDBEvent.AttributeValue
+            {
+                M = new Dictionary<string, DynamoDBEvent.AttributeValue>
+                {
+                    { "Key1", new DynamoDBEvent.AttributeValue { S = "Value1" } },
+                    { "Key2", new DynamoDBEvent.AttributeValue { N = "2" } }
+                }
+            };
+            var sdkAttribute = lambdaAttribute.ConvertToSdkAttribute();
+
+            Assert.NotNull(sdkAttribute);
+            Assert.Equal(2, sdkAttribute.M.Count);
+            Assert.Equal("Value1", sdkAttribute.M["Key1"].S);
+            Assert.Equal("2", sdkAttribute.M["Key2"].N);
+        }
+
+        [Fact]
+        public void ConvertToSdkAttributeValueDictionary_ValidDictionary_ReturnsSdkDictionary()
+        {
+            var lambdaAttributes = new Dictionary<string, DynamoDBEvent.AttributeValue>
+            {
+                { "Key1", new DynamoDBEvent.AttributeValue { S = "Value1" } },
+                { "Key2", new DynamoDBEvent.AttributeValue { N = "2" } }
+            };
+            var sdkDictionary = lambdaAttributes.ConvertToSdkAttributeValueDictionary();
+
+            Assert.NotNull(sdkDictionary);
+            Assert.Equal(2, sdkDictionary.Count);
+            Assert.Equal("Value1", sdkDictionary["Key1"].S);
+            Assert.Equal("2", sdkDictionary["Key2"].N);
+        }
+
+        [Fact]
+        public void ConvertToSdkAttributeValueDictionary_NullDictionary_ReturnsEmptySdkDictionary()
+        {
+            Dictionary<string, DynamoDBEvent.AttributeValue> lambdaAttributes = null!;
+            var sdkDictionary = lambdaAttributes.ConvertToSdkAttributeValueDictionary();
+
+            Assert.NotNull(sdkDictionary);
+            Assert.Empty(sdkDictionary);
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DynamoDBEvents.SDK.Convertor.Tests/DynamodbIdentityConvertorTests.cs
+++ b/Libraries/test/Amazon.Lambda.DynamoDBEvents.SDK.Convertor.Tests/DynamodbIdentityConvertorTests.cs
@@ -1,0 +1,37 @@
+namespace Amazon.Lambda.DynamoDBEvents.SDK.Convertor.Tests
+{
+    public class DynamodbIdentityConvertorTests
+    {
+        [Fact]
+        public void ConvertToSdkIdentity_NullLambdaIdentity_ReturnsNull()
+        {
+            // Arrange
+            DynamoDBEvent.Identity lambdaIdentity = null;
+
+            // Act
+            var result = lambdaIdentity.ConvertToSdkIdentity();
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ConvertToSdkIdentity_ValidLambdaIdentity_ReturnsSdkIdentity()
+        {
+            // Arrange
+            var lambdaIdentity = new DynamoDBEvent.Identity
+            {
+                PrincipalId = "dynamodb.amazonaws.com",
+                Type = "Service"
+            };
+
+            // Act
+            var result = lambdaIdentity.ConvertToSdkIdentity();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(lambdaIdentity.PrincipalId, result.PrincipalId);
+            Assert.Equal(lambdaIdentity.Type, result.Type);
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DynamoDBEvents.SDK.Convertor.Tests/DynamodbStreamRecordConvertorTests.cs
+++ b/Libraries/test/Amazon.Lambda.DynamoDBEvents.SDK.Convertor.Tests/DynamodbStreamRecordConvertorTests.cs
@@ -1,0 +1,66 @@
+namespace Amazon.Lambda.DynamoDBEvents.SDK.Convertor.Tests
+{
+    public class DynamodbStreamRecordConvertorTests
+    {
+        [Fact]
+        public void ConvertToSdkStreamRecord_NullLambdaStreamRecord_ReturnsNull()
+        {
+            // Arrange
+            DynamoDBEvent.StreamRecord lambdaStreamRecord = null;
+
+            // Act
+            var result = lambdaStreamRecord.ConvertToSdkStreamRecord();
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ConvertToSdkStreamRecord_ValidLambdaStreamRecord_ReturnsSdkStreamRecord()
+        {
+            // Arrange
+            var lambdaStreamRecord = new DynamoDBEvent.StreamRecord
+            {
+                ApproximateCreationDateTime = DateTime.UtcNow,
+                Keys = new Dictionary<string, DynamoDBEvent.AttributeValue>
+                {
+                    { "Id", new DynamoDBEvent.AttributeValue { S = "123" } }
+                },
+                NewImage = new Dictionary<string, DynamoDBEvent.AttributeValue>
+                {
+                    { "Name", new DynamoDBEvent.AttributeValue { S = "Test" } }
+                },
+                OldImage = new Dictionary<string, DynamoDBEvent.AttributeValue>
+                {
+                    { "Name", new DynamoDBEvent.AttributeValue { S = "OldTest" } }
+                },
+                SequenceNumber = "1234567890",
+                SizeBytes = 1024,
+                StreamViewType = "NEW_AND_OLD_IMAGES"
+            };
+
+            // Act
+            var result = lambdaStreamRecord.ConvertToSdkStreamRecord();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(lambdaStreamRecord.ApproximateCreationDateTime, result.ApproximateCreationDateTime);
+            Assert.Equal(lambdaStreamRecord.SequenceNumber, result.SequenceNumber);
+            Assert.Equal(lambdaStreamRecord.SizeBytes, result.SizeBytes);
+            Assert.Equal(lambdaStreamRecord.StreamViewType, result.StreamViewType);
+
+            Assert.NotNull(result.Keys);
+            Assert.Single(result.Keys);
+            Assert.Equal(lambdaStreamRecord.Keys["Id"].S, result.Keys["Id"].S);
+
+            Assert.NotNull(result.NewImage);
+            Assert.Single(result.NewImage);
+            Assert.Equal(lambdaStreamRecord.NewImage["Name"].S, result.NewImage["Name"].S);
+
+            Assert.NotNull(result.OldImage);
+            Assert.Single(result.OldImage);
+            Assert.Equal(lambdaStreamRecord.OldImage["Name"].S, result.OldImage["Name"].S);
+        }
+    }
+}
+


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-lambda-dotnet/discussions/1657

*Description of changes:*

- Addition of DynamoDBEvents SDK Converter Package: Implements converters that transform raw DynamoDB event data into .NET classes, enhancing developer experience by providing a more intuitive object model.
- Unit Tests: Includes comprehensive unit tests to ensure the reliability and correctness of the conversion logic.
- Documentation Updates: Adds usage examples and API documentation to guide developers in integrating the new converters into their Lambda function


Java’s DynamodbAttributeValueTransformer provides a similar solution. The .NET SDK does not have a native implementation, but this extension library can achieve feature parity.

ConvertToSdkAttribute: Converts DynamoDBEvent.AttributeValue to Amazon.DynamoDBv2.Model.AttributeValue.
ConvertToSdkAttributeValueDictionary: Converts a dictionary of Lambda attributes to SDK attributes.
ConvertToSdkIdentity: Converts DynamoDBEvent.Identity to Amazon.DynamoDBv2.Model.Identity.
ConvertToSdkStreamRecord: Converts DynamoDBEvent.StreamRecord to Amazon.DynamoDBv2.Model.StreamRecord.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
