### PR TITLE
Marked ProxyRequestContext.Error property as Obsolete for APIGatewayProxyRequest.

### DIFF
--- a/.autover/changes/cfe4a449-209e-41ec-9a35-929b0d0d3afb.json
+++ b/.autover/changes/cfe4a449-209e-41ec-9a35-929b0d0d3afb.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.APIGatewayEvents",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Marked ProxyRequestContext.Error property as Obsolete for APIGatewayProxyRequest."
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayProxyRequest.cs
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayProxyRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace Amazon.Lambda.APIGatewayEvents
+namespace Amazon.Lambda.APIGatewayEvents
 {
     using System;
     using System.Collections.Generic;
@@ -234,10 +234,11 @@
             /// Gets and sets the operation name.
             /// </summary>
             public string OperationName { get; set; }
-            
+
             /// <summary>
             /// Gets and sets the error.
             /// </summary>
+            [Obsolete("This property is obsolete since it is not used by AWS API Gateway and will never have value set by the service.")]
             public string Error { get; set; }
             
             /// <summary>


### PR DESCRIPTION
*Issue #, if available:* P340365477

*Description of changes:*
Marked `ProxyRequestContext.Error` property as Obsolete for `APIGatewayProxyRequest`.
___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
