### PR TITLE
chore: improve test flakiness

### DIFF
--- a/.autover/changes/9cf844c3-1a90-46ec-9430-93724dcb4512.json
+++ b/.autover/changes/9cf844c3-1a90-46ec-9430-93724dcb4512.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.TestTool.BlazorTester",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Minor fixes and improvements"
+      ]
+    }
+  ]
+}

--- a/.autover/changes/9cf844c3-1a90-46ec-9430-93724dcb4512.json
+++ b/.autover/changes/9cf844c3-1a90-46ec-9430-93724dcb4512.json
@@ -4,7 +4,7 @@
       "Name": "Amazon.Lambda.TestTool.BlazorTester",
       "Type": "Patch",
       "ChangelogMessages": [
-        "Minor fixes and improvements"
+        "Minor fixes to improve the testability of the package"
       ]
     }
   ]

--- a/.autover/changes/a119819e-ba57-424d-a0be-d941eea599f9.json
+++ b/.autover/changes/a119819e-ba57-424d-a0be-d941eea599f9.json
@@ -4,7 +4,7 @@
       "Name": "Amazon.Lambda.RuntimeSupport",
       "Type": "Patch",
       "ChangelogMessages": [
-        "Minor fixes and improvements"
+        "Minor fixes to improve the testability of the package"
       ]
     }
   ]

--- a/.autover/changes/a119819e-ba57-424d-a0be-d941eea599f9.json
+++ b/.autover/changes/a119819e-ba57-424d-a0be-d941eea599f9.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.RuntimeSupport",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Minor fixes and improvements"
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/ConsoleLoggerWriter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/ConsoleLoggerWriter.cs
@@ -227,6 +227,7 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
         /// <param name="stdErrorWriter"></param>
         public LogLevelLoggerWriter(TextWriter stdOutWriter, TextWriter stdErrorWriter)
         {
+            _environmentVariables = new SystemEnvironmentVariables();
             Initialize(stdOutWriter, stdErrorWriter);
         }
 
@@ -325,7 +326,7 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
             {
                 get
                 {
-                    if (Utils.IsUsingMultiConcurrency(_environmentVariables))
+                    if (_currentRuntimeApiHeadersStorage != null && Utils.IsUsingMultiConcurrency(_environmentVariables))
                     {
                         return _currentRuntimeApiHeadersStorage.Value;
                     }
@@ -333,7 +334,7 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers
                 }
                 set
                 {
-                    if (Utils.IsUsingMultiConcurrency(_environmentVariables))
+                    if (_currentRuntimeApiHeadersStorage != null && Utils.IsUsingMultiConcurrency(_environmentVariables))
                     {
                         _currentRuntimeApiHeadersStorage.Value = value;
                     }

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/HandlerTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/HandlerTests.cs
@@ -250,7 +250,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             var userCodeLoader = new UserCodeLoader(new SystemEnvironmentVariables(), handler, _internalLogger);
             var initializer = new UserCodeInitializer(userCodeLoader, _internalLogger);
             var handlerWrapper = HandlerWrapper.GetHandlerWrapper(userCodeLoader.Invoke);
-            var bootstrap = new LambdaBootstrap(handlerWrapper, initializer.InitializeAsync)
+            var bootstrap = new LambdaBootstrap(handlerWrapper.Handler, initializer.InitializeAsync, null, _environmentVariables)
             {
                 Client = testRuntimeApiClient
             };
@@ -388,7 +388,9 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 var userCodeLoader = new UserCodeLoader(new SystemEnvironmentVariables(), handler, _internalLogger);
                 var handlerWrapper = HandlerWrapper.GetHandlerWrapper(userCodeLoader.Invoke);
                 var initializer = new UserCodeInitializer(userCodeLoader, _internalLogger);
-                var bootstrap = new LambdaBootstrap(handlerWrapper, initializer.InitializeAsync)
+                // Pass null initializer to bootstrap so RunAsync won't re-invoke Init(),
+                // which would re-register AssemblyLoad event handlers and re-construct the invoke delegate.
+                var bootstrap = new LambdaBootstrap(handlerWrapper.Handler, null, null, _environmentVariables)
                 {
                     Client = testRuntimeApiClient
                 };
@@ -403,7 +405,13 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                     Assert.DoesNotContain($"^^[{assertLoggedByInitialize}]^^", actionWriter.ToString());
                 }
 
-                await bootstrap.InitializeAsync();
+                await initializer.InitializeAsync();
+
+                // Re-set logging actions after initialization in case Init's AssemblyLoad event
+                // handler overwrote them when loading Amazon.Lambda.Core as a handler dependency.
+                UserCodeLoader.SetCustomerLoggerLogAction(assembly, actionWriter.ToLoggingAction(), _internalLogger);
+                UserCodeLoader.SetCustomerLoggerLogAction(assembly, actionWriter.ToLoggingWithLevelAction(), _internalLogger);
+                UserCodeLoader.SetCustomerLoggerLogAction(assembly, actionWriter.ToLoggingWithLevelAndExceptionAction(), _internalLogger);
 
                 if (assertLoggedByInitialize != null)
                 {

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaBootstrapTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaBootstrapTests.cs
@@ -165,7 +165,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
         [Fact]
         public async Task HandlerThrowsException()
         {
-            using (var bootstrap = new LambdaBootstrap(_testFunction.BaseHandlerThrowsAsync, null))
+            using (var bootstrap = new LambdaBootstrap(_testFunction.BaseHandlerThrowsAsync, null, null, _environmentVariables))
             {
                 bootstrap.Client = _testRuntimeApiClient;
                 Assert.Null(_environmentVariables.GetEnvironmentVariable(LambdaEnvironment.EnvVarTraceId));
@@ -183,7 +183,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
         {
             const string testInput = "a MiXeD cAsE sTrInG";
 
-            using (var bootstrap = new LambdaBootstrap(_testFunction.BaseHandlerToUpperAsync, null))
+            using (var bootstrap = new LambdaBootstrap(_testFunction.BaseHandlerToUpperAsync, null, null, _environmentVariables))
             {
                 _testRuntimeApiClient.FunctionInput = Encoding.UTF8.GetBytes(testInput);
                 bootstrap.Client = _testRuntimeApiClient;
@@ -201,7 +201,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
         [Fact]
         public async Task HandlerReturnsNull()
         {
-            using (var bootstrap = new LambdaBootstrap(_testFunction.BaseHandlerReturnsNullAsync, null))
+            using (var bootstrap = new LambdaBootstrap(_testFunction.BaseHandlerReturnsNullAsync, null, null, _environmentVariables))
             {
                 _testRuntimeApiClient.FunctionInput = new byte[0];
                 bootstrap.Client = _testRuntimeApiClient;

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/BaseApiGatewayTest.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/BaseApiGatewayTest.cs
@@ -48,6 +48,7 @@ public abstract class BaseApiGatewayTest
             CancellationTokenSource.Dispose();
             CancellationTokenSource = new CancellationTokenSource();
         }
+        Environment.SetEnvironmentVariable("APIGATEWAY_EMULATOR_ROUTE_CONFIG", null);
     }
 
     protected async Task StartTestToolProcessAsync(ApiGatewayEmulatorMode apiGatewayMode, string routeName, int lambdaPort, int apiGatewayPort, CancellationTokenSource cancellationTokenSource, string httpMethod = "POST")

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/SQSEventSourceTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/SQSEventSourceTests.cs
@@ -183,7 +183,7 @@ public class SQSEventSourceTests : BaseApiGatewayTest
             await sqsClient.SendMessageAsync(queueUrl2, "MessageFromQueue2");
 
             var startTime = DateTime.UtcNow;
-            while (listOfProcessedMessages.Count == 0 && DateTime.UtcNow < startTime.AddMinutes(2))
+            while (listOfProcessedMessages.Count < 2 && DateTime.UtcNow < startTime.AddMinutes(2))
             {
                 Assert.False(lambdaTask.IsFaulted, "Lambda function failed: " + lambdaTask.Exception?.ToString());
                 await Task.Delay(500);

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.Tests.Common/Helpers/TestHelpers.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.Tests.Common/Helpers/TestHelpers.cs
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Net;
+using System.Net.Sockets;
+
 namespace Amazon.Lambda.TestTool.Tests.Common.Helpers;
 
 public static class TestHelpers
@@ -39,16 +42,22 @@ public static class TestHelpers
         }
     }
 
-    private static int _maxLambdaRuntimePort = 6000;
-    private static int _maxApiGatewayPort = 9000;
+    private static int GetFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
 
     public static int GetNextLambdaRuntimePort()
     {
-        return Interlocked.Increment(ref _maxLambdaRuntimePort);
+        return GetFreePort();
     }
 
     public static int GetNextApiGatewayPort()
     {
-        return Interlocked.Increment(ref _maxApiGatewayPort);
+        return GetFreePort();
     }
 }

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/RuntimeApiTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/RuntimeApiTests.cs
@@ -39,6 +39,8 @@ public class RuntimeApiTests(ITestOutputHelper testOutputHelper)
         var testToolProcess = TestToolProcess.Startup(options, cancellationTokenSource.Token);
         try
         {
+            Assert.True(await TestHelpers.WaitForApiToStartAsync($"{testToolProcess.ServiceUrl}/lambda-runtime-api/healthcheck"));
+
             var lambdaClient = ConstructLambdaServiceClient(testToolProcess.ServiceUrl);
             var invokeFunction = new InvokeRequest
             {
@@ -92,6 +94,8 @@ public class RuntimeApiTests(ITestOutputHelper testOutputHelper)
         var testToolProcess = TestToolProcess.Startup(options, cancellationTokenSource.Token);
         try
         {
+            Assert.True(await TestHelpers.WaitForApiToStartAsync($"{testToolProcess.ServiceUrl}/lambda-runtime-api/healthcheck"));
+
             var handler = (string input, ILambdaContext context) =>
             {
                 Thread.Sleep(1000); // Add a sleep to prove the LambdaRuntimeApi waited for the completion.

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/TestToolStartup.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/TestToolStartup.cs
@@ -10,7 +10,6 @@ namespace Amazon.Lambda.TestTool
 {
     public class TestToolStartup
     {
-        private static bool shouldDisableLogs;
 
         public class RunConfiguration
         {
@@ -37,7 +36,7 @@ namespace Amazon.Lambda.TestTool
             try
             {
                 var commandOptions = CommandLineOptions.Parse(args);
-                shouldDisableLogs = Utils.ShouldDisableLogs(commandOptions);
+                var shouldDisableLogs = Utils.ShouldDisableLogs(commandOptions);
 
                 if (!shouldDisableLogs) Utils.PrintToolTitle(productName);
 
@@ -76,7 +75,7 @@ namespace Amazon.Lambda.TestTool
 
                 if (commandOptions.NoUI)
                 {
-                    ExecuteWithNoUi(localLambdaOptions, commandOptions, lambdaAssemblyDirectory, runConfiguration);
+                    ExecuteWithNoUi(localLambdaOptions, commandOptions, lambdaAssemblyDirectory, runConfiguration, shouldDisableLogs);
                 }
                 else
                 {
@@ -118,16 +117,16 @@ namespace Amazon.Lambda.TestTool
         }
 
 
-        public static void ExecuteWithNoUi(LocalLambdaOptions localLambdaOptions, CommandLineOptions commandOptions, string lambdaAssemblyDirectory, RunConfiguration runConfiguration)
+        public static void ExecuteWithNoUi(LocalLambdaOptions localLambdaOptions, CommandLineOptions commandOptions, string lambdaAssemblyDirectory, RunConfiguration runConfiguration, bool shouldDisableLogs)
         {
             if (!shouldDisableLogs) runConfiguration.OutputWriter.WriteLine("Executing Lambda function without web interface");
             var lambdaProjectDirectory = Utils.FindLambdaProjectDirectory(lambdaAssemblyDirectory);
 
-            string configFile = DetermineConfigFile(commandOptions, lambdaAssemblyDirectory: lambdaAssemblyDirectory, lambdaProjectDirectory: lambdaProjectDirectory);
-            LambdaConfigInfo configInfo = LoadLambdaConfigInfo(configFile, commandOptions, lambdaAssemblyDirectory: lambdaAssemblyDirectory, lambdaProjectDirectory: lambdaProjectDirectory, runConfiguration);
-            LambdaFunction lambdaFunction = LoadLambdaFunction(configInfo, localLambdaOptions, commandOptions, lambdaAssemblyDirectory: lambdaAssemblyDirectory, lambdaProjectDirectory: lambdaProjectDirectory, runConfiguration);
+            string configFile = DetermineConfigFile(commandOptions, lambdaAssemblyDirectory: lambdaAssemblyDirectory, lambdaProjectDirectory: lambdaProjectDirectory, shouldDisableLogs: shouldDisableLogs);
+            LambdaConfigInfo configInfo = LoadLambdaConfigInfo(configFile, commandOptions, lambdaAssemblyDirectory: lambdaAssemblyDirectory, lambdaProjectDirectory: lambdaProjectDirectory, runConfiguration, shouldDisableLogs: shouldDisableLogs);
+            LambdaFunction lambdaFunction = LoadLambdaFunction(configInfo, localLambdaOptions, commandOptions, lambdaAssemblyDirectory: lambdaAssemblyDirectory, lambdaProjectDirectory: lambdaProjectDirectory, runConfiguration, shouldDisableLogs: shouldDisableLogs);
 
-            string payload = DeterminePayload(localLambdaOptions, commandOptions, lambdaAssemblyDirectory: lambdaAssemblyDirectory, lambdaProjectDirectory: lambdaProjectDirectory, runConfiguration);
+            string payload = DeterminePayload(localLambdaOptions, commandOptions, lambdaAssemblyDirectory: lambdaAssemblyDirectory, lambdaProjectDirectory: lambdaProjectDirectory, runConfiguration, shouldDisableLogs: shouldDisableLogs);
 
             var awsProfile = commandOptions.AWSProfile ?? configInfo.AWSProfile;
             if (!string.IsNullOrEmpty(awsProfile))
@@ -166,7 +165,7 @@ namespace Amazon.Lambda.TestTool
                 Function = lambdaFunction
             };
 
-            ExecuteRequest(request, localLambdaOptions, runConfiguration);
+            ExecuteRequest(request, localLambdaOptions, runConfiguration, shouldDisableLogs);
 
 
             if (runConfiguration.Mode == RunConfiguration.RunMode.Normal && commandOptions.PauseExit)
@@ -176,7 +175,7 @@ namespace Amazon.Lambda.TestTool
             }
         }
 
-        private static string DetermineConfigFile(CommandLineOptions commandOptions, string lambdaAssemblyDirectory, string lambdaProjectDirectory)
+        private static string DetermineConfigFile(CommandLineOptions commandOptions, string lambdaAssemblyDirectory, string lambdaProjectDirectory, bool shouldDisableLogs)
         {
             string configFile = null;
             if (string.IsNullOrEmpty(commandOptions.ConfigFile))
@@ -199,7 +198,7 @@ namespace Amazon.Lambda.TestTool
             return configFile;
         }
 
-        private static LambdaConfigInfo LoadLambdaConfigInfo(string configFile, CommandLineOptions commandOptions, string lambdaAssemblyDirectory, string lambdaProjectDirectory, RunConfiguration runConfiguration)
+        private static LambdaConfigInfo LoadLambdaConfigInfo(string configFile, CommandLineOptions commandOptions, string lambdaAssemblyDirectory, string lambdaProjectDirectory, RunConfiguration runConfiguration, bool shouldDisableLogs)
         {
             LambdaConfigInfo configInfo;
             if (configFile != null)
@@ -226,7 +225,7 @@ namespace Amazon.Lambda.TestTool
             return configInfo;
         }
 
-        private static LambdaFunction LoadLambdaFunction(LambdaConfigInfo configInfo, LocalLambdaOptions localLambdaOptions, CommandLineOptions commandOptions, string lambdaAssemblyDirectory, string lambdaProjectDirectory, RunConfiguration runConfiguration)
+        private static LambdaFunction LoadLambdaFunction(LambdaConfigInfo configInfo, LocalLambdaOptions localLambdaOptions, CommandLineOptions commandOptions, string lambdaAssemblyDirectory, string lambdaProjectDirectory, RunConfiguration runConfiguration, bool shouldDisableLogs)
         {
             // If no function handler was explicitly set and there is only one function defined in the config file then assume the user wants to debug that function.
             var functionHandler = commandOptions.FunctionHandler;
@@ -264,7 +263,7 @@ namespace Amazon.Lambda.TestTool
             return lambdaFunction;
         }
 
-        private static string DeterminePayload(LocalLambdaOptions localLambdaOptions, CommandLineOptions commandOptions, string lambdaAssemblyDirectory, string lambdaProjectDirectory, RunConfiguration runConfiguration)
+        private static string DeterminePayload(LocalLambdaOptions localLambdaOptions, CommandLineOptions commandOptions, string lambdaAssemblyDirectory, string lambdaProjectDirectory, RunConfiguration runConfiguration, bool shouldDisableLogs)
         {
             var payload = commandOptions.Payload;
 
@@ -346,7 +345,7 @@ namespace Amazon.Lambda.TestTool
             return payload;
         }
 
-        private static void ExecuteRequest(ExecutionRequest request, LocalLambdaOptions localLambdaOptions, RunConfiguration runConfiguration)
+        private static void ExecuteRequest(ExecutionRequest request, LocalLambdaOptions localLambdaOptions, RunConfiguration runConfiguration, bool shouldDisableLogs)
         {
             try
             {


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-8563

*Description of changes:*
I did a lot of passes with AI every time I ran into a test failure. These changes are fixes to all the issues I ran into. I ran the tests 10 times in a row and they passed consistently. There may still be tests that are flaky but these changes have made the test runs more consistent.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
