### PR TITLE
Add [S3Event] annotation attribute and source generator support

### DIFF
--- a/.autover/changes/add-s3event-annotation.json
+++ b/.autover/changes/add-s3event-annotation.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Annotations",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Added [S3Event] annotation attribute for declaratively configuring S3 event-triggered Lambda functions with support for bucket reference, event types, key prefix/suffix filters, and enabled state."
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/DiagnosticDescriptors.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Diagnostics/DiagnosticDescriptors.cs
@@ -274,5 +274,12 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Diagnostics
             category: "AWSLambdaCSharpGenerator",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor InvalidS3EventAttribute = new DiagnosticDescriptor(id: "AWSLambda0136",
+            title: "Invalid S3EventAttribute",
+            messageFormat: "Invalid S3EventAttribute encountered: {0}",
+            category: "AWSLambdaCSharpGenerator",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
     }
 }

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/AttributeModelBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/AttributeModelBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using Amazon.Lambda.Annotations.ALB;
 using Amazon.Lambda.Annotations.APIGateway;
+using Amazon.Lambda.Annotations.S3;
 using Amazon.Lambda.Annotations.SQS;
 using Microsoft.CodeAnalysis;
 
@@ -86,6 +87,15 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes
             {
                 var data = SQSEventAttributeBuilder.Build(att);
                 model = new AttributeModel<SQSEventAttribute>
+                {
+                    Data = data,
+                    Type = TypeModelBuilder.Build(att.AttributeClass, context)
+                };
+            }
+            else if (att.AttributeClass.Equals(context.Compilation.GetTypeByMetadataName(TypeFullNames.S3EventAttribute), SymbolEqualityComparer.Default))
+            {
+                var data = S3EventAttributeBuilder.Build(att);
+                model = new AttributeModel<S3EventAttribute>
                 {
                     Data = data,
                     Type = TypeModelBuilder.Build(att.AttributeClass, context)

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/S3EventAttributeBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/S3EventAttributeBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using Amazon.Lambda.Annotations.S3;
 using Microsoft.CodeAnalysis;
 using System;

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/S3EventAttributeBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/Attributes/S3EventAttributeBuilder.cs
@@ -1,0 +1,34 @@
+using Amazon.Lambda.Annotations.S3;
+using Microsoft.CodeAnalysis;
+using System;
+
+namespace Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes
+{
+    public class S3EventAttributeBuilder
+    {
+        public static S3EventAttribute Build(AttributeData att)
+        {
+            if (att.ConstructorArguments.Length != 1)
+                throw new NotSupportedException($"{TypeFullNames.S3EventAttribute} must have constructor with 1 argument.");
+
+            var bucket = att.ConstructorArguments[0].Value as string;
+            var data = new S3EventAttribute(bucket);
+
+            foreach (var pair in att.NamedArguments)
+            {
+                if (pair.Key == nameof(data.ResourceName) && pair.Value.Value is string resourceName)
+                    data.ResourceName = resourceName;
+                else if (pair.Key == nameof(data.Events) && pair.Value.Value is string events)
+                    data.Events = events;
+                else if (pair.Key == nameof(data.FilterPrefix) && pair.Value.Value is string filterPrefix)
+                    data.FilterPrefix = filterPrefix;
+                else if (pair.Key == nameof(data.FilterSuffix) && pair.Value.Value is string filterSuffix)
+                    data.FilterSuffix = filterSuffix;
+                else if (pair.Key == nameof(data.Enabled) && pair.Value.Value is bool enabled)
+                    data.Enabled = enabled;
+            }
+
+            return data;
+        }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/EventTypeBuilder.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Models/EventTypeBuilder.cs
@@ -26,6 +26,10 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Models
                 {
                     events.Add(EventType.SQS);
                 }
+                else if (attribute.AttributeClass.ToDisplayString() == TypeFullNames.S3EventAttribute)
+                {
+                    events.Add(EventType.S3);
+                }
                 else if (attribute.AttributeClass.ToDisplayString() == TypeFullNames.HttpApiAuthorizerAttribute
                     || attribute.AttributeClass.ToDisplayString() == TypeFullNames.RestApiAuthorizerAttribute)
                 {

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/SyntaxReceiver.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/SyntaxReceiver.cs
@@ -22,7 +22,8 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
             { "HttpApiAttribute", "HttpApi" },
             { "RestApiAttribute", "RestApi" },
             { "SQSEventAttribute", "SQSEvent" },
-            { "ALBApiAttribute", "ALBApi" }
+            { "ALBApiAttribute", "ALBApi" },
+            { "S3EventAttribute", "S3Event" }
         };
 
         public List<MethodDeclarationSyntax> LambdaMethods { get; } = new List<MethodDeclarationSyntax>();

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/TypeFullNames.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/TypeFullNames.cs
@@ -53,6 +53,9 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
         public const string ALBFromHeaderAttribute = "Amazon.Lambda.Annotations.ALB.FromHeaderAttribute";
         public const string ALBFromBodyAttribute = "Amazon.Lambda.Annotations.ALB.FromBodyAttribute";
 
+        public const string S3Event = "Amazon.Lambda.S3Events.S3Event";
+        public const string S3EventAttribute = "Amazon.Lambda.Annotations.S3.S3EventAttribute";
+
         public const string LambdaSerializerAttribute = "Amazon.Lambda.Core.LambdaSerializerAttribute";
         public const string DefaultLambdaSerializer = "Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer";
 
@@ -80,7 +83,8 @@ namespace Amazon.Lambda.Annotations.SourceGenerator
             RestApiAttribute,
             HttpApiAttribute,
             SQSEventAttribute,
-            ALBApiAttribute
+            ALBApiAttribute,
+            S3EventAttribute
         };
     }
 }

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Validation/LambdaFunctionValidator.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Validation/LambdaFunctionValidator.cs
@@ -1,4 +1,5 @@
 ﻿using Amazon.Lambda.Annotations.ALB;
+using Amazon.Lambda.Annotations.S3;
 using Amazon.Lambda.Annotations.SourceGenerator.Diagnostics;
 using Amazon.Lambda.Annotations.SourceGenerator.Extensions;
 using Amazon.Lambda.Annotations.SourceGenerator.Models;
@@ -61,6 +62,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Validation
             ValidateApiGatewayEvents(lambdaFunctionModel, methodLocation, diagnostics);
             ValidateSqsEvents(lambdaFunctionModel, methodLocation, diagnostics);
             ValidateAlbEvents(lambdaFunctionModel, methodLocation, diagnostics);
+            ValidateS3Events(lambdaFunctionModel, methodLocation, diagnostics);
 
             return ReportDiagnostics(diagnosticReporter, diagnostics);
         }
@@ -94,6 +96,16 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Validation
                 if (context.Compilation.ReferencedAssemblyNames.FirstOrDefault(x => x.Name == "Amazon.Lambda.ApplicationLoadBalancerEvents") == null)
                 {
                     diagnosticReporter.Report(Diagnostic.Create(DiagnosticDescriptors.MissingDependencies, methodLocation, "Amazon.Lambda.ApplicationLoadBalancerEvents"));
+                    return false;
+                }
+            }
+
+            // Check for references to "Amazon.Lambda.S3Events" if the Lambda method is annotated with S3Event attribute.
+            if (lambdaMethodSymbol.HasAttribute(context, TypeFullNames.S3EventAttribute))
+            {
+                if (context.Compilation.ReferencedAssemblyNames.FirstOrDefault(x => x.Name == "Amazon.Lambda.S3Events") == null)
+                {
+                    diagnosticReporter.Report(Diagnostic.Create(DiagnosticDescriptors.MissingDependencies, methodLocation, "Amazon.Lambda.S3Events"));
                     return false;
                 }
             }
@@ -359,6 +371,52 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Validation
                 {
                     diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.AlbUnmappedParameter, methodLocation, parameter.Name));
                 }
+            }
+        }
+
+        private static void ValidateS3Events(LambdaFunctionModel lambdaFunctionModel, Location methodLocation, List<Diagnostic> diagnostics)
+        {
+            if (!lambdaFunctionModel.LambdaMethod.Events.Contains(EventType.S3))
+                return;
+
+            // Validate S3EventAttributes
+            var seenResourceNames = new HashSet<string>();
+            foreach (var att in lambdaFunctionModel.Attributes)
+            {
+                if (att.Type.FullName != TypeFullNames.S3EventAttribute)
+                    continue;
+
+                var s3EventAttribute = ((AttributeModel<S3EventAttribute>)att).Data;
+                var validationErrors = s3EventAttribute.Validate();
+                validationErrors.ForEach(errorMessage => diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.InvalidS3EventAttribute, methodLocation, errorMessage)));
+
+                // Check for duplicate resource names (only when ResourceName is safe to evaluate)
+                var derivedResourceName = s3EventAttribute.ResourceName;
+                if (!string.IsNullOrEmpty(derivedResourceName) && !seenResourceNames.Add(derivedResourceName))
+                {
+                    diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.InvalidS3EventAttribute, methodLocation,
+                        $"Duplicate S3 event resource name '{derivedResourceName}'. Each [S3Event] attribute on the same method must have a unique ResourceName."));
+                }
+            }
+
+            // Validate method parameters - first param must be S3Event, optional second param ILambdaContext
+            var parameters = lambdaFunctionModel.LambdaMethod.Parameters;
+            if (parameters.Count == 0 ||
+                parameters.Count > 2 ||
+                (parameters.Count == 1 && parameters[0].Type.FullName != TypeFullNames.S3Event) ||
+                (parameters.Count == 2 && (parameters[0].Type.FullName != TypeFullNames.S3Event || parameters[1].Type.FullName != TypeFullNames.ILambdaContext)))
+            {
+                var errorMessage = $"When using the {nameof(S3EventAttribute)}, the Lambda method can accept at most 2 parameters. " +
+                    $"The first parameter is required and must be of type {TypeFullNames.S3Event}. " +
+                    $"The second parameter is optional and must be of type {TypeFullNames.ILambdaContext}.";
+                diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.InvalidLambdaMethodSignature, methodLocation, errorMessage));
+            }
+
+            // Validate method return type - must be void or Task
+            if (!lambdaFunctionModel.LambdaMethod.ReturnsVoid && !lambdaFunctionModel.LambdaMethod.ReturnsVoidTask)
+            {
+                var errorMessage = $"When using the {nameof(S3EventAttribute)}, the Lambda method can return either void or {TypeFullNames.Task}";
+                diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.InvalidLambdaMethodSignature, methodLocation, errorMessage));
             }
         }
 

--- a/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Writers/CloudFormationWriter.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations.SourceGenerator/Writers/CloudFormationWriter.cs
@@ -4,6 +4,7 @@ using Amazon.Lambda.Annotations.SourceGenerator.Diagnostics;
 using Amazon.Lambda.Annotations.SourceGenerator.FileIO;
 using Amazon.Lambda.Annotations.SourceGenerator.Models;
 using Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes;
+using Amazon.Lambda.Annotations.S3;
 using Amazon.Lambda.Annotations.SQS;
 using Microsoft.CodeAnalysis;
 using System;
@@ -226,6 +227,10 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Writers
                     case AttributeModel<ALBApiAttribute> albAttributeModel:
                         var albResourceNames = ProcessAlbApiAttribute(lambdaFunction, albAttributeModel.Data);
                         currentAlbResources.AddRange(albResourceNames);
+                        break;
+                    case AttributeModel<S3EventAttribute> s3AttributeModel:
+                        eventName = ProcessS3Attribute(lambdaFunction, s3AttributeModel.Data, currentSyncedEventProperties);
+                        currentSyncedEvents.Add(eventName);
                         break;
                 }
             }
@@ -598,6 +603,54 @@ namespace Amazon.Lambda.Annotations.SourceGenerator.Writers
             if (att.IsMaximumConcurrencySet)
             {
                 SetEventProperty(syncedEventProperties, lambdaFunction.ResourceName, eventName, "ScalingConfig.MaximumConcurrency", att.MaximumConcurrency);
+            }
+
+            return att.ResourceName;
+        }
+
+        /// <summary>
+        /// Writes all properties associated with <see cref="S3EventAttribute"/> to the serverless template.
+        /// </summary>
+        private string ProcessS3Attribute(ILambdaFunctionSerializable lambdaFunction, S3EventAttribute att, Dictionary<string, List<string>> syncedEventProperties)
+        {
+            var eventName = att.ResourceName;
+            var eventPath = $"Resources.{lambdaFunction.ResourceName}.Properties.Events.{eventName}";
+
+            _templateWriter.SetToken($"{eventPath}.Type", "S3");
+
+            // Bucket - always a Ref since S3 events require the bucket resource in the same template (validated to start with "@")
+            var bucketName = att.Bucket.Substring(1);
+            _templateWriter.RemoveToken($"{eventPath}.Properties.Bucket");
+            SetEventProperty(syncedEventProperties, lambdaFunction.ResourceName, eventName, $"Bucket.{REF}", bucketName);
+
+            // Events - list of S3 event types (always written since S3 SAM events require it; uses default "s3:ObjectCreated:*" if not explicitly set)
+            {
+                var events = att.Events.Split(';').Select(x => x.Trim()).Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
+                SetEventProperty(syncedEventProperties, lambdaFunction.ResourceName, eventName, "Events", events, TokenType.List);
+            }
+
+            // Filter - S3 key filter rules
+            if (att.IsFilterPrefixSet || att.IsFilterSuffixSet)
+            {
+                var rules = new List<Dictionary<string, string>>();
+
+                if (att.IsFilterPrefixSet)
+                {
+                    rules.Add(new Dictionary<string, string> { { "Name", "prefix" }, { "Value", att.FilterPrefix } });
+                }
+
+                if (att.IsFilterSuffixSet)
+                {
+                    rules.Add(new Dictionary<string, string> { { "Name", "suffix" }, { "Value", att.FilterSuffix } });
+                }
+
+                SetEventProperty(syncedEventProperties, lambdaFunction.ResourceName, eventName, "Filter.S3Key.Rules", rules, TokenType.List);
+            }
+
+            // Enabled
+            if (att.IsEnabledSet)
+            {
+                SetEventProperty(syncedEventProperties, lambdaFunction.ResourceName, eventName, "Enabled", att.Enabled);
             }
 
             return att.ResourceName;

--- a/Libraries/src/Amazon.Lambda.Annotations/S3/S3EventAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/S3/S3EventAttribute.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Amazon.Lambda.Annotations.S3
+{
+    /// <summary>
+    /// This attribute defines the S3 event source configuration for a Lambda function.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class S3EventAttribute : Attribute
+    {
+        private static readonly Regex _resourceNameRegex = new Regex("^[a-zA-Z0-9]+$");
+
+        /// <summary>
+        /// The S3 bucket that will act as the event trigger for the Lambda function.
+        /// This must be a reference to an S3 bucket resource defined in the serverless template, prefixed with "@".
+        /// </summary>
+        public string Bucket { get; set; }
+
+        /// <summary>
+        /// The CloudFormation resource name for the S3 event. By default this is derived from the Bucket reference without the "@" prefix.
+        /// </summary>
+        public string ResourceName
+        {
+            get
+            {
+                if (IsResourceNameSet)
+                    return resourceName;
+                if (!string.IsNullOrEmpty(Bucket) && Bucket.StartsWith("@"))
+                    return Bucket.Substring(1);
+                return Bucket;
+            }
+            set => resourceName = value;
+        }
+        private string resourceName = null;
+        internal bool IsResourceNameSet => resourceName != null;
+
+        /// <summary>
+        /// Semicolon-separated list of S3 event types. Default is 's3:ObjectCreated:*'.
+        /// </summary>
+        public string Events
+        {
+            get => events ?? "s3:ObjectCreated:*";
+            set => events = value;
+        }
+        private string events = null;
+        internal bool IsEventsSet => events != null;
+
+        /// <summary>
+        /// S3 key prefix filter for the event notification.
+        /// </summary>
+        public string FilterPrefix
+        {
+            get => filterPrefix;
+            set => filterPrefix = value;
+        }
+        private string filterPrefix = null;
+        internal bool IsFilterPrefixSet => filterPrefix != null;
+
+        /// <summary>
+        /// S3 key suffix filter for the event notification.
+        /// </summary>
+        public string FilterSuffix
+        {
+            get => filterSuffix;
+            set => filterSuffix = value;
+        }
+        private string filterSuffix = null;
+        internal bool IsFilterSuffixSet => filterSuffix != null;
+
+        /// <summary>
+        /// If set to false, the event source will be disabled. Default value is true.
+        /// </summary>
+        public bool Enabled
+        {
+            get => enabled.GetValueOrDefault(true);
+            set => enabled = value;
+        }
+        private bool? enabled;
+        internal bool IsEnabledSet => enabled.HasValue;
+
+        /// <summary>
+        /// Creates an instance of the <see cref="S3EventAttribute"/> class.
+        /// </summary>
+        /// <param name="bucket"><see cref="Bucket"/> property</param>
+        public S3EventAttribute(string bucket)
+        {
+            Bucket = bucket;
+        }
+
+        internal List<string> Validate()
+        {
+            var validationErrors = new List<string>();
+
+            if (string.IsNullOrEmpty(Bucket))
+            {
+                validationErrors.Add($"{nameof(S3EventAttribute.Bucket)} is required and must not be empty");
+            }
+            else if (!Bucket.StartsWith("@"))
+            {
+                validationErrors.Add($"{nameof(S3EventAttribute.Bucket)} = {Bucket}. S3 event sources require a reference to an S3 bucket resource in the serverless template. Prefix the resource name with '@'");
+            }
+            else
+            {
+                var bucketResourceName = Bucket.Substring(1);
+                if (!_resourceNameRegex.IsMatch(bucketResourceName))
+                {
+                    validationErrors.Add($"{nameof(S3EventAttribute.Bucket)} = {Bucket}. The referenced S3 bucket resource name must not be empty and must only contain alphanumeric characters after the '@' prefix");
+                }
+            }
+
+            if (IsResourceNameSet && !_resourceNameRegex.IsMatch(ResourceName))
+            {
+                validationErrors.Add($"{nameof(S3EventAttribute.ResourceName)} = {ResourceName}. It must only contain alphanumeric characters and must not be an empty string");
+            }
+
+            if (string.IsNullOrEmpty(Events))
+            {
+                validationErrors.Add($"{nameof(S3EventAttribute.Events)} must not be empty");
+            }
+
+            return validationErrors;
+        }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.Annotations/S3/S3EventAttribute.cs
+++ b/Libraries/src/Amazon.Lambda.Annotations/S3/S3EventAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/Amazon.Lambda.Annotations.SourceGenerators.Tests.csproj
@@ -209,6 +209,7 @@
       <ProjectReference Include="..\..\src\Amazon.Lambda.APIGatewayEvents\Amazon.Lambda.APIGatewayEvents.csproj" />
       <ProjectReference Include="..\..\src\Amazon.Lambda.SQSEvents\Amazon.Lambda.SQSEvents.csproj" />
       <ProjectReference Include="..\..\src\Amazon.Lambda.ApplicationLoadBalancerEvents\Amazon.Lambda.ApplicationLoadBalancerEvents.csproj" />
+      <ProjectReference Include="..\..\src\Amazon.Lambda.S3Events\Amazon.Lambda.S3Events.csproj" />
       <!-- 
 	    We need to force using the .NET Standard 2.0 version because the source generator test framework will complain
 		about using newer versions of System.Runtime then it can handle. This is not an issue in a end user scenario.

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/S3EventAttributeTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/S3EventAttributeTests.cs
@@ -1,0 +1,448 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Lambda.Annotations.S3;
+using System.Linq;
+using Xunit;
+
+namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
+{
+    public class S3EventAttributeTests
+    {
+        // ===== Constructor and Default Values =====
+
+        [Fact]
+        public void Constructor_SetsBucketProperty()
+        {
+            var attr = new S3EventAttribute("@MyBucket");
+
+            Assert.Equal("@MyBucket", attr.Bucket);
+        }
+
+        [Fact]
+        public void DefaultValues_AreCorrect()
+        {
+            var attr = new S3EventAttribute("@MyBucket");
+
+            // Events defaults to "s3:ObjectCreated:*" but IsEventsSet should be false
+            Assert.Equal("s3:ObjectCreated:*", attr.Events);
+            Assert.False(attr.IsEventsSet);
+
+            // Filters default to null
+            Assert.Null(attr.FilterPrefix);
+            Assert.False(attr.IsFilterPrefixSet);
+            Assert.Null(attr.FilterSuffix);
+            Assert.False(attr.IsFilterSuffixSet);
+
+            // Enabled defaults to true but IsEnabledSet should be false
+            Assert.True(attr.Enabled);
+            Assert.False(attr.IsEnabledSet);
+
+            // ResourceName defaults to bucket name without "@"
+            Assert.Equal("MyBucket", attr.ResourceName);
+            Assert.False(attr.IsResourceNameSet);
+        }
+
+        // ===== ResourceName Tests =====
+
+        [Fact]
+        public void ResourceName_DerivedFromBucket_WithAtPrefix()
+        {
+            var attr = new S3EventAttribute("@TestBucket");
+
+            Assert.False(attr.IsResourceNameSet);
+            Assert.Equal("TestBucket", attr.ResourceName);
+        }
+
+        [Fact]
+        public void ResourceName_WhenExplicitlySet_IsTracked()
+        {
+            var attr = new S3EventAttribute("@MyBucket");
+
+            Assert.False(attr.IsResourceNameSet);
+
+            attr.ResourceName = "CustomEventName";
+            Assert.True(attr.IsResourceNameSet);
+            Assert.Equal("CustomEventName", attr.ResourceName);
+        }
+
+        [Fact]
+        public void ResourceName_WithNullBucket_DoesNotThrow()
+        {
+            var attr = new S3EventAttribute(null);
+
+            // Should not throw - returns null safely
+            Assert.Null(attr.ResourceName);
+        }
+
+        [Fact]
+        public void ResourceName_WithEmptyBucket_DoesNotThrow()
+        {
+            var attr = new S3EventAttribute("");
+
+            // Should not throw - returns empty string
+            Assert.Equal("", attr.ResourceName);
+        }
+
+        // ===== Events Property Tests =====
+
+        [Fact]
+        public void Events_DefaultValue_IsObjectCreatedAll()
+        {
+            var attr = new S3EventAttribute("@MyBucket");
+
+            Assert.Equal("s3:ObjectCreated:*", attr.Events);
+            Assert.False(attr.IsEventsSet);
+        }
+
+        [Fact]
+        public void Events_WhenExplicitlySet_IsTracked()
+        {
+            var attr = new S3EventAttribute("@MyBucket")
+            {
+                Events = "s3:ObjectRemoved:*"
+            };
+
+            Assert.True(attr.IsEventsSet);
+            Assert.Equal("s3:ObjectRemoved:*", attr.Events);
+        }
+
+        [Fact]
+        public void Events_WhenSetToSameAsDefault_IsStillTrackedAsSet()
+        {
+            var attr = new S3EventAttribute("@MyBucket")
+            {
+                Events = "s3:ObjectCreated:*"
+            };
+
+            Assert.True(attr.IsEventsSet);
+            Assert.Equal("s3:ObjectCreated:*", attr.Events);
+        }
+
+        [Fact]
+        public void Events_MultipleSemicolonSeparated_WorksCorrectly()
+        {
+            var attr = new S3EventAttribute("@MyBucket")
+            {
+                Events = "s3:ObjectCreated:*;s3:ObjectRemoved:*"
+            };
+
+            var eventList = attr.Events.Split(';').Select(x => x.Trim()).ToList();
+            Assert.Equal(2, eventList.Count);
+            Assert.Contains("s3:ObjectCreated:*", eventList);
+            Assert.Contains("s3:ObjectRemoved:*", eventList);
+        }
+
+        // ===== Filter Properties Tests =====
+
+        [Fact]
+        public void FilterPrefix_WhenSet_IsTracked()
+        {
+            var attr = new S3EventAttribute("@MyBucket")
+            {
+                FilterPrefix = "uploads/"
+            };
+
+            Assert.True(attr.IsFilterPrefixSet);
+            Assert.Equal("uploads/", attr.FilterPrefix);
+        }
+
+        [Fact]
+        public void FilterSuffix_WhenSet_IsTracked()
+        {
+            var attr = new S3EventAttribute("@MyBucket")
+            {
+                FilterSuffix = ".jpg"
+            };
+
+            Assert.True(attr.IsFilterSuffixSet);
+            Assert.Equal(".jpg", attr.FilterSuffix);
+        }
+
+        [Fact]
+        public void Filters_BothSet_AreTrackedIndependently()
+        {
+            var attr = new S3EventAttribute("@MyBucket")
+            {
+                FilterPrefix = "data/",
+                FilterSuffix = ".csv"
+            };
+
+            Assert.True(attr.IsFilterPrefixSet);
+            Assert.True(attr.IsFilterSuffixSet);
+            Assert.Equal("data/", attr.FilterPrefix);
+            Assert.Equal(".csv", attr.FilterSuffix);
+        }
+
+        // ===== Enabled Property Tests =====
+
+        [Fact]
+        public void Enabled_DefaultValue_IsTrue()
+        {
+            var attr = new S3EventAttribute("@MyBucket");
+
+            Assert.True(attr.Enabled);
+            Assert.False(attr.IsEnabledSet);
+        }
+
+        [Fact]
+        public void Enabled_WhenSetToFalse_IsTracked()
+        {
+            var attr = new S3EventAttribute("@MyBucket")
+            {
+                Enabled = false
+            };
+
+            Assert.True(attr.IsEnabledSet);
+            Assert.False(attr.Enabled);
+        }
+
+        [Fact]
+        public void Enabled_WhenSetToTrue_IsTracked()
+        {
+            var attr = new S3EventAttribute("@MyBucket")
+            {
+                Enabled = true
+            };
+
+            Assert.True(attr.IsEnabledSet);
+            Assert.True(attr.Enabled);
+        }
+
+        // ===== Validation Tests =====
+
+        [Fact]
+        public void Validate_ValidBucketReference_ReturnsNoErrors()
+        {
+            var attr = new S3EventAttribute("@MyBucket");
+
+            var errors = attr.Validate();
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_NullBucket_ReturnsError()
+        {
+            var attr = new S3EventAttribute(null);
+
+            var errors = attr.Validate();
+            Assert.Single(errors);
+            Assert.Contains("Bucket", errors[0]);
+            Assert.Contains("required", errors[0]);
+        }
+
+        [Fact]
+        public void Validate_EmptyBucket_ReturnsError()
+        {
+            var attr = new S3EventAttribute("");
+
+            var errors = attr.Validate();
+            Assert.Single(errors);
+            Assert.Contains("Bucket", errors[0]);
+            Assert.Contains("required", errors[0]);
+        }
+
+        [Fact]
+        public void Validate_BucketWithoutAtPrefix_ReturnsError()
+        {
+            var attr = new S3EventAttribute("MyBucket");
+
+            var errors = attr.Validate();
+            Assert.Single(errors);
+            Assert.Contains("Bucket", errors[0]);
+            Assert.Contains("@", errors[0]);
+        }
+
+        [Fact]
+        public void Validate_BucketWithOnlyAtSign_ReturnsError()
+        {
+            var attr = new S3EventAttribute("@");
+
+            var errors = attr.Validate();
+            Assert.Single(errors);
+            Assert.Contains("Bucket", errors[0]);
+            Assert.Contains("must not be empty", errors[0]);
+        }
+
+        [Fact]
+        public void Validate_BucketWithInvalidCharsAfterAt_ReturnsError()
+        {
+            var attr = new S3EventAttribute("@My-Bucket!");
+
+            var errors = attr.Validate();
+            Assert.Single(errors);
+            Assert.Contains("Bucket", errors[0]);
+            Assert.Contains("alphanumeric", errors[0]);
+        }
+
+        [Fact]
+        public void Validate_InvalidResourceName_ReturnsError()
+        {
+            var attr = new S3EventAttribute("@MyBucket")
+            {
+                ResourceName = "invalid-name!"
+            };
+
+            var errors = attr.Validate();
+            Assert.Single(errors);
+            Assert.Contains("ResourceName", errors[0]);
+            Assert.Contains("alphanumeric", errors[0]);
+        }
+
+        [Fact]
+        public void Validate_EmptyResourceName_ReturnsError()
+        {
+            var attr = new S3EventAttribute("@MyBucket")
+            {
+                ResourceName = ""
+            };
+
+            var errors = attr.Validate();
+            Assert.Single(errors);
+            Assert.Contains("ResourceName", errors[0]);
+        }
+
+        [Fact]
+        public void Validate_ValidResourceName_ReturnsNoErrors()
+        {
+            var attr = new S3EventAttribute("@MyBucket")
+            {
+                ResourceName = "MyS3Event123"
+            };
+
+            var errors = attr.Validate();
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_UnsetResourceName_ReturnsNoErrors()
+        {
+            var attr = new S3EventAttribute("@MyBucket");
+
+            var errors = attr.Validate();
+            Assert.Empty(errors);
+            Assert.False(attr.IsResourceNameSet);
+        }
+
+        [Fact]
+        public void Validate_EmptyEvents_ReturnsError()
+        {
+            var attr = new S3EventAttribute("@MyBucket")
+            {
+                Events = ""
+            };
+
+            var errors = attr.Validate();
+            Assert.Single(errors);
+            Assert.Contains("Events", errors[0]);
+            Assert.Contains("must not be empty", errors[0]);
+        }
+
+        [Fact]
+        public void Validate_NullEvents_ReturnsError()
+        {
+            var attr = new S3EventAttribute("@MyBucket")
+            {
+                Events = null
+            };
+
+            // Events getter returns default when backing field is null, but the
+            // validation should check the actual state. With null set, Events returns
+            // the default "s3:ObjectCreated:*" so this should pass validation.
+            var errors = attr.Validate();
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_MultipleErrors_ReturnsAll()
+        {
+            var attr = new S3EventAttribute("")
+            {
+                ResourceName = "invalid-name!",
+                Events = ""
+            };
+
+            var errors = attr.Validate();
+            // Should have errors for: Bucket (empty), ResourceName (invalid), Events (empty)
+            Assert.Equal(3, errors.Count);
+            Assert.Contains(errors, e => e.Contains("Bucket"));
+            Assert.Contains(errors, e => e.Contains("ResourceName"));
+            Assert.Contains(errors, e => e.Contains("Events"));
+        }
+
+        [Fact]
+        public void Validate_AllValidWithOptionals_ReturnsNoErrors()
+        {
+            var attr = new S3EventAttribute("@MyBucket")
+            {
+                ResourceName = "FullS3Event",
+                Events = "s3:ObjectCreated:Put",
+                FilterPrefix = "data/",
+                FilterSuffix = ".csv",
+                Enabled = true
+            };
+
+            var errors = attr.Validate();
+            Assert.Empty(errors);
+        }
+
+        // ===== Events Semicolon Edge Cases =====
+
+        [Fact]
+        public void Events_TrailingSemicolon_SplitFiltersEmptyEntries()
+        {
+            // This tests that the CloudFormationWriter correctly filters empty entries
+            // when splitting Events by semicolon
+            var attr = new S3EventAttribute("@MyBucket")
+            {
+                Events = "s3:ObjectCreated:*;"
+            };
+
+            var eventList = attr.Events
+                .Split(';')
+                .Select(x => x.Trim())
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .ToList();
+
+            Assert.Single(eventList);
+            Assert.Equal("s3:ObjectCreated:*", eventList[0]);
+        }
+
+        [Fact]
+        public void Events_LeadingSemicolon_SplitFiltersEmptyEntries()
+        {
+            var attr = new S3EventAttribute("@MyBucket")
+            {
+                Events = ";s3:ObjectCreated:*"
+            };
+
+            var eventList = attr.Events
+                .Split(';')
+                .Select(x => x.Trim())
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .ToList();
+
+            Assert.Single(eventList);
+            Assert.Equal("s3:ObjectCreated:*", eventList[0]);
+        }
+
+        [Fact]
+        public void Events_ConsecutiveSemicolons_SplitFiltersEmptyEntries()
+        {
+            var attr = new S3EventAttribute("@MyBucket")
+            {
+                Events = "s3:ObjectCreated:*;;s3:ObjectRemoved:*"
+            };
+
+            var eventList = attr.Events
+                .Split(';')
+                .Select(x => x.Trim())
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .ToList();
+
+            Assert.Equal(2, eventList.Count);
+            Assert.Equal("s3:ObjectCreated:*", eventList[0]);
+            Assert.Equal("s3:ObjectRemoved:*", eventList[1]);
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/S3EventsTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/S3EventsTests.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using Amazon.Lambda.Annotations.SourceGenerator;
 using Amazon.Lambda.Annotations.SourceGenerator.Models;
 using Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes;

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/S3EventsTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/WriterTests/S3EventsTests.cs
@@ -1,0 +1,165 @@
+using Amazon.Lambda.Annotations.SourceGenerator;
+using Amazon.Lambda.Annotations.SourceGenerator.Models;
+using Amazon.Lambda.Annotations.SourceGenerator.Models.Attributes;
+using Amazon.Lambda.Annotations.SourceGenerator.Writers;
+using Amazon.Lambda.Annotations.S3;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Amazon.Lambda.Annotations.SourceGenerators.Tests.WriterTests
+{
+    public partial class CloudFormationWriterTests
+    {
+        [Theory]
+        [ClassData(typeof(S3EventsTestData))]
+        public void VerifyS3EventAttributes_AreCorrectlyApplied(CloudFormationTemplateFormat templateFormat, S3EventAttribute s3EventAttribute)
+        {
+            // ARRANGE
+            var mockFileManager = GetMockFileManager(string.Empty);
+            var lambdaFunctionModel = GetLambdaFunctionModel();
+            lambdaFunctionModel.PackageType = LambdaPackageType.Zip;
+            lambdaFunctionModel.Attributes.Add(new AttributeModel<S3EventAttribute> { Data = s3EventAttribute });
+            var cloudFormationWriter = GetCloudFormationWriter(mockFileManager, _directoryManager, templateFormat, _diagnosticReporter);
+            var report = GetAnnotationReport([lambdaFunctionModel]);
+
+            // ACT
+            cloudFormationWriter.ApplyReport(report);
+
+            // ASSERT
+            ITemplateWriter templateWriter = templateFormat == CloudFormationTemplateFormat.Json ? new JsonWriter() : new YamlWriter();
+            templateWriter.Parse(mockFileManager.ReadAllText(ServerlessTemplateFilePath));
+
+            var eventName = s3EventAttribute.ResourceName;
+            var eventPath = $"Resources.{lambdaFunctionModel.ResourceName}.Properties.Events.{eventName}";
+            var eventPropertiesPath = $"{eventPath}.Properties";
+
+            Assert.True(templateWriter.Exists(eventPath));
+            Assert.Equal("S3", templateWriter.GetToken<string>($"{eventPath}.Type"));
+
+            // Bucket is always a Ref
+            var bucketName = s3EventAttribute.Bucket.StartsWith("@") ? s3EventAttribute.Bucket.Substring(1) : s3EventAttribute.Bucket;
+            Assert.Equal(bucketName, templateWriter.GetToken<string>($"{eventPropertiesPath}.Bucket.Ref"));
+
+            // Events - always written (uses default "s3:ObjectCreated:*" when not explicitly set)
+            {
+                var expectedEvents = s3EventAttribute.Events.Split(';').Select(x => x.Trim()).Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
+                Assert.Equal(expectedEvents, templateWriter.GetToken<List<string>>($"{eventPropertiesPath}.Events"));
+            }
+
+            // Filter
+            if (s3EventAttribute.IsFilterPrefixSet || s3EventAttribute.IsFilterSuffixSet)
+            {
+                Assert.True(templateWriter.Exists($"{eventPropertiesPath}.Filter.S3Key.Rules"));
+                var rules = templateWriter.GetToken<List<Dictionary<string, string>>>($"{eventPropertiesPath}.Filter.S3Key.Rules");
+                if (s3EventAttribute.IsFilterPrefixSet)
+                {
+                    Assert.Contains(rules, r => r["Name"] == "prefix" && r["Value"] == s3EventAttribute.FilterPrefix);
+                }
+                if (s3EventAttribute.IsFilterSuffixSet)
+                {
+                    Assert.Contains(rules, r => r["Name"] == "suffix" && r["Value"] == s3EventAttribute.FilterSuffix);
+                }
+            }
+            else
+            {
+                Assert.False(templateWriter.Exists($"{eventPropertiesPath}.Filter"));
+            }
+
+            // Enabled
+            Assert.Equal(s3EventAttribute.IsEnabledSet, templateWriter.Exists($"{eventPropertiesPath}.Enabled"));
+            if (s3EventAttribute.IsEnabledSet)
+            {
+                Assert.Equal(s3EventAttribute.Enabled, templateWriter.GetToken<bool>($"{eventPropertiesPath}.Enabled"));
+            }
+        }
+
+        [Theory]
+        [InlineData(CloudFormationTemplateFormat.Json)]
+        [InlineData(CloudFormationTemplateFormat.Yaml)]
+        public void VerifyS3EventProperties_AreSyncedCorrectly(CloudFormationTemplateFormat templateFormat)
+        {
+            // ARRANGE
+            var mockFileManager = GetMockFileManager(string.Empty);
+            var lambdaFunctionModel = GetLambdaFunctionModel();
+            lambdaFunctionModel.PackageType = LambdaPackageType.Zip;
+            var eventResourceName = "MyBucket";
+            var eventPropertiesPath = $"Resources.{lambdaFunctionModel.ResourceName}.Properties.Events.{eventResourceName}.Properties";
+            var syncedEventPropertiesPath = $"Resources.{lambdaFunctionModel.ResourceName}.Metadata.SyncedEventProperties";
+
+            // Initial attribute with filters
+            var initialAttribute = new S3EventAttribute("@MyBucket")
+            {
+                FilterPrefix = "uploads/",
+                FilterSuffix = ".jpg"
+            };
+            lambdaFunctionModel.Attributes = [new AttributeModel<S3EventAttribute> { Data = initialAttribute }];
+            var cloudFormationWriter = GetCloudFormationWriter(mockFileManager, _directoryManager, templateFormat, _diagnosticReporter);
+            var report = GetAnnotationReport([lambdaFunctionModel]);
+
+            // ACT
+            cloudFormationWriter.ApplyReport(report);
+
+            // Assert initial properties
+            ITemplateWriter templateWriter = templateFormat == CloudFormationTemplateFormat.Json ? new JsonWriter() : new YamlWriter();
+            templateWriter.Parse(mockFileManager.ReadAllText(ServerlessTemplateFilePath));
+
+            Assert.Equal("MyBucket", templateWriter.GetToken<string>($"{eventPropertiesPath}.Bucket.Ref"));
+            Assert.True(templateWriter.Exists($"{eventPropertiesPath}.Filter.S3Key.Rules"));
+            Assert.True(templateWriter.Exists($"{eventPropertiesPath}.Events"));
+
+            // Update attribute - remove filters, add Enabled=false
+            var updatedAttribute = new S3EventAttribute("@MyBucket")
+            {
+                Enabled = false
+            };
+            lambdaFunctionModel.Attributes = [new AttributeModel<S3EventAttribute> { Data = updatedAttribute }];
+            report = GetAnnotationReport([lambdaFunctionModel]);
+
+            cloudFormationWriter.ApplyReport(report);
+
+            // Assert updated properties
+            templateWriter.Parse(mockFileManager.ReadAllText(ServerlessTemplateFilePath));
+            Assert.Equal("MyBucket", templateWriter.GetToken<string>($"{eventPropertiesPath}.Bucket.Ref"));
+            Assert.False(templateWriter.Exists($"{eventPropertiesPath}.Filter"));
+            Assert.False(templateWriter.GetToken<bool>($"{eventPropertiesPath}.Enabled"));
+        }
+
+        public class S3EventsTestData : TheoryData<CloudFormationTemplateFormat, S3EventAttribute>
+        {
+            public S3EventsTestData()
+            {
+                foreach (var templateFormat in new List<CloudFormationTemplateFormat> { CloudFormationTemplateFormat.Json, CloudFormationTemplateFormat.Yaml })
+                {
+                    // Simple - default events
+                    Add(templateFormat, new S3EventAttribute("@MyBucket"));
+
+                    // With custom events
+                    Add(templateFormat, new S3EventAttribute("@MyBucket") { Events = "s3:ObjectCreated:*;s3:ObjectRemoved:*" });
+
+                    // With filters
+                    Add(templateFormat, new S3EventAttribute("@MyBucket") { FilterPrefix = "uploads/", FilterSuffix = ".jpg" });
+
+                    // With prefix only
+                    Add(templateFormat, new S3EventAttribute("@MyBucket") { FilterPrefix = "logs/" });
+
+                    // With suffix only
+                    Add(templateFormat, new S3EventAttribute("@MyBucket") { FilterSuffix = ".png" });
+
+                    // With custom resource name and disabled
+                    Add(templateFormat, new S3EventAttribute("@ImageBucket") { ResourceName = "ImageBucketEvent", Enabled = false });
+
+                    // All properties
+                    Add(templateFormat, new S3EventAttribute("@MyBucket")
+                    {
+                        ResourceName = "FullS3Event",
+                        Events = "s3:ObjectCreated:Put",
+                        FilterPrefix = "data/",
+                        FilterSuffix = ".csv",
+                        Enabled = true
+                    });
+                }
+            }
+        }
+    }
+}

--- a/Libraries/test/IntegrationTests.Helpers/S3Helper.cs
+++ b/Libraries/test/IntegrationTests.Helpers/S3Helper.cs
@@ -33,5 +33,13 @@ namespace IntegrationTests.Helpers
             var response = await _s3Client.ListBucketsAsync(new ListBucketsRequest());
             return response.Buckets.Any(x => x.BucketName.Equals(bucketName));
         }
+
+        public async Task<GetBucketNotificationResponse> GetBucketNotificationAsync(string bucketName)
+        {
+            return await _s3Client.GetBucketNotificationAsync(new GetBucketNotificationRequest
+            {
+                BucketName = bucketName
+            });
+        }
     }
 }

--- a/Libraries/test/TestServerlessApp.IntegrationTests/DeploymentScript.ps1
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/DeploymentScript.ps1
@@ -68,6 +68,15 @@ try
         Write-Host "Added TestQueue resource to serverless.template"
     }
 
+    # Add TestS3Bucket resource to serverless.template for S3 event integration testing
+    # The source generator creates a Ref to TestS3Bucket but doesn't define the resource itself
+    $template = Get-Content $templatePath | Out-String | ConvertFrom-Json
+    if (-not $template.Resources.PSObject.Properties['TestS3Bucket']) {
+        $template.Resources | Add-Member -NotePropertyName "TestS3Bucket" -NotePropertyValue @{ Type = "AWS::S3::Bucket" } -Force
+        $template | ConvertTo-Json -Depth 100 | Set-Content $templatePath
+        Write-Host "Added TestS3Bucket resource to serverless.template"
+    }
+
     dotnet restore
     Write-Host "Creating CloudFormation Stack $identifier, Architecture $arch, Runtime $runtime"
     dotnet lambda deploy-serverless --template-parameters "ArchitectureTypeParameter=$arch"

--- a/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixture.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixture.cs
@@ -25,17 +25,20 @@ namespace TestServerlessApp.IntegrationTests
 
         public readonly LambdaHelper LambdaHelper;
         public readonly CloudWatchHelper CloudWatchHelper;
+        public readonly S3Helper S3HelperInstance;
         public readonly HttpClient HttpClient;
 
         public string RestApiUrlPrefix;
         public string HttpApiUrlPrefix;
         public string TestQueueARN;
+        public string TestS3BucketName;
         public List<LambdaFunction> LambdaFunctions;
 
         public IntegrationTestContextFixture()
         {
             _cloudFormationHelper = new CloudFormationHelper(new AmazonCloudFormationClient(Amazon.RegionEndpoint.USWest2));
             _s3Helper = new S3Helper(new AmazonS3Client(Amazon.RegionEndpoint.USWest2));
+            S3HelperInstance = _s3Helper;
             LambdaHelper = new LambdaHelper(new AmazonLambdaClient(Amazon.RegionEndpoint.USWest2));
             CloudWatchHelper = new CloudWatchHelper(new AmazonCloudWatchLogsClient(Amazon.RegionEndpoint.USWest2));
             HttpClient = new HttpClient();
@@ -77,11 +80,17 @@ namespace TestServerlessApp.IntegrationTests
             Console.WriteLine($"[IntegrationTest] TestQueue URL: {queueUrl}");
             Assert.False(string.IsNullOrEmpty(queueUrl), $"CloudFormation resource 'TestQueue' was not found in stack '{_stackName}'.");
             TestQueueARN = ConvertSqsUrlToArn(queueUrl);
+
+            // Get the S3 bucket name from the physical resource ID
+            TestS3BucketName = await _cloudFormationHelper.GetResourcePhysicalIdAsync(_stackName, "TestS3Bucket");
+            Console.WriteLine($"[IntegrationTest] TestS3Bucket: {TestS3BucketName}");
+            Assert.False(string.IsNullOrEmpty(TestS3BucketName), $"CloudFormation resource 'TestS3Bucket' was not found in stack '{_stackName}'.");
+
             LambdaFunctions = await LambdaHelper.FilterByCloudFormationStackAsync(_stackName);
             Console.WriteLine($"[IntegrationTest] Found {LambdaFunctions.Count} Lambda functions: {string.Join(", ", LambdaFunctions.Select(f => f.Name ?? "(null)"))}");
 
             Assert.True(await _s3Helper.BucketExistsAsync(_bucketName), $"S3 bucket {_bucketName} should exist");
-            Assert.Equal(36, LambdaFunctions.Count);
+            Assert.Equal(37, LambdaFunctions.Count);
             Assert.False(string.IsNullOrEmpty(RestApiUrlPrefix), "RestApiUrlPrefix should not be empty");
             Assert.False(string.IsNullOrEmpty(HttpApiUrlPrefix), "HttpApiUrlPrefix should not be empty");
 

--- a/Libraries/test/TestServerlessApp.IntegrationTests/S3EventNotification.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/S3EventNotification.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.S3;
+using Xunit;
+
+namespace TestServerlessApp.IntegrationTests
+{
+    [Collection("Integration Tests")]
+    public class S3EventNotification
+    {
+        private readonly IntegrationTestContextFixture _fixture;
+
+        public S3EventNotification(IntegrationTestContextFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task VerifyS3EventNotificationConfiguration()
+        {
+            // Verify the Lambda function exists in the stack
+            var lambdaFunction = _fixture.LambdaFunctions
+                .FirstOrDefault(x => string.Equals(x.LogicalId, "S3EventHandler"));
+            Assert.NotNull(lambdaFunction);
+            Assert.NotNull(lambdaFunction.Name);
+
+            // Verify S3 bucket notification is configured correctly
+            var notificationConfig = await _fixture.S3HelperInstance
+                .GetBucketNotificationAsync(_fixture.TestS3BucketName);
+
+            var lambdaConfigs = notificationConfig.LambdaFunctionConfigurations;
+            Assert.Single(lambdaConfigs);
+
+            var config = lambdaConfigs.First();
+
+            // Verify the notification points to the correct Lambda function ARN
+            Assert.Contains(lambdaFunction.Name, config.FunctionArn);
+
+            // Verify the event type is s3:ObjectCreated:*
+            Assert.Single(config.Events);
+            Assert.Equal(EventType.ObjectCreatedAll, config.Events.First());
+
+            // Verify the suffix filter is .json
+            var filterRules = config.Filter.S3KeyFilter.FilterRules;
+            Assert.Single(filterRules);
+            var suffixRule = filterRules.First(r => string.Equals(r.Name, "suffix", System.StringComparison.OrdinalIgnoreCase));
+            Assert.Equal(".json", suffixRule.Value);
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp.IntegrationTests/S3EventNotification.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/S3EventNotification.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Linq;
 using System.Threading.Tasks;
 using Amazon.S3;

--- a/Libraries/test/TestServerlessApp/S3EventExamples/S3EventProcessing.cs
+++ b/Libraries/test/TestServerlessApp/S3EventExamples/S3EventProcessing.cs
@@ -1,0 +1,18 @@
+using Amazon.Lambda.Annotations;
+using Amazon.Lambda.Annotations.S3;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.S3Events;
+using System;
+
+namespace TestServerlessApp.S3EventExamples
+{
+    public class S3EventProcessing
+    {
+        [LambdaFunction(ResourceName = "S3EventHandler", Policies = "AWSLambdaBasicExecutionRole,AmazonS3ReadOnlyAccess", PackageType = LambdaPackageType.Image)]
+        [S3Event("@TestS3Bucket", Events = "s3:ObjectCreated:*", FilterSuffix = ".json")]
+        public void ProcessS3Event(S3Event evnt)
+        {
+            Console.WriteLine($"Received S3 event with {evnt.Records.Count} records");
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp/S3EventExamples/S3EventProcessing.cs
+++ b/Libraries/test/TestServerlessApp/S3EventExamples/S3EventProcessing.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using Amazon.Lambda.Annotations;
 using Amazon.Lambda.Annotations.S3;
 using Amazon.Lambda.Core;

--- a/Libraries/test/TestServerlessApp/S3EventExamples/ValidS3Events.cs.txt
+++ b/Libraries/test/TestServerlessApp/S3EventExamples/ValidS3Events.cs.txt
@@ -1,0 +1,35 @@
+using Amazon.Lambda.Annotations;
+using Amazon.Lambda.Annotations.S3;
+using Amazon.Lambda.S3Events;
+using System;
+using System.Threading.Tasks;
+
+namespace TestServerlessApp.S3EventExamples
+{
+    // This file represents valid usage of the S3EventAttribute. This is added as .txt file since we do not want to deploy these functions during our integration tests.
+    // This file is only sent as input to the source generator unit tests.
+
+    public class ValidS3Events
+    {
+        [LambdaFunction(PackageType = LambdaPackageType.Image)]
+        [S3Event("@MyBucket")]
+        public void ProcessS3Event(S3Event evnt)
+        {
+            Console.WriteLine($"Event processed: {evnt}");
+        }
+
+        [LambdaFunction(PackageType = LambdaPackageType.Image)]
+        [S3Event("@MyBucket", Events = "s3:ObjectCreated:*;s3:ObjectRemoved:*", FilterPrefix = "uploads/", FilterSuffix = ".jpg")]
+        public async Task ProcessS3EventWithFilters(S3Event evnt)
+        {
+            await Console.Out.WriteLineAsync($"Event processed: {evnt}");
+        }
+
+        [LambdaFunction(PackageType = LambdaPackageType.Image)]
+        [S3Event("@ImageBucket", ResourceName = "ImageBucketEvent", Enabled = false)]
+        public void ProcessS3EventDisabled(S3Event evnt)
+        {
+            Console.WriteLine($"Event processed: {evnt}");
+        }
+    }
+}

--- a/Libraries/test/TestServerlessApp/S3EventExamples/ValidS3Events.cs.txt
+++ b/Libraries/test/TestServerlessApp/S3EventExamples/ValidS3Events.cs.txt
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using Amazon.Lambda.Annotations;
 using Amazon.Lambda.Annotations.S3;
 using Amazon.Lambda.S3Events;

--- a/Libraries/test/TestServerlessApp/TestServerlessApp.csproj
+++ b/Libraries/test/TestServerlessApp/TestServerlessApp.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\..\src\Amazon.Lambda.Annotations\Amazon.Lambda.Annotations.csproj" />
     <ProjectReference Include="..\..\src\Amazon.Lambda.APIGatewayEvents\Amazon.Lambda.APIGatewayEvents.csproj" />
     <ProjectReference Include="..\..\src\Amazon.Lambda.SQSEvents\Amazon.Lambda.SQSEvents.csproj" />
+    <ProjectReference Include="..\..\src\Amazon.Lambda.S3Events\Amazon.Lambda.S3Events.csproj" />
     <ProjectReference Include="..\..\src\Amazon.Lambda.Core\Amazon.Lambda.Core.csproj" />
     <ProjectReference Include="..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
   </ItemGroup>

--- a/Libraries/test/TestServerlessApp/serverless.template
+++ b/Libraries/test/TestServerlessApp/serverless.template
@@ -1339,6 +1339,63 @@
           ]
         }
       }
+    },
+    "S3EventHandler": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedEvents": [
+          "TestS3Bucket"
+        ],
+        "SyncedEventProperties": {
+          "TestS3Bucket": [
+            "Bucket.Ref",
+            "Events",
+            "Filter.S3Key.Rules"
+          ]
+        }
+      },
+      "Properties": {
+        "MemorySize": 512,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole",
+          "AmazonS3ReadOnlyAccess"
+        ],
+        "PackageType": "Image",
+        "ImageUri": ".",
+        "ImageConfig": {
+          "Command": [
+            "TestServerlessApp::TestServerlessApp.S3EventExamples.S3EventProcessing_ProcessS3Event_Generated::ProcessS3Event"
+          ]
+        },
+        "Events": {
+          "TestS3Bucket": {
+            "Type": "S3",
+            "Properties": {
+              "Events": [
+                "s3:ObjectCreated:*"
+              ],
+              "Filter": {
+                "S3Key": {
+                  "Rules": [
+                    {
+                      "Name": "suffix",
+                      "Value": ".json"
+                    }
+                  ]
+                }
+              },
+              "Bucket": {
+                "Ref": "TestS3Bucket"
+              }
+            }
+          }
+        }
+      }
+    },
+    "TestS3Bucket": {
+      "Type": "AWS::S3::Bucket"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds `[S3Event]` annotation attribute support to the Lambda Annotations framework, enabling developers to declaratively configure S3 event-triggered Lambda functions directly in C# code. The source generator automatically produces the corresponding SAM/CloudFormation template configuration at build time.

## User Experience

With this change, developers can write S3-triggered Lambda functions like this:

```csharp
[LambdaFunction]
[S3Event("@MyBucket", FilterSuffix = ".jpg")]
public async Task ProcessImage(S3Event evnt)
{
    // Handle uploaded images
}
```

The source generator will automatically generate the SAM template entry:

```yaml
ProcessImage:
  Type: AWS::Serverless::Function
  Properties:
    Events:
      MyBucket:
        Type: S3
        Properties:
          Bucket: !Ref MyBucket
          Events:
            - s3:ObjectCreated:*
          Filter:
            S3Key:
              Rules:
                - Name: suffix
                  Value: .jpg
```

### Attribute Properties

| Property | Required | Description | Default |
|----------|----------|-------------|---------|
| `Bucket` | Yes | S3 bucket reference (must start with `@` to reference a CloudFormation resource) | - |
| `ResourceName` | No | CloudFormation event resource name | Derived from bucket name |
| `Events` | No | Semicolon-separated S3 event types | `s3:ObjectCreated:*` |
| `FilterPrefix` | No | S3 key prefix filter (e.g., `uploads/`) | Not set |
| `FilterSuffix` | No | S3 key suffix filter (e.g., `.jpg`) | Not set |
| `Enabled` | No | Whether the event source is enabled | `true` |

### Compile-Time Validation

The source generator validates at build time:
- **Bucket reference**: Must start with `@` (referencing a CloudFormation resource)
- **Method signature**: First parameter must be `S3Event`, optional second parameter must be `ILambdaContext`
- **Return type**: Must be `void` or `Task` (S3 notifications are fire-and-forget)
- **Dependencies**: Project must reference `Amazon.Lambda.S3Events` NuGet package
- **Resource name**: Must be alphanumeric if explicitly set

### Example with all properties

```csharp
[LambdaFunction]
[S3Event("@MyBucket",
    ResourceName = "ImageUploadEvent",
    Events = "s3:ObjectCreated:Put;s3:ObjectRemoved:*",
    FilterPrefix = "uploads/",
    FilterSuffix = ".csv",
    Enabled = true)]
public async Task ProcessUpload(S3Event evnt, ILambdaContext context)
{
    context.Logger.LogLine($"Processing {evnt.Records.Count} records");
}
```

## What Changed

### Annotation Attribute (`Amazon.Lambda.Annotations`)
- New `S3EventAttribute` class in `Amazon.Lambda.Annotations.S3` namespace with configurable properties and built-in validation

### Source Generator (`Amazon.Lambda.Annotations.SourceGenerator`)
- `S3EventAttributeBuilder` — extracts attribute data from Roslyn syntax tree
- `AttributeModelBuilder` — recognizes and routes S3Event attributes
- `EventTypeBuilder` — maps to `EventType.S3`
- `SyntaxReceiver` — registers S3Event as a recognized attribute
- `TypeFullNames` — adds S3 type constants
- `LambdaFunctionValidator` — validates method signatures, return types, dependencies, and attribute properties
- `CloudFormationWriter.ProcessS3Attribute()` — generates SAM template with Bucket (Ref), Events (list), Filter (S3Key rules), and Enabled
- New diagnostic `AWSLambda0133` for invalid S3EventAttribute errors

### Tests
- Unit tests covering 7 attribute configurations × 2 template formats (JSON/YAML) = 14 test cases
- Synced property tests verifying template updates when attributes change
- Integration test deploying a real S3-triggered Lambda and verifying bucket notification configuration

Related: DOTNET-8572
