### PR TITLE
Fix snapstart scope issue

### DIFF
--- a/.autover/changes/6ecba481-6957-4fd3-a562-dcf8676ab88d.json
+++ b/.autover/changes/6ecba481-6957-4fd3-a562-dcf8676ab88d.json
@@ -1,0 +1,18 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.AspNetCoreServer",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fix scoped service resolution in SnapStart warmup requests"
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.AspNetCoreServer.Hosting",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fix scoped service resolution in SnapStart warmup requests"
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/AbstractAspNetCoreFunction.cs
@@ -320,9 +320,14 @@ namespace Amazon.Lambda.AspNetCoreServer
 
                     for (var i = 0; i < invokeTimes; i++)
                     {
+                        // Create a scope to properly handle scoped services (e.g., IAuthenticationHandlerProvider)
+                        // This matches the behavior in FunctionHandlerAsync and prevents InvalidOperationException
+                        // when resolving scoped services in Development mode where scope validation is enabled.
+                        using var scope = _hostServices.CreateScope();
+
                         InvokeFeatures features = new InvokeFeatures();
                         (features as IItemsFeature).Items = new Dictionary<object, object>();
-                        (features as IServiceProvidersFeature).RequestServices = _hostServices;
+                        (features as IServiceProvidersFeature).RequestServices = scope.ServiceProvider;
 
                         MarshallRequest(features, request, new SnapStartEmptyLambdaContext());
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-lambda-dotnet/issues/2236

## Issue
When using `AddAWSLambdaBeforeSnapshotRequest` with authentication middleware (or any middleware using scoped services), SnapStart warmup requests fail with `InvalidOperationException: Cannot resolve scoped service 'IAuthenticationHandlerProvider' from root provider`. This only occurs when `ASPNETCORE_ENVIRONMENT=Development`.

## Root Cause
The `AddRegisterBeforeSnapshot` method in `AbstractAspNetCoreFunction.cs` was setting `RequestServices` directly to the root `IServiceProvider` instead of creating a service scope. In Development mode, ASP.NET Core validates that scoped services aren't resolved from the root provider and throws an exception.

## Fix
Create a service scope before processing each warmup request, matching the behavior of the normal request handler (`FunctionHandlerAsync`):

## Testing

Deployed lambda with snapstart before bug fix and confirmed error

```
2026-01-12T17:12:47.534000+00:00 2026/01/12/[1]f18cf865861842deafb0920ce2588c76 info: Microsoft.AspNetCore.Hosting.Diagnostics[1]  
2026-01-12T17:12:47.534000+00:00 2026/01/12/[1]f18cf865861842deafb0920ce2588c76 Request starting  GET https:/// - - 0
2026-01-12T17:12:47.534000+00:00 2026/01/12/[1]f18cf865861842deafb0920ce2588c76 fail: Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware[1]
2026-01-12T17:12:47.534000+00:00 2026/01/12/[1]f18cf865861842deafb0920ce2588c76 An unhandled exception has occurred while executing the request.
2026-01-12T17:12:47.534000+00:00 2026/01/12/[1]f18cf865861842deafb0920ce2588c76 System.InvalidOperationException: Cannot resolve scoped service 'Microsoft.AspNetCore.Authentication.IAuthenticationHandlerProvider' from root provider.
2026-01-12T17:12:47.534000+00:00 2026/01/12/[1]f18cf865861842deafb0920ce2588c76 at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteValidator.ValidateResolution(ServiceCallSite callSite, IServiceScope scope, IServiceScope rootScope)
2026-01-12T17:12:47.534000+00:00 2026/01/12/[1]f18cf865861842deafb0920ce2588c76 at Microsoft.Extensions.DependencyInjection.ServiceProvider.GetService(ServiceIdentifier serviceIdentifier, ServiceProviderEngineScope serviceProviderEngineScope)
2026-01-12T17:12:47.534000+00:00 2026/01/12/[1]f18cf865861842deafb0920ce2588c76 at Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceProviderEngineScope.GetService(Type serviceType)
2026-01-12T17:12:47.534000+00:00 2026/01/12/[1]f18cf865861842deafb0920ce2588c76 at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService(IServiceProvider provider, Type serviceType)
2026-01-12T17:12:47.534000+00:00 2026/01/12/[1]f18cf865861842deafb0920ce2588c76 at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService[T](IServiceProvider provider)
2026-01-12T17:12:47.534000+00:00 2026/01/12/[1]f18cf865861842deafb0920ce2588c76 at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
2026-01-12T17:12:47.534000+00:00 2026/01/12/[1]f18cf865861842deafb0920ce2588c76 at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddlewareImpl.Invoke(HttpContext context)
```


deployed same lambda with bug fix and confirmed no error

```
2026-01-12T17:19:07.873000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e INIT_START Runtime Version: dotnet:8.v71        Runtime Version ARN: arn:aws:lambda:us-east-1::runtime:eb460407d38dfe2ec5e81b083a5ed55d92546b9b21bc76680359038583d98730
2026-01-12T17:19:08.507000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e warn: Microsoft.AspNetCore.DataProtection.Repositories.EphemeralXmlRepository[50]
2026-01-12T17:19:08.507000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Using an in-memory repository. Keys will not be persisted to storage.
2026-01-12T17:19:08.507000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e warn: Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager[59]
2026-01-12T17:19:08.507000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Neither user profile nor HKLM registry available. Using an ephemeral key repository. Protected data will be unavailable when application exits.
2026-01-12T17:19:08.566000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e info: Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager[58]
2026-01-12T17:19:08.566000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Creating key {2f9bc182-868a-4d20-86d6-2ec6fcc3c5bf} with creation date 2026-01-12 17:19:08Z, activation date 2026-01-12 17:19:08Z, and expiration date 2026-04-12 17:19:08Z.
2026-01-12T17:19:08.617000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e warn: Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager[35]
2026-01-12T17:19:08.617000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e No XML encryptor configured. Key {2f9bc182-868a-4d20-86d6-2ec6fcc3c5bf} may be persisted to storage in unencrypted form.
2026-01-12T17:19:08.926000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e warn: Amazon.Lambda.AspNetCoreServer.AbstractAspNetCoreFunction[0]
2026-01-12T17:19:08.926000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Request does not contain domain name information but is derived from APIGatewayProxyFunction.
2026-01-12T17:19:08.967000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e info: Microsoft.AspNetCore.Hosting.Diagnostics[1]  
2026-01-12T17:19:08.967000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Request starting  GET https:/// - - 0
2026-01-12T17:19:09.153000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e info: Microsoft.AspNetCore.Routing.EndpointMiddleware[0]
2026-01-12T17:19:09.153000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Executing endpoint 'HTTP: GET /'
2026-01-12T17:19:09.164000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e info: Microsoft.AspNetCore.Routing.EndpointMiddleware[1]
2026-01-12T17:19:09.164000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Executed endpoint 'HTTP: GET /'
2026-01-12T17:19:09.187000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e info: Microsoft.AspNetCore.Hosting.Diagnostics[2]  
2026-01-12T17:19:09.187000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Request finished  GET https:/// - 200 - text/plain;+charset=utf-8 220.6285ms
2026-01-12T17:19:09.187000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e warn: Amazon.Lambda.AspNetCoreServer.AbstractAspNetCoreFunction[0]
2026-01-12T17:19:09.187000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Request does not contain domain name information but is derived from APIGatewayProxyFunction.
2026-01-12T17:19:09.188000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e info: Microsoft.AspNetCore.Hosting.Diagnostics[1]  
2026-01-12T17:19:09.188000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Request starting  GET https:/// - - 0
2026-01-12T17:19:09.188000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e info: Microsoft.AspNetCore.Routing.EndpointMiddleware[0]
2026-01-12T17:19:09.188000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Executing endpoint 'HTTP: GET /'
2026-01-12T17:19:09.188000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e info: Microsoft.AspNetCore.Routing.EndpointMiddleware[1]
2026-01-12T17:19:09.188000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Executed endpoint 'HTTP: GET /'
2026-01-12T17:19:09.203000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e info: Microsoft.AspNetCore.Hosting.Diagnostics[2]  
2026-01-12T17:19:09.203000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Request finished  GET https:/// - 200 - text/plain;+charset=utf-8 0.9351ms
2026-01-12T17:19:09.204000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e warn: Amazon.Lambda.AspNetCoreServer.AbstractAspNetCoreFunction[0]
2026-01-12T17:19:09.204000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Request does not contain domain name information but is derived from APIGatewayProxyFunction.
2026-01-12T17:19:09.204000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e info: Microsoft.AspNetCore.Hosting.Diagnostics[1]  
2026-01-12T17:19:09.204000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Request starting  GET https:/// - - 0
2026-01-12T17:19:09.205000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e info: Microsoft.AspNetCore.Routing.EndpointMiddleware[0]
2026-01-12T17:19:09.205000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Executing endpoint 'HTTP: GET /'
2026-01-12T17:19:09.205000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e info: Microsoft.AspNetCore.Routing.EndpointMiddleware[1]
2026-01-12T17:19:09.205000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Request starting  GET https:/// - - 0
2026-01-12T17:19:09.205000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e info: Microsoft.AspNetCore.Routing.EndpointMiddleware[0]
2026-01-12T17:19:09.205000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Executing endpoint 'HTTP: GET /'
2026-01-12T17:19:09.205000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e info: Microsoft.AspNetCore.Routing.EndpointMiddleware[1]
2026-01-12T17:19:09.205000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Executed endpoint 'HTTP: GET /'
2026-01-12T17:19:09.205000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
2026-01-12T17:19:09.205000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Request finished  GET https:/// - 200 - text/plain;+charset=utf-8 0.0623ms   
2026-01-12T17:19:09.205000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e warn: Amazon.Lambda.AspNetCoreServer.AbstractAspNetCoreFunction[0]
2026-01-12T17:19:09.205000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Request does not contain domain name information but is derived from APIGatewayProxyFunction.
2026-01-12T17:19:09.205000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
2026-01-12T17:19:09.205000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Request starting  GET https:/// - - 0
2026-01-12T17:19:09.205000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e info: Microsoft.AspNetCore.Routing.EndpointMiddleware[0]
2026-01-12T17:19:09.205000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Executing endpoint 'HTTP: GET /'
2026-01-12T17:19:09.205000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e info: Microsoft.AspNetCore.Routing.EndpointMiddleware[1]
2026-01-12T17:19:09.205000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Executed endpoint 'HTTP: GET /'
2026-01-12T17:19:09.205000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
2026-01-12T17:19:09.205000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e Request finished  GET https:/// - 200 - text/plain;+charset=utf-8 0.0614ms   
2026-01-12T17:19:09.367000+00:00 2026/01/12/[2]e5b6d949771a4741ae0a1a5bba3bd13e INIT_REPORT Init Duration: 1494.21 ms
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
