### PR TITLE
Update packages to use license expression for the NuGet packaging

### DIFF
--- a/.autover/changes/f0ec7a11-87ca-4cb5-b21f-781d6eb3c711.json
+++ b/.autover/changes/f0ec7a11-87ca-4cb5-b21f-781d6eb3c711.json
@@ -1,0 +1,137 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.ApplicationLoadBalancerEvents",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update NuGet package to use license expression. License was not change and remains Apache 2."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.CloudWatchEvents",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update NuGet package to use license expression. License was not change and remains Apache 2."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.CloudWatchLogsEvents",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update NuGet package to use license expression. License was not change and remains Apache 2."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.ConfigEvents",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update NuGet package to use license expression. License was not change and remains Apache 2."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.ConnectEvents",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update NuGet package to use license expression. License was not change and remains Apache 2."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.DynamoDBEvents",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update NuGet package to use license expression. License was not change and remains Apache 2."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.KafkaEvents",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update NuGet package to use license expression. License was not change and remains Apache 2."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.KinesisAnalyticsEvents",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update NuGet package to use license expression. License was not change and remains Apache 2."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.KinesisFirehoseEvents",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update NuGet package to use license expression. License was not change and remains Apache 2."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.LexEvents",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update NuGet package to use license expression. License was not change and remains Apache 2."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.LexV2Events",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update NuGet package to use license expression. License was not change and remains Apache 2."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.MQEvents",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update NuGet package to use license expression. License was not change and remains Apache 2."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.PowerShellHost",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update NuGet package to use license expression. License was not change and remains Apache 2."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.S3Events",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update NuGet package to use license expression. License was not change and remains Apache 2."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.Serialization.Json",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update NuGet package to use license expression. License was not change and remains Apache 2."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.Serialization.SystemTextJson",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update NuGet package to use license expression. License was not change and remains Apache 2."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.SimpleEmailEvents",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update NuGet package to use license expression. License was not change and remains Apache 2."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.SNSEvents",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update NuGet package to use license expression. License was not change and remains Apache 2."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.SQSEvents",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update NuGet package to use license expression. License was not change and remains Apache 2."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/2186

*Description of changes:*
In commit https://github.com/aws/aws-lambda-dotnet/commit/c7f075934be237b7dddf12ffe1da8b2845a07fd7#diff-eba9642e986662ff2a58555ba7ce160d2074918e232616b6ac291eecd3fe42c5 made November 2024 we changed the common.props build file to use a license expression instead of a link which is the preferred method. Packages that have not had a release since that commit still have in NuGet packages that use a license url which is deprecated.

This PR forces a release of all the packages that haven't been released since the commit to make sure the latest version uses license expression.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
