### PR TITLE
ci: add a test sweeper after CodeBuild run

### DIFF
--- a/.github/workflows/aws-ci.yml
+++ b/.github/workflows/aws-ci.yml
@@ -1,4 +1,3 @@
-
 name: AWS CI
 
 on:
@@ -7,7 +6,7 @@ on:
     branches:
       - master
       - dev
-      - 'feature/**'
+      - "feature/**"
 
 permissions:
   id-token: write
@@ -16,7 +15,7 @@ jobs:
   run-ci:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
+      - name: Configure Load Balancer Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 #v4
         with:
           role-to-assume: ${{ secrets.CI_MAIN_TESTING_ACCOUNT_ROLE_ARN }}
@@ -40,8 +39,14 @@ jobs:
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
           project-name: ${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}
+      - name: Invoke Test Sweeper Lambda
+        if: always()
+        shell: pwsh
+        run: |
+          aws lambda invoke response.json --function-name "${{ secrets.CI_TESTING_TEST_SWEEPER_LAMBDA_NAME }}" --cli-binary-format raw-in-base64-out --payload '{"Tags": "aws-repo=${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}"}'
       - name: CodeBuild Link
         shell: pwsh
         run: |
           $buildId = "${{ steps.codebuild.outputs.aws-build-id }}"
           echo $buildId
+


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7993

*Description of changes:*
Add a step in AWS CI that invokes a Test Sweeper Lambda function. The Test Sweeper accepts a CFN tag which indicates which stacks to be cleaned up.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
