### PR TITLE
Add KeyDecoded property to get the S3 object key url decoded

### DIFF
--- a/.autover/changes/c139490c-1180-4fd1-b368-7d36414fe62d.json
+++ b/.autover/changes/c139490c-1180-4fd1-b368-7d36414fe62d.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.S3Events",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add KeyDecoded property to get the S3 object key url decoded"
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.S3Events/S3Event.cs
+++ b/Libraries/src/Amazon.Lambda.S3Events/S3Event.cs
@@ -57,8 +57,21 @@ namespace Amazon.Lambda.S3Events
         {
             /// <summary>
             /// Gets and sets the key for the object stored in S3.
+            /// <para>
+            /// Note: S3 events sent to Lambda will have the object key in the JSON document url encoded. For example if the object key name contains a space character it will be represented as +.
+            /// This property returns the object key exactly as it is received in the S3 event including being url encoded. To get the key decoded use the <see cref="KeyDecoded"/> property.
+            /// </para>
             /// </summary>
             public string Key { get; set; }
+
+            /// <summary>
+            /// Gets and the url decoded key for the object stored in S3.
+            /// <para>
+            /// Note: S3 events sent to Lambda will have the object key in the JSON document url encoded. For example if the object key name contains a space character it will be represented as +.
+            /// This read only property returns the value of <see cref="Key"/> property url decoded.
+            /// </para>
+            /// </summary>
+            public string KeyDecoded => System.Net.WebUtility.UrlDecode(Key);
 
             /// <summary>
             /// Gets and sets the size of the object in S3.

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -256,7 +256,7 @@ namespace Amazon.Lambda.Tests
             {
                 var s3Event = serializer.Deserialize<S3Event>(fileStream);
 
-                Assert.Equal(s3Event.Records.Count, 1);
+                Assert.Equal(s3Event.Records.Count, 2);
                 var record = s3Event.Records[0];
                 Assert.Equal(record.EventVersion, "2.0");
                 Assert.Equal(record.EventTime.ToUniversalTime(), DateTime.Parse("1970-01-01T00:00:00.000Z").ToUniversalTime());
@@ -275,6 +275,9 @@ namespace Amazon.Lambda.Tests
                 Assert.Equal(record.EventName, "ObjectCreated:Put");
                 Assert.Equal(record.UserIdentity.PrincipalId, "EXAMPLE");
                 Assert.Equal(record.EventSource, "aws:s3");
+
+                // In the events file the key is New+File.jpg simulating the key being url encoded.
+                Assert.Equal("New File.jpg", s3Event.Records[1].S3.Object.KeyDecoded);
 
                 Handle(s3Event);
             }

--- a/Libraries/test/EventsTests.Shared/s3-event.json
+++ b/Libraries/test/EventsTests.Shared/s3-event.json
@@ -1,36 +1,69 @@
-﻿{
+{
   "Records": [
     {
-      "eventVersion": "2.0",
-      "eventTime": "1970-01-01T00:00:00.000Z",
-      "requestParameters": { "sourceIPAddress": "127.0.0.1" },
-      "s3": {
-        "configurationId": "testConfigRule",
-        "object": { 
-          "eTag": "0123456789abcdef0123456789abcdef",
-          "sequencer": "0A1B2C3D4E5F678901",
-          "key": "HappyFace.jpg",
-          "size": 1024
+        "eventVersion": "2.0",
+        "eventTime": "1970-01-01T00:00:00.000Z",
+        "requestParameters": { "sourceIPAddress": "127.0.0.1" },
+        "s3": {
+            "configurationId": "testConfigRule",
+            "object": {
+                "eTag": "0123456789abcdef0123456789abcdef",
+                "sequencer": "0A1B2C3D4E5F678901",
+                "key": "HappyFace.jpg",
+                "size": 1024
+            },
+            "bucket": {
+                "arn": "arn:aws:s3:::mybucket",
+                "name": "sourcebucket",
+                "ownerIdentity": {
+                    "principalId": "EXAMPLE"
+                }
+            },
+            "s3SchemaVersion": "1.0"
         },
-        "bucket": {
-          "arn": "arn:aws:s3:::mybucket",
-          "name": "sourcebucket", 
-          "ownerIdentity": {
+        "responseElements": {
+            "x-amz-id-2": "EXAMPLE123/5678abcdefghijklambdaisawesome/mnopqrstuvwxyzABCDEFGH",
+            "x-amz-request-id": "EXAMPLE123456789"
+        },
+        "awsRegion": "us-east-1",
+        "eventName": "ObjectCreated:Put",
+        "userIdentity": {
             "principalId": "EXAMPLE"
-          }
         },
-        "s3SchemaVersion": "1.0"
-      },
-      "responseElements": {
-        "x-amz-id-2": "EXAMPLE123/5678abcdefghijklambdaisawesome/mnopqrstuvwxyzABCDEFGH",
-        "x-amz-request-id": "EXAMPLE123456789"
-      },
-      "awsRegion": "us-east-1",
-      "eventName": "ObjectCreated:Put",
-      "userIdentity": {
-        "principalId": "EXAMPLE"
-      }, 
-      "eventSource": "aws:s3"
+        "eventSource": "aws:s3"
+    },
+    {
+        "eventVersion": "2.0",
+        "eventTime": "1970-01-01T00:00:00.000Z",
+        "requestParameters": { "sourceIPAddress": "127.0.0.1" },
+        "s3": {
+            "configurationId": "testConfigRule",
+            "object": {
+                "eTag": "0123456789abcdef0123456789abcdef",
+                "sequencer": "0A1B2C3D4E5F678901",
+                "key": "New+File.jpg",
+                "size": 1024
+            },
+            "bucket": {
+                "arn": "arn:aws:s3:::mybucket",
+                "name": "sourcebucket",
+                "ownerIdentity": {
+                    "principalId": "EXAMPLE"
+                }
+            },
+            "s3SchemaVersion": "1.0"
+        },
+        "responseElements": {
+            "x-amz-id-2": "EXAMPLE123/5678abcdefghijklambdaisawesome/mnopqrstuvwxyzABCDEFGH",
+            "x-amz-request-id": "EXAMPLE123456789"
+        },
+        "awsRegion": "us-east-1",
+        "eventName": "ObjectCreated:Put",
+        "userIdentity": {
+            "principalId": "EXAMPLE"
+        },
+        "eventSource": "aws:s3"
     }
+
   ]
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1182

*Description of changes:*
S3 object keys come into Lambda url encoded and is what the `S3ObjectEntity.Key` property returns. Consumers must decode the key if there are special characters in the object key. To make it easier for users this PR adds a readonly `S3ObjectEntity.KeyDecoded` property to handle decoded. I choose `KeyDecoded` instead of `DecodedKey` to possibly make it more discoverable via intellisense with the `Key` and `KeyDecoded` property potentially near each other.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
