### PR TITLE
Reduce PowerShell Lambda INIT time by omitting unwanted files from pa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Release 2026-05-20
+
+### AWSLambdaPSCore PowerShell Module (5.0.2)
+* Reduce Lambda cold start INIT times by stripping files that are not used at runtime (PowerShell help XML and .pdb debug symbols) from AWS-authored modules (AWSPowerShell.NetCore and AWS.Tools.*) during packaging
+
 ## Release 2026-05-18
 
 ### Amazon.Lambda.Core (3.1.0)

--- a/PowerShell/Module/AWSLambdaPSCore.psd1
+++ b/PowerShell/Module/AWSLambdaPSCore.psd1
@@ -12,7 +12,7 @@
 RootModule = 'AWSLambdaPSCore.psm1'
 
 # Version number of this module.
-ModuleVersion = '5.0.1.0'
+ModuleVersion = '5.0.2.0'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core'

--- a/PowerShell/Module/Private/_Constants.ps1
+++ b/PowerShell/Module/Private/_Constants.ps1
@@ -32,3 +32,32 @@ if (!($AwsPowerShellLambdaRuntime))
 {
     New-Variable -Name AwsPowerShellLambdaRuntime -Value 'dotnet10' -Option Constant
 }
+
+if (!($AwsModuleStripFilters))
+{
+    # File patterns inside AWS-authored PowerShell modules that have no purpose at
+    # Lambda runtime (no interactive shell, no Get-Help, no debugger). Stripping
+    # them reduces package size and INIT (cold-start) duration. LICENSE / NOTICE
+    # files are intentionally retained.
+    #
+    # The '*.xml' pattern matches case-insensitively, covering:
+    #   - <Module>.dll-Help.xml — PowerShell MAML help
+    #   - <Module>.XML          — .NET XMLDoc compiler output (IntelliSense data)
+    #   - PSGetModuleInfo.xml   — PowerShellGet install metadata
+    # Format.ps1xml / Types.ps1xml are NOT matched because their extension is
+    # .ps1xml (not .xml) and the wildcard requires a literal '.xml' suffix.
+    New-Variable -Name AwsModuleStripFilters -Value @(
+        '*.xml',
+        '*.pdb'
+    ) -Option Constant
+}
+
+if (!($AwsAuthoredModuleNamePatterns))
+{
+    # Only AWS-authored modules under Modules/ are stripped; third-party / community
+    # modules are left untouched.
+    New-Variable -Name AwsAuthoredModuleNamePatterns -Value @(
+        'AWSPowerShell.NetCore',
+        'AWS.Tools.*'
+    ) -Option Constant
+}

--- a/PowerShell/Module/Private/_DeploymentFunctions.ps1
+++ b/PowerShell/Module/Private/_DeploymentFunctions.ps1
@@ -479,6 +479,57 @@ function _formatArray
     return $sb.ToString()
 }
 
+function _stripAwsModuleFiles
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$ModulesRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$Filters,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$ModuleNamePatterns
+    )
+
+    if (!(Test-Path -Path $ModulesRoot))
+    {
+        return
+    }
+
+    foreach ($moduleDir in (Get-ChildItem -Path $ModulesRoot -Directory))
+    {
+        $matchesAws = $false
+        foreach ($pattern in $ModuleNamePatterns)
+        {
+            if ($moduleDir.Name -like $pattern)
+            {
+                $matchesAws = $true
+                break
+            }
+        }
+
+        if (-not $matchesAws)
+        {
+            continue
+        }
+
+        $removed = Get-ChildItem -Path $moduleDir.FullName -Recurse -File -Include $Filters -ErrorAction SilentlyContinue
+        foreach ($file in $removed)
+        {
+            Write-Verbose ('Removing AWS module file: {0}' -f $file.FullName)
+            Remove-Item -LiteralPath $file.FullName -Force -ErrorAction SilentlyContinue
+        }
+
+        $count = ($removed | Measure-Object).Count
+        if ($count -gt 0)
+        {
+            Write-Verbose ('Stripped {0} unwanted file(s) from AWS module {1}' -f $count, $moduleDir.Name)
+        }
+    }
+}
+
 function _prepareDependentPowerShellModules
 {
     param
@@ -567,6 +618,11 @@ function _prepareDependentPowerShellModules
     }
     ## Add verbosity that no RequiredModules found
     else {Write-Verbose "No RequiredModules found for script '$Script'"}
+
+    _stripAwsModuleFiles `
+        -ModulesRoot $SavedModulesDirectory `
+        -Filters $AwsModuleStripFilters `
+        -ModuleNamePatterns $AwsAuthoredModuleNamePatterns
 }
 
 function _findLocalModule

--- a/PowerShell/Tests/Get-AWSPowerShelLambdaTemplate.Tests.ps1
+++ b/PowerShell/Tests/Get-AWSPowerShelLambdaTemplate.Tests.ps1
@@ -7,31 +7,33 @@ Import-Module $moduleManifestPath
 InModuleScope -ModuleName $module -ScriptBlock {
     Describe -Name 'Get-AWSPowerShellLambdaTemplate' -Fixture {
 
-        function LoadFakeData
-        {
-            ConvertTo-Json -InputObject @{
-                manifestVersion = 1
-                blueprints      = @(
-                    @{
-                        name        = 'Basic'
-                        description = 'Bare bones script'
-                        content     = @(
-                            @{
-                                source   = 'basic.ps1.txt'
-                                output   = '{basename}.ps1'
-                                filetype = 'lambdaFunction'
-                            },
-                            @{
-                                source = 'readme.txt'
-                                output = 'readme.txt'
-                            }
-                        )
-                    }
-                )
+        BeforeAll {
+            function LoadFakeData
+            {
+                ConvertTo-Json -InputObject @{
+                    manifestVersion = 1
+                    blueprints      = @(
+                        @{
+                            name        = 'Basic'
+                            description = 'Bare bones script'
+                            content     = @(
+                                @{
+                                    source   = 'basic.ps1.txt'
+                                    output   = '{basename}.ps1'
+                                    filetype = 'lambdaFunction'
+                                },
+                                @{
+                                    source = 'readme.txt'
+                                    output = 'readme.txt'
+                                }
+                            )
+                        }
+                    )
+                }
             }
+            Mock -CommandName '_getHostedBlueprintsContent' -MockWith {LoadFakeData}
+            Mock -CommandName '_getLocalBlueprintsContent' -MockWith {LoadFakeData}
         }
-        Mock -CommandName '_getHostedBlueprintsContent' -MockWith {LoadFakeData}
-        Mock -CommandName '_getLocalBlueprintsContent' -MockWith {LoadFakeData}
 
         Context -Name 'Online Templates' -Fixture {
             It -Name 'Retrieves Blueprints from online sources by default' -Test {

--- a/PowerShell/Tests/_stripAwsModuleFiles.Tests.ps1
+++ b/PowerShell/Tests/_stripAwsModuleFiles.Tests.ps1
@@ -1,0 +1,251 @@
+$module = 'AWSLambdaPSCore'
+$moduleManifestPath = [System.IO.Path]::Combine('..', 'Module', "$module.psd1")
+
+if (Get-Module -Name $module) {Remove-Module -Name $module}
+Import-Module $moduleManifestPath
+
+  InModuleScope -ModuleName $module -ScriptBlock {
+    Describe -Name '_stripAwsModuleFiles' -Fixture {
+
+        BeforeAll {
+            function New-FakeModuleDir
+            {
+                param
+                (
+                    [Parameter(Mandatory = $true)][string]$Root,
+                    [Parameter(Mandatory = $true)][string]$Name,
+                    [Parameter()][string[]]$ExtraFiles = @()
+                )
+
+                $dir = Join-Path -Path $Root -ChildPath $Name
+                New-Item -ItemType Directory -Path $dir -Force | Out-Null
+
+                $defaults = @(
+                    'AWS.Tools.S3.dll-Help.xml',
+                    'AWS.Tools.S3-Help.xml',
+                    'LICENSE',
+                    'LICENSE.txt',
+                    'NOTICE',
+                    'NOTICE.txt',
+                    'AWS.Tools.S3.pdb',
+                    'AWS.Tools.S3.psm1',
+                    'AWS.Tools.S3.psd1'
+                )
+                foreach ($f in ($defaults + $ExtraFiles))
+                {
+                    Set-Content -Path (Join-Path -Path $dir -ChildPath $f) -Value 'x' -Force
+                }
+                return $dir
+            }
+        }
+
+        Context -Name 'AWS-authored module directories' -Fixture {
+
+            It -Name 'Strips unwanted files from AWS.Tools.* modules' -Test {
+                $root = Join-Path -Path $TestDrive -ChildPath 'aws-tools'
+                New-Item -ItemType Directory -Path $root -Force | Out-Null
+                $moduleDir = New-FakeModuleDir -Root $root -Name 'AWS.Tools.S3'
+
+                _stripAwsModuleFiles `
+                    -ModulesRoot $root `
+                    -Filters $AwsModuleStripFilters `
+                    -ModuleNamePatterns $AwsAuthoredModuleNamePatterns
+
+                Test-Path -Path (Join-Path $moduleDir 'AWS.Tools.S3.dll-Help.xml')  | Should -BeFalse
+                Test-Path -Path (Join-Path $moduleDir 'AWS.Tools.S3-Help.xml')      | Should -BeFalse
+                Test-Path -Path (Join-Path $moduleDir 'AWS.Tools.S3.pdb')           | Should -BeFalse
+                Test-Path -Path (Join-Path $moduleDir 'LICENSE')                    | Should -BeTrue
+                Test-Path -Path (Join-Path $moduleDir 'LICENSE.txt')                | Should -BeTrue
+                Test-Path -Path (Join-Path $moduleDir 'NOTICE')                     | Should -BeTrue
+                Test-Path -Path (Join-Path $moduleDir 'NOTICE.txt')                 | Should -BeTrue
+                Test-Path -Path (Join-Path $moduleDir 'AWS.Tools.S3.psm1')          | Should -BeTrue
+                Test-Path -Path (Join-Path $moduleDir 'AWS.Tools.S3.psd1')          | Should -BeTrue
+            }
+
+            It -Name 'Strips unwanted files from AWSPowerShell.NetCore (exact-name match)' -Test {
+                $root = Join-Path -Path $TestDrive -ChildPath 'monolithic'
+                New-Item -ItemType Directory -Path $root -Force | Out-Null
+                $moduleDir = New-FakeModuleDir -Root $root -Name 'AWSPowerShell.NetCore'
+
+                _stripAwsModuleFiles `
+                    -ModulesRoot $root `
+                    -Filters $AwsModuleStripFilters `
+                    -ModuleNamePatterns $AwsAuthoredModuleNamePatterns
+
+                Test-Path -Path (Join-Path $moduleDir 'AWS.Tools.S3.pdb')      | Should -BeFalse
+                Test-Path -Path (Join-Path $moduleDir 'LICENSE')               | Should -BeTrue
+                Test-Path -Path (Join-Path $moduleDir 'AWS.Tools.S3.psm1')     | Should -BeTrue
+            }
+
+            It -Name 'Recurses into nested version subdirectories' -Test {
+                $root = Join-Path -Path $TestDrive -ChildPath 'versioned'
+                New-Item -ItemType Directory -Path $root -Force | Out-Null
+                $versionDir = Join-Path -Path $root -ChildPath 'AWS.Tools.EC2\1.2.3'
+                New-Item -ItemType Directory -Path $versionDir -Force | Out-Null
+                Set-Content -Path (Join-Path $versionDir 'AWS.Tools.EC2.dll-Help.xml') -Value 'x'
+                Set-Content -Path (Join-Path $versionDir 'AWS.Tools.EC2.pdb') -Value 'x'
+                Set-Content -Path (Join-Path $versionDir 'AWS.Tools.EC2.psm1') -Value 'x'
+
+                _stripAwsModuleFiles `
+                    -ModulesRoot $root `
+                    -Filters $AwsModuleStripFilters `
+                    -ModuleNamePatterns $AwsAuthoredModuleNamePatterns
+
+                Test-Path -Path (Join-Path $versionDir 'AWS.Tools.EC2.dll-Help.xml') | Should -BeFalse
+                Test-Path -Path (Join-Path $versionDir 'AWS.Tools.EC2.pdb')          | Should -BeFalse
+                Test-Path -Path (Join-Path $versionDir 'AWS.Tools.EC2.psm1')         | Should -BeTrue
+            }
+        }
+
+        Context -Name 'Non-AWS module directories' -Fixture {
+
+            It -Name 'Leaves third-party modules untouched' -Test {
+                $root = Join-Path -Path $TestDrive -ChildPath 'third-party'
+                New-Item -ItemType Directory -Path $root -Force | Out-Null
+                $moduleDir = New-FakeModuleDir -Root $root -Name 'Pester'
+
+                _stripAwsModuleFiles `
+                    -ModulesRoot $root `
+                    -Filters $AwsModuleStripFilters `
+                    -ModuleNamePatterns $AwsAuthoredModuleNamePatterns
+
+                Test-Path -Path (Join-Path $moduleDir 'AWS.Tools.S3.dll-Help.xml') | Should -BeTrue
+                Test-Path -Path (Join-Path $moduleDir 'LICENSE')                   | Should -BeTrue
+                Test-Path -Path (Join-Path $moduleDir 'NOTICE')                    | Should -BeTrue
+                Test-Path -Path (Join-Path $moduleDir 'AWS.Tools.S3.pdb')          | Should -BeTrue
+                Test-Path -Path (Join-Path $moduleDir 'AWS.Tools.S3.psm1')         | Should -BeTrue
+            }
+
+            It -Name 'Strips AWS module while leaving co-resident third-party module untouched' -Test {
+                $root = Join-Path -Path $TestDrive -ChildPath 'mixed'
+                New-Item -ItemType Directory -Path $root -Force | Out-Null
+                $awsDir   = New-FakeModuleDir -Root $root -Name 'AWS.Tools.Lambda'
+                $otherDir = New-FakeModuleDir -Root $root -Name 'PSReadLine'
+
+                _stripAwsModuleFiles `
+                    -ModulesRoot $root `
+                    -Filters $AwsModuleStripFilters `
+                    -ModuleNamePatterns $AwsAuthoredModuleNamePatterns
+
+                # AWS module: .pdb stripped, LICENSE retained
+                Test-Path -Path (Join-Path $awsDir 'AWS.Tools.S3.pdb')   | Should -BeFalse
+                Test-Path -Path (Join-Path $awsDir 'LICENSE')            | Should -BeTrue
+
+                # Third-party module: nothing touched
+                Test-Path -Path (Join-Path $otherDir 'AWS.Tools.S3.pdb') | Should -BeTrue
+                Test-Path -Path (Join-Path $otherDir 'LICENSE')          | Should -BeTrue
+            }
+        }
+
+        Context -Name 'Files intentionally retained' -Fixture {
+
+            It -Name 'Does not remove LICENSE or NOTICE files (Apache 2.0 retention)' -Test {
+                $root = Join-Path -Path $TestDrive -ChildPath 'license-retained'
+                New-Item -ItemType Directory -Path $root -Force | Out-Null
+                $moduleDir = New-FakeModuleDir -Root $root -Name 'AWS.Tools.S3'
+
+                _stripAwsModuleFiles `
+                    -ModulesRoot $root `
+                    -Filters $AwsModuleStripFilters `
+                    -ModuleNamePatterns $AwsAuthoredModuleNamePatterns
+
+                Test-Path -Path (Join-Path $moduleDir 'LICENSE')     | Should -BeTrue
+                Test-Path -Path (Join-Path $moduleDir 'LICENSE.txt') | Should -BeTrue
+                Test-Path -Path (Join-Path $moduleDir 'NOTICE')      | Should -BeTrue
+                Test-Path -Path (Join-Path $moduleDir 'NOTICE.txt')  | Should -BeTrue
+            }
+
+            It -Name 'Does not remove Format.ps1xml or Types.ps1xml files' -Test {
+                $root = Join-Path -Path $TestDrive -ChildPath 'narrow-xml'
+                New-Item -ItemType Directory -Path $root -Force | Out-Null
+                $moduleDir = New-FakeModuleDir -Root $root -Name 'AWS.Tools.S3' -ExtraFiles @(
+                    'AWS.Tools.S3.Format.ps1xml',
+                    'AWS.Tools.S3.Types.ps1xml'
+                )
+
+                _stripAwsModuleFiles `
+                    -ModulesRoot $root `
+                    -Filters $AwsModuleStripFilters `
+                    -ModuleNamePatterns $AwsAuthoredModuleNamePatterns
+
+                Test-Path -Path (Join-Path $moduleDir 'AWS.Tools.S3.dll-Help.xml')  | Should -BeFalse
+                Test-Path -Path (Join-Path $moduleDir 'AWS.Tools.S3.Format.ps1xml') | Should -BeTrue
+                Test-Path -Path (Join-Path $moduleDir 'AWS.Tools.S3.Types.ps1xml')  | Should -BeTrue
+            }
+
+            It -Name 'Strips XMLDoc (.XML) and PSGetModuleInfo.xml' -Test {
+                $root = Join-Path -Path $TestDrive -ChildPath 'xmldoc'
+                New-Item -ItemType Directory -Path $root -Force | Out-Null
+                $moduleDir = New-FakeModuleDir -Root $root -Name 'AWS.Tools.S3' -ExtraFiles @(
+                    'AWS.Tools.S3.XML',
+                    'PSGetModuleInfo.xml'
+                )
+
+                _stripAwsModuleFiles `
+                    -ModulesRoot $root `
+                    -Filters $AwsModuleStripFilters `
+                    -ModuleNamePatterns $AwsAuthoredModuleNamePatterns
+
+                Test-Path -Path (Join-Path $moduleDir 'AWS.Tools.S3.XML')   | Should -BeFalse
+                Test-Path -Path (Join-Path $moduleDir 'PSGetModuleInfo.xml') | Should -BeFalse
+            }
+
+            It -Name 'Does not remove Aliases.psm1 or Completers.psm1' -Test {
+                $root = Join-Path -Path $TestDrive -ChildPath 'preserve-nested'
+                New-Item -ItemType Directory -Path $root -Force | Out-Null
+                $moduleDir = New-FakeModuleDir -Root $root -Name 'AWS.Tools.S3' -ExtraFiles @(
+                    'AWS.Tools.S3.Aliases.psm1',
+                    'AWS.Tools.S3.Completers.psm1'
+                )
+
+                _stripAwsModuleFiles `
+                    -ModulesRoot $root `
+                    -Filters $AwsModuleStripFilters `
+                    -ModuleNamePatterns $AwsAuthoredModuleNamePatterns
+
+                Test-Path -Path (Join-Path $moduleDir 'AWS.Tools.S3.Aliases.psm1')    | Should -BeTrue
+                Test-Path -Path (Join-Path $moduleDir 'AWS.Tools.S3.Completers.psm1') | Should -BeTrue
+            }
+        }
+
+        Context -Name 'Robustness' -Fixture {
+
+            It -Name 'Is idempotent (second run is a clean no-op)' -Test {
+                $root = Join-Path -Path $TestDrive -ChildPath 'idempotent'
+                New-Item -ItemType Directory -Path $root -Force | Out-Null
+                $moduleDir = New-FakeModuleDir -Root $root -Name 'AWS.Tools.S3'
+
+                _stripAwsModuleFiles `
+                    -ModulesRoot $root `
+                    -Filters $AwsModuleStripFilters `
+                    -ModuleNamePatterns $AwsAuthoredModuleNamePatterns
+
+                { _stripAwsModuleFiles `
+                    -ModulesRoot $root `
+                    -Filters $AwsModuleStripFilters `
+                    -ModuleNamePatterns $AwsAuthoredModuleNamePatterns } | Should -Not -Throw
+
+                Test-Path -Path (Join-Path $moduleDir 'AWS.Tools.S3.psm1') | Should -BeTrue
+            }
+
+            It -Name 'No-ops gracefully when ModulesRoot does not exist' -Test {
+                $missing = Join-Path -Path $TestDrive -ChildPath 'does-not-exist'
+
+                { _stripAwsModuleFiles `
+                    -ModulesRoot $missing `
+                    -Filters $AwsModuleStripFilters `
+                    -ModuleNamePatterns $AwsAuthoredModuleNamePatterns } | Should -Not -Throw
+            }
+
+            It -Name 'No-ops on empty ModulesRoot' -Test {
+                $root = Join-Path -Path $TestDrive -ChildPath 'empty-root'
+                New-Item -ItemType Directory -Path $root -Force | Out-Null
+
+                { _stripAwsModuleFiles `
+                    -ModulesRoot $root `
+                    -Filters $AwsModuleStripFilters `
+                    -ModuleNamePatterns $AwsAuthoredModuleNamePatterns } | Should -Not -Throw
+            }
+        }
+    } # End Describe
+} # End InModuleScope


### PR DESCRIPTION
**Description of changes:**

`New-AWSPowerShellLambdaPackage` now strips files that have no purpose at Lambda runtime from AWS-authored PowerShell modules during packaging:

  - **Files stripped:** `*.xml` (PowerShell help XML, .NET XMLDoc, PowerShellGet metadata) and `*.pdb` (debug symbols).
  - **Scope:** Only `AWSPowerShell.NetCore` and `AWS.Tools.*` modules under the package's `Modules/` directory. Third-party PowerShell modules are not touched.

---

#### Measured Impact

  Cold-start INIT measured against a matched-runtime baseline (`dotnet10`, `Microsoft.PowerShell.SDK 7.5.4`, 512 MB, us-east-1, 100 cold starts each).

  **AWS.Tools.EC2 example (largest module tested):**

  | Architecture | Mean Init (Unstripped) | Mean Init (Stripped) | Δ ms | Improvement % |
  |---|---|---|---|---|
  | x86_64 | 2563.7 ms | 2448.6 ms | **−115.1 ms** | **4.49%** |
  | arm64  | 2939.6 ms | 2805.6 ms | **−134.0 ms** | **4.56%** |

  EC2 also showed a notable tail-latency improvement: P99 dropped from 4697.8 ms → 2954.4 ms on x86_64 (−1.7s).

  Across services, the improvement scales with bytes stripped per module, averaging **~5% INIT reduction** on chunky modules. All users of `New-AWSPowerShellLambdaPackage` benefit automatically with no script or invocation changes.

---

  #### Test Plan

  - [x] All Pester tests pass (`Invoke-Pester PowerShell/Tests/`)
  - [x] Manual end-to-end packaging of STS, S3, EC2 handlers on x86_64 and arm64
  - [x] Functions deployed to AWS Lambda and invoked successfully without `Module load failed` or `Cannot find` errors in CloudWatch logs
  - [x] Cold-start benchmarks (100 invocations × 6 functions) compared against matched-runtime unstripped baseline

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.