### PR TITLE
Update AWSLambdaPSCore to target .NET 10 managed runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Release 2026-02-18
+
+### AWSLambdaPSCore PowerShell Module (5.0.0)
+* Updated to target the .NET 10 Lambda runtime
+
 ## Release 2026-02-10
 
 ### Amazon.Lambda.Annotations (1.9.0)

--- a/PowerShell/Module/AWSLambdaPSCore.psd1
+++ b/PowerShell/Module/AWSLambdaPSCore.psd1
@@ -12,7 +12,7 @@
 RootModule = 'AWSLambdaPSCore.psm1'
 
 # Version number of this module.
-ModuleVersion = '4.0.4.0'
+ModuleVersion = '5.0.0.0'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core'

--- a/PowerShell/Module/Private/_Constants.ps1
+++ b/PowerShell/Module/Private/_Constants.ps1
@@ -20,15 +20,15 @@ if (!($AwsPowerShellFunctionEnvName))
 
 if (!($AwsPowerShellDefaultSdkVersion))
 {
-    New-Variable -Name AwsPowerShellDefaultSdkVersion -Value '7.4.5' -Option Constant
+    New-Variable -Name AwsPowerShellDefaultSdkVersion -Value '7.5.4' -Option Constant
 }
 
 if (!($AwsPowerShellTargetFramework))
 {
-    New-Variable -Name AwsPowerShellTargetFramework -Value 'net8.0' -Option Constant
+    New-Variable -Name AwsPowerShellTargetFramework -Value 'net10.0' -Option Constant
 }
 
 if (!($AwsPowerShellLambdaRuntime))
 {
-    New-Variable -Name AwsPowerShellLambdaRuntime -Value 'dotnet8' -Option Constant
+    New-Variable -Name AwsPowerShellLambdaRuntime -Value 'dotnet10' -Option Constant
 }

--- a/PowerShell/Module/Templates/Blueprints/Basic/basic.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/Basic/basic.ps1.txt
@@ -9,7 +9,7 @@
 # To include PowerShell modules with your Lambda function, like the AWS.Tools.S3 module, add a "#Requires" statement
 # indicating the module and version. If using an AWS.Tools.* module the AWS.Tools.Common module is also required.
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='5.0.158'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/CloudFormationCustomResource/cloudformationcustomresource.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/CloudFormationCustomResource/cloudformationcustomresource.ps1.txt
@@ -9,7 +9,7 @@
 # To include PowerShell modules with your Lambda function, like the AWS.Tools.S3 module, add a "#Requires" statement
 # indicating the module and version. If using an AWS.Tools.* module the AWS.Tools.Common module is also required.
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='5.0.158'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/CodeCommitTrigger/codecommittrigger.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/CodeCommitTrigger/codecommittrigger.ps1.txt
@@ -9,7 +9,7 @@
 # To include PowerShell modules with your Lambda function, like the AWS.Tools.S3 module, add a "#Requires" statement
 # indicating the module and version. If using an AWS.Tools.* module the AWS.Tools.Common module is also required.
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='5.0.158'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/DetectLabels/detectlabels.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/DetectLabels/detectlabels.ps1.txt
@@ -9,9 +9,9 @@
 # To include PowerShell modules with your Lambda function, like the AWS.Tools.S3 module, add a "#Requires" statement
 # indicating the module and version. If using an AWS.Tools.* module the AWS.Tools.Common module is also required.
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
-#Requires -Modules @{ModuleName='AWS.Tools.Rekognition';ModuleVersion='4.1.518'}
-#Requires -Modules @{ModuleName='AWS.Tools.S3';ModuleVersion='4.1.518'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='5.0.158'}
+#Requires -Modules @{ModuleName='AWS.Tools.Rekognition';ModuleVersion='5.0.158'}
+#Requires -Modules @{ModuleName='AWS.Tools.S3';ModuleVersion='5.0.158'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/KinesisStreamProcessor/kinesisstreamprocessor.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/KinesisStreamProcessor/kinesisstreamprocessor.ps1.txt
@@ -9,7 +9,7 @@
 # To include PowerShell modules with your Lambda function, like the AWS.Tools.S3 module, add a "#Requires" statement
 # indicating the module and version. If using an AWS.Tools.* module the AWS.Tools.Common module is also required.
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='5.0.158'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/S3Event/s3event.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/S3Event/s3event.ps1.txt
@@ -12,8 +12,8 @@
 # The following link contains documentation describing the structure of the S3 event object.
 # https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
-#Requires -Modules @{ModuleName='AWS.Tools.S3';ModuleVersion='4.1.518'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='5.0.158'}
+#Requires -Modules @{ModuleName='AWS.Tools.S3';ModuleVersion='5.0.158'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/S3EventToSNS/s3tosns.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/S3EventToSNS/s3tosns.ps1.txt
@@ -15,8 +15,8 @@
 # This example demonstrates how to process an S3 Event that follows the process:
 # S3 Event -> SNS Topic -> Lambda Function
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
-#Requires -Modules @{ModuleName='AWS.Tools.S3';ModuleVersion='4.1.518'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='5.0.158'}
+#Requires -Modules @{ModuleName='AWS.Tools.S3';ModuleVersion='5.0.158'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/S3EventToSNSToSQS/s3tosnstosqs.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/S3EventToSNSToSQS/s3tosnstosqs.ps1.txt
@@ -15,8 +15,8 @@
 # This example demonstrates how to process an S3 Event that follows the process:
 # S3 Event -> SNS Topic -> SQS Queue -> Lambda Function
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
-#Requires -Modules @{ModuleName='AWS.Tools.S3';ModuleVersion='4.1.518'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='5.0.158'}
+#Requires -Modules @{ModuleName='AWS.Tools.S3';ModuleVersion='5.0.158'}
 
 # Uncomment to send the input event to CloudWatch Logs
 #Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/S3EventToSQS/s3tosqs.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/S3EventToSQS/s3tosqs.ps1.txt
@@ -15,8 +15,8 @@
 # This example demonstrates how to process an S3 Event that follows the process:
 # S3 Event -> SQS Queue -> Lambda Function
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
-#Requires -Modules @{ModuleName='AWS.Tools.S3';ModuleVersion='4.1.518'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='5.0.158'}
+#Requires -Modules @{ModuleName='AWS.Tools.S3';ModuleVersion='5.0.158'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/SNSSubscription/snssubscription.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/SNSSubscription/snssubscription.ps1.txt
@@ -9,7 +9,7 @@
 # To include PowerShell modules with your Lambda function, like the AWS.Tools.S3 module, add a "#Requires" statement
 # indicating the module and version. If using an AWS.Tools.* module the AWS.Tools.Common module is also required.
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='5.0.158'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/SNSToSQS/snstosqs.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/SNSToSQS/snstosqs.ps1.txt
@@ -12,7 +12,7 @@
 # This example demonstrates how to process an SNS Message that follows the process:
 # SNS topic -> SQS Queue -> Lambda Function
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.5.0.158'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/SQSQueueProcessor/sqsprocessor.ps1.txt
+++ b/PowerShell/Module/Templates/Blueprints/SQSQueueProcessor/sqsprocessor.ps1.txt
@@ -12,7 +12,7 @@
 # This example demonstrates how to process an SQS Queue:
 # SQS Queue -> Lambda Function
 
-#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.1.518'}
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='5.0.158'}
 
 # Uncomment to send the input event to CloudWatch Logs
 # Write-Host (ConvertTo-Json -InputObject $LambdaInput -Compress -Depth 5)

--- a/PowerShell/Module/Templates/Blueprints/projectfile.csproj.txt
+++ b/PowerShell/Module/Templates/Blueprints/projectfile.csproj.txt
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     </PropertyGroup>
 
@@ -16,7 +16,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.PowerShell.SDK" Version="POWERSHELL_SDK_VERSION" />
 
-        <PackageReference Include="Amazon.Lambda.Core" Version="2.3.0" />
-        <PackageReference Include="Amazon.Lambda.PowerShellHost" Version="3.0.1" />
+        <PackageReference Include="Amazon.Lambda.Core" Version="2.8.1" />
+        <PackageReference Include="Amazon.Lambda.PowerShellHost" Version="3.0.3" />
     </ItemGroup>
 </Project>

--- a/PowerShell/README.md
+++ b/PowerShell/README.md
@@ -17,11 +17,11 @@ If you are using Visual Studio Code on Windows as your IDE, you need to ensure i
 configured for PowerShell Core. To learn how to configure Visual Studio Code for 
 PowerShell Core, see the following: https://learn.microsoft.com/en-us/powershell/scripting/dev-cross-plat/vscode/using-vscode?view=powershell-7.4
 
-Next, we need to install the .NET 8 SDK. Because PowerShell Core is built on top of 
-.NET Core, the Lambda support for PowerShell uses the same .NET 8 Lambda runtime for 
-both .NET Core and PowerShell based Lambda functions. The .NET 8 SDK is used by 
+Next, we need to install the .NET 10 SDK. Because PowerShell Core is built on top of 
+.NET Core, the Lambda support for PowerShell uses the same .NET 10 Lambda runtime for 
+both .NET Core and PowerShell based Lambda functions. The .NET 10 SDK is used by 
 the new PowerShell publishing cmdlets for Lambda to create the Lambda deployment 
-package. You can find the .NET 8 SDK [here]( https://www.microsoft.com/net/download). Be 
+package. You can find the .NET 10 SDK [here]( https://www.microsoft.com/net/download). Be 
 sure to install the SDK, not the runtime installation.
 
 The last component we need for the development environment is the 
@@ -43,9 +43,9 @@ New-AWSPowerShellLambdaPackage|Creates the Lambda deployment package that can be
 
 ## Troubleshooting
 ### Enabling Debug output
-In PowerShell, [Write-Debug](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/write-debug?view=powershell-7.4) CmdLet could be used to write debug message to the console. However, by default, debug messages are not displayed in the console, but you can display them by using the **Debug** parameter or the **$DebugPreference** variable.
+In PowerShell, [Write-Debug](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/write-debug) CmdLet could be used to write debug message to the console. However, by default, debug messages are not displayed in the console, but you can display them by using the **Debug** parameter or the **$DebugPreference** variable.
 
-The default value of [DebugPreference](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.4#debugpreference) variable is `SilentlyContinue`, which means the debug message isn't displayed and execution continues without interruption. The `-Debug` parameter could be used to override the `$DebugPreference` value.
+The default value of [DebugPreference](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables#debugpreference) variable is `SilentlyContinue`, which means the debug message isn't displayed and execution continues without interruption. The `-Debug` parameter could be used to override the `$DebugPreference` value.
 
 Enabling output of `Write-Debug` to CloudWatch logs is a 2 step process:
 - In PowerShell Lambda script, 


### PR DESCRIPTION
*Description of changes:*
Following the pattern done when the [.NET 8 managed runtime](https://github.com/aws/aws-lambda-dotnet/pull/1674) was released this updates the AWSLambdaPSCore module to use the .NET 10 runtime. This is a major version update like we did for previous new runtimes. Changes include

* Updated constant values to target .NET 10
* Update NuGet dependencies to latest versions
* Update the version of AWS.Tools modules being referenced in the templates
* Update README file

There is no automatic versioning for this module so I manually updated the version number and added the change log entry.

### Testing
I ran the tests for the module and did E2E tests deploying a PowerShell function to Lambda using the .NET 10 runtime


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
