### PR TITLE
Update global logger to support logging with level and arguments.

### DIFF
--- a/.autover/changes/d0822afd-daf4-437a-9437-2a9492c135b7.json
+++ b/.autover/changes/d0822afd-daf4-437a-9437-2a9492c135b7.json
@@ -1,0 +1,18 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.RuntimeSupport",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Add support for parameterized logging method to global logger LambdaLogger in Amazon.Lambda.Core"
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.RuntimeSupport",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add support for parameterized logging method to global logger LambdaLogger. Method is marked as preview till new version of Amazon.Lambda.RuntimeSupport is deployed to managed runtime."
+      ]
+    }	
+  ]
+}

--- a/.autover/changes/d0822afd-daf4-437a-9437-2a9492c135b7.json
+++ b/.autover/changes/d0822afd-daf4-437a-9437-2a9492c135b7.json
@@ -8,7 +8,7 @@
       ]
     },
     {
-      "Name": "Amazon.Lambda.RuntimeSupport",
+      "Name": "Amazon.Lambda.Core",
       "Type": "Patch",
       "ChangelogMessages": [
         "Add support for parameterized logging method to global logger LambdaLogger. Method is marked as preview till new version of Amazon.Lambda.RuntimeSupport is deployed to managed runtime."

--- a/Libraries/src/Amazon.Lambda.Core/LambdaLogger.cs
+++ b/Libraries/src/Amazon.Lambda.Core/LambdaLogger.cs
@@ -12,7 +12,7 @@ namespace Amazon.Lambda.Core
     /// </summary>
     public static class LambdaLogger
     {
-        // The name of this field must not change or be readonly because Amazon.Runtime.Support will use reflection to replace the
+        // The name of this field must not change or be readonly because Amazon.Lambda.RuntimeSupport will use reflection to replace the
         // value with an Action that directs the logging into its logging system.
 #pragma warning disable IDE0044 // Add readonly modifier
         private static Action<string> _loggingAction = LogToConsole;
@@ -38,7 +38,7 @@ namespace Amazon.Lambda.Core
 
 #if NET6_0_OR_GREATER
 
-        // The name of this field must not change or be readonly because Amazon.Runtime.Support will use reflection to replace the
+        // The name of this field must not change or be readonly because Amazon.Lambda.RuntimeSupport will use reflection to replace the
         // value with an Action that directs the logging into its logging system.
 #pragma warning disable IDE0044 // Add readonly modifier
         private static Action<string, string, object[]> _loggingWithLevelAction = LogWithLevelToConsole;
@@ -48,7 +48,7 @@ namespace Amazon.Lambda.Core
         private static void LogWithLevelToConsole(string level, string message, params object[] args)
         {
             // Formatting here is not important, it is used for debugging Amazon.Lambda.Core only.
-            // In a real scenario Amazon.Runtime.Support will change the value of _loggingWithLevelAction
+            // In a real scenario Amazon.Lambda.RuntimeSupport will change the value of _loggingWithLevelAction
             // to an Action inside it's logging system to handle the real formatting.
             var sb = new StringBuilder();
             sb.Append(level).Append(": ").Append(message);
@@ -67,7 +67,7 @@ namespace Amazon.Lambda.Core
 
         private const string ParameterizedPreviewMessage =
             "This method has been mark as preview till the Lambda .NET Managed runtime has been updated with the backing implementation of this method. " +
-            "It is possible to use this method whilein preview if the Lambda function is deployed as an executable and uses the latest version of Amazon.Lambda.RuntimeSupport.";
+            "It is possible to use this method while in preview if the Lambda function is deployed as an executable and uses the latest version of Amazon.Lambda.RuntimeSupport.";
 
         /// <summary>
         /// Logs a message to AWS CloudWatch Logs.

--- a/Libraries/src/Amazon.Lambda.Core/LambdaLogger.cs
+++ b/Libraries/src/Amazon.Lambda.Core/LambdaLogger.cs
@@ -1,4 +1,7 @@
-﻿using System;
+using System;
+using System.Reflection.Emit;
+using System.Runtime.Versioning;
+using System.Text;
 
 namespace Amazon.Lambda.Core
 {
@@ -9,8 +12,11 @@ namespace Amazon.Lambda.Core
     /// </summary>
     public static class LambdaLogger
     {
-        // Logging action, logs to Console by default
+        // The name of this field must not change or be readonly because Amazon.Runtime.Support will use reflection to replace the
+        // value with an Action that directs the logging into its logging system.
+#pragma warning disable IDE0044 // Add readonly modifier
         private static Action<string> _loggingAction = LogToConsole;
+#pragma warning restore IDE0044 // Add readonly modifier
 
         // Logs message to console
         private static void LogToConsole(string message)
@@ -29,5 +35,66 @@ namespace Amazon.Lambda.Core
         {
             _loggingAction(message);
         }
+
+#if NET6_0_OR_GREATER
+
+        // The name of this field must not change or be readonly because Amazon.Runtime.Support will use reflection to replace the
+        // value with an Action that directs the logging into its logging system.
+#pragma warning disable IDE0044 // Add readonly modifier
+        private static Action<string, string, object[]> _loggingWithLevelAction = LogWithLevelToConsole;
+#pragma warning restore IDE0044 // Add readonly modifier
+
+        // Logs message to console
+        private static void LogWithLevelToConsole(string level, string message, params object[] args)
+        {
+            // Formatting here is not important, it is used for debugging Amazon.Lambda.Core only.
+            // In a real scenario Amazon.Runtime.Support will change the value of _loggingWithLevelAction
+            // to an Action inside it's logging system to handle the real formatting.
+            var sb = new StringBuilder();
+            sb.Append(level).Append(": ").Append(message);
+            if (args?.Length > 0)
+            {
+                sb.Append(" Arguments:");
+                foreach(var arg in args)
+                {
+                    sb.Append(" \"");
+                    sb.Append(arg);
+                    sb.Append("\"");
+                }
+            }
+            Console.WriteLine(sb.ToString());
+        }
+
+        private const string ParameterizedPreviewMessage =
+            "This method has been mark as preview till the Lambda .NET Managed runtime has been updated with the backing implementation of this method. " +
+            "It is possible to use this method whilein preview if the Lambda function is deployed as an executable and uses the latest version of Amazon.Lambda.RuntimeSupport.";
+
+        /// <summary>
+        /// Logs a message to AWS CloudWatch Logs.
+        /// 
+        /// Logging will not be done:
+        ///  If the role provided to the function does not have sufficient permissions.
+        /// </summary>
+        /// <param name="level">The log level of the message</param>
+        /// <param name="message">Message to log. The message may have format arguments.</param>
+        /// <param name="args">Arguments to format the message with.</param>
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        public static void Log(string level, string message, params object[] args)
+        {
+            _loggingWithLevelAction(level, message, args);
+        }
+
+        /// <summary>
+        /// Logs a message to AWS CloudWatch Logs.
+        /// 
+        /// Logging will not be done:
+        ///  If the role provided to the function does not have sufficient permissions.
+        /// </summary>
+        /// <param name="level">The log level of the message</param>
+        /// <param name="message">Message to log. The message may have format arguments.</param>
+        /// <param name="args">Arguments to format the message with.</param>
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        public static void Log(LogLevel level, string message, params object[] args) => Log(level.ToString(), message, args);
+#endif
     }
 }

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/ConsoleLoggerWriter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/ConsoleLoggerWriter.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
@@ -240,16 +240,25 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
         /// </summary>
         private void ConfigureLoggingActionField()
         {
-            var lambdaILoggerType = typeof(Amazon.Lambda.Core.LambdaLogger);
-            if (lambdaILoggerType == null)
+            var lambdaLoggerType = typeof(Amazon.Lambda.Core.LambdaLogger);
+            if (lambdaLoggerType == null)
                 return;
 
-            var loggingActionField = lambdaILoggerType.GetTypeInfo().GetField("_loggingAction", BindingFlags.NonPublic | BindingFlags.Static);
-            if (loggingActionField == null)
-                return;
+            var loggingActionField = lambdaLoggerType.GetTypeInfo().GetField("_loggingAction", BindingFlags.NonPublic | BindingFlags.Static);
+            if (loggingActionField != null)
+            {
+                Action<string> loggingAction = (message => FormattedWriteLine(null, message));
+                loggingActionField.SetValue(null, loggingAction);
+            }
 
-            Action<string> callback = (message => FormattedWriteLine(null, message));
-            loggingActionField.SetValue(null, callback);
+
+            var loggingWithLevelActionField = lambdaLoggerType.GetTypeInfo().GetField("_loggingWithLevelAction", BindingFlags.NonPublic | BindingFlags.Static);
+            if (loggingWithLevelActionField != null)
+            {
+                Action<string, string, object[]> loggingWithLevelAction = ((level, message, args) => FormattedWriteLine(level, message, args));
+                loggingWithLevelActionField.SetValue(null, loggingWithLevelAction);
+
+            }
         }
 
         /// <inheritdoc/>

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/CustomRuntimeTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/CustomRuntimeTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License").
@@ -106,6 +106,7 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
                     await RunTestSuccessAsync(lambdaClient, "UnintendedDisposeTest", "not-used", "UnintendedDisposeTest-SUCCESS");
                     await RunTestSuccessAsync(lambdaClient, "LoggingStressTest", "not-used", "LoggingStressTest-success");
 
+                    await RunGlobalLoggingTestAsync(lambdaClient, "GlobalLoggingTest");
                     await RunJsonLoggingWithUnhandledExceptionAsync(lambdaClient);
 
                     await RunLoggingTestAsync(lambdaClient, "LoggingTest", RuntimeLogLevel.Trace, LogConfigSource.LambdaAPI);
@@ -120,7 +121,6 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
                     await RunLoggingTestAsync(lambdaClient, "LoggingTest", RuntimeLogLevel.Warning, LogConfigSource.DotnetEnvironment);
                     await RunLoggingTestAsync(lambdaClient, "LoggingTest", RuntimeLogLevel.Error, LogConfigSource.DotnetEnvironment);
                     await RunLoggingTestAsync(lambdaClient, "LoggingTest", RuntimeLogLevel.Critical, LogConfigSource.DotnetEnvironment);
-
 
                     await RunUnformattedLoggingTestAsync(lambdaClient, "LoggingTest");
 
@@ -315,6 +315,19 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
             {
                 Assert.DoesNotContain("A critical log", log);
             }
+        }
+
+        private async Task RunGlobalLoggingTestAsync(AmazonLambdaClient lambdaClient, string handler)
+        {
+            await UpdateHandlerAsync(lambdaClient, handler);
+
+            var invokeResponse = await InvokeFunctionAsync(lambdaClient, JsonConvert.SerializeObject(""));
+            Assert.True(invokeResponse.HttpStatusCode == System.Net.HttpStatusCode.OK);
+            Assert.True(invokeResponse.FunctionError == null);
+
+            var log = System.Text.UTF8Encoding.UTF8.GetString(Convert.FromBase64String(invokeResponse.LogResult));
+
+            Assert.Contains("This is a global log message with foobar as an argument", log);
         }
 
         private async Task RunUnformattedLoggingTestAsync(AmazonLambdaClient lambdaClient, string handler)

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/CustomRuntimeFunctionTest/CustomRuntimeFunction.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/CustomRuntimeFunctionTest/CustomRuntimeFunction.cs
@@ -1,4 +1,4 @@
-﻿using Amazon.Lambda.Core;
+using Amazon.Lambda.Core;
 using Amazon.Lambda.RuntimeSupport;
 using Amazon.Lambda.Serialization.SystemTextJson;
 using System;
@@ -47,6 +47,9 @@ namespace CustomRuntimeFunctionTest
                         break;
                     case nameof(LoggingStressTest):
                         bootstrap = new LambdaBootstrap(LoggingStressTest);
+                        break;
+                    case nameof(GlobalLoggingTest):
+                        bootstrap = new LambdaBootstrap(GlobalLoggingTest);
                         break;
                     case nameof(LoggingTest):
                         bootstrap = new LambdaBootstrap(LoggingTest);
@@ -167,6 +170,15 @@ namespace CustomRuntimeFunctionTest
             Task.WaitAll(task1, task2, task3);
 
             return Task.FromResult(GetInvocationResponse(nameof(LoggingStressTest), "success"));
+        }
+
+
+        private static Task<InvocationResponse> GlobalLoggingTest(InvocationRequest invocation)
+        {
+#pragma warning disable CA2252
+            LambdaLogger.Log(LogLevel.Information, "This is a global log message with {argument} as an argument", "foobar");
+#pragma warning restore CA2252
+            return Task.FromResult(GetInvocationResponse(nameof(GlobalLoggingTest), true));
         }
 
         private static Task<InvocationResponse> LoggingTest(InvocationRequest invocation)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1747#issuecomment-2596925013

*Description of changes:*
Add to the global logger `LambdaLogger` in Amazon.Lambda.Core a new parameterized logging method that takes in log level. The method is marked as preview till the new version of Amazon.Lambda.RuntimeSupport is deployed to the managed runtime.

Once the PR is deployed to the managed runtime we can update `Amazon.Lambda.Logging.AspNetCore` to use this new method so the log levels will be honored.

## Testing
Ran tests and added an integ test cases for the new logging scenario.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
