### PR TITLE
Fix static assets when running in non prod mode

### DIFF
--- a/.autover/changes/fix-static-assets-non-production-env.json
+++ b/.autover/changes/fix-static-assets-non-production-env.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.TestTool",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fixed static assets (CSS, JS, BlazorMonaco) failing to load when ASPNETCORE_ENVIRONMENT or DOTNET_ENVIRONMENT is set to a non-Production value by always serving static files from the tool's install directory."
+      ]
+    }
+  ]
+}

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -75,4 +75,13 @@
   <ItemGroup>
     <None Include="../../README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
+
+
+  <!-- Ensure wwwroot content is copied to output directory -->
+  <ItemGroup>
+    <Content Update="wwwroot\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/TestToolProcess.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/TestToolProcess.cs
@@ -60,10 +60,8 @@ public class TestToolProcess
         builder.Services.AddHttpContextAccessor();
 
         var wwwrootPath = Path.Combine(AppContext.BaseDirectory, "wwwroot");
-        if (builder.Environment.IsProduction())
-        {
-            builder.Services.AddSingleton<IFileProvider>(new PhysicalFileProvider(wwwrootPath));
-        }
+        var wwwrootFileProvider = new PhysicalFileProvider(wwwrootPath);
+        builder.Services.AddSingleton<IFileProvider>(wwwrootFileProvider);
         builder.Services.AddSingleton<IDirectoryManager, DirectoryManager>();
 
         var serviceHttp = $"http://{settings.LambdaEmulatorHost}:{settings.LambdaEmulatorPort}";
@@ -87,19 +85,20 @@ public class TestToolProcess
 
         var app = builder.Build();
 
-        if (app.Environment.IsProduction())
-        {
-            app.UseStaticFiles(new StaticFileOptions
-            {
-                FileProvider = new PhysicalFileProvider(wwwrootPath)
-            });
-        }
-        else
+        if (!app.Environment.IsProduction())
         {
             // nosemgrep: csharp.lang.security.stacktrace-disclosure.stacktrace-disclosure
             app.UseDeveloperExceptionPage();
-            app.UseStaticFiles();
         }
+
+        // Always use the explicit file provider to serve static files from the tool's install
+        // directory. Without this, non-Production environments attempt to use the static web
+        // assets manifest which contains absolute paths from the build machine and will fail
+        // when running as an installed global tool on a different machine.
+        app.UseStaticFiles(new StaticFileOptions
+        {
+            FileProvider = wwwrootFileProvider
+        });
 
         app.UseAntiforgery();
 


### PR DESCRIPTION
## Fix static assets failing to load when ASPNETCORE_ENVIRONMENT is set to non-Production value

Fixes #2118

### Description

When `ASPNETCORE_ENVIRONMENT` or `DOTNET_ENVIRONMENT` is set to anything other than `Production` (e.g., `Development`), the Lambda Test Tool's static assets (CSS, JS, BlazorMonaco) fail to load with 404 errors, rendering the web UI completely broken.

**Root cause:** In `TestToolProcess.cs`, static file serving was conditional on `app.Environment.IsProduction()`. In Production mode, an explicit `PhysicalFileProvider` pointing to `AppContext.BaseDirectory/wwwroot` was used, correctly serving files from the tool's install directory. In non-Production mode, the bare `app.UseStaticFiles()` was called instead, which relies on the static web assets manifest (`staticwebassets.runtime.json`). This manifest contains absolute paths from the build machine (source directories and NuGet cache paths) that don't exist on end-user machines, causing all static asset requests to return 404.

**Fix:** Always use the explicit `PhysicalFileProvider` to serve static files from the tool's install directory (`AppContext.BaseDirectory/wwwroot`), regardless of the environment. `UseDeveloperExceptionPage()` is still conditionally applied for non-Production environments.

### Testing

**Setup:**
```powershell
cd Tools\LambdaTestTool-v2\src\Amazon.Lambda.TestTool
dotnet pack -c Release
dotnet tool uninstall -g amazon.lambda.testtool
dotnet tool install -g amazon.lambda.testtool --version 0.13.0 --add-source bin\Release
```

**Before fix — reproduce the bug:**
```powershell
cd C:\Users\<user>\Desktop  # navigate away from the repo source directory
$env:ASPNETCORE_ENVIRONMENT = 'Development'
dotnet-lambda-test-tool start --lambda-emulator-port 5099 --no-launch-window
```
From a second terminal:
```powershell
(Invoke-WebRequest -Uri 'http://localhost:5099/app.css').StatusCode
# Returns 404 ❌
```

**After fix — verify the fix:**
```powershell
# Re-pack and re-install with the fix applied, then:
cd C:\Users\<user>\Desktop
$env:ASPNETCORE_ENVIRONMENT = 'Development'
dotnet-lambda-test-tool start --lambda-emulator-port 5099 --no-launch-window
```
From a second terminal:
```powershell
(Invoke-WebRequest -Uri 'http://localhost:5099/app.css').StatusCode
# Returns 200 ✅
```

**Baseline — confirm no regression in Production mode:**
```powershell
$env:ASPNETCORE_ENVIRONMENT = $null
dotnet-lambda-test-tool start --lambda-emulator-port 5099 --no-launch-window
```
```powershell
(Invoke-WebRequest -Uri 'http://localhost:5099/app.css').StatusCode
# Returns 200 ✅
```

---
