### PR TITLE
Reset Stream Position back to 0

### DIFF
--- a/.autover/changes/pr2150-reset-stream-position.json
+++ b/.autover/changes/pr2150-reset-stream-position.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.AspNetCoreServer",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Reset the response body stream position to 0 after converting the ASP.NET Core response body to the Lambda response."
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayHttpApiV2ProxyFunction.cs
@@ -257,7 +257,7 @@ namespace Amazon.Lambda.AspNetCoreServer
                 }
 
                 (response.Body, response.IsBase64Encoded) = Utilities.ConvertAspNetCoreBodyToLambdaBody(responseFeatures.Body, rcEncoding);
-
+                responseFeatures.Body.Position = 0L;
             }
 
             PostMarshallResponseFeature(responseFeatures, response, lambdaContext);


### PR DESCRIPTION
Features from ASP Net Core like Output cache aren't working probably because of this

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
