### PR TITLE
Lambda Logging improvements

### DIFF
--- a/.autover/changes/16cc3c6a-8fa0-410b-ba57-74221abb086a.json
+++ b/.autover/changes/16cc3c6a-8fa0-410b-ba57-74221abb086a.json
@@ -30,7 +30,7 @@
     },  
     {
       "Name": "Amazon.Lambda.Logging.AspNetCore",
-      "Type": "Minor",
+      "Type": "Major",
       "ChangelogMessages": [
         "Add support Lambda log levels",
 		"Change build target from .NET Standard 2.0 to .NET 6 and NET 8 to match Amazon.Lambda.AspNetCoreServer"
@@ -38,7 +38,7 @@
     },  
     {
       "Name": "Amazon.Lambda.TestUtilities",
-      "Type": "Minor",
+      "Type": "Major",
       "ChangelogMessages": [
         "Update Amazon.Lambda.TestUtitlies to have implementation of the newer logging methods",
 		"Change build target from .NET Standard 2.0 to .NET 6 and NET 8 to match Amazon.Lambda.AspNetCoreServer"

--- a/.autover/changes/16cc3c6a-8fa0-410b-ba57-74221abb086a.json
+++ b/.autover/changes/16cc3c6a-8fa0-410b-ba57-74221abb086a.json
@@ -1,0 +1,48 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.RuntimeSupport",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add support for parameterized logging method with exception to global logger LambdaLogger in Amazon.Lambda.Core"
+      ]
+    },  
+    {
+      "Name": "Amazon.Lambda.Core",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Added log level version of the static logging functions on Amazon.Lambda.Core.LambdaLogger"
+      ]
+    }   
+    {
+      "Name": "Amazon.Lambda.AspNetCoreServer",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update Amazon.Lambda.Logging.AspNetCore dependency"
+      ]
+    },    
+    {
+      "Name": "Amazon.Lambda.AspNetCoreServer.Hosting",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update Amazon.Lambda.Logging.AspNetCore dependency"
+      ]
+    },  
+    {
+      "Name": "Amazon.Lambda.Logging.AspNetCore",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Add support Lambda log levels",
+		"Change build target from .NET Standard 2.0 to .NET 6 and NET 8 to match Amazon.Lambda.AspNetCoreServer"
+      ]
+    },  
+    {
+      "Name": "Amazon.Lambda.TestUtilities",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Update Amazon.Lambda.TestUtitlies to have implementation of the newer logging methods",
+		"Change build target from .NET Standard 2.0 to .NET 6 and NET 8 to match Amazon.Lambda.AspNetCoreServer"
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.Core/LambdaLogger.cs
+++ b/Libraries/src/Amazon.Lambda.Core/LambdaLogger.cs
@@ -42,6 +42,7 @@ namespace Amazon.Lambda.Core
         // value with an Action that directs the logging into its logging system.
 #pragma warning disable IDE0044 // Add readonly modifier
         private static Action<string, string, object[]> _loggingWithLevelAction = LogWithLevelToConsole;
+        private static Action<string, Exception, string, object[]> _loggingWithLevelAndExceptionAction = LogWithLevelAndExceptionToConsole;
 #pragma warning restore IDE0044 // Add readonly modifier
 
         // Logs message to console
@@ -65,6 +66,15 @@ namespace Amazon.Lambda.Core
             Console.WriteLine(sb.ToString());
         }
 
+        private static void LogWithLevelAndExceptionToConsole(string level, Exception exception, string message, params object[] args)
+        {
+            // Formatting here is not important, it is used for debugging Amazon.Lambda.Core only.
+            // In a real scenario Amazon.Lambda.RuntimeSupport will change the value of _loggingWithLevelAction
+            // to an Action inside it's logging system to handle the real formatting.
+            LogWithLevelToConsole(level, message, args);
+            Console.WriteLine(exception);
+        }
+
         private const string ParameterizedPreviewMessage =
             "This method has been mark as preview till the Lambda .NET Managed runtime has been updated with the backing implementation of this method. " +
             "It is possible to use this method while in preview if the Lambda function is deployed as an executable and uses the latest version of Amazon.Lambda.RuntimeSupport.";
@@ -78,7 +88,6 @@ namespace Amazon.Lambda.Core
         /// <param name="level">The log level of the message</param>
         /// <param name="message">Message to log. The message may have format arguments.</param>
         /// <param name="args">Arguments to format the message with.</param>
-        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
         public static void Log(string level, string message, params object[] args)
         {
             _loggingWithLevelAction(level, message, args);
@@ -93,8 +102,36 @@ namespace Amazon.Lambda.Core
         /// <param name="level">The log level of the message</param>
         /// <param name="message">Message to log. The message may have format arguments.</param>
         /// <param name="args">Arguments to format the message with.</param>
-        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
         public static void Log(LogLevel level, string message, params object[] args) => Log(level.ToString(), message, args);
+
+        /// <summary>
+        /// Logs a message to AWS CloudWatch Logs.
+        /// 
+        /// Logging will not be done:
+        ///  If the role provided to the function does not have sufficient permissions.
+        /// </summary>
+        /// <param name="level">The log level of the message</param>
+        /// <param name="exception">Exception to include with the logging.</param>
+        /// <param name="message">Message to log. The message may have format arguments.</param>
+        /// <param name="args">Arguments to format the message with.</param>
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        public static void Log(string level, Exception exception, string message, params object[] args)
+        {
+            _loggingWithLevelAndExceptionAction(level, exception, message, args);
+        }
+
+        /// <summary>
+        /// Logs a message to AWS CloudWatch Logs.
+        /// 
+        /// Logging will not be done:
+        ///  If the role provided to the function does not have sufficient permissions.
+        /// </summary>
+        /// <param name="level">The log level of the message</param>
+        /// <param name="exception">Exception to include with the logging.</param>
+        /// <param name="message">Message to log. The message may have format arguments.</param>
+        /// <param name="args">Arguments to format the message with.</param>
+        [RequiresPreviewFeatures(ParameterizedPreviewMessage)]
+        public static void Log(LogLevel level, Exception exception, string message, params object[] args) => Log(level.ToString(), exception, message, args);
 #endif
     }
 }

--- a/Libraries/src/Amazon.Lambda.Logging.AspNetCore/Amazon.Lambda.Logging.AspNetCore.csproj
+++ b/Libraries/src/Amazon.Lambda.Logging.AspNetCore/Amazon.Lambda.Logging.AspNetCore.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>Amazon Lambda .NET Core support - Logging ASP.NET Core package.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.Logging.AspNetCore</AssemblyTitle>
     <Version>3.1.1</Version>
     <AssemblyName>Amazon.Lambda.Logging.AspNetCore</AssemblyName>

--- a/Libraries/src/Amazon.Lambda.Logging.AspNetCore/LambdaILogger.cs
+++ b/Libraries/src/Amazon.Lambda.Logging.AspNetCore/LambdaILogger.cs
@@ -29,6 +29,17 @@ namespace Microsoft.Extensions.Logging
 				_options.Filter(_categoryName, logLevel));
 		}
 
+        /// <summary>
+        /// The Log method called by the ILogger framework to log message to logger's target. In the Lambda case the formatted logging will be
+        /// sent to the Amazon.Lambda.Core.LambdaLogger's Log method.
+        /// </summary>
+        /// <typeparam name="TState"></typeparam>
+        /// <param name="logLevel"></param>
+        /// <param name="eventId"></param>
+        /// <param name="state"></param>
+        /// <param name="exception"></param>
+        /// <param name="formatter"></param>
+        /// <exception cref="ArgumentNullException"></exception>
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
             if (formatter == null)
@@ -40,8 +51,6 @@ namespace Microsoft.Extensions.Logging
             {
                 return;
             }
-
-            var lambdaLogLevel = ConvertLogLevel(logLevel);
 
             var components = new List<string>(4);
             if (_options.IncludeLogLevel)
@@ -74,6 +83,7 @@ namespace Microsoft.Extensions.Logging
 
             var finalText = string.Join(" ", components);
 
+            var lambdaLogLevel = ConvertLogLevel(logLevel);
             Amazon.Lambda.Core.LambdaLogger.Log(lambdaLogLevel, finalText);
         }
 

--- a/Libraries/src/Amazon.Lambda.Logging.AspNetCore/LambdaILogger.cs
+++ b/Libraries/src/Amazon.Lambda.Logging.AspNetCore/LambdaILogger.cs
@@ -3,31 +3,31 @@ using System.Collections.Generic;
 
 namespace Microsoft.Extensions.Logging
 {
-	internal class LambdaILogger : ILogger
-	{
-		// Private fields
-		private readonly string _categoryName;
-		private readonly LambdaLoggerOptions _options;
+    internal class LambdaILogger : ILogger
+    {
+        // Private fields
+        private readonly string _categoryName;
+        private readonly LambdaLoggerOptions _options;
 
 
-		internal IExternalScopeProvider ScopeProvider { get; set; }
+        internal IExternalScopeProvider ScopeProvider { get; set; }
 
-		// Constructor
-		public LambdaILogger(string categoryName, LambdaLoggerOptions options)
-		{
-			_categoryName = categoryName;
-			_options = options;
-		}
+        // Constructor
+        public LambdaILogger(string categoryName, LambdaLoggerOptions options)
+        {
+            _categoryName = categoryName;
+            _options = options;
+        }
 
-		// ILogger methods
-		public IDisposable BeginScope<TState>(TState state) => ScopeProvider?.Push(state) ?? new NoOpDisposable();
+        // ILogger methods
+        public IDisposable BeginScope<TState>(TState state) => ScopeProvider?.Push(state) ?? new NoOpDisposable();
 
-		public bool IsEnabled(LogLevel logLevel)
-		{
-			return (
-				_options.Filter == null ||
-				_options.Filter(_categoryName, logLevel));
-		}
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return (
+                _options.Filter == null ||
+                _options.Filter(_categoryName, logLevel));
+        }
 
         /// <summary>
         /// The Log method called by the ILogger framework to log message to logger's target. In the Lambda case the formatted logging will be
@@ -108,33 +108,33 @@ namespace Microsoft.Extensions.Logging
             }
         }
 
-		private void GetScopeInformation(List<string> logMessageComponents)
-		{
-			var scopeProvider = ScopeProvider;
+        private void GetScopeInformation(List<string> logMessageComponents)
+        {
+            var scopeProvider = ScopeProvider;
 
-			if (_options.IncludeScopes && scopeProvider != null)
-			{
-				var initialCount = logMessageComponents.Count;
+            if (_options.IncludeScopes && scopeProvider != null)
+            {
+                var initialCount = logMessageComponents.Count;
 
-				scopeProvider.ForEachScope((scope, list) =>
-				{
-					list.Add(scope.ToString());
-				}, (logMessageComponents));
+                scopeProvider.ForEachScope((scope, list) =>
+                {
+                    list.Add(scope.ToString());
+                }, (logMessageComponents));
 
-				if (logMessageComponents.Count > initialCount)
-				{
-					logMessageComponents.Add("=>");
-				}
-			}
-		}
+                if (logMessageComponents.Count > initialCount)
+                {
+                    logMessageComponents.Add("=>");
+                }
+            }
+        }
 
-		// Private classes	       
-		private class NoOpDisposable : IDisposable
-		{
-			public void Dispose()
-			{
-			}
-		}
+        // Private classes	       
+        private class NoOpDisposable : IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
 
-	}
+    }
 }

--- a/Libraries/src/Amazon.Lambda.Logging.AspNetCore/LambdaLoggerOptions.cs
+++ b/Libraries/src/Amazon.Lambda.Logging.AspNetCore/LambdaLoggerOptions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,8 +18,8 @@ namespace Microsoft.Extensions.Logging
         private const string INCLUDE_CATEGORY_KEY = "IncludeCategory";
         private const string INCLUDE_NEWLINE_KEY = "IncludeNewline";
         private const string INCLUDE_EXCEPTION_KEY = "IncludeException";
-		private const string INCLUDE_EVENT_ID_KEY = "IncludeEventId";
-		private const string INCLUDE_SCOPES_KEY = "IncludeScopes";
+        private const string INCLUDE_EVENT_ID_KEY = "IncludeEventId";
+        private const string INCLUDE_SCOPES_KEY = "IncludeScopes";
         private const string LOG_LEVEL_KEY = "LogLevel";
         private const string DEFAULT_CATEGORY = "Default";
 
@@ -60,7 +60,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         public bool IncludeScopes { get; set; }
 
-		/// <summary>
+        /// <summary>
         /// Function used to filter events based on the log level.
         /// Default value is null and will instruct logger to log everything.
         /// </summary>

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeLoader.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeLoader.cs
@@ -35,6 +35,8 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
     {
         private const string UserInvokeException = "An exception occurred while invoking customer handler.";
         private const string LambdaLoggingActionFieldName = "_loggingAction";
+        private const string LambdaLoggingWithLevelActionFieldName = "_loggingWithLevelAction";
+        private const string LambdaLoggingWithLevelAndExceptionActionFieldName = "_loggingWithLevelAndExceptionAction";
 
         internal const string LambdaCoreAssemblyName = "Amazon.Lambda.Core";
 
@@ -183,6 +185,82 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
             {
                 throw LambdaExceptions.ValidationException(e, Errors.UserCodeLoader.Internal.UnableToSetField,
                     Types.LambdaLoggerTypeName, LambdaLoggingActionFieldName);
+            }
+        }
+
+        internal static void SetCustomerLoggerLogAction(Assembly coreAssembly, Action<string, string, object[]> loggingWithLevelAction, InternalLogger internalLogger)
+        {
+            if (coreAssembly == null)
+            {
+                throw new ArgumentNullException(nameof(coreAssembly));
+            }
+
+            if (loggingWithLevelAction == null)
+            {
+                throw new ArgumentNullException(nameof(loggingWithLevelAction));
+            }
+
+            internalLogger.LogDebug($"UCL : Retrieving type '{Types.LambdaLoggerTypeName}'");
+            var lambdaILoggerType = coreAssembly.GetType(Types.LambdaLoggerTypeName);
+            if (lambdaILoggerType == null)
+            {
+                throw LambdaExceptions.ValidationException(Errors.UserCodeLoader.Internal.UnableToLocateType, Types.LambdaLoggerTypeName);
+            }
+
+            internalLogger.LogDebug($"UCL : Retrieving field '{LambdaLoggingWithLevelActionFieldName}'");
+            var loggingActionField = lambdaILoggerType.GetTypeInfo().GetField(LambdaLoggingWithLevelActionFieldName, BindingFlags.NonPublic | BindingFlags.Static);
+            if (loggingActionField == null)
+            {
+                throw LambdaExceptions.ValidationException(Errors.UserCodeLoader.Internal.UnableToRetrieveField, LambdaLoggingWithLevelActionFieldName, Types.LambdaLoggerTypeName);
+            }
+
+            internalLogger.LogDebug($"UCL : Setting field '{LambdaLoggingWithLevelActionFieldName}'");
+            try
+            {
+                loggingActionField.SetValue(null, loggingWithLevelAction);
+            }
+            catch (Exception e)
+            {
+                throw LambdaExceptions.ValidationException(e, Errors.UserCodeLoader.Internal.UnableToSetField,
+                    Types.LambdaLoggerTypeName, LambdaLoggingWithLevelActionFieldName);
+            }
+        }
+
+        internal static void SetCustomerLoggerLogAction(Assembly coreAssembly, Action<string, Exception, string, object[]> loggingWithAndExceptionLevelAction, InternalLogger internalLogger)
+        {
+            if (coreAssembly == null)
+            {
+                throw new ArgumentNullException(nameof(coreAssembly));
+            }
+
+            if (loggingWithAndExceptionLevelAction == null)
+            {
+                throw new ArgumentNullException(nameof(loggingWithAndExceptionLevelAction));
+            }
+
+            internalLogger.LogDebug($"UCL : Retrieving type '{Types.LambdaLoggerTypeName}'");
+            var lambdaILoggerType = coreAssembly.GetType(Types.LambdaLoggerTypeName);
+            if (lambdaILoggerType == null)
+            {
+                throw LambdaExceptions.ValidationException(Errors.UserCodeLoader.Internal.UnableToLocateType, Types.LambdaLoggerTypeName);
+            }
+
+            internalLogger.LogDebug($"UCL : Retrieving field '{LambdaLoggingWithLevelAndExceptionActionFieldName}'");
+            var loggingActionField = lambdaILoggerType.GetTypeInfo().GetField(LambdaLoggingWithLevelAndExceptionActionFieldName, BindingFlags.NonPublic | BindingFlags.Static);
+            if (loggingActionField == null)
+            {
+                throw LambdaExceptions.ValidationException(Errors.UserCodeLoader.Internal.UnableToRetrieveField, LambdaLoggingWithLevelAndExceptionActionFieldName, Types.LambdaLoggerTypeName);
+            }
+
+            internalLogger.LogDebug($"UCL : Setting field '{LambdaLoggingWithLevelAndExceptionActionFieldName}'");
+            try
+            {
+                loggingActionField.SetValue(null, loggingWithAndExceptionLevelAction);
+            }
+            catch (Exception e)
+            {
+                throw LambdaExceptions.ValidationException(e, Errors.UserCodeLoader.Internal.UnableToSetField,
+                    Types.LambdaLoggerTypeName, LambdaLoggingWithLevelAndExceptionActionFieldName);
             }
         }
 

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeLoader.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeLoader.cs
@@ -150,6 +150,13 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
             _invokeDelegate(lambdaData, lambdaContext, outStream);
         }
 
+        /// <summary>
+        /// Sets the backing logger action field in Amazon.Logging.Core to redirect logs into Amazon.Lambda.RuntimeSupport.
+        /// </summary>
+        /// <param name="coreAssembly"></param>
+        /// <param name="customerLoggingAction"></param>
+        /// <param name="internalLogger"></param>
+        /// <exception cref="ArgumentNullException"></exception>
         internal static void SetCustomerLoggerLogAction(Assembly coreAssembly, Action<string> customerLoggingAction, InternalLogger internalLogger)
         {
             if (coreAssembly == null)
@@ -187,6 +194,14 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
                     Types.LambdaLoggerTypeName, LambdaLoggingActionFieldName);
             }
         }
+
+        /// <summary>
+        /// Sets the backing logger action field in Amazon.Logging.Core to redirect logs into Amazon.Lambda.RuntimeSupport.
+        /// </summary>
+        /// <param name="coreAssembly"></param>
+        /// <param name="loggingWithLevelAction"></param>
+        /// <param name="internalLogger"></param>
+        /// <exception cref="ArgumentNullException"></exception>
 
         internal static void SetCustomerLoggerLogAction(Assembly coreAssembly, Action<string, string, object[]> loggingWithLevelAction, InternalLogger internalLogger)
         {
@@ -226,6 +241,13 @@ namespace Amazon.Lambda.RuntimeSupport.Bootstrap
             }
         }
 
+        /// <summary>
+        /// Sets the backing logger action field in Amazon.Logging.Core to redirect logs into Amazon.Lambda.RuntimeSupport.
+        /// </summary>
+        /// <param name="coreAssembly"></param>
+        /// <param name="loggingWithAndExceptionLevelAction"></param>
+        /// <param name="internalLogger"></param>
+        /// <exception cref="ArgumentNullException"></exception>
         internal static void SetCustomerLoggerLogAction(Assembly coreAssembly, Action<string, Exception, string, object[]> loggingWithAndExceptionLevelAction, InternalLogger internalLogger)
         {
             if (coreAssembly == null)

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/ConsoleLoggerWriter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/ConsoleLoggerWriter.cs
@@ -247,7 +247,7 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
             var loggingActionField = lambdaLoggerType.GetTypeInfo().GetField("_loggingAction", BindingFlags.NonPublic | BindingFlags.Static);
             if (loggingActionField != null)
             {
-                Action<string> loggingAction = (message => FormattedWriteLine(null, message));
+                Action<string> loggingAction = message => FormattedWriteLine(null, message);
                 loggingActionField.SetValue(null, loggingAction);
             }
 
@@ -255,9 +255,15 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
             var loggingWithLevelActionField = lambdaLoggerType.GetTypeInfo().GetField("_loggingWithLevelAction", BindingFlags.NonPublic | BindingFlags.Static);
             if (loggingWithLevelActionField != null)
             {
-                Action<string, string, object[]> loggingWithLevelAction = ((level, message, args) => FormattedWriteLine(level, message, args));
+                Action<string, string, object[]> loggingWithLevelAction = (level, message, args) => FormattedWriteLine(level, message, args);
                 loggingWithLevelActionField.SetValue(null, loggingWithLevelAction);
+            }
 
+            var loggingWithLevelAndExceptionActionField = lambdaLoggerType.GetTypeInfo().GetField("_loggingWithLevelAndExceptionAction", BindingFlags.NonPublic | BindingFlags.Static);
+            if (loggingWithLevelAndExceptionActionField != null)
+            {
+                Action<string, Exception, string, object[]> loggingWithLevelAndExceptionAction = (level, exception, message, args) => FormattedWriteLine(level, exception, message, args);
+                loggingWithLevelAndExceptionActionField.SetValue(null, loggingWithLevelAndExceptionAction);
             }
         }
 

--- a/Libraries/src/Amazon.Lambda.TestUtilities/Amazon.Lambda.TestUtilities.csproj
+++ b/Libraries/src/Amazon.Lambda.TestUtilities/Amazon.Lambda.TestUtilities.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>Amazon.Lambda.TestUtilties includes stub implementations of interfaces defined in Amazon.Lambda.Core and helper methods.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AssemblyTitle>Amazon.Lambda.TestUtilities</AssemblyTitle>
     <Version>2.0.0</Version>
     <AssemblyName>Amazon.Lambda.TestUtilities</AssemblyName>

--- a/Libraries/src/Amazon.Lambda.TestUtilities/TestLambdaLogger.cs
+++ b/Libraries/src/Amazon.Lambda.TestUtilities/TestLambdaLogger.cs
@@ -38,6 +38,11 @@ namespace Amazon.Lambda.TestUtilities
             Console.WriteLine(message);
         }
 
+        /// <summary>
+        /// Write log messages to the console and the Buffer.
+        /// </summary>
+        /// <param name="level"></param>
+        /// <param name="message"></param>
         public void Log(string level, string message)
         {
             var formmattedString = $"{level}: {message}";
@@ -45,6 +50,12 @@ namespace Amazon.Lambda.TestUtilities
             Console.WriteLine(formmattedString);
         }
 
+        /// <summary>
+        /// Write log messages to the console and the Buffer.
+        /// </summary>
+        /// <param name="level"></param>
+        /// <param name="message"></param>
+        /// <param name="args"></param>
         public void Log(string level, string message, params object[] args)
         {
             var builder = new StringBuilder();
@@ -63,6 +74,13 @@ namespace Amazon.Lambda.TestUtilities
             Console.WriteLine(formmattedString);
         }
 
+        /// <summary>
+        /// Write log messages to the console and the Buffer.
+        /// </summary>
+        /// <param name="level"></param>
+        /// <param name="exception"></param>
+        /// <param name="message"></param>
+        /// <param name="args"></param>
         public void Log(string level, Exception exception, string message, params object[] args)
         {
             var builder = new StringBuilder();

--- a/Libraries/src/Amazon.Lambda.TestUtilities/TestLambdaLogger.cs
+++ b/Libraries/src/Amazon.Lambda.TestUtilities/TestLambdaLogger.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -36,6 +36,54 @@ namespace Amazon.Lambda.TestUtilities
         {
             Buffer.AppendLine(message);
             Console.WriteLine(message);
+        }
+
+        public void Log(string level, string message)
+        {
+            var formmattedString = $"{level}: {message}";
+            Buffer.AppendLine(formmattedString);
+            Console.WriteLine(formmattedString);
+        }
+
+        public void Log(string level, string message, params object[] args)
+        {
+            var builder = new StringBuilder();
+            builder.Append($"{level}: {message}");
+            if (args != null && args.Length > 0)
+            {
+                builder.AppendLine();
+                foreach (var arg in args)
+                {
+                    builder.AppendLine($"\t{arg}");
+                }
+            }
+
+            var formmattedString = builder.ToString();
+            Buffer.AppendLine(formmattedString);
+            Console.WriteLine(formmattedString);
+        }
+
+        public void Log(string level, Exception exception, string message, params object[] args)
+        {
+            var builder = new StringBuilder();
+            builder.Append($"{level}: {message}");
+            if (args != null && args.Length > 0)
+            {
+                builder.AppendLine();
+                foreach (var arg in args)
+                {
+                    builder.AppendLine($"\t{arg}");
+                }
+            }
+            if (exception != null)
+            {
+                builder.AppendLine();
+                builder.AppendLine(exception.ToString());
+            }
+
+            var formmattedString = builder.ToString();
+            Buffer.AppendLine(formmattedString);
+            Console.WriteLine(formmattedString);
         }
     }
 }

--- a/Libraries/test/Amazon.Lambda.Core.Tests/Amazon.Lambda.Core.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.Core.Tests/Amazon.Lambda.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Amazon.Lambda.Core.Tests</AssemblyName>
     <PackageId>Amazon.Lambda.Core.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -9,11 +9,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Amazon.Lambda.Core\Amazon.Lambda.Core.csproj" />
+    <ProjectReference Include="..\..\src\Amazon.Lambda.TestUtilities\Amazon.Lambda.TestUtilities.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="AWSSDK.Core" Version="3.7.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>

--- a/Libraries/test/Amazon.Lambda.Core.Tests/TestUtilitiesLoggingTest.cs
+++ b/Libraries/test/Amazon.Lambda.Core.Tests/TestUtilitiesLoggingTest.cs
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+using System.Linq;
+using Amazon.Lambda.TestUtilities;
+using Amazon.Lambda.Core;
+
+namespace Amazon.Lambda.Tests
+{
+    public class TestUtilitiesLoggingTest
+    {
+        [Fact]
+        public void LogWithLevelAndMessage()
+        {
+            ILambdaLogger logger = new TestLambdaLogger();
+            logger.Log(LogLevel.Warning, "This is a warning");
+
+            Assert.Contains("Warning: This is a warning", ((TestLambdaLogger)logger).Buffer.ToString());
+        }
+
+        [Fact]
+        public void LogWithLevelAndMessageAndParameters()
+        {
+            ILambdaLogger logger = new TestLambdaLogger();
+            logger.Log(LogLevel.Warning, "This is {name}", "garp");
+
+            Assert.Contains("Warning: This is {name}", ((TestLambdaLogger)logger).Buffer.ToString());
+            Assert.Contains("\tgarp", ((TestLambdaLogger)logger).Buffer.ToString());
+        }
+
+        [Fact]
+        public void LogWithLevelAndMessageAndParametersAndExecption()
+        {
+            ILambdaLogger logger = new TestLambdaLogger();
+
+            var exception = new ArgumentException("Bad Name");
+            logger.Log(LogLevel.Warning, exception, "This is {name}", "garp");
+
+
+            Assert.Contains("Warning: This is {name}", ((TestLambdaLogger)logger).Buffer.ToString());
+            Assert.Contains("\tgarp", ((TestLambdaLogger)logger).Buffer.ToString());
+            Assert.Contains("ArgumentException", ((TestLambdaLogger)logger).Buffer.ToString());
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.Logging.AspNetCore.Tests/LoggingTests.cs
+++ b/Libraries/test/Amazon.Lambda.Logging.AspNetCore.Tests/LoggingTests.cs
@@ -76,6 +76,9 @@ namespace Amazon.Lambda.Tests
 				// check that there are no unexpected strings in the text
 				Assert.DoesNotContain(SHOULD_NOT_APPEAR, text);
 
+                // Confirm log level was written to log
+                Assert.Contains("Critical:", text);
+
 				// check that all expected strings are in the text
 				for (int i = 0; i < count; i++)
 				{
@@ -552,7 +555,20 @@ namespace Amazon.Lambda.Tests
 			Assert.NotNull(loggingActionField);
 
 			loggingActionField.SetValue(null, loggingAction);
-		}
+
+            Action<string, string, object[]> loggingWithLevelAction = (level, message, parameters) =>  {
+                var formattedMessage = $"{level}: {message}: parameter count: {parameters?.Length}";
+                loggingAction(formattedMessage);
+            };
+
+            var loggingWithLevelActionField = lambdaLoggerType
+                .GetTypeInfo()
+                .GetField("_loggingWithLevelAction", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(loggingActionField);
+
+            loggingWithLevelActionField.SetValue(null, loggingWithLevelAction);
+        }
+
 		private static int CountOccurences(string text, string substring)
 		{
 			int occurences = 0;

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/BaseCustomRuntimeTest.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/BaseCustomRuntimeTest.cs
@@ -1,4 +1,4 @@
-﻿using Amazon.IdentityManagement;
+using Amazon.IdentityManagement;
 using Amazon.IdentityManagement.Model;
 using Amazon.Lambda.Model;
 using Amazon.S3;
@@ -267,7 +267,7 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
                     S3Bucket = bucketName,
                     S3Key = DeploymentZipKey
                 },
-                Handler = this.Handler,
+                Handler = Handler,
                 MemorySize = FUNCTION_MEMORY_MB,
                 Timeout = 30,
                 Runtime = Runtime.Dotnet6,

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/CustomRuntimeTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/CustomRuntimeTests.cs
@@ -106,6 +106,7 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
                     await RunTestSuccessAsync(lambdaClient, "UnintendedDisposeTest", "not-used", "UnintendedDisposeTest-SUCCESS");
                     await RunTestSuccessAsync(lambdaClient, "LoggingStressTest", "not-used", "LoggingStressTest-success");
 
+                    await RunGlobalLoggingWithExceptionTestAsync(lambdaClient, "GlobalLoggingWithExceptionTest");
                     await RunGlobalLoggingTestAsync(lambdaClient, "GlobalLoggingTest");
                     await RunJsonLoggingWithUnhandledExceptionAsync(lambdaClient);
 
@@ -328,6 +329,21 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
             var log = System.Text.UTF8Encoding.UTF8.GetString(Convert.FromBase64String(invokeResponse.LogResult));
 
             Assert.Contains("This is a global log message with foobar as an argument", log);
+        }
+
+        private async Task RunGlobalLoggingWithExceptionTestAsync(AmazonLambdaClient lambdaClient, string handler)
+        {
+            await UpdateHandlerAsync(lambdaClient, handler);
+
+            var invokeResponse = await InvokeFunctionAsync(lambdaClient, JsonConvert.SerializeObject(""));
+            Assert.True(invokeResponse.HttpStatusCode == System.Net.HttpStatusCode.OK);
+            Assert.True(invokeResponse.FunctionError == null);
+
+            var log = System.Text.UTF8Encoding.UTF8.GetString(Convert.FromBase64String(invokeResponse.LogResult));
+
+            Assert.Contains("This is a global log message with foobar as an argument", log);
+            Assert.Contains("ArgumentException", log);
+            Assert.Contains("This is the wrong argument", log);
         }
 
         private async Task RunUnformattedLoggingTestAsync(AmazonLambdaClient lambdaClient, string handler)

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/HandlerTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/HandlerTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
@@ -393,9 +393,10 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                     Client = testRuntimeApiClient
                 };
 
-                var loggerAction = actionWriter.ToLoggingAction();
                 var assembly = AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(UserCodeLoader.LambdaCoreAssemblyName));
-                UserCodeLoader.SetCustomerLoggerLogAction(assembly, loggerAction, _internalLogger);
+                UserCodeLoader.SetCustomerLoggerLogAction(assembly, actionWriter.ToLoggingAction(), _internalLogger);
+                UserCodeLoader.SetCustomerLoggerLogAction(assembly, actionWriter.ToLoggingWithLevelAction(), _internalLogger);
+                UserCodeLoader.SetCustomerLoggerLogAction(assembly, actionWriter.ToLoggingWithLevelAndExceptionAction(), _internalLogger);
 
                 if (assertLoggedByInitialize != null)
                 {

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/StringWriterExtensions.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/StringWriterExtensions.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
@@ -65,6 +65,24 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests.TestHelpers
         public static Action<string> ToLoggingAction(this TextWriter writer)
         {
             return writer.WriteLine;
+        }
+
+        public static Action<string, string, object[]> ToLoggingWithLevelAction(this TextWriter writer)
+        {
+            return (l, m, p) =>
+            {
+                var formattedMessage = $"{l}: {m}";
+                writer.WriteLine(formattedMessage);
+            };
+        }
+
+        public static Action<string, Exception, string, object[]> ToLoggingWithLevelAndExceptionAction(this TextWriter writer)
+        {
+            return (l, e, m, p) =>
+            {
+                var formattedMessage = $"{l}: {m}\n{e}";
+                writer.WriteLine(formattedMessage);
+            };
         }
 
         public static Action<string> ToLoggingAction(this ITestOutputHelper writer)

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/CustomRuntimeFunctionTest/CustomRuntimeFunction.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/CustomRuntimeFunctionTest/CustomRuntimeFunction.cs
@@ -51,6 +51,9 @@ namespace CustomRuntimeFunctionTest
                     case nameof(GlobalLoggingTest):
                         bootstrap = new LambdaBootstrap(GlobalLoggingTest);
                         break;
+                    case nameof(GlobalLoggingWithExceptionTest):
+                        bootstrap = new LambdaBootstrap(GlobalLoggingWithExceptionTest);
+                        break;
                     case nameof(LoggingTest):
                         bootstrap = new LambdaBootstrap(LoggingTest);
                         break;
@@ -172,12 +175,18 @@ namespace CustomRuntimeFunctionTest
             return Task.FromResult(GetInvocationResponse(nameof(LoggingStressTest), "success"));
         }
 
+        private static Task<InvocationResponse> GlobalLoggingWithExceptionTest(InvocationRequest invocation)
+        {
+#pragma warning disable CA2252
+            var exception = new ArgumentException("This is the wrong argument");
+            LambdaLogger.Log(LogLevel.Error, exception, "This is a global log message with {argument} as an argument", "foobar");
+#pragma warning restore CA2252
+            return Task.FromResult(GetInvocationResponse(nameof(GlobalLoggingWithExceptionTest), true));
+        }
 
         private static Task<InvocationResponse> GlobalLoggingTest(InvocationRequest invocation)
         {
-#pragma warning disable CA2252
             LambdaLogger.Log(LogLevel.Information, "This is a global log message with {argument} as an argument", "foobar");
-#pragma warning restore CA2252
             return Task.FromResult(GetInvocationResponse(nameof(GlobalLoggingTest), true));
         }
 

--- a/Libraries/test/TestFunctionFSharp/TestFunctionCSharp/TestFunctionCSharp.csproj
+++ b/Libraries/test/TestFunctionFSharp/TestFunctionCSharp/TestFunctionCSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>TestFunctionCSharp</AssemblyName>
     <OutputType>Library</OutputType>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Libraries/test/TestFunctionFSharp/TestFunctionFSharp/TestFunctionFSharp.fsproj
+++ b/Libraries/test/TestFunctionFSharp/TestFunctionFSharp/TestFunctionFSharp.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>TestFunctionFSharp</AssemblyName>
     <OutputType>Library</OutputType>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/2032


*Description of changes:*
* In Amazon.Lambda.Logging.AspNetCore convert the ASP.NET Core log level into the Lambda log level and then pass the level into the logging method 
* Update Amazon.Lambda.TestUtitlies to have implementation of the newer logging methods 
* Add a new static global static logging method that takes in log level, message, parameters and exception. 
* Passing in exception in the global static logger was missing.

I had also wanted to update Amazon.Lambda.Logging.AspNetCore to support converting the log method to JSON if that was enabled in Lambda. Since we are missing the global static logging method that takes in exception I couldn't do that without losing the exception in the log. Once that new method added in RuntimeSupport in this PR is deployed to the managed runtimes I can go back and add the support.


I updated Amazon.Lambda.Logging.AspNetCore and Amazon.Lambda.TestUtitlies  to target .NET 6.0 and .NET 8.0 instead of .NET Standard 2.0. That was needed so I have access to the parameterized logging methods. I didn't do it as a major version bump because I figured where else could you have run these packages then one of those targets. I don't feel to strong on that and if others feel I should do it as a major version bump I'm okay with that.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
