### PR TITLE
Fix integ tests to make sure IAM role is cleaned up after test run

### DIFF
--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/BaseCustomRuntimeTest.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/BaseCustomRuntimeTest.cs
@@ -79,7 +79,6 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
 
             if (!roleAlreadyExisted)
             {
-                // Detach managed policies
                 try
                 {
                     var listAttachedPoliciesRequest = new ListAttachedRolePoliciesRequest


### PR DESCRIPTION
*Description of changes:*
Noticed our CI account was failing tests because we had too many orphan IAM roles being left around from previous test runs. I tracked down where the role was being created and updated the delete code which was was failing because we need to be sure to remove attach policies first.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
