### PR TITLE
Fix issue with long debugging sessions causing events to be retried

### DIFF
--- a/.autover/changes/6c77f6f7-8750-4b71-a4bd-8976d6b5fc1e.json
+++ b/.autover/changes/6c77f6f7-8750-4b71-a4bd-8976d6b5fc1e.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.TestTool",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fix issue with long debugging sessions causing events to be retried"
+      ]
+    }
+  ]
+}

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Services/LambdaClient.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Services/LambdaClient.cs
@@ -34,7 +34,13 @@ public class LambdaClient : ILambdaClient, IDisposable
     {
         var config = new AmazonLambdaConfig
         {
-            ServiceURL = endpoint
+            ServiceURL = endpoint,
+
+            // Turn of retries since the calls we are making are locally and we don't want retry happening while waiting for debugging.
+            MaxErrorRetry = 0,
+
+            // Set to infinite to allow debugging without timeouts causing retrigger of events
+            Timeout = Timeout.InfiniteTimeSpan
         };
         return new AmazonLambdaClient(
             new Amazon.Runtime.BasicAWSCredentials("accessKey", "secretKey"),


### PR DESCRIPTION
*Description of changes:*
Found while using the SQS event source feature of the test tool. If the function is being debugged goes on for a few minutes the .NET SDK that sent the event to the test tool's runtime api will timeout. When it timeouts it will retry the request queuing another event. This only happens in cases where the SDK is used to post an event in request/response mode like the SQS event source.

To fix this I turned off retries on the Lambda client used to send requests and set the timeout on the client to infinite. I know infinite is a terrible choice for a real production system but since this scenario is for allowing users to debug their function that could go on for any amount of time.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
