### PR TITLE
Update create-release-pr.yml

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   id-token: write
+  repository-projects: read
 
 jobs:
   release-pr:


### PR DESCRIPTION
https://github.com/cli/cli/issues/9166#issuecomment-2147152513


```
pr_url="$(gh pr create --title "Release 2026-04-22" --body "## Release 2026-04-22
  
  ### Amazon.Lambda.Annotations (1.15.0)
  * Added [DynamoDBEvent] annotation attribute for declaratively configuring DynamoDB stream-triggered Lambda functions with support for stream reference, batch size, starting position, batching window, filters, and enabled state.
  * Added [ScheduleEvent] annotation attribute for declaratively configuring schedule-triggered Lambda functions with support for rate and cron expressions, description, input, and enabled state." --base dev --head releases/next-release)"
  gh label create "Release PR" --description "A Release PR that includes versioning and changelog changes" -c "#FF0000" -f
  gh pr edit $pr_url --add-label "Release PR"
  shell: /usr/bin/bash -e {0}
  env:
    INPUT_OVERRIDE_VERSION: 
    AWS_DEFAULT_REGION: us-west-2
    AWS_REGION: us-west-2
    AWS_ACCESS_KEY_ID: ***
    AWS_SECRET_ACCESS_KEY: ***
    AWS_SESSION_TOKEN: ***
    AWS_SECRET_TOKEN: ***
    SECRETS_LIST_CLEAN_UP: ["AWS_SECRET_TOKEN"]
    DOTNET_ROOT: /usr/share/dotnet
    GITHUB_TOKEN: ***
GraphQL: Resource not accessible by personal access token (repository.pullRequest.reviewRequests.nodes.0.requestedReviewer)

```

trying to fix this error