### PR TITLE
Suppress warnings for "Missing XML comment for publicly visible type or member " for test projects

### DIFF
--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/Amazon.Lambda.TestTool.IntegrationTests.csproj
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/Amazon.Lambda.TestTool.IntegrationTests.csproj
@@ -7,6 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.Tests.Common/Amazon.Lambda.TestTool.Tests.Common.csproj
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.Tests.Common/Amazon.Lambda.TestTool.Tests.Common.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <NoWarn>1591</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Amazon.Lambda.TestTool.UnitTests.csproj
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Amazon.Lambda.TestTool.UnitTests.csproj
@@ -8,6 +8,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Suppress warnings for "Missing XML comment for publicly visible type or member " for test projects since we do not need to add comments to those functions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
