### PR TITLE
Update test cleanup sweeper to always use fresh credentials

### DIFF
--- a/.github/workflows/aws-ci.yml
+++ b/.github/workflows/aws-ci.yml
@@ -39,6 +39,12 @@ jobs:
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
           project-name: ${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}
+      - name: Configure Sweeper Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 #v4
+        with:
+          role-to-assume: ${{ secrets.CI_MAIN_TESTING_ACCOUNT_ROLE_ARN }}
+          role-duration-seconds: 7200
+          aws-region: us-west-2
       - name: Invoke Test Sweeper Lambda
         if: always()
         shell: pwsh
@@ -49,4 +55,3 @@ jobs:
         run: |
           $buildId = "${{ steps.codebuild.outputs.aws-build-id }}"
           echo $buildId
-

--- a/.github/workflows/aws-ci.yml
+++ b/.github/workflows/aws-ci.yml
@@ -39,11 +39,11 @@ jobs:
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
           project-name: ${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}
-      - name: Configure Sweeper Credentials
+      - name: Configure Test Sweeper Lambda Credentials
         if: always()
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 #v4
         with:
-          role-to-assume: ${{ secrets.CI_MAIN_TESTING_ACCOUNT_ROLE_ARN }}
+          role-to-assume: ${{ steps.lambda.outputs.roleArn }}
           role-duration-seconds: 7200
           aws-region: us-west-2
       - name: Invoke Test Sweeper Lambda

--- a/.github/workflows/aws-ci.yml
+++ b/.github/workflows/aws-ci.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           project-name: ${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}
       - name: Configure Sweeper Credentials
+        if: always()
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 #v4
         with:
           role-to-assume: ${{ secrets.CI_MAIN_TESTING_ACCOUNT_ROLE_ARN }}


### PR DESCRIPTION
*Issue #, if available:* DOTNET-8031

*Description of changes:*
Update test cleanup sweeper to always use fresh credentials.
This is needed because sometimes the tests time out after 2 hours and the creds are invalidated after that time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
