### PR TITLE
fix: stop copying test tool static assets manually

### DIFF
--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -21,10 +21,6 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(Configuration) == 'Release'">
-    <None Include="$(OutputPath)\publish\wwwroot\" Pack="true" PackagePath="tools\net8.0\any\wwwroot" Visible="false" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.0" />

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/PackagingTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/PackagingTests.cs
@@ -19,10 +19,77 @@ public class PackagingTests : IDisposable
     }
 
     [Fact]
+    public void VerifyPackageContentsHasStaticAssets()
+    {
+        var projectPath = Path.Combine(_workingDirectory, "Tools", "LambdaTestTool-v2", "src", "Amazon.Lambda.TestTool", "Amazon.Lambda.TestTool.csproj");
+        _output.WriteLine("Packing TestTool...");
+        var packProcess = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = $"pack -c Release --no-build --no-restore {projectPath}",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            }
+        };
+
+        packProcess.Start();
+        string packOutput = packProcess.StandardOutput.ReadToEnd();
+        string packError = packProcess.StandardError.ReadToEnd();
+        packProcess.WaitForExit(int.MaxValue);
+
+        _output.WriteLine("Pack Output:");
+        _output.WriteLine(packOutput);
+        if (!string.IsNullOrEmpty(packError))
+        {
+            _output.WriteLine("Pack Errors:");
+            _output.WriteLine(packError);
+        }
+
+        Assert.Equal(0, packProcess.ExitCode);
+
+        var packageDir = Path.Combine(Path.GetDirectoryName(projectPath)!, "bin", "Release");
+        _output.WriteLine($"Looking for package in: {packageDir}");
+
+        var packageFiles = Directory.GetFiles(packageDir, "*.nupkg", SearchOption.AllDirectories);
+        Assert.True(packageFiles.Length > 0, $"No .nupkg files found in {packageDir}");
+
+        var packagePath = packageFiles[0];
+        _output.WriteLine($"Found package: {packagePath}");
+
+        using var archive = ZipFile.OpenRead(packagePath);
+
+        // Get all files for this framework
+        var frameworkFiles = archive.Entries
+            .Where(e => e.FullName.StartsWith($"tools/net8.0/any/wwwroot"))
+            .Select(e => e.FullName)
+            .ToList();
+
+        // Verify essential files exist
+        var essentialFiles = new[]
+        {
+            $"tools/net8.0/any/wwwroot/bootstrap-icons/",
+            $"tools/net8.0/any/wwwroot/bootstrap/",
+            $"tools/net8.0/any/wwwroot/_content/BlazorMonaco/"
+        };
+
+        var missingFiles = essentialFiles.Where(f => !frameworkFiles.Any(x => x.StartsWith(f))).ToList();
+
+        if (missingFiles.Any())
+        {
+            Assert.Fail($"The following static assets are missing:\n" +
+                        string.Join("\n", missingFiles));
+        }
+    }
+
+    [Fact]
     public void VerifyPackageContentsHasRuntimeSupport()
     {
         var projectPath = Path.Combine(_workingDirectory, "Tools", "LambdaTestTool-v2", "src", "Amazon.Lambda.TestTool", "Amazon.Lambda.TestTool.csproj");
-        var expectedFrameworks = new string[] { "net6.0", "net8.0", "net9.0" };
+        var expectedFrameworks = new string[] { "net6.0", "net8.0", "net9.0", "net10.0" };
         _output.WriteLine("Packing TestTool...");
         var packProcess = new Process
         {

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Utilities/DirectoryHelpers.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Utilities/DirectoryHelpers.cs
@@ -63,7 +63,7 @@ public static class DirectoryHelpers
             File.SetAttributes(tempPath, FileAttributes.Normal);
         }
 
-        foreach (var subdir in dirs.Where(x => !x.Name.Equals(".git")))
+        foreach (var subdir in dirs.Where(x => !x.Name.Equals(".git") && !x.Name.Equals(".vs")))
         {
             var tempPath = Path.Combine(destDirName, subdir.Name);
             var subDir = new DirectoryInfo(subdir.FullName);


### PR DESCRIPTION
*Description of changes:*
Stop copying the Lambda Test Tool static assets manually since they are now included by default in .NET 10 Preview 6. We have a GH Issue open for Microsoft https://github.com/dotnet/sdk/issues/49840 to understand if this change is intended or not. I have also added a unit test to check if the static assets are included.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
