### PR TITLE
Add grouping for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,3 @@
-# Set update schedule for GitHub Actions
-
 version: 2
 updates:
 
@@ -11,3 +9,9 @@ updates:
     labels:
       - "Release Not Needed"
     target-branch: "dev"
+    # Group all github-actions updates into a single PR
+    groups:
+      all-github-actions:
+        applies-to: "version-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
Group all GitHub Actions updates into a single PR.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
