### PR TITLE
Fix up some template labels that were not updated from .NET 8 to .NET 10

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2026/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/.template.config/template.json
@@ -6,7 +6,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Lambda ASP.NET Core Web API (.NET 8 Container Image)",
+  "name": "Lambda ASP.NET Core Web API (.NET 10 Container Image)",
   "identity": "AWS.Lambda.Serverless.Image.AspNetCoreWebAPI.FSharp",
   "groupIdentity": "AWS.Lambda.Serverless.Image.AspNetCoreWebAPI",
   "shortName": "serverless.image.AspNetCoreWebAPI",

--- a/Blueprints/BlueprintDefinitions/vs2026/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2026/AspNetCoreWebAPI-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -46,7 +46,7 @@ have the .NET project built inside the container. Below is an example of buildin
 ```dockerfile
 FROM public.ecr.aws/lambda/dotnet:10 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 as build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.csproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.csproj"

--- a/Blueprints/BlueprintDefinitions/vs2026/AspNetCoreWebAPI-Image/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/AspNetCoreWebAPI-Image/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": "ASP.NET Core 8 (Container Image)",
+  "display-name": "ASP.NET Core 10 (Container Image)",
   "system-name": "AspNetCoreWebAPIImage",
-  "description": "Serverless ASP.NET Core 8 Web API packaged as a container image.",
+  "description": "Serverless ASP.NET Core 10 Web API packaged as a container image.",
   "sort-order": 250,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2026/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/.template.config/template.json
@@ -6,7 +6,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Lambda ASP.NET Core Web API (.NET 8 Container Image)",
+  "name": "Lambda ASP.NET Core Web API (.NET 10 Container Image)",
   "identity": "AWS.Lambda.Serverless.Image.AspNetCoreWebAPI.CSharp",
   "groupIdentity": "AWS.Lambda.Serverless.Image.AspNetCoreWebAPI",
   "shortName": "serverless.image.AspNetCoreWebAPI",

--- a/Blueprints/BlueprintDefinitions/vs2026/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2026/AspNetCoreWebAPI-Image/template/src/BlueprintBaseName.1/Readme.md
@@ -52,7 +52,7 @@ have the .NET project built inside the container. Below is an example of buildin
 
 ```dockerfile
 FROM public.ecr.aws/lambda/dotnet:10
-FROM mcr.microsoft.com/dotnet/sdk:8.0 as build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.csproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.csproj"

--- a/Blueprints/BlueprintDefinitions/vs2026/EmptyFunction-Image-FSharp/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/EmptyFunction-Image-FSharp/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": ".NET 8 (Container Image)",
+  "display-name": ".NET 10 (Container Image)",
   "system-name": "EmptyImageFunction",
-  "description": "A .NET 8 Lambda function packaged as a container image.",
+  "description": "A .NET 10 Lambda function packaged as a container image.",
   "sort-order": 225,
   "hidden-tags": [
     "F#",

--- a/Blueprints/BlueprintDefinitions/vs2026/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Function"
   ],
-  "name": "Lambda Empty Function (.NET 8 Container Image)",
+  "name": "Lambda Empty Function (.NET 10 Container Image)",
   "identity": "AWS.Lambda.Function.Image.Empty.FSharp",
   "groupIdentity": "AWS.Lambda.Function.Image.Empty",
   "shortName": "lambda.image.EmptyFunction",

--- a/Blueprints/BlueprintDefinitions/vs2026/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2026/EmptyFunction-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -24,7 +24,7 @@ have the .NET project built inside the container. Below is an example of buildin
 ```dockerfile
 FROM public.ecr.aws/lambda/dotnet:10 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 as build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.fsproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.fsproj"

--- a/Blueprints/BlueprintDefinitions/vs2026/EmptyFunction-Image/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/EmptyFunction-Image/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": ".NET 8 (Container Image)",
+  "display-name": ".NET 10 (Container Image)",
   "system-name": "EmptyImageFunction",
-  "description": "A .NET 8 Lambda function packaged as a container image.",
+  "description": "A .NET 10 Lambda function packaged as a container image.",
   "sort-order": 225,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2026/EmptyFunction-Image/template/src/BlueprintBaseName.1/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/EmptyFunction-Image/template/src/BlueprintBaseName.1/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Function"
   ],
-  "name": "Lambda Empty Function (.NET .8 Container Image)",
+  "name": "Lambda Empty Function (.NET 10 Container Image)",
   "identity": "AWS.Lambda.Function.Image.Empty.CSharp",
   "groupIdentity": "AWS.Lambda.Function.Image.Empty",
   "shortName": "lambda.image.EmptyFunction",

--- a/Blueprints/BlueprintDefinitions/vs2026/EmptyFunction-Image/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2026/EmptyFunction-Image/template/src/BlueprintBaseName.1/Readme.md
@@ -24,7 +24,7 @@ have the .NET project built inside the container. Below is an example of buildin
 ```dockerfile
 FROM public.ecr.aws/lambda/dotnet:10 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 as build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.csproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.csproj"

--- a/Blueprints/BlueprintDefinitions/vs2026/EmptyServerless-Image-FSharp/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/EmptyServerless-Image-FSharp/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": ".NET 8 (Container Image) Serverless Application",
+  "display-name": ".NET 10 (Container Image) Serverless Application",
   "system-name": "EmptyImageServerless",
-  "description": ".NET 8 Lambda function packaged as a container image and deploy through AWS CloudFormation.",
+  "description": ".NET 10 Lambda function packaged as a container image and deploy through AWS CloudFormation.",
   "sort-order": 225,
   "hidden-tags": [
     "F#",

--- a/Blueprints/BlueprintDefinitions/vs2026/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Lambda Empty Serverless (.NET 8 Container Image)",
+  "name": "Lambda Empty Serverless (.NET 10 Container Image)",
   "identity": "AWS.Lambda.Serverless.Image.Empty.FSharp",
   "groupIdentity": "AWS.Lambda.Image.Serverless.Empty",
   "shortName": "serverless.image.EmptyServerless",

--- a/Blueprints/BlueprintDefinitions/vs2026/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2026/EmptyServerless-Image-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -24,9 +24,9 @@ Alternatively the Docker file could be written to use [multi-stage](https://docs
 have the .NET project built inside the container. Below is an example of building the .NET project inside the image.
 
 ```dockerfile
-FROM public.ecr.aws/lambda/8 AS base
+FROM public.ecr.aws/lambda/dotnet:10 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 as build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.csproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.csproj"

--- a/Blueprints/BlueprintDefinitions/vs2026/EmptyServerless-Image/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/EmptyServerless-Image/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": ".NET 8 (Container Image) Serverless Application",
+  "display-name": ".NET 10 (Container Image) Serverless Application",
   "system-name": "EmptyImageServerless",
-  "description": ".NET 8 Lambda function packaged as a container image and deploy through AWS CloudFormation.",
+  "description": ".NET 10 Lambda function packaged as a container image and deploy through AWS CloudFormation.",
   "sort-order": 225,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2026/EmptyServerless-Image/template/src/BlueprintBaseName.1/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/EmptyServerless-Image/template/src/BlueprintBaseName.1/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Lambda Empty Serverless (.NET 8 Container Image)",
+  "name": "Lambda Empty Serverless (.NET 10 Container Image)",
   "identity": "AWS.Lambda.Serverless.Image.Empty.CSharp",
   "groupIdentity": "AWS.Lambda.Image.Serverless.Empty",
   "shortName": "serverless.image.EmptyServerless",

--- a/Blueprints/BlueprintDefinitions/vs2026/EmptyServerless-Image/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2026/EmptyServerless-Image/template/src/BlueprintBaseName.1/Readme.md
@@ -27,7 +27,7 @@ have the .NET project built inside the container. Below is an example of buildin
 ```dockerfile
 FROM public.ecr.aws/lambda/dotnet:10 AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 as build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 as build
 WORKDIR /src
 COPY ["BlueprintBaseName.1.csproj", "BlueprintBaseName.1/"]
 RUN dotnet restore "BlueprintBaseName.1/BlueprintBaseName.1.csproj"

--- a/Blueprints/BlueprintDefinitions/vs2026/NativeAOTFunction-FSharp/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/NativeAOTFunction-FSharp/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": "Native AOT (.NET 8)",
+  "display-name": "Native AOT (.NET 10)",
   "system-name": "NativeAotFunction",
-  "description": "A project configured for deployment using .NET 8's Native AOT feature.",
+  "description": "A project configured for deployment using .NET 10's Native AOT feature.",
   "sort-order": 110,
   "hidden-tags": [
     "F#",

--- a/Blueprints/BlueprintDefinitions/vs2026/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Function"
   ],
-  "name": "Lambda Function project configured for deployment using .NET 8's Native AOT feature.",
+  "name": "Lambda Function project configured for deployment using .NET 10's Native AOT feature.",
   "identity": "AWS.Lambda.Function.NativeAot.FSharp",
   "groupIdentity": "AWS.Lambda.Function.NativeAOT",
   "shortName": "lambda.NativeAOT",

--- a/Blueprints/BlueprintDefinitions/vs2026/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2026/NativeAOTFunction-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -22,7 +22,7 @@ set to `true` to strip debugging symbols from the deployed executable to reduce 
 
 When publishing with Native AOT the build OS and Architecture must match the target platform that the application will run. For AWS Lambda that target
 platform is Amazon Linux 2023. The AWS tooling for Lambda like the AWS Toolkit for Visual Studio, .NET Global Tool Amazon.Lambda.Tools and SAM CLI will 
-perform a container build using a .NET 8 Amazon Linux 2023 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
+perform a container build using a .NET 10 Amazon Linux 2023 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
 when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2023 build environments. To install docker go to https://www.docker.com/.
 
 ### Trimming

--- a/Blueprints/BlueprintDefinitions/vs2026/NativeAOTFunction/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/NativeAOTFunction/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": "Native AOT (.NET 8)",
+  "display-name": "Native AOT (.NET 10)",
   "system-name": "NativeAotFunction",
-  "description": "A project configured for deployment using .NET 8's Native AOT feature.",
+  "description": "A project configured for deployment using .NET 10's Native AOT feature.",
   "sort-order": 110,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2026/NativeAOTFunction/template/src/BlueprintBaseName.1/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/NativeAOTFunction/template/src/BlueprintBaseName.1/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Function"
   ],
-  "name": "Lambda Function project configured for deployment using .NET 8's Native AOT feature.",
+  "name": "Lambda Function project configured for deployment using .NET 10's Native AOT feature.",
   "identity": "AWS.Lambda.Function.NativeAOT.CSharp",
   "groupIdentity": "AWS.Lambda.Function.NativeAOT",
   "shortName": "lambda.NativeAOT",

--- a/Blueprints/BlueprintDefinitions/vs2026/NativeAOTFunction/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2026/NativeAOTFunction/template/src/BlueprintBaseName.1/Readme.md
@@ -22,7 +22,7 @@ set to `true` to strip debugging symbols from the deployed executable to reduce 
 
 When publishing with Native AOT the build OS and Architecture must match the target platform that the application will run. For AWS Lambda that target
 platform is Amazon Linux 2023. The AWS tooling for Lambda like the AWS Toolkit for Visual Studio, .NET Global Tool Amazon.Lambda.Tools and SAM CLI will 
-perform a container build using a .NET 8 Amazon Linux 2023 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
+perform a container build using a .NET 10 Amazon Linux 2023 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
 when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2023 build environments. To install docker go to https://www.docker.com/.
 
 ### Trimming

--- a/Blueprints/BlueprintDefinitions/vs2026/NativeAOTServerless-FSharp/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/NativeAOTServerless-FSharp/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": "Native AOT (.NET 8)",
+  "display-name": "Native AOT (.NET 10)",
   "system-name": "NativeAotFunction",
-  "description": "A project configured for deployment using .NET 8's Native AOT feature.",
+  "description": "A project configured for deployment using .NET 10's Native AOT feature.",
   "sort-order": 120,
   "hidden-tags": [
     "F#",

--- a/Blueprints/BlueprintDefinitions/vs2026/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Serverless project configured for deployment using .NET 8's Native AOT feature.",
+  "name": "Serverless project configured for deployment using .NET 10's Native AOT feature.",
   "identity": "AWS.Serverless.NativeAot.FSharp",
   "groupIdentity": "AWS.Serverless.NativeAOT",
   "shortName": "serverless.NativeAOT",

--- a/Blueprints/BlueprintDefinitions/vs2026/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2026/NativeAOTServerless-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -24,7 +24,7 @@ set to `true` to strip debugging symbols from the deployed executable to reduce 
 
 When publishing with Native AOT the build OS and Architecture must match the target platform that the application will run. For AWS Lambda that target
 platform is Amazon Linux 2023. The AWS tooling for Lambda like the AWS Toolkit for Visual Studio, .NET Global Tool Amazon.Lambda.Tools and SAM CLI will 
-perform a container build using a .NET 8 Amazon Linux 2023 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
+perform a container build using a .NET 10 Amazon Linux 2023 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
 when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2023 build environments. To install docker go to https://www.docker.com/.
 
 ### Trimming

--- a/Blueprints/BlueprintDefinitions/vs2026/NativeAOTServerless/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/NativeAOTServerless/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
-  "display-name": "Native AOT (.NET 8)",
+  "display-name": "Native AOT (.NET 10)",
   "system-name": "NativeAotFunction",
-  "description": "A project configured for deployment using .NET 8's Native AOT feature.",
+  "description": "A project configured for deployment using .NET 10's Native AOT feature.",
   "sort-order": 120,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2026/NativeAOTServerless/template/src/BlueprintBaseName.1/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/NativeAOTServerless/template/src/BlueprintBaseName.1/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Serverless project configured for deployment using .NET 8's Native AOT feature.",
+  "name": "Serverless project configured for deployment using .NET 10's Native AOT feature.",
   "identity": "AWS.Serverless.NativeAOT.CSharp",
   "groupIdentity": "AWS.Serverless.NativeAOT",
   "shortName": "serverless.NativeAOT",

--- a/Blueprints/BlueprintDefinitions/vs2026/NativeAOTServerless/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2026/NativeAOTServerless/template/src/BlueprintBaseName.1/Readme.md
@@ -32,7 +32,7 @@ set to `true` to strip debugging symbols from the deployed executable to reduce 
 
 When publishing with Native AOT the build OS and Architecture must match the target platform that the application will run. For AWS Lambda that target
 platform is Amazon Linux 2023. The AWS tooling for Lambda like the AWS Toolkit for Visual Studio, .NET Global Tool Amazon.Lambda.Tools and SAM CLI will 
-perform a container build using a .NET 8 Amazon Linux 2023 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
+perform a container build using a .NET 10 Amazon Linux 2023 build image when `PublishAot` is set to `true`. This means **docker is a requirement**
 when packaging .NET Native AOT Lambda functions on non-Amazon Linux 2023 build environments. To install docker go to https://www.docker.com/.
 
 ### Trimming


### PR DESCRIPTION
*Description of changes:*
Found a few more labels in the Lambda templates that were still saying .NET 8 when they should have said .NET 10

I added the `Release Not Needed` because I don't need a change file since dev already has a change file that calls out template updates.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
