### PR TITLE
Update Lambda TestTool README to include .NET 10

### DIFF
--- a/Tools/LambdaTestTool/README.md
+++ b/Tools/LambdaTestTool/README.md
@@ -37,6 +37,7 @@ that the Lambda function will be run in. Below is the list of published versions
 | .NET 7.0 (Deprecated) | Amazon.Lambda.TestTool-7.0 | dotnet-lambda-test-tool-7.0.exe |
 | .NET 8.0 | Amazon.Lambda.TestTool-8.0 | dotnet-lambda-test-tool-8.0.exe |
 | .NET 9.0 | Amazon.Lambda.TestTool-9.0 | dotnet-lambda-test-tool-9.0.exe |
+| .NET 10.0 | Amazon.Lambda.TestTool-10.0 | dotnet-lambda-test-tool-10.0.exe |
 
 ## AWS Credentials
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/2298
*Description of changes:*
Updates the lambda test tool readme to include .NET 10

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
