### PR TITLE
Update to version 2.7.0 of Amazon.Lambda.Core

### DIFF
--- a/.autover/changes/4f6cf0ab-d0b7-4d9f-9200-d0508677596e.json
+++ b/.autover/changes/4f6cf0ab-d0b7-4d9f-9200-d0508677596e.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.TestTool.BlazorTester",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update to version 2.7.0 of Amazon.Lambda.Core"
+      ]
+    }
+  ]
+}

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.7.0" />
     <PackageReference Include="AWSSDK.SSO" Version="3.7.400.85" />
     <PackageReference Include="AWSSDK.SSOOIDC" Version="3.7.400.86" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/2106

*Description of changes:*
We have released new versions of Amazon.Lambda.Core with new logging APIs. The test tool takes a dependency on this package and needs to have the latest version. Otherwise user's Lambda function that tries to use the new logging APIs will get missing method exception.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
