### PR TITLE
Add SSO dependencies to support credential profiles that are using SSO

### DIFF
--- a/.autover/changes/4fa617cf-36b8-4ac7-a4e8-18e3aed7e9b2.json
+++ b/.autover/changes/4fa617cf-36b8-4ac7-a4e8-18e3aed7e9b2.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.TestTool",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add SSO dependencies to support credential profiles that are using SSO"
+      ]
+    }
+  ]
+}

--- a/.autover/changes/4fa617cf-36b8-4ac7-a4e8-18e3aed7e9b2.json
+++ b/.autover/changes/4fa617cf-36b8-4ac7-a4e8-18e3aed7e9b2.json
@@ -4,7 +4,8 @@
       "Name": "Amazon.Lambda.TestTool",
       "Type": "Patch",
       "ChangelogMessages": [
-        "Add SSO dependencies to support credential profiles that are using SSO"
+        "Add SSO dependencies to support credential profiles that are using SSO",
+        "Update version of AWS SDK for .NET to V4"
       ]
     }
   ]

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <Import Project="..\..\..\..\buildtools\common.props" />
   <PropertyGroup>
@@ -27,11 +27,11 @@
 
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.400" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.7.412.23" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.400.139" />
-    <PackageReference Include="AWSSDK.SSO" Version="3.7.400.139" />
-    <PackageReference Include="AWSSDK.SSOOIDC" Version="3.7.401.17" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.Lambda" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SSO" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.0" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.1" />

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -28,8 +28,10 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.400" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.7.411.17" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.400.109" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.7.412.23" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.400.139" />
+    <PackageReference Include="AWSSDK.SSO" Version="3.7.400.139" />
+    <PackageReference Include="AWSSDK.SSOOIDC" Version="3.7.401.17" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.1" />

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Program.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Program.cs
@@ -7,6 +7,9 @@ using Amazon.Lambda.TestTool.Extensions;
 using Amazon.Lambda.TestTool.Services;
 using Spectre.Console.Cli;
 
+// Till we do the full inspection for collection maintain the S3 behavior for initializing collections.
+Amazon.AWSConfigs.InitializeCollections = true;
+
 var serviceCollection = new ServiceCollection();
 
 serviceCollection.AddCustomServices();

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/Amazon.Lambda.TestTool.IntegrationTests.csproj
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/Amazon.Lambda.TestTool.IntegrationTests.csproj
@@ -15,13 +15,13 @@
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.13.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.1" />
-    <PackageReference Include="AWSSDK.APIGateway" Version="3.7.402.16" />
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.403.17" />
-	  <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.405.17" />
-    <PackageReference Include="AWSSDK.ApiGatewayV2" Version="3.7.402.16" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.7.412.23" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.401.88" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.400.139" />
+    <PackageReference Include="AWSSDK.APIGateway" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="4.0.0" />
+	  <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.ApiGatewayV2" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.Lambda" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0" />

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/Amazon.Lambda.TestTool.IntegrationTests.csproj
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/Amazon.Lambda.TestTool.IntegrationTests.csproj
@@ -11,17 +11,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
-    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.12.3" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.5.1" />
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.13.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.1" />
-    <PackageReference Include="AWSSDK.APIGateway" Version="3.7.401.19" />
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.401.22" />
-	  <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.403.24" />
-    <PackageReference Include="AWSSDK.ApiGatewayV2" Version="3.7.400.75" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.7.411.18" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.401.24" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.400.110" />
+    <PackageReference Include="AWSSDK.APIGateway" Version="3.7.402.16" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.403.17" />
+	  <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.405.17" />
+    <PackageReference Include="AWSSDK.ApiGatewayV2" Version="3.7.402.16" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.7.412.23" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.401.88" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.400.139" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0" />

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Amazon.Lambda.TestTool.UnitTests.csproj
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Amazon.Lambda.TestTool.UnitTests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.13.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.7.412.23" />
+    <PackageReference Include="AWSSDK.Lambda" Version="4.0.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Amazon.Lambda.TestTool.UnitTests.csproj
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Amazon.Lambda.TestTool.UnitTests.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.12.3" />
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.13.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.7.411.18" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.7.412.23" />
     <PackageReference Include="coverlet.collector" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/integrations-on-dotnet-aspire-for-aws/issues/73

*Description of changes:*
Add the SSO dependencies so if a credential profile is referring to an SSO profile the cached SSO token can be resolved into AWS credentials. 

PR has been updated to now target V4 of the AWS SDK for .NET now that V4 has been release for general availability.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
