### PR TITLE
doc: update readme to point at changelog correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Repository for the AWS NuGet packages and Blueprints to support writing AWS Lambda functions using .NET Core.
 
-For a history of releases view the [release change log](RELEASE.CHANGELOG.md)
+For a history of releases view the [release change log](CHANGELOG.md)
 
 ## Table of Contents
 - [AWS Lambda for .NET Core ![Gitter](https://gitter.im/aws/aws-lambda-dotnet?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)](#aws-lambda-for-net-core-img-srchttpsbadgesgitterimjoin20chatsvg-altgitter)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The readme was pointing at `RELEASE.CHANGELOG.MD`, which appears to not exist and 404s. I'm assuming it's supposed to point at changelog.md and have changed to reflect that.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
