### PR TITLE
Update libicu on Lambda container images

### DIFF
--- a/LambdaRuntimeDockerfiles/Images/net10/amd64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net10/amd64/Dockerfile
@@ -8,7 +8,7 @@ ARG AMAZON_LINUX=public.ecr.aws/lambda/provided:al2023
 
 FROM $AMAZON_LINUX AS base
 
-RUN dnf install libicu-67.1-7.amzn2023.0.3.x86_64 --assumeyes
+RUN dnf install libicu-67.1-7.amzn2023.0.4.x86_64 --assumeyes
 
 FROM base AS builder-net10
 ARG ASPNET_VERSION

--- a/LambdaRuntimeDockerfiles/Images/net10/arm64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net10/arm64/Dockerfile
@@ -8,7 +8,7 @@ ARG AMAZON_LINUX=public.ecr.aws/lambda/provided:al2023
 
 FROM $AMAZON_LINUX AS base
 
-RUN dnf install libicu-67.1-7.amzn2023.0.3.aarch64 --assumeyes
+RUN dnf install libicu-67.1-7.amzn2023.0.4.aarch64 --assumeyes
 
 FROM base AS builder-net10
 ARG ASPNET_VERSION

--- a/LambdaRuntimeDockerfiles/Images/net8/amd64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net8/amd64/Dockerfile
@@ -8,7 +8,7 @@ ARG AMAZON_LINUX=public.ecr.aws/lambda/provided:al2023
 
 FROM $AMAZON_LINUX AS base
 
-RUN dnf install libicu-67.1-7.amzn2023.0.3.x86_64 --assumeyes
+RUN dnf install libicu-67.1-7.amzn2023.0.4.x86_64 --assumeyes
 
 FROM base AS builder-net8
 ARG ASPNET_VERSION

--- a/LambdaRuntimeDockerfiles/Images/net8/arm64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net8/arm64/Dockerfile
@@ -8,7 +8,7 @@ ARG AMAZON_LINUX=public.ecr.aws/lambda/provided:al2023
 
 FROM $AMAZON_LINUX AS base
 
-RUN dnf install libicu-67.1-7.amzn2023.0.3.aarch64 --assumeyes
+RUN dnf install libicu-67.1-7.amzn2023.0.4.aarch64 --assumeyes
 
 FROM base AS builder-net8
 ARG ASPNET_VERSION

--- a/LambdaRuntimeDockerfiles/Images/net9/amd64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net9/amd64/Dockerfile
@@ -8,7 +8,7 @@ ARG AMAZON_LINUX=public.ecr.aws/lambda/provided:al2023
 
 FROM $AMAZON_LINUX AS base
 
-RUN dnf install libicu-67.1-7.amzn2023.0.3.x86_64 --assumeyes
+RUN dnf install libicu-67.1-7.amzn2023.0.4.x86_64 --assumeyes
 
 FROM base AS builder-net9
 ARG ASPNET_VERSION

--- a/LambdaRuntimeDockerfiles/Images/net9/arm64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net9/arm64/Dockerfile
@@ -8,7 +8,7 @@ ARG AMAZON_LINUX=public.ecr.aws/lambda/provided:al2023
 
 FROM $AMAZON_LINUX AS base
 
-RUN dnf install libicu-67.1-7.amzn2023.0.3.aarch64 --assumeyes
+RUN dnf install libicu-67.1-7.amzn2023.0.4.aarch64 --assumeyes
 
 FROM base AS builder-net9
 ARG ASPNET_VERSION


### PR DESCRIPTION
*Description of changes:*
Address CVE in `libicu` by updating to version `0.4`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
