### PR TITLE
Fixed previous release issue to now include templates targeting .NET 10

### DIFF
--- a/.autover/autover.json
+++ b/.autover/autover.json
@@ -134,7 +134,7 @@
     },
     {
       "Name": "Amazon.Lambda.Templates",
-      "Path": "Blueprints/BlueprintDefinitions/vs2022/Templates.csproj"
+      "Path": "Blueprints/BlueprintDefinitions/vs2026/Templates.csproj"
     },
     {
       "Name": "SnapshotRestore.Registry",

--- a/.autover/changes/3e3eb0be-5317-4a8d-9890-4e637259ee4f.json
+++ b/.autover/changes/3e3eb0be-5317-4a8d-9890-4e637259ee4f.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Templates",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fixed previous release issue to now include templates targeting .NET 10"
+      ]
+    }
+  ]
+}

--- a/Blueprints/BlueprintDefinitions/vs2022/Templates.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2022/Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <Version>8.0.0</Version>
+    <Version>7.5.0</Version>
     <PackageId>Amazon.Lambda.Templates</PackageId>
     <Title>AWS Lambda Templates</Title>
     <Authors>Amazon Web Services</Authors>

--- a/Blueprints/BlueprintDefinitions/vs2026/Templates.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2026/Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <Version>7.5.0</Version>
+    <Version>8.0.0</Version>
     <PackageId>Amazon.Lambda.Templates</PackageId>
     <Title>AWS Lambda Templates</Title>
     <Authors>Amazon Web Services</Authors>


### PR DESCRIPTION
*Description of changes:*
In the previous release of `Amazon.Lambda.Templates` we were supposed to release from the `Blueprints\BlueprintDefinitions\vs2026` folder but we didn't update the autover config so the `Blueprints\BlueprintDefinitions\vs2022` version was released so we didn't include the .NET 10 version of the templates.

To fix this I reverted the version bump in `Blueprints\BlueprintDefinitions\vs2022` and then applied the previous version bump to `Blueprints\BlueprintDefinitions\vs2026` and fixed the autover config. I ran the `autover version` command to confirm the correct package was version bumped.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
