### PR TITLE
Update event packages for V4 SDK

### DIFF
--- a/.autover/changes/be8e0154-524e-402e-bb5d-ab1a0c3dea95.json
+++ b/.autover/changes/be8e0154-524e-402e-bb5d-ab1a0c3dea95.json
@@ -1,0 +1,18 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.DynamoDBEvents.SDK.Convertor",
+      "Type": "Major",
+      "ChangelogMessages": [
+        "Update to AWS SDK for .NET V4"
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.KinesisEvents",
+      "Type": "Major",
+      "ChangelogMessages": [
+        "Update to AWS SDK for .NET V4"
+      ]
+    }	
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/Amazon.Lambda.DynamoDBEvents.SDK.Convertor.csproj
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/Amazon.Lambda.DynamoDBEvents.SDK.Convertor.csproj
@@ -16,7 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.405.23" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.DynamoDBStreams" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/DynamodbAttributeValueConvertor.cs
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/DynamodbAttributeValueConvertor.cs
@@ -97,5 +97,96 @@ namespace Amazon.Lambda.DynamoDBEvents.SDK.Convertor
 
             return sdkDictionary;
         }
+
+        /// <summary>
+        /// Convert Lambda AttributeValue to SDK AttributeValue
+        /// </summary>
+        /// <param name="lambdaAttribute">The Lambda AttributeValue to convert.</param>
+        /// <returns>The converted SDK AttributeValue.</returns>
+        public static Amazon.DynamoDBStreams.Model.AttributeValue ConvertToSdkStreamAttribute(this
+            DynamoDBEvent.AttributeValue lambdaAttribute)
+        {
+            if (lambdaAttribute == null)
+                return null;
+
+            var sdkAttribute = new Amazon.DynamoDBStreams.Model.AttributeValue();
+
+            // String
+            if (!string.IsNullOrEmpty(lambdaAttribute.S))
+                sdkAttribute.S = lambdaAttribute.S;
+
+            // Number
+            else if (!string.IsNullOrEmpty(lambdaAttribute.N))
+                sdkAttribute.N = lambdaAttribute.N;
+
+            // Boolean
+            else if (lambdaAttribute.BOOL.HasValue)
+            {
+                sdkAttribute.BOOL = lambdaAttribute.BOOL.Value;
+            }
+
+            // Null
+            else if (lambdaAttribute.NULL.HasValue)
+                sdkAttribute.NULL = lambdaAttribute.NULL.Value;
+
+            // Binary
+            else if (lambdaAttribute.B != null)
+                sdkAttribute.B = lambdaAttribute.B;
+
+            // String Set
+            else if (lambdaAttribute.SS != null)
+                sdkAttribute.SS = new List<string>(lambdaAttribute.SS);
+
+            // Number Set
+            else if (lambdaAttribute.NS != null)
+                sdkAttribute.NS = new List<string>(lambdaAttribute.NS);
+
+            // Binary Set
+            else if (lambdaAttribute.BS != null)
+                sdkAttribute.BS = lambdaAttribute.BS;
+
+            // List
+            else if (lambdaAttribute.L != null)
+            {
+                sdkAttribute.L = new List<Amazon.DynamoDBStreams.Model.AttributeValue>();
+                foreach (var item in lambdaAttribute.L)
+                {
+                    sdkAttribute.L.Add(item.ConvertToSdkStreamAttribute());
+                }
+            }
+
+            // Map
+            else if (lambdaAttribute.M != null)
+            {
+                sdkAttribute.M = new Dictionary<string, Amazon.DynamoDBStreams.Model.AttributeValue>();
+                foreach (var kvp in lambdaAttribute.M)
+                {
+                    sdkAttribute.M[kvp.Key] = kvp.Value.ConvertToSdkStreamAttribute();
+                }
+            }
+
+            return sdkAttribute;
+        }
+
+        /// <summary>
+        /// Convert Dictionary of Lambda AttributeValue to SDK Dictionary of AttributeValue
+        /// </summary>
+        /// <param name="lambdaAttributes">The dictionary of Lambda AttributeValue to convert.</param>
+        /// <returns>The converted dictionary of SDK AttributeValue.</returns>
+        public static Dictionary<string, Amazon.DynamoDBStreams.Model.AttributeValue> ConvertToSdkStreamAttributeValueDictionary(
+           this Dictionary<string, DynamoDBEvent.AttributeValue> lambdaAttributes)
+        {
+            var sdkDictionary = new Dictionary<string, Amazon.DynamoDBStreams.Model.AttributeValue>();
+
+            if (lambdaAttributes == null)
+                return sdkDictionary;
+
+            foreach (var kvp in lambdaAttributes)
+            {
+                sdkDictionary[kvp.Key] = ConvertToSdkStreamAttribute(kvp.Value);
+            }
+
+            return sdkDictionary;
+        }
     }
 }

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/DynamodbIdentityConvertor.cs
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/DynamodbIdentityConvertor.cs
@@ -11,12 +11,12 @@ namespace Amazon.Lambda.DynamoDBEvents.SDK.Convertor
         /// </summary>
         /// <param name="lambdaIdentity">The Lambda Identity to convert.</param>
         /// <returns>The converted SDK Identity.</returns>
-        public static Amazon.DynamoDBv2.Model.Identity ConvertToSdkIdentity(this DynamoDBEvent.Identity lambdaIdentity)
+        public static Amazon.DynamoDBStreams.Model.Identity ConvertToSdkIdentity(this DynamoDBEvent.Identity lambdaIdentity)
         {
             if (lambdaIdentity == null)
                 return null;
 
-            var sdkIdentity = new Amazon.DynamoDBv2.Model.Identity
+            var sdkIdentity = new Amazon.DynamoDBStreams.Model.Identity
             {
                 PrincipalId = lambdaIdentity.PrincipalId,
                 Type = lambdaIdentity.Type

--- a/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/DynamodbStreamRecordConvertor.cs
+++ b/Libraries/src/Amazon.Lambda.DynamoDBEvents.SDK.Convertor/DynamodbStreamRecordConvertor.cs
@@ -11,17 +11,17 @@ namespace Amazon.Lambda.DynamoDBEvents.SDK.Convertor
         /// </summary>
         /// <param name="lambdaStreamRecord">The Lambda StreamRecord to convert.</param>
         /// <returns>The converted SDK StreamRecord.</returns>
-        public static Amazon.DynamoDBv2.Model.StreamRecord ConvertToSdkStreamRecord(this DynamoDBEvent.StreamRecord lambdaStreamRecord)
+        public static Amazon.DynamoDBStreams.Model.StreamRecord ConvertToSdkStreamRecord(this DynamoDBEvent.StreamRecord lambdaStreamRecord)
         {
             if (lambdaStreamRecord == null)
                 return null;
 
-            var sdkStreamRecord = new Amazon.DynamoDBv2.Model.StreamRecord
+            var sdkStreamRecord = new Amazon.DynamoDBStreams.Model.StreamRecord
             {
                 ApproximateCreationDateTime = lambdaStreamRecord.ApproximateCreationDateTime,
-                Keys = lambdaStreamRecord.Keys?.ConvertToSdkAttributeValueDictionary(),
-                NewImage = lambdaStreamRecord.NewImage?.ConvertToSdkAttributeValueDictionary(),
-                OldImage = lambdaStreamRecord.OldImage?.ConvertToSdkAttributeValueDictionary(),
+                Keys = lambdaStreamRecord.Keys?.ConvertToSdkStreamAttributeValueDictionary(),
+                NewImage = lambdaStreamRecord.NewImage?.ConvertToSdkStreamAttributeValueDictionary(),
+                OldImage = lambdaStreamRecord.OldImage?.ConvertToSdkStreamAttributeValueDictionary(),
                 SequenceNumber = lambdaStreamRecord.SequenceNumber,
                 SizeBytes = lambdaStreamRecord.SizeBytes,
                 StreamViewType = lambdaStreamRecord.StreamViewType

--- a/Libraries/src/Amazon.Lambda.KinesisEvents/Amazon.Lambda.KinesisEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.KinesisEvents/Amazon.Lambda.KinesisEvents.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Kinesis" Version="3.7.0" />
+    <PackageReference Include="AWSSDK.Kinesis" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Libraries/test/EventsTests.NET6/EventsTests.NET6.csproj
+++ b/Libraries/test/EventsTests.NET6/EventsTests.NET6.csproj
@@ -55,14 +55,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.301.14" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="AWSSDK.Core" Version="3.7.302.13" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Libraries/test/EventsTests.NET8/EventsTests.NET8.csproj
+++ b/Libraries/test/EventsTests.NET8/EventsTests.NET8.csproj
@@ -47,14 +47,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.301.14" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="AWSSDK.Core" Version="3.7.302.13" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Libraries/test/EventsTests.NETCore31/EventsTests.NETCore31.csproj
+++ b/Libraries/test/EventsTests.NETCore31/EventsTests.NETCore31.csproj
@@ -55,11 +55,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.301.14" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="AWSSDK.Core" Version="3.7.302.13" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -319,9 +319,9 @@ namespace Amazon.Lambda.Tests
 #if NET8_0_OR_GREATER
                 // Starting with .NET 7 the precision of the underlying AddSeconds method was changed.
                 // https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/7.0/datetime-add-precision
-                Assert.Equal(636162383234769999, record.Kinesis.ApproximateArrivalTimestamp.ToUniversalTime().Ticks);
+                Assert.Equal(636162383234769999, record.Kinesis.ApproximateArrivalTimestamp.Value.ToUniversalTime().Ticks);
 #else
-                Assert.Equal(636162383234770000, record.Kinesis.ApproximateArrivalTimestamp.ToUniversalTime().Ticks);
+                Assert.Equal(636162383234770000, record.Kinesis.ApproximateArrivalTimestamp.Value.ToUniversalTime().Ticks);
 #endif
 
                 Handle(kinesisEvent);
@@ -409,7 +409,7 @@ namespace Amazon.Lambda.Tests
                 var dataBytes = record.Kinesis.Data.ToArray();
                 Assert.Equal(Convert.ToBase64String(dataBytes), "SGVsbG8sIHRoaXMgaXMgYSB0ZXN0Lg==");
                 Assert.Equal(Encoding.UTF8.GetString(dataBytes), "Hello, this is a test.");
-                Assert.Equal(637430942750000000, record.Kinesis.ApproximateArrivalTimestamp.ToUniversalTime().Ticks);
+                Assert.Equal(637430942750000000, record.Kinesis.ApproximateArrivalTimestamp.Value.ToUniversalTime().Ticks);
 
                 Handle(kinesisTimeWindowEvent);
             }


### PR DESCRIPTION
*Description of changes:*
The Amazon.Lambda.DynamoDBEvents.SDK.Converter and Amazon.Lambda.KinesisEvents have an SDK dependency. This PR updates those packages to reference V4 as a major version update for the event packages.

For the Amazon.Lambda.DynamoDBEvents.SDK.Converter I had to duplicate a fair amount of conversion code because in V3 world there was one `AttributeValue` type across DynamoDB and DynamoDB streams but in V4 they are separate types. Although the have the same shape the don't share an interface so the conversion code had to be duplicated.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
