### PR TITLE
Lambda Test Tool v2 add .NET 10 build target

### DIFF
--- a/.autover/changes/e84bcfae-d83c-49bc-8841-4ed8c61f1271.json
+++ b/.autover/changes/e84bcfae-d83c-49bc-8841-4ed8c61f1271.json
@@ -1,0 +1,12 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.TestTool",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Add .NET 10 build target",
+		"Update to latest versions of the AWS SDK for .NET"
+      ]
+    }
+  ]
+}

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <Import Project="..\..\..\..\buildtools\common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>A tool to help debug and test your .NET AWS Lambda functions locally.</Description>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Product>AWS .NET Lambda Test Tool</Product>
@@ -22,15 +22,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.0" />
-    <PackageReference Include="AWSSDK.Lambda" Version="4.0.0" />
-    <PackageReference Include="AWSSDK.SQS" Version="4.0.0" />
-    <PackageReference Include="AWSSDK.SSO" Version="4.0.0" />
-    <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.0" />
+    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.1" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.22" />
+    <PackageReference Include="AWSSDK.Lambda" Version="4.0.13.1" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.14" />
+    <PackageReference Include="AWSSDK.SSO" Version="4.0.2.13" />
+    <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.3.14" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.1" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.3" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.11" />
     <PackageReference Include="BlazorMonaco" Version="3.2.0" />
   </ItemGroup>
@@ -46,7 +46,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="PublishRuntimeSupportFiles" DependsOnTargets="GetRuntimeSupportTargetFrameworks" BeforeTargets="Build">
+  <Target Name="PublishRuntimeSupportFiles" DependsOnTargets="GetRuntimeSupportTargetFrameworks" BeforeTargets="Build" Condition="'$(TargetFramework)' == 'net10.0'">
     <Exec Command="dotnet publish &quot;$(MSBuildThisFileDirectory)../../../../Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj&quot; -c $(Configuration) -f %(TargetFrameworks.Identity) /p:ExecutableOutputType=true /p:AlternateAssemblyName=Amazon.Lambda.RuntimeSupport.TestTool" />
   </Target>
 

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/Amazon.Lambda.TestTool.IntegrationTests.csproj
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/Amazon.Lambda.TestTool.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -11,17 +11,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.5.1" />
-    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.13.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.1" />
-    <PackageReference Include="AWSSDK.APIGateway" Version="4.0.0" />
-    <PackageReference Include="AWSSDK.CloudFormation" Version="4.0.0" />
-	  <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.0" />
-    <PackageReference Include="AWSSDK.ApiGatewayV2" Version="4.0.0" />
-    <PackageReference Include="AWSSDK.Lambda" Version="4.0.0" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.0" />
-    <PackageReference Include="AWSSDK.SQS" Version="4.0.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.8.1" />
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.14.2" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.5" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.3" />
+    <PackageReference Include="AWSSDK.APIGateway" Version="4.0.5.8" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="4.0.8.8" />
+	  <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.9.7" />
+    <PackageReference Include="AWSSDK.ApiGatewayV2" Version="4.0.4.9" />
+    <PackageReference Include="AWSSDK.Lambda" Version="4.0.13.1" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.9" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.14" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0" />

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.Tests.Common/Amazon.Lambda.TestTool.Tests.Common.csproj
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.Tests.Common/Amazon.Lambda.TestTool.Tests.Common.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <NoWarn>1591</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.1" />
+      <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.3" />
       <PackageReference Include="xunit" Version="2.9.3" />
       <PackageReference Include="xunit.assert" Version="2.9.3" />
     </ItemGroup>

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Amazon.Lambda.TestTool.UnitTests.csproj
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Amazon.Lambda.TestTool.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\..\..\buildtools\common.props" />
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.13.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
-    <PackageReference Include="AWSSDK.Lambda" Version="4.0.0" />
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.14.2" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.5" />
+    <PackageReference Include="AWSSDK.Lambda" Version="4.0.13.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
*Description of changes:*
Tracking down issues with getting the Lambda experience working better in VS Code. I'm getting some issues with the test tool not finding the `blazor.web.js` file when run through Aspire + VS Code but the issues go away when I build the test tool for .NET 10. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
