### PR TITLE
Add Lambda-Runtime-Deadline-Ms response header

### DIFF
--- a/.autover/changes/cec1c49e-0a82-4cb0-bc2e-76d702ea3209.json
+++ b/.autover/changes/cec1c49e-0a82-4cb0-bc2e-76d702ea3209.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.TestTool",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add Lambda-Runtime-Deadline-Ms response header"
+      ]
+    }
+  ]
+}

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Services/LambdaRuntimeAPI.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Services/LambdaRuntimeAPI.cs
@@ -145,6 +145,9 @@ public class LambdaRuntimeApi
         Console.WriteLine(HeaderBreak);
         Console.WriteLine($"Next invocation returned: {activeEvent.AwsRequestId}");
 
+        // Set the deadline to the Lambda max length of 15 minutes. Formatted as Epoch MS.
+        long deadline = ((long)(DateTime.UtcNow.AddMinutes(15) - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds);
+        ctx.Response.Headers["Lambda-Runtime-Deadline-Ms"] = deadline.ToString();
 
         ctx.Response.Headers["Lambda-Runtime-Aws-Request-Id"] = activeEvent.AwsRequestId;
         ctx.Response.Headers["Lambda-Runtime-Trace-Id"] = Guid.NewGuid().ToString();


### PR DESCRIPTION
*Description of changes:*
While trying out the tool with a Rust Lambda function directed to the tool I noticed that it failed because we aren't setting the `Lambda-Runtime-Deadline-Ms` header on the Lambda Runtime API get next invocation method. Since we don't have a real value I set the value to 15 minutes which is the max a Lambda function is supposed to run.

After making this change I was able to attach a Rust Lambda function to the tool and debug.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
