### PR TITLE
chore: Update test tool tests to not use env vars for lambda runtime api

### DIFF
--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/Amazon.Lambda.TestTool.IntegrationTests.csproj
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/Amazon.Lambda.TestTool.IntegrationTests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
-    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.12.0" />
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.12.3" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.1" />
     <PackageReference Include="AWSSDK.APIGateway" Version="3.7.401.19" />

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/ApiGatewayEmulatorProcessTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/ApiGatewayEmulatorProcessTests.cs
@@ -42,8 +42,7 @@ public class ApiGatewayEmulatorProcessTests(ITestOutputHelper testOutputHelper)
             await WaitForGatewayHealthCheck(apiGatewayPort);
             var handler = (APIGatewayHttpApiV2ProxyRequest request, ILambdaContext context) =>
             {
-                var env = Environment.GetEnvironmentVariable("AWS_LAMBDA_RUNTIME_API");
-                testOutputHelper.WriteLine($"TestLambdaToUpperV2: {env}");
+                testOutputHelper.WriteLine($"TestLambdaToUpperV2");
                 return new APIGatewayHttpApiV2ProxyResponse
                 {
                     StatusCode = 200,
@@ -51,8 +50,8 @@ public class ApiGatewayEmulatorProcessTests(ITestOutputHelper testOutputHelper)
                 };
             };
 
-            Environment.SetEnvironmentVariable("AWS_LAMBDA_RUNTIME_API", $"localhost:{lambdaPort}/testfunction");
             _ = LambdaBootstrapBuilder.Create(handler, new DefaultLambdaJsonSerializer())
+                .ConfigureOptions(x => x.RuntimeApiEndpoint = $"localhost:{lambdaPort}/testfunction")
                 .Build()
                 .RunAsync(_cancellationTokenSource.Token);
 
@@ -83,8 +82,7 @@ public class ApiGatewayEmulatorProcessTests(ITestOutputHelper testOutputHelper)
             await WaitForGatewayHealthCheck(apiGatewayPort);
             var handler = (APIGatewayProxyRequest request, ILambdaContext context) =>
             {
-                var env = Environment.GetEnvironmentVariable("AWS_LAMBDA_RUNTIME_API");
-                testOutputHelper.WriteLine($"TestLambdaToUpperRest: {env}");
+                testOutputHelper.WriteLine($"TestLambdaToUpperRest");
                 return new APIGatewayProxyResponse()
                 {
                     StatusCode = 200,
@@ -93,8 +91,8 @@ public class ApiGatewayEmulatorProcessTests(ITestOutputHelper testOutputHelper)
                 };
             };
 
-            Environment.SetEnvironmentVariable("AWS_LAMBDA_RUNTIME_API", $"localhost:{lambdaPort}/testfunction");
             _ = LambdaBootstrapBuilder.Create(handler, new DefaultLambdaJsonSerializer())
+                .ConfigureOptions(x => x.RuntimeApiEndpoint = $"localhost:{lambdaPort}/testfunction")
                 .Build()
                 .RunAsync(_cancellationTokenSource.Token);
 
@@ -125,8 +123,7 @@ public class ApiGatewayEmulatorProcessTests(ITestOutputHelper testOutputHelper)
             await WaitForGatewayHealthCheck(apiGatewayPort);
             var handler = (APIGatewayProxyRequest request, ILambdaContext context) =>
             {
-                var env = Environment.GetEnvironmentVariable("AWS_LAMBDA_RUNTIME_API");
-                testOutputHelper.WriteLine($"TestLambdaToUpperV1: {env}");
+                testOutputHelper.WriteLine($"TestLambdaToUpperV1");
                 return new APIGatewayProxyResponse()
                 {
                     StatusCode = 200,
@@ -135,8 +132,8 @@ public class ApiGatewayEmulatorProcessTests(ITestOutputHelper testOutputHelper)
                 };
             };
 
-            Environment.SetEnvironmentVariable("AWS_LAMBDA_RUNTIME_API", $"localhost:{lambdaPort}/testfunction");
             _ = LambdaBootstrapBuilder.Create(handler, new DefaultLambdaJsonSerializer())
+                .ConfigureOptions(x => x.RuntimeApiEndpoint = $"localhost:{lambdaPort}/testfunction")
                 .Build()
                 .RunAsync(_cancellationTokenSource.Token);
 
@@ -167,8 +164,7 @@ public class ApiGatewayEmulatorProcessTests(ITestOutputHelper testOutputHelper)
             await WaitForGatewayHealthCheck(apiGatewayPort);
             var handler = (APIGatewayHttpApiV2ProxyRequest request, ILambdaContext context) =>
             {
-                var env = Environment.GetEnvironmentVariable("AWS_LAMBDA_RUNTIME_API");
-                testOutputHelper.WriteLine($"TestLambdaBinaryResponse: {env}");
+                testOutputHelper.WriteLine($"TestLambdaBinaryResponse");
                 // Create a simple binary pattern (for example, counting bytes from 0 to 255)
                 byte[] binaryData = new byte[256];
                 for (int i = 0; i < 256; i++)
@@ -188,8 +184,8 @@ public class ApiGatewayEmulatorProcessTests(ITestOutputHelper testOutputHelper)
                 };
             };
 
-            Environment.SetEnvironmentVariable("AWS_LAMBDA_RUNTIME_API", $"localhost:{lambdaPort}/binaryfunction");
             _ = LambdaBootstrapBuilder.Create(handler, new DefaultLambdaJsonSerializer())
+                .ConfigureOptions(x => x.RuntimeApiEndpoint = $"localhost:{lambdaPort}/binaryfunction")
                 .Build()
                 .RunAsync(_cancellationTokenSource.Token);
 
@@ -226,13 +222,12 @@ public class ApiGatewayEmulatorProcessTests(ITestOutputHelper testOutputHelper)
             await WaitForGatewayHealthCheck(apiGatewayPort);
             var handler = (APIGatewayHttpApiV2ProxyRequest request, ILambdaContext context) =>
             {
-                var env = Environment.GetEnvironmentVariable("AWS_LAMBDA_RUNTIME_API");
-                testOutputHelper.WriteLine($"TestLambdaReturnString: {env}");
+                testOutputHelper.WriteLine($"TestLambdaReturnString");
                 return request.Body.ToUpper();
             };
 
-            Environment.SetEnvironmentVariable("AWS_LAMBDA_RUNTIME_API", $"localhost:{lambdaPort}/stringfunction");
             _ = LambdaBootstrapBuilder.Create(handler, new DefaultLambdaJsonSerializer())
+                .ConfigureOptions(x => x.RuntimeApiEndpoint = $"localhost:{lambdaPort}/stringfunction")
                 .Build()
                 .RunAsync(_cancellationTokenSource.Token);
 
@@ -263,8 +258,7 @@ public class ApiGatewayEmulatorProcessTests(ITestOutputHelper testOutputHelper)
             await WaitForGatewayHealthCheck(apiGatewayPort);
             var handler = (APIGatewayHttpApiV2ProxyRequest request, ILambdaContext context) =>
             {
-                var env = Environment.GetEnvironmentVariable("AWS_LAMBDA_RUNTIME_API");
-                testOutputHelper.WriteLine($"TestLambdaWithNullEndpoint: {env}");
+                testOutputHelper.WriteLine($"TestLambdaWithNullEndpoint");
                 return new APIGatewayHttpApiV2ProxyResponse
                 {
                     StatusCode = 200,
@@ -272,8 +266,8 @@ public class ApiGatewayEmulatorProcessTests(ITestOutputHelper testOutputHelper)
                 };
             };
 
-            Environment.SetEnvironmentVariable("AWS_LAMBDA_RUNTIME_API", $"localhost:{lambdaPort}/testfunction");
             _ = LambdaBootstrapBuilder.Create(handler, new DefaultLambdaJsonSerializer())
+                .ConfigureOptions(x => x.RuntimeApiEndpoint = $"localhost:{lambdaPort}/testfunction")
                 .Build()
                 .RunAsync(_cancellationTokenSource.Token);
 

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Amazon.Lambda.TestTool.UnitTests.csproj
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Amazon.Lambda.TestTool.UnitTests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.12.2" />
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.12.3" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
     <PackageReference Include="AWSSDK.Lambda" Version="3.7.411.18" />
     <PackageReference Include="coverlet.collector" Version="6.0.3">

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/RuntimeApiTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/RuntimeApiTests.cs
@@ -19,11 +19,7 @@ namespace Amazon.Lambda.TestTool.UnitTests;
 
 public class RuntimeApiTests
 {
-#if DEBUG
-    [Fact]
-#else
-    [Fact(Skip = "Skipping this test as it is not working properly.")]
-#endif
+    [RetryFact]
     public async Task AddEventToDataStore()
     {
         const string functionName = "FunctionFoo";
@@ -62,10 +58,10 @@ public class RuntimeApiTests
                 return input.ToUpper();
             };
 
-            Environment.SetEnvironmentVariable("AWS_LAMBDA_RUNTIME_API", $"{options.LambdaEmulatorHost}:{options.LambdaEmulatorPort}/{functionName}");
             _ = LambdaBootstrapBuilder.Create(handler, new DefaultLambdaJsonSerializer())
-                    .Build()
-                    .RunAsync(cancellationTokenSource.Token);
+                .ConfigureOptions(x => x.RuntimeApiEndpoint = $"{options.LambdaEmulatorHost}:{options.LambdaEmulatorPort}/{functionName}")
+                .Build()
+                .RunAsync(cancellationTokenSource.Token);
 
             await Task.Delay(2_000, cancellationTokenSource.Token);
             Assert.True(handlerCalled);
@@ -96,10 +92,10 @@ public class RuntimeApiTests
                 return input.ToUpper();
             };
 
-            Environment.SetEnvironmentVariable("AWS_LAMBDA_RUNTIME_API", $"{options.LambdaEmulatorHost}:{options.LambdaEmulatorPort}/{functionName}");
             _ = LambdaBootstrapBuilder.Create(handler, new DefaultLambdaJsonSerializer())
-                    .Build()
-                    .RunAsync(cancellationTokenSource.Token);
+                .ConfigureOptions(x => x.RuntimeApiEndpoint = $"{options.LambdaEmulatorHost}:{options.LambdaEmulatorPort}/{functionName}")
+                .Build()
+                .RunAsync(cancellationTokenSource.Token);
 
             var lambdaClient = ConstructLambdaServiceClient(testToolProcess.ServiceUrl);
 


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7962

*Description of changes:*
* Updated tests to set the Lambda Runtime API endpoint using ConfigureOptions on RuntimeSupport instead of using env vars

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
