### PR TITLE
Update Lambda Runtime Images for NET 11

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+Dockerfile text eol=lf

--- a/.github/workflows/auto-update-Dockerfiles.yml
+++ b/.github/workflows/auto-update-Dockerfiles.yml
@@ -10,7 +10,7 @@ on:
     - cron: '0 0 * * *'
   # Allows to run this workflow manually from the Actions tab for testing
   workflow_dispatch:
-    
+
 
 
 jobs:
@@ -23,6 +23,8 @@ jobs:
       NET_9_ARM64_Dockerfile: "LambdaRuntimeDockerfiles/Images/net9/arm64/Dockerfile"
       NET_10_AMD64_Dockerfile: "LambdaRuntimeDockerfiles/Images/net10/amd64/Dockerfile"
       NET_10_ARM64_Dockerfile: "LambdaRuntimeDockerfiles/Images/net10/arm64/Dockerfile"
+      NET_11_AMD64_Dockerfile: "LambdaRuntimeDockerfiles/Images/net11/amd64/Dockerfile"
+      NET_11_ARM64_Dockerfile: "LambdaRuntimeDockerfiles/Images/net11/arm64/Dockerfile"
 
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
@@ -114,6 +116,34 @@ jobs:
             Write-Host "Skipping .NET 10 ARM64 update - No version detected"
           }
 
+      # Update .NET 11 AMD64 Dockerfile
+      - name: Update .NET 11 AMD64
+        id: update-net11-amd64
+        shell: pwsh
+        env:
+          DOCKERFILE_PATH: ${{ env.NET_11_AMD64_Dockerfile }}
+        run: |
+          $version = & "./LambdaRuntimeDockerfiles/get-latest-aspnet-versions.ps1" -MajorVersion "11"
+          if (-not [string]::IsNullOrEmpty($version)) {
+            & "./LambdaRuntimeDockerfiles/update-dockerfile.ps1" -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion $version
+          } else {
+            Write-Host "Skipping .NET 11 AMD64 update - No version detected"
+          }
+
+      # Update .NET 11 ARM64 Dockerfile
+      - name: Update .NET 11 ARM64
+        id: update-net11-arm64
+        shell: pwsh
+        env:
+          DOCKERFILE_PATH: ${{ env.NET_11_ARM64_Dockerfile }}
+        run: |
+          $version = & "./LambdaRuntimeDockerfiles/get-latest-aspnet-versions.ps1" -MajorVersion "11"
+          if (-not [string]::IsNullOrEmpty($version)) {
+            & "./LambdaRuntimeDockerfiles/update-dockerfile.ps1" -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion $version
+          } else {
+            Write-Host "Skipping .NET 11 ARM64 update - No version detected"
+          }
+
       # Commit changes and create a branch
       - name: Commit and Push
         id: commit-push
@@ -159,25 +189,27 @@ jobs:
           destination_branch: "dev"
           pr_title: 'chore: Daily ASP.NET Core version update in Dockerfiles'
           pr_body: "This PR automatically updates the Dockerfiles to use the latest ASP.NET Core version.
-            
+
             Verify that the Dockerfiles have correct versions and matching SHA512 checksums for ASP.NET Core runtime.
-            
+
             All .NET versions: https://dotnet.microsoft.com/en-us/download/dotnet
-            
+
             *Description of changes:*
             \n${{ format
-                (
-                  '{0}\n{1}\n{2}\n{3}\n{4}\n{5}',
-                  join(steps.update-net8-amd64.outputs.MESSAGE, '\n'),
-                  join(steps.update-net8-arm64.outputs.MESSAGE, '\n'),
-                  join(steps.update-net9-amd64.outputs.MESSAGE, '\n'),
-                  join(steps.update-net9-arm64.outputs.MESSAGE, '\n'),
-                  join(steps.update-net10-amd64.outputs.MESSAGE, '\n'),
-                  join(steps.update-net10-arm64.outputs.MESSAGE, '\n')
-                )
+            (
+            '{0}\n{1}\n{2}\n{3}\n{4}\n{5}\n{6}\n{7}',
+            join(steps.update-net8-amd64.outputs.MESSAGE, '\n'),
+            join(steps.update-net8-arm64.outputs.MESSAGE, '\n'),
+            join(steps.update-net9-amd64.outputs.MESSAGE, '\n'),
+            join(steps.update-net9-arm64.outputs.MESSAGE, '\n'),
+            join(steps.update-net10-amd64.outputs.MESSAGE, '\n'),
+            join(steps.update-net10-arm64.outputs.MESSAGE, '\n'),
+            join(steps.update-net11-amd64.outputs.MESSAGE, '\n'),
+            join(steps.update-net11-arm64.outputs.MESSAGE, '\n')
+            )
             }}"
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          
+
       # Add "Release Not Needed" label to the PR
       - name: Add Release Not Needed label
         if: ${{ steps.pull-request.outputs.pr_number }}

--- a/.github/workflows/build-lambda-runtime-dockerfiles.yml
+++ b/.github/workflows/build-lambda-runtime-dockerfiles.yml
@@ -1,0 +1,64 @@
+name: Build Lambda Runtime Images
+
+on:
+  pull_request:
+    paths:
+      - "LambdaRuntimeDockerfiles/**"
+  push:
+    paths:
+      - "LambdaRuntimeDockerfiles/**"
+
+permissions:
+  contents: read
+
+jobs:
+  build-runtime-images:
+    name: Build runtime image (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: NET 8 AMD64
+            dockerfile: LambdaRuntimeDockerfiles/Images/net8/amd64/Dockerfile
+            platform: linux/amd64
+          - name: NET 8 ARM64
+            dockerfile: LambdaRuntimeDockerfiles/Images/net8/arm64/Dockerfile
+            platform: linux/arm64
+          - name: NET 9 AMD64
+            dockerfile: LambdaRuntimeDockerfiles/Images/net9/amd64/Dockerfile
+            platform: linux/amd64
+          - name: NET 9 ARM64
+            dockerfile: LambdaRuntimeDockerfiles/Images/net9/arm64/Dockerfile
+            platform: linux/arm64
+          - name: NET 10 AMD64
+            dockerfile: LambdaRuntimeDockerfiles/Images/net10/amd64/Dockerfile
+            platform: linux/amd64
+          - name: NET 10 ARM64
+            dockerfile: LambdaRuntimeDockerfiles/Images/net10/arm64/Dockerfile
+            platform: linux/arm64
+          - name: NET 11 AMD64
+            dockerfile: LambdaRuntimeDockerfiles/Images/net11/amd64/Dockerfile
+            platform: linux/amd64
+          - name: NET 11 ARM64
+            dockerfile: LambdaRuntimeDockerfiles/Images/net11/arm64/Dockerfile
+            platform: linux/arm64
+
+    steps:
+      - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2 #v4.2.2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build ${{ matrix.name }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: ${{ matrix.platform }}
+          push: false
+          provenance: false
+

--- a/.github/workflows/update-Dockerfiles.yml
+++ b/.github/workflows/update-Dockerfiles.yml
@@ -50,6 +50,20 @@ on:
         description: ".NET 10 Next Version"
         type: string
         required: true
+      NET_11_AMD64:
+        description: ".NET 11 AMD64"
+        type: boolean
+        required: true
+        default: true
+      NET_11_ARM64:
+        description: ".NET 11 ARM64"
+        type: boolean
+        required: true
+        default: true
+      NET_11_NEXT_VERSION:
+        description: ".NET 11 Next Version"
+        type: string
+        required: true
 
 jobs:
   build:
@@ -61,6 +75,8 @@ jobs:
       NET_9_ARM64_Dockerfile: "LambdaRuntimeDockerfiles/Images/net9/arm64/Dockerfile"
       NET_10_AMD64_Dockerfile: "LambdaRuntimeDockerfiles/Images/net10/amd64/Dockerfile"
       NET_10_ARM64_Dockerfile: "LambdaRuntimeDockerfiles/Images/net10/arm64/Dockerfile"
+      NET_11_AMD64_Dockerfile: "LambdaRuntimeDockerfiles/Images/net11/amd64/Dockerfile"
+      NET_11_ARM64_Dockerfile: "LambdaRuntimeDockerfiles/Images/net11/arm64/Dockerfile"
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -129,6 +145,26 @@ jobs:
           .\LambdaRuntimeDockerfiles\update-dockerfile.ps1 -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion "${{ env.NEXT_VERSION }}"
         if: ${{ github.event.inputs.NET_10_ARM64 == 'true' }}
 
+      - name: Update .NET 11 AMD64
+        id: update-net11-amd64
+        shell: pwsh
+        env:
+          DOCKERFILE_PATH: ${{ env.NET_11_AMD64_Dockerfile }}
+          NEXT_VERSION: ${{ github.event.inputs.NET_11_NEXT_VERSION }}
+        run: |
+          .\LambdaRuntimeDockerfiles\update-dockerfile.ps1 -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion "${{ env.NEXT_VERSION }}"
+        if: ${{ github.event.inputs.NET_11_AMD64 == 'true' }}
+
+      - name: Update .NET 11 ARM64
+        id: update-net11-arm64
+        shell: pwsh
+        env:
+          DOCKERFILE_PATH: ${{ env.NET_11_ARM64_Dockerfile }}
+          NEXT_VERSION: ${{ github.event.inputs.NET_11_NEXT_VERSION }}
+        run: |
+          .\LambdaRuntimeDockerfiles\update-dockerfile.ps1 -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion "${{ env.NEXT_VERSION }}"
+        if: ${{ github.event.inputs.NET_11_ARM64 == 'true' }}
+
       # Update Dockerfiles if newer version of ASP.NET Core is available
       - name: Commit and Push
         id: commit-push
@@ -158,15 +194,17 @@ jobs:
             \n\nAll .NET versions https://dotnet.microsoft.com/en-us/download/dotnet
             \n\n*Description of changes:*
             \n${{ format
-                (
-                  '{0}\n{1}\n{2}\n{3}\n{4}\n{5}',
-                  join(steps.update-net8-amd64.outputs.MESSAGE, '\n'),
-                  join(steps.update-net8-arm64.outputs.MESSAGE, '\n'),
-                  join(steps.update-net9-amd64.outputs.MESSAGE, '\n'),
-                  join(steps.update-net9-arm64.outputs.MESSAGE, '\n'),
-                  join(steps.update-net10-amd64.outputs.MESSAGE, '\n'),
-                  join(steps.update-net10-arm64.outputs.MESSAGE, '\n')
-                )
+            (
+            '{0}\n{1}\n{2}\n{3}\n{4}\n{5}\n{6}\n{7}',
+            join(steps.update-net8-amd64.outputs.MESSAGE, '\n'),
+            join(steps.update-net8-arm64.outputs.MESSAGE, '\n'),
+            join(steps.update-net9-amd64.outputs.MESSAGE, '\n'),
+            join(steps.update-net9-arm64.outputs.MESSAGE, '\n'),
+            join(steps.update-net10-amd64.outputs.MESSAGE, '\n'),
+            join(steps.update-net10-arm64.outputs.MESSAGE, '\n'),
+            join(steps.update-net11-amd64.outputs.MESSAGE, '\n'),
+            join(steps.update-net11-arm64.outputs.MESSAGE, '\n')
+            )
             }}"
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/LambdaRuntimeDockerfiles/Images/net10/amd64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net10/amd64/Dockerfile
@@ -27,21 +27,20 @@ RUN curl -SL --output aspnetcore.tar.gz https://builds.dotnet.microsoft.com/dotn
     && rm aspnetcore.tar.gz
 
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0-preview-trixie-slim AS builder
+FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS builder
 WORKDIR /src
 COPY ["Libraries/src/Amazon.Lambda.RuntimeSupport", "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/"]
 COPY ["Libraries/src/SnapshotRestore.Registry", "Repo/Libraries/src/SnapshotRestore.Registry/"]
 COPY ["Libraries/src/Amazon.Lambda.Core", "Repo/Libraries/src/Amazon.Lambda.Core/"]
 COPY ["buildtools/", "Repo/buildtools/"]
 RUN dotnet restore "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj" /p:TargetFrameworks=net10.0
-WORKDIR "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport"
+WORKDIR /src/Repo/Libraries/src/Amazon.Lambda.RuntimeSupport
 RUN dotnet build "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net10.0 --runtime linux-x64 -c Release -o /app/build
 
 
 FROM builder AS publish
 RUN dotnet publish "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net10.0 -f net10.0 --runtime linux-x64 --self-contained false -p:PublishReadyToRun=true -c Release -o /app/publish
-RUN apt-get update && apt-get install -y dos2unix
-RUN dos2unix /app/publish/bootstrap.sh && \
+RUN sed -i 's/\r$//' /app/publish/bootstrap.sh && \
     mv /app/publish/bootstrap.sh /app/publish/bootstrap && \
     chmod +x /app/publish/bootstrap
 RUN touch /app/publish/empty-certificates.crt

--- a/LambdaRuntimeDockerfiles/Images/net11/amd64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net11/amd64/Dockerfile
@@ -1,16 +1,16 @@
 # Based on Docker image from: https://github.com/dotnet/dotnet-docker/
 
-ARG ASPNET_VERSION=10.0.4
-ARG ASPNET_SHA512=a0b3c029e48bd269b656d8893762e8f1c4a799ea51a56f8a38e4ad456c0961b03a2cddee304a2cecb705e56bc9c54f36831d4526a208db0b190eba226d889674
+ARG ASPNET_VERSION=11.0.0-preview.2.26159.112
+ARG ASPNET_SHA512=4c02fbb66bc4b7389e0f43c0ea96a3046954eb3c7ad06bf0f8d90997c2e603dd0a3929e2b29b9e8933cc76341fb5e62ebe5bcb83d9a31419bdd1195904ff5af6
 
-ARG LAMBDA_RUNTIME_NAME=dotnet10
+ARG LAMBDA_RUNTIME_NAME=dotnet11
 ARG AMAZON_LINUX=public.ecr.aws/lambda/provided:al2023
 
 FROM $AMAZON_LINUX AS base
 
-RUN dnf install libicu-67.1-7.amzn2023.0.4.aarch64 --assumeyes
+RUN dnf install libicu-67.1-7.amzn2023.0.4.x86_64 --assumeyes
 
-FROM base AS builder-net10
+FROM base AS builder-net11
 ARG ASPNET_VERSION
 ARG ASPNET_SHA512
 
@@ -20,26 +20,26 @@ WORKDIR /dotnet
 RUN dnf install tar gzip --assumeyes
 
 # Install the ASP.NET Core shared framework
-RUN curl -SL --output aspnetcore.tar.gz https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-arm64.tar.gz \
+RUN curl -SL --output aspnetcore.tar.gz https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-x64.tar.gz \
     && aspnetcore_sha512=$ASPNET_SHA512 \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz -C /dotnet \
     && rm aspnetcore.tar.gz
 
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS builder
+FROM mcr.microsoft.com/dotnet/sdk:11.0-preview-resolute AS builder
 WORKDIR /src
 COPY ["Libraries/src/Amazon.Lambda.RuntimeSupport", "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/"]
 COPY ["Libraries/src/SnapshotRestore.Registry", "Repo/Libraries/src/SnapshotRestore.Registry/"]
 COPY ["Libraries/src/Amazon.Lambda.Core", "Repo/Libraries/src/Amazon.Lambda.Core/"]
 COPY ["buildtools/", "Repo/buildtools/"]
-RUN dotnet restore "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj" /p:TargetFrameworks=net10.0
+RUN dotnet restore "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj" /p:TargetFrameworks=net11.0
 WORKDIR /src/Repo/Libraries/src/Amazon.Lambda.RuntimeSupport
-RUN dotnet build "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net10.0 --runtime linux-arm64 -c Release -o /app/build
+RUN dotnet build "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net11.0 --runtime linux-x64 -c Release -o /app/build
 
 
 FROM builder AS publish
-RUN dotnet publish "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net10.0 -f net10.0 --runtime linux-arm64 --self-contained false -p:PublishReadyToRun=true -c Release -o /app/publish
+RUN dotnet publish "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net11.0 -f net11.0 --runtime linux-x64 --self-contained false -p:PublishReadyToRun=true -c Release -o /app/publish
 RUN sed -i 's/\r$//' /app/publish/bootstrap.sh && \
     mv /app/publish/bootstrap.sh /app/publish/bootstrap && \
     chmod +x /app/publish/bootstrap
@@ -63,7 +63,7 @@ ENV \
     # Disable Microsoft's telemetry collection
     DOTNET_CLI_TELEMETRY_OPTOUT=true
 
-COPY --from=builder-net10    /dotnet         ${DOTNET_ROOT}
+COPY --from=builder-net11    /dotnet         ${DOTNET_ROOT}
 COPY --from=publish         /app/publish    ${LAMBDA_RUNTIME_DIR}
 
 # Generate runtime-release file

--- a/LambdaRuntimeDockerfiles/Images/net11/arm64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net11/arm64/Dockerfile
@@ -1,16 +1,16 @@
 # Based on Docker image from: https://github.com/dotnet/dotnet-docker/
 
-ARG ASPNET_VERSION=10.0.4
-ARG ASPNET_SHA512=a0b3c029e48bd269b656d8893762e8f1c4a799ea51a56f8a38e4ad456c0961b03a2cddee304a2cecb705e56bc9c54f36831d4526a208db0b190eba226d889674
+ARG ASPNET_VERSION=11.0.0-preview.2.26159.112
+ARG ASPNET_SHA512=711914b72530c8b6ba49e5077942893a52bf5508cc082b09ae04f5c72ae4a09dd78699ffcad16dd25a2fe43d586533f897dcdb5c82ab2982ff6b4ad6fdfe5a58
 
-ARG LAMBDA_RUNTIME_NAME=dotnet10
+ARG LAMBDA_RUNTIME_NAME=dotnet11
 ARG AMAZON_LINUX=public.ecr.aws/lambda/provided:al2023
 
 FROM $AMAZON_LINUX AS base
 
 RUN dnf install libicu-67.1-7.amzn2023.0.4.aarch64 --assumeyes
 
-FROM base AS builder-net10
+FROM base AS builder-net11
 ARG ASPNET_VERSION
 ARG ASPNET_SHA512
 
@@ -27,19 +27,19 @@ RUN curl -SL --output aspnetcore.tar.gz https://builds.dotnet.microsoft.com/dotn
     && rm aspnetcore.tar.gz
 
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS builder
+FROM mcr.microsoft.com/dotnet/sdk:11.0-preview-resolute AS builder
 WORKDIR /src
 COPY ["Libraries/src/Amazon.Lambda.RuntimeSupport", "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/"]
 COPY ["Libraries/src/SnapshotRestore.Registry", "Repo/Libraries/src/SnapshotRestore.Registry/"]
 COPY ["Libraries/src/Amazon.Lambda.Core", "Repo/Libraries/src/Amazon.Lambda.Core/"]
 COPY ["buildtools/", "Repo/buildtools/"]
-RUN dotnet restore "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj" /p:TargetFrameworks=net10.0
+RUN dotnet restore "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj" /p:TargetFrameworks=net11.0
 WORKDIR /src/Repo/Libraries/src/Amazon.Lambda.RuntimeSupport
-RUN dotnet build "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net10.0 --runtime linux-arm64 -c Release -o /app/build
+RUN dotnet build "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net11.0 --runtime linux-arm64 -c Release -o /app/build
 
 
 FROM builder AS publish
-RUN dotnet publish "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net10.0 -f net10.0 --runtime linux-arm64 --self-contained false -p:PublishReadyToRun=true -c Release -o /app/publish
+RUN dotnet publish "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net11.0 -f net11.0 --runtime linux-arm64 --self-contained false -p:PublishReadyToRun=true -c Release -o /app/publish
 RUN sed -i 's/\r$//' /app/publish/bootstrap.sh && \
     mv /app/publish/bootstrap.sh /app/publish/bootstrap && \
     chmod +x /app/publish/bootstrap
@@ -63,7 +63,7 @@ ENV \
     # Disable Microsoft's telemetry collection
     DOTNET_CLI_TELEMETRY_OPTOUT=true
 
-COPY --from=builder-net10    /dotnet         ${DOTNET_ROOT}
+COPY --from=builder-net11    /dotnet         ${DOTNET_ROOT}
 COPY --from=publish         /app/publish    ${LAMBDA_RUNTIME_DIR}
 
 # Generate runtime-release file

--- a/LambdaRuntimeDockerfiles/Images/net8/amd64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net8/amd64/Dockerfile
@@ -35,7 +35,7 @@ COPY ["Libraries/src/Amazon.Lambda.Core", "Repo/Libraries/src/Amazon.Lambda.Core
 COPY ["Libraries/src/SnapshotRestore.Registry", "Repo/Libraries/src/SnapshotRestore.Registry/"]
 COPY ["buildtools/", "Repo/buildtools/"]
 RUN dotnet restore "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj" /p:TargetFrameworks=net8.0
-WORKDIR "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport"
+WORKDIR /src/Repo/Libraries/src/Amazon.Lambda.RuntimeSupport
 RUN dotnet build "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net8.0 --runtime linux-x64 -c Release -o /app/build
 
 

--- a/LambdaRuntimeDockerfiles/Images/net8/arm64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net8/arm64/Dockerfile
@@ -35,7 +35,7 @@ COPY ["Libraries/src/Amazon.Lambda.Core", "Repo/Libraries/src/Amazon.Lambda.Core
 COPY ["Libraries/src/SnapshotRestore.Registry", "Repo/Libraries/src/SnapshotRestore.Registry/"]
 COPY ["buildtools/", "Repo/buildtools/"]
 RUN dotnet restore "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj" /p:TargetFrameworks=net8.0
-WORKDIR "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport"
+WORKDIR /src/Repo/Libraries/src/Amazon.Lambda.RuntimeSupport
 RUN dotnet build "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net8.0 --runtime linux-arm64 -c Release -o /app/build
 
 

--- a/LambdaRuntimeDockerfiles/Images/net9/amd64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net9/amd64/Dockerfile
@@ -34,7 +34,7 @@ COPY ["Libraries/src/SnapshotRestore.Registry", "Repo/Libraries/src/SnapshotRest
 COPY ["Libraries/src/Amazon.Lambda.Core", "Repo/Libraries/src/Amazon.Lambda.Core/"]
 COPY ["buildtools/", "Repo/buildtools/"]
 RUN dotnet restore "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj" /p:TargetFrameworks=net9.0
-WORKDIR "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport"
+WORKDIR /src/Repo/Libraries/src/Amazon.Lambda.RuntimeSupport
 RUN dotnet build "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net9.0 --runtime linux-x64 -c Release -o /app/build
 
 

--- a/LambdaRuntimeDockerfiles/Images/net9/arm64/Dockerfile
+++ b/LambdaRuntimeDockerfiles/Images/net9/arm64/Dockerfile
@@ -34,7 +34,7 @@ COPY ["Libraries/src/SnapshotRestore.Registry", "Repo/Libraries/src/SnapshotRest
 COPY ["Libraries/src/Amazon.Lambda.Core", "Repo/Libraries/src/Amazon.Lambda.Core/"]
 COPY ["buildtools/", "Repo/buildtools/"]
 RUN dotnet restore "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj" /p:TargetFrameworks=net9.0
-WORKDIR "Repo/Libraries/src/Amazon.Lambda.RuntimeSupport"
+WORKDIR /src/Repo/Libraries/src/Amazon.Lambda.RuntimeSupport
 RUN dotnet build "Amazon.Lambda.RuntimeSupport.csproj" /p:ExecutableOutputType=true /p:GenerateDocumentationFile=false /p:TargetFrameworks=net9.0 --runtime linux-arm64 -c Release -o /app/build
 
 

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\..\buildtools\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <Version>1.14.2</Version>
     <Description>Provides a bootstrap and Lambda Runtime API Client to help you to develop custom .NET Core Lambda Runtimes.</Description>
     <AssemblyTitle>Amazon.Lambda.RuntimeSupport</AssemblyTitle>
@@ -35,7 +35,7 @@
     <DefineConstants>$(DefineConstants);ExecutableOutputType</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0' or '$(TargetFramework)' == 'net11.0'">
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
   </PropertyGroup>
@@ -55,7 +55,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Amazon.Lambda.Core\Amazon.Lambda.Core.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0' or '$(TargetFramework)' == 'net11.0'">
     <ProjectReference Include="..\SnapshotRestore.Registry\SnapshotRestore.Registry.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/Libraries/src/SnapshotRestore.Registry/SnapshotRestore.Registry.csproj
+++ b/Libraries/src/SnapshotRestore.Registry/SnapshotRestore.Registry.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\..\buildtools\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <Version>1.0.1</Version>
     <Description>Provides a Restore Hooks library to help you register before snapshot and after restore hooks.</Description>
     <AssemblyTitle>SnapshotRestore.Registry</AssemblyTitle>

--- a/buildtools/ci.buildspec.yml
+++ b/buildtools/ci.buildspec.yml
@@ -11,8 +11,10 @@ phases:
       - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 3.1
       - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 9.0
       - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 10.0
+      - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 11.0
   build:
     commands:
       - dotnet msbuild buildtools/build.proj /t:testtoolv2-tests /p:Cicd=true
-      - dotnet msbuild buildtools/build.proj /t:unit-tests /p:Cicd=true 
+      - dotnet msbuild buildtools/build.proj /t:unit-tests /p:Cicd=true
       - dotnet msbuild buildtools/build.proj /t:integ-tests /p:Cicd=true
+


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-8546

*Description of changes:*
* Added .NET 11 Lambda Runtime Images
* Switched NET 10 and NET 11 SDK Docker stages to use Ubuntu images instead of Debian which is no longer produced starting NET 10. We missed updating NET 10 earlier so doing it now. This change caused me to stop using `apt-get` and instead use `sed` to remove Windows line endings from the shell script. `sed` is available by default on Ubuntu.
* Updated the existing GitHub workflows to include the NET 11 images
* Added new GitHub workflow that builds all Lambda Runtime images anytime a file in the `LambdaRuntimeDockerfiles` directory is updated.
* Added NET 11 target to `RuntimeSupport` and `SnapshotRestore.Registry`

NOTE: Another PR is still needed to update the Pipelines to build these new images

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
