### PR TITLE
Fix release candidate (rc) handling

### DIFF
--- a/.github/workflows/auto-update-Dockerfiles.yml
+++ b/.github/workflows/auto-update-Dockerfiles.yml
@@ -28,7 +28,7 @@ jobs:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2 #v4.2.2
         with:
-          ref: 'gcbeatty/rc'
+          ref: 'dev'
 
       # Update .NET 8 AMD64 Dockerfile
       - name: Update .NET 8 AMD64

--- a/.github/workflows/auto-update-Dockerfiles.yml
+++ b/.github/workflows/auto-update-Dockerfiles.yml
@@ -135,6 +135,9 @@ jobs:
             git add "**/*Dockerfile"
             git commit -m "chore: Daily ASP.NET Core version update in Dockerfiles"
             
+            # Always delete the remote branch before pushing to avoid stale branch errors
+            git push origin --delete $remoteBranch 2>$null
+            
             # Push local branch to remote branch (force push to consistent remote branch name)
             git push --force-with-lease origin "${localBranch}:${remoteBranch}"
             

--- a/.github/workflows/auto-update-Dockerfiles.yml
+++ b/.github/workflows/auto-update-Dockerfiles.yml
@@ -139,7 +139,7 @@ jobs:
             git push origin --delete $remoteBranch 2>$null
             
             # Push local branch to remote branch (force push to consistent remote branch name)
-            git push --force-with-lease origin "${localBranch}:${remoteBranch}"
+            git push --force origin "${localBranch}:${remoteBranch}"
             
             # Write the remote branch name to GITHUB_OUTPUT for use in the PR step
             Add-Content -Path $env:GITHUB_OUTPUT -Value "BRANCH=$remoteBranch"

--- a/.github/workflows/auto-update-Dockerfiles.yml
+++ b/.github/workflows/auto-update-Dockerfiles.yml
@@ -28,7 +28,7 @@ jobs:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2 #v4.2.2
         with:
-          ref: 'dev'
+          ref: 'gcbeatty/rc'
 
       # Update .NET 8 AMD64 Dockerfile
       - name: Update .NET 8 AMD64


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
.net 10 rc was just released and the current changes didnt [handle it](https://github.com/aws/aws-lambda-dotnet/actions/runs/17718813435). This updates it so that rc's are handled. 

testing https://github.com/aws/aws-lambda-dotnet/actions/runs/17736789918 (it doesnt have changes because we already released the latest versions (but you can see everything parsed correctly now)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
