### PR TITLE
chore: add cfn tag to integ tests

### DIFF
--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/Helpers/CloudFormationHelper.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/Helpers/CloudFormationHelper.cs
@@ -21,7 +21,12 @@ namespace Amazon.Lambda.TestTool.IntegrationTests.Helpers
             {
                 StackName = stackName,
                 TemplateBody = templateBody,
-                Capabilities = new List<string> { "CAPABILITY_IAM" }
+                Capabilities = new List<string> { "CAPABILITY_IAM" },
+                Tags = new List<Tag>
+                {
+                    new Tag { Key = "aws-tests", Value = typeof(CloudFormationHelper).FullName },
+                    new Tag { Key = "aws-repo", Value = "aws-lambda-dotnet" }
+                }
             });
             return response.StackId;
         }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7993

*Description of changes:*
Add a CFN Tag to be able to filter the test stacks from a sweeper in order to accurately delete any leftover stacks.
The tag's key is `aws-tests` and it's value is the class that created it to help us easily pinpoint it's source. In this case, the value will be `Amazon.Lambda.TestTool.IntegrationTests.Helpers.CloudFormationHelper`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
