### PR TITLE
Fix malformed change file

### DIFF
--- a/.autover/changes/16cc3c6a-8fa0-410b-ba57-74221abb086a.json
+++ b/.autover/changes/16cc3c6a-8fa0-410b-ba57-74221abb086a.json
@@ -13,7 +13,7 @@
       "ChangelogMessages": [
         "Added log level version of the static logging functions on Amazon.Lambda.Core.LambdaLogger"
       ]
-    }   
+    },
     {
       "Name": "Amazon.Lambda.AspNetCoreServer",
       "Type": "Patch",


### PR DESCRIPTION
*Description of changes:*
In PR https://github.com/aws/aws-lambda-dotnet/pull/2062 the change log file is malformed missing a comma. This is causing the create release PR to fail. This PR fixes the JSON.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
