### PR TITLE
fix: fix issue with sample requests not applying

### DIFF
--- a/.autover/changes/40022108-c9b1-45ba-9b5e-a3b2ae56fc4e.json
+++ b/.autover/changes/40022108-c9b1-45ba-9b5e-a3b2ae56fc4e.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.TestTool",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fix issue causing sample requests to not be applied if a config path is not supplied"
+      ]
+    }
+  ]
+}

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Services/LambdaRequestManager.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Services/LambdaRequestManager.cs
@@ -3,6 +3,7 @@
 
 using System.Xml.Linq;
 using Amazon.Lambda.TestTool.Models;
+using Amazon.Lambda.TestTool.Services.IO;
 using Microsoft.Extensions.Options;
 
 namespace Amazon.Lambda.TestTool.Services;
@@ -10,9 +11,9 @@ namespace Amazon.Lambda.TestTool.Services;
 /// <summary>
 /// This class manages the sample Lambda input requests. This includes the pre-canned requests and saved requests.
 /// </summary>
-public class LambdaRequestManager(IOptions<LambdaOptions> lambdaOptions) : ILambdaRequestManager
+public class LambdaRequestManager(IOptions<LambdaOptions> lambdaOptions, IDirectoryManager directoryManager) : ILambdaRequestManager
 {
-    private string? GetRequestDirectory(string functionName) => !string.IsNullOrEmpty(lambdaOptions.Value.ConfigStoragePath) ? Path.Combine(lambdaOptions.Value.ConfigStoragePath, Constants.SavedRequestDirectory, functionName) : null;
+    private string? GetRequestDirectory(string functionName) => !string.IsNullOrEmpty(lambdaOptions.Value.ConfigStoragePath) ? Path.Combine(lambdaOptions.Value.ConfigStoragePath, Constants.SavedRequestDirectory, functionName) : Path.Combine(directoryManager.GetCurrentDirectory(), Constants.SavedRequestDirectory);
 
     /// <inheritdoc />
     public IDictionary<string, IList<LambdaRequest>> GetLambdaRequests(string functionName, bool includeSampleRequests = true, bool includeSavedRequests = true)


### PR DESCRIPTION
*Description of changes:*
Fix issue causing sample requests to not be applied if a config path is not supplied. After https://github.com/aws/aws-lambda-dotnet/pull/2095, the default path for sample requests was set to null. This PR applies the previous logic for when a config path is not provided.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
