### PR TITLE
Make unit/integ tests more reliable

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Amazon.Lambda.RuntimeSupport.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\..\buildtools\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Version>1.14.3</Version>
     <Description>Provides a bootstrap and Lambda Runtime API Client to help you to develop custom .NET Core Lambda Runtimes.</Description>
     <AssemblyTitle>Amazon.Lambda.RuntimeSupport</AssemblyTitle>

--- a/Libraries/src/SnapshotRestore.Registry/SnapshotRestore.Registry.csproj
+++ b/Libraries/src/SnapshotRestore.Registry/SnapshotRestore.Registry.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\..\buildtools\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Version>1.0.1</Version>
     <Description>Provides a Restore Hooks library to help you register before snapshot and after restore hooks.</Description>
     <AssemblyTitle>SnapshotRestore.Registry</AssemblyTitle>

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/ApiGatewayStreamingTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/ApiGatewayStreamingTests.cs
@@ -129,36 +129,6 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
         }
 
         [Fact]
-        public async Task OnCompletedCallback_IsExecuted()
-        {
-            var apiUrl = await _fixture.GetApiUrlAsync();
-            using var httpClient = new HttpClient();
-
-            var response = await httpClient.GetWithRetryAsync($"{apiUrl}oncompleted-test");
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            var body = await response.Content.ReadAsStringAsync();
-            Output.WriteLine($"Body: {body}");
-            Assert.Contains("OnCompleted callback registered", body);
-
-            // The OnCompleted callback runs AFTER the response is sent, so we need to
-            // poll the verify endpoint until the callback has executed. Additionally,
-            // Lambda may route the verify request to a different execution environment,
-            // so we retry to eventually hit the same instance that ran the callback.
-            var verifyResponse = await httpClient.GetWithRetryAsync(
-                $"{apiUrl}oncompleted-verify",
-                HttpStatusCode.OK,
-                async resp =>
-                {
-                    var content = await resp.Content.ReadAsStringAsync();
-                    Output.WriteLine($"Verify body: {content}");
-                    var doc = JsonDocument.Parse(content);
-                    return doc.RootElement.GetProperty("onCompletedExecuted").GetBoolean();
-                },
-                maxRetries: 10, delaySeconds: 3);
-            Assert.Equal(HttpStatusCode.OK, verifyResponse.StatusCode);
-        }
-
-        [Fact]
         public async Task CustomHeaders_PassedThrough()
         {
             var apiUrl = await _fixture.GetApiUrlAsync();

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/ApiGatewayStreamingTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/ApiGatewayStreamingTests.cs
@@ -140,14 +140,22 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
             Output.WriteLine($"Body: {body}");
             Assert.Contains("OnCompleted callback registered", body);
 
-            var verifyResponse = await httpClient.GetWithRetryAsync($"{apiUrl}oncompleted-verify");
+            // The OnCompleted callback runs AFTER the response is sent, so we need to
+            // poll the verify endpoint until the callback has executed. Additionally,
+            // Lambda may route the verify request to a different execution environment,
+            // so we retry to eventually hit the same instance that ran the callback.
+            var verifyResponse = await httpClient.GetWithRetryAsync(
+                $"{apiUrl}oncompleted-verify",
+                HttpStatusCode.OK,
+                async resp =>
+                {
+                    var content = await resp.Content.ReadAsStringAsync();
+                    Output.WriteLine($"Verify body: {content}");
+                    var doc = JsonDocument.Parse(content);
+                    return doc.RootElement.GetProperty("onCompletedExecuted").GetBoolean();
+                },
+                maxRetries: 10, delaySeconds: 3);
             Assert.Equal(HttpStatusCode.OK, verifyResponse.StatusCode);
-            var verifyBody = await verifyResponse.Content.ReadAsStringAsync();
-            Output.WriteLine($"Verify body: {verifyBody}");
-
-            var doc = JsonDocument.Parse(verifyBody);
-            Assert.True(doc.RootElement.GetProperty("onCompletedExecuted").GetBoolean(),
-                "OnCompleted callback should have been executed");
         }
 
         [Fact]
@@ -198,8 +206,9 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
             var apiUrl = await _fixture.GetApiUrlAsync();
             using var httpClient = new HttpClient();
 
-            var content = new StringContent("Hello from integration test", Encoding.UTF8, "text/plain");
-            var response = await httpClient.PostAsync($"{apiUrl}echo-body", content);
+            var response = await httpClient.PostWithRetryAsync(
+                $"{apiUrl}echo-body",
+                new StringContent("Hello from integration test", Encoding.UTF8, "text/plain"));
 
             Output.WriteLine($"Status: {response.StatusCode}");
             var body = await response.Content.ReadAsStringAsync();
@@ -401,7 +410,7 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
         private async Task WaitForEndpointAsync()
         {
             using var httpClient = new HttpClient();
-            var maxRetries = 10;
+            var maxRetries = 20;
             for (var i = 0; i < maxRetries; i++)
             {
                 try
@@ -428,11 +437,47 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
             HttpStatusCode expectedCode = HttpStatusCode.OK,
             int maxRetries = 5, int delaySeconds = 5)
         {
+            return await GetWithRetryAsync(httpClient, url, expectedCode, null, maxRetries, delaySeconds);
+        }
+
+        public static async Task<HttpResponseMessage> GetWithRetryAsync(
+            this HttpClient httpClient, string url,
+            HttpStatusCode expectedCode,
+            Func<HttpResponseMessage, Task<bool>> contentValidator,
+            int maxRetries = 5, int delaySeconds = 5)
+        {
             for (var i = 0; i < maxRetries; i++)
             {
                 try
                 {
                     var response = await httpClient.GetAsync(url);
+                    if (response.StatusCode == expectedCode)
+                    {
+                        if (contentValidator == null || await contentValidator(response))
+                        {
+                            return response;
+                        }
+                    }
+                }
+                catch
+                {
+                    // Ignore and retry
+                }
+                await Task.Delay(TimeSpan.FromSeconds(delaySeconds));
+            }
+            throw new Exception($"Failed to get expected response from {url} after {maxRetries} attempts");
+        }
+
+        public static async Task<HttpResponseMessage> PostWithRetryAsync(
+            this HttpClient httpClient, string url, HttpContent content,
+            HttpStatusCode expectedCode = HttpStatusCode.OK,
+            int maxRetries = 5, int delaySeconds = 5)
+        {
+            for (var i = 0; i < maxRetries; i++)
+            {
+                try
+                {
+                    var response = await httpClient.PostAsync(url, content);
                     if (response.StatusCode == expectedCode)
                     {
                         return response;
@@ -442,9 +487,22 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
                 {
                     // Ignore and retry
                 }
+                // HttpContent can only be consumed once; create fresh content for retries
+                content = await CloneHttpContentAsync(content);
                 await Task.Delay(TimeSpan.FromSeconds(delaySeconds));
             }
             throw new Exception($"Failed to get expected status code {expectedCode} from {url} after {maxRetries} attempts");
+        }
+
+        private static async Task<HttpContent> CloneHttpContentAsync(HttpContent original)
+        {
+            var bytes = await original.ReadAsByteArrayAsync();
+            var clone = new ByteArrayContent(bytes);
+            if (original.Headers.ContentType != null)
+            {
+                clone.Headers.ContentType = original.Headers.ContentType;
+            }
+            return clone;
         }
     }
 }

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/HandlerTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/HandlerTests.cs
@@ -285,6 +285,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
         private async Task<string> InvokeAsync(LambdaBootstrap bootstrap, string dataIn, TestRuntimeApiClient testRuntimeApiClient)
         {
             testRuntimeApiClient.FunctionInput = dataIn != null ? Encoding.UTF8.GetBytes(dataIn) : new byte[0];
+            testRuntimeApiClient.LastOutputStream = null;
 
             using (var cancellationTokenSource = new CancellationTokenSource())
             {

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/HandlerTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/HandlerTests.cs
@@ -31,7 +31,7 @@ using Xunit.Abstractions;
 
 namespace Amazon.Lambda.RuntimeSupport.UnitTests
 {
-    [Collection("ResponseStreamFactory")]
+    [Collection("RuntimeSupportStateCheck")]
     public class HandlerTests
     {
         private const string AggregateExceptionTestMarker = "AggregateExceptionTesting";

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/HandlerWrapperTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/HandlerWrapperTests.cs
@@ -23,6 +23,7 @@ using Xunit;
 
 namespace Amazon.Lambda.RuntimeSupport.UnitTests
 {
+    [Collection("RuntimeSupportStateCheck")]
     public class HandlerWrapperTests
     {
         private static readonly JsonSerializer Serializer = new JsonSerializer();

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaBootstrapTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaBootstrapTests.cs
@@ -319,7 +319,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 return new InvocationResponse(Stream.Null, false);
             };
 
-            using (var bootstrap = new LambdaBootstrap(handler, null))
+            using (var bootstrap = new LambdaBootstrap(handler, null, null, new TestEnvironmentVariables()))
             {
                 bootstrap.Client = streamingClient;
                 await bootstrap.InvokeOnceAsync();
@@ -346,7 +346,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 return new InvocationResponse(outputStream);
             };
 
-            using (var bootstrap = new LambdaBootstrap(handler, null))
+            using (var bootstrap = new LambdaBootstrap(handler, null, null, new TestEnvironmentVariables()))
             {
                 bootstrap.Client = streamingClient;
                 await bootstrap.InvokeOnceAsync();
@@ -374,7 +374,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 throw new InvalidOperationException("midstream failure");
             };
 
-            using (var bootstrap = new LambdaBootstrap(handler, null))
+            using (var bootstrap = new LambdaBootstrap(handler, null, null, new TestEnvironmentVariables()))
             {
                 bootstrap.Client = streamingClient;
                 await bootstrap.InvokeOnceAsync();
@@ -404,7 +404,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 throw new InvalidOperationException("pre-stream failure");
             };
 
-            using (var bootstrap = new LambdaBootstrap(handler, null))
+            using (var bootstrap = new LambdaBootstrap(handler, null, null, new TestEnvironmentVariables()))
             {
                 bootstrap.Client = streamingClient;
                 await bootstrap.InvokeOnceAsync();
@@ -430,7 +430,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 return new InvocationResponse(Stream.Null, false);
             };
 
-            using (var bootstrap = new LambdaBootstrap(handler, null))
+            using (var bootstrap = new LambdaBootstrap(handler, null, null, new TestEnvironmentVariables()))
             {
                 bootstrap.Client = streamingClient;
                 await bootstrap.InvokeOnceAsync();

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaBootstrapTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaBootstrapTests.cs
@@ -31,7 +31,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
     /// Tests to test LambdaBootstrap when it's constructed using its actual constructor.
     /// Tests of the static GetLambdaBootstrap methods can be found in LambdaBootstrapWrapperTests.
     /// </summary>
-    [Collection("ResponseStreamFactory")]
+    [Collection("RuntimeSupportStateCheck")]
     public class LambdaBootstrapTests
     {
         readonly TestHandler _testFunction;

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaResponseStreamingCoreTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaResponseStreamingCoreTests.cs
@@ -398,7 +398,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
     // LambdaResponseStreamFactory tests
     // ─────────────────────────────────────────────────────────────────────────────
 
-    [Collection("ResponseStreamFactory")]
+    [Collection("RuntimeSupportStateCheck")]
     public class LambdaResponseStreamFactoryTests : IDisposable
     {
 

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/ResponseStreamFactoryTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/ResponseStreamFactoryTests.cs
@@ -21,7 +21,7 @@ using Xunit;
 
 namespace Amazon.Lambda.RuntimeSupport.UnitTests
 {
-    [Collection("ResponseStreamFactory")]
+    [Collection("RuntimeSupportStateCheck")]
     public class ResponseStreamFactoryTests : IDisposable
     {
         private const long MaxResponseSize = 20 * 1024 * 1024;

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/StreamingE2EWithMoq.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/StreamingE2EWithMoq.cs
@@ -249,51 +249,6 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
         }
 
         /// <summary>
-        /// End-to-end: midstream error sets error state on ResponseStream with exception details.
-        /// In production, RawStreamingHttpClient reads this state and writes trailing headers.
-        /// </summary>
-        [Fact]
-        public async Task MidstreamError_SetsErrorStateWithExceptionDetails()
-        {
-            var client = CreateClient();
-            const string errorMessage = "something went wrong mid-stream";
-
-            // Signal so the handler waits until the streaming pipeline is fully
-            // established (WaitForCompletionAsync is actively listening) before throwing.
-            var streamingReady = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            client.OnStreamingReady = () => streamingReady.TrySetResult(true);
-
-            LambdaBootstrapHandler handler = async (invocation) =>
-            {
-                var stream = ResponseStreamFactory.CreateStream(Array.Empty<byte>());
-                await stream.WriteAsync(Encoding.UTF8.GetBytes("some data"));
-                // Wait until StartStreamingResponseAsync has reached WaitForCompletionAsync
-                // so the completion signal will be observed when ReportError fires.
-                await streamingReady.Task;
-                throw new InvalidOperationException(errorMessage);
-            };
-
-            using var bootstrap = new LambdaBootstrap(handler, null, null, new TestEnvironmentVariables());
-            bootstrap.Client = client;
-            await bootstrap.InvokeOnceAsync();
-
-            Assert.True(client.StartStreamingCalled);
-            Assert.NotNull(client.LastResponseStream);
-            Assert.True(client.LastResponseStream.HasError);
-            Assert.NotNull(client.LastResponseStream.ReportedError);
-            Assert.IsType<InvalidOperationException>(client.LastResponseStream.ReportedError);
-            Assert.Equal(errorMessage, client.LastResponseStream.ReportedError.Message);
-
-            // Verify the handler's data was still captured before the error.
-            // Read directly from the output stream that was provided to the ResponseStream,
-            // which avoids any timing dependency on when CapturedHttpBytes is assigned
-            // relative to the SendTask completion.
-            Assert.NotNull(client.CapturedOutputStream);
-            var output = Encoding.UTF8.GetString(client.CapturedOutputStream.ToArray());
-            Assert.Contains("some data", output);
-        }
-
-        /// <summary>
         /// Multi-concurrency: concurrent invocations use AsyncLocal for state isolation.
         /// Each invocation independently uses streaming or buffered mode without interference.
         /// </summary>

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/StreamingE2EWithMoq.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/StreamingE2EWithMoq.cs
@@ -26,15 +26,15 @@ using Xunit;
 
 namespace Amazon.Lambda.RuntimeSupport.UnitTests
 {
-    [CollectionDefinition("ResponseStreamFactory")]
-    public class ResponseStreamFactoryCollection { }
+    [CollectionDefinition("RuntimeSupportStateCheck")]
+    public class RuntimeSupportStateCheckCollection { }
 
     /// <summary>
     /// End-to-end integration tests for the true-streaming architecture.
     /// These tests exercise the full pipeline: LambdaBootstrap → ResponseStreamFactory →
     /// ResponseStream → captured HTTP output stream.
     /// </summary>
-    [Collection("ResponseStreamFactory")]
+    [Collection("RuntimeSupportStateCheck")]
     public class StreamingE2EWithMoq : IDisposable
     {
         public void Dispose()
@@ -162,7 +162,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 return new InvocationResponse(Stream.Null, false);
             };
 
-            using var bootstrap = new LambdaBootstrap(handler, null);
+            using var bootstrap = new LambdaBootstrap(handler, null, null, new TestEnvironmentVariables());
             bootstrap.Client = client;
             await bootstrap.InvokeOnceAsync();
 
@@ -189,7 +189,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 return new InvocationResponse(Stream.Null, false);
             };
 
-            using var bootstrap = new LambdaBootstrap(handler, null);
+            using var bootstrap = new LambdaBootstrap(handler, null, null, new TestEnvironmentVariables());
             bootstrap.Client = client;
             await bootstrap.InvokeOnceAsync();
 
@@ -213,7 +213,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 return new InvocationResponse(new MemoryStream(responseBody));
             };
 
-            using var bootstrap = new LambdaBootstrap(handler, null);
+            using var bootstrap = new LambdaBootstrap(handler, null, null, new TestEnvironmentVariables());
             bootstrap.Client = client;
             await bootstrap.InvokeOnceAsync();
 
@@ -237,7 +237,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 return new InvocationResponse(new MemoryStream(responseBody));
             };
 
-            using var bootstrap = new LambdaBootstrap(handler, null);
+            using var bootstrap = new LambdaBootstrap(handler, null, null, new TestEnvironmentVariables());
             bootstrap.Client = client;
             await bootstrap.InvokeOnceAsync();
 
@@ -273,7 +273,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 throw new InvalidOperationException(errorMessage);
             };
 
-            using var bootstrap = new LambdaBootstrap(handler, null);
+            using var bootstrap = new LambdaBootstrap(handler, null, null, new TestEnvironmentVariables());
             bootstrap.Client = client;
             await bootstrap.InvokeOnceAsync();
 
@@ -457,7 +457,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 return new InvocationResponse(new MemoryStream(Encoding.UTF8.GetBytes("classic response")));
             };
 
-            using var bootstrap = new LambdaBootstrap(handler, null);
+            using var bootstrap = new LambdaBootstrap(handler, null, null, new TestEnvironmentVariables());
             bootstrap.Client = client;
             await bootstrap.InvokeOnceAsync();
 
@@ -481,7 +481,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 return new InvocationResponse(new MemoryStream(expected));
             };
 
-            using var bootstrap = new LambdaBootstrap(handler, null);
+            using var bootstrap = new LambdaBootstrap(handler, null, null, new TestEnvironmentVariables());
             bootstrap.Client = client;
             await bootstrap.InvokeOnceAsync();
 
@@ -506,7 +506,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 return new InvocationResponse(Stream.Null, false);
             };
 
-            using var bootstrap = new LambdaBootstrap(handler, null);
+            using var bootstrap = new LambdaBootstrap(handler, null, null, new TestEnvironmentVariables());
             bootstrap.Client = client;
 
             // Should not throw
@@ -529,7 +529,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 throw new Exception("classic handler error");
             };
 
-            using var bootstrap = new LambdaBootstrap(handler, null);
+            using var bootstrap = new LambdaBootstrap(handler, null, null, new TestEnvironmentVariables());
             bootstrap.Client = client;
             await bootstrap.InvokeOnceAsync();
 

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestRuntimeApiClient.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestRuntimeApiClient.cs
@@ -50,7 +50,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
 
         public string LastTraceId { get; private set; }
         public byte[] FunctionInput { get; set; }
-        public Stream LastOutputStream { get; private set; }
+        public Stream LastOutputStream { get; internal set; }
         public Exception LastRecordedException { get; private set; }
 
         public void VerifyOutput(string expectedOutput)

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/AspNetCoreStreamingApiGatewayTest/Program.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/AspNetCoreStreamingApiGatewayTest/Program.cs
@@ -61,37 +61,6 @@ app.MapGet("/json-response", (HttpContext context) =>
     return Results.Json(new { message = "Hello from streaming Lambda", timestamp = DateTime.UtcNow.ToString("o") });
 });
 
-app.MapGet("/oncompleted-test", async (HttpContext context) =>
-{
-    // Register an OnCompleted callback that writes a marker to a response header.
-    // Since headers are sent in the prelude before the body, we use a different approach:
-    // write a marker into the body from the OnCompleted callback via a shared flag.
-    var completedMarker = new CompletedMarker();
-    context.Response.RegisterForDispose(completedMarker);
-
-    context.Response.OnCompleted(async (state) =>
-    {
-        var marker = (CompletedMarker)state;
-        marker.WasExecuted = true;
-        // Write to a static so the next request can verify it ran
-        CompletedMarkerStore.LastMarkerExecuted = true;
-    }, completedMarker);
-
-    context.Response.ContentType = "text/plain";
-    context.Response.StatusCode = 200;
-
-    var stream = context.Response.BodyWriter.AsStream();
-    using var writer = new StreamWriter(stream, leaveOpen: true);
-    await writer.WriteAsync("OnCompleted callback registered");
-    await writer.FlushAsync();
-});
-
-app.MapGet("/oncompleted-verify", (HttpContext context) =>
-{
-    // Returns whether the OnCompleted callback from the previous request was executed
-    return Results.Json(new { onCompletedExecuted = CompletedMarkerStore.LastMarkerExecuted });
-});
-
 app.MapGet("/custom-headers", (HttpContext context) =>
 {
     context.Response.StatusCode = 201;
@@ -121,13 +90,3 @@ app.MapPost("/echo-body", async (HttpContext context) =>
 
 app.Run();
 
-class CompletedMarker : IDisposable
-{
-    public bool WasExecuted { get; set; }
-    public void Dispose() { }
-}
-
-static class CompletedMarkerStore
-{
-    public static bool LastMarkerExecuted { get; set; }
-}

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/PackagingTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/PackagingTests.cs
@@ -89,7 +89,7 @@ public class PackagingTests : IDisposable
     public void VerifyPackageContentsHasRuntimeSupport()
     {
         var projectPath = Path.Combine(_workingDirectory, "Tools", "LambdaTestTool-v2", "src", "Amazon.Lambda.TestTool", "Amazon.Lambda.TestTool.csproj");
-        var expectedFrameworks = new string[] { "net8.0", "net9.0", "net10.0", "net11.0" };
+        var expectedFrameworks = new string[] { "net8.0", "net9.0", "net10.0" };
         _output.WriteLine("Packing TestTool...");
         var packProcess = new Process
         {


### PR DESCRIPTION
*Description of changes:*
Work on making the tests more reliable and PR checks succeed without retries. After the PR changes I was able to run the PR checks 5 times in a row with no issues.

Changes:
* Removed the `OnCompletedCallback_IsExecuted` integ test. The test was relying on making a second invoke to Lambda see if a state variable was set from previous run. There is no way to guarantee the second invokes will go to the same Lambda compute instance. The scenario being tested was checking if the ASP.NET Core OnComplete callbacks are called. But the OnComplete callbacks don't have access to the response stream so there is no way to write something back to the caller to say I was called. Hence the reason the AI generated integ test relied on the second call. The fact that the test did pass when the invokes did go to same Lambda compute environment show the feature does work but we don't want to have this flaky test.
* Renamed the `ResponseStreamFactory` collection to `RuntimeSupportStateCheck` and applied it to more tests that are testing RuntimeSupport so they would not run in parallel. RuntimeSupport has logic via statics that assume there is only a single instance running a single invocation. All these unit tests run under a few seconds so I'm not worried about tests not running in parallel
* Updated tests creating `LambdaBootstrap` to pass in mock environment variable collections to avoid bleeding environment variable between tests.
* Removed the `MidstreamError_SetsErrorStateWithExceptionDetails` unit test. There were too many issues mock of the runtime api to get the timing a 100% right. The scenario being tested is covered in integ tests.

I also removed the .NET 11 targets from RuntimeSupport and SnapShotRestore because we don't need it for OCI images and it was causing issues building in VS. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
