### PR TITLE
Add Amazon.Lambda.DurableExecution project scaffolding

### DIFF
--- a/.autover/autover.json
+++ b/.autover/autover.json
@@ -48,6 +48,10 @@
       "Path": "Libraries/src/Amazon.Lambda.Core/Amazon.Lambda.Core.csproj"
     },
     {
+      "Name": "Amazon.Lambda.DurableExecution",
+      "Path": "Libraries/src/Amazon.Lambda.DurableExecution/Amazon.Lambda.DurableExecution.csproj"
+    },
+    {
       "Name": "Amazon.Lambda.DynamoDBEvents",
       "Path": "Libraries/src/Amazon.Lambda.DynamoDBEvents/Amazon.Lambda.DynamoDBEvents.csproj"
     },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,7 @@ The available projects are:
 * Amazon.Lambda.ConfigEvents
 * Amazon.Lambda.ConnectEvents
 * Amazon.Lambda.Core
+* Amazon.Lambda.DurableExecution
 * Amazon.Lambda.DynamoDBEvents
 * Amazon.Lambda.DynamoDBEvents.SDK.Convertor
 * Amazon.Lambda.KafkaEvents

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Amazon.Lambda.DurableExecution.csproj
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Amazon.Lambda.DurableExecution.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\..\buildtools\common.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>$(DefaultPackageTargets)</TargetFrameworks>
+    <Description>Amazon Lambda .NET SDK for Durable Execution - write multi-step workflows that persist state automatically.</Description>
+    <AssemblyTitle>Amazon.Lambda.DurableExecution</AssemblyTitle>
+    <Version>0.1.0</Version>
+    <AssemblyName>Amazon.Lambda.DurableExecution</AssemblyName>
+    <PackageId>Amazon.Lambda.DurableExecution</PackageId>
+    <PackageTags>AWS;Amazon;Lambda;Durable;Workflow</PackageTags>
+    <IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Amazon.Lambda.DurableExecution.Tests, PublicKey="0024000004800000940000000602000000240000525341310004000001000100db5f59f098d27276c7833875a6263a3cc74ab17ba9a9df0b52aedbe7252745db7274d5271fd79c1f08f668ecfa8eaab5626fa76adc811d3c8fc55859b0d09d3bc0a84eecd0ba891f2b8a2fc55141cdcc37c2053d53491e650a479967c3622762977900eddbf1252ed08a2413f00a28f3a0752a81203f03ccb7f684db373518b4"</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Amazon.Lambda.Core\Amazon.Lambda.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.Lambda" Version="4.0.13.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/src/Amazon.Lambda.DurableExecution/AssemblyMarker.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/AssemblyMarker.cs
@@ -1,0 +1,5 @@
+namespace Amazon.Lambda.DurableExecution;
+
+internal static class AssemblyMarker
+{
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/Amazon.Lambda.DurableExecution.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/Amazon.Lambda.DurableExecution.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(DefaultPackageTargets)</TargetFrameworks>
+    <AssemblyName>Amazon.Lambda.DurableExecution.Tests</AssemblyName>
+    <PackageId>Amazon.Lambda.DurableExecution.Tests</PackageId>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyOriginatorKeyFile>..\..\..\buildtools\public.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/Amazon.Lambda.DurableExecution.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/Amazon.Lambda.DurableExecution.Tests.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\..\..\buildtools\common.props" />
+
   <PropertyGroup>
     <TargetFrameworks>$(DefaultPackageTargets)</TargetFrameworks>
     <AssemblyName>Amazon.Lambda.DurableExecution.Tests</AssemblyName>
@@ -9,6 +11,7 @@
     <SignAssembly>true</SignAssembly>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+	<NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/AssemblyLoadTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/AssemblyLoadTests.cs
@@ -1,0 +1,13 @@
+using Xunit;
+
+namespace Amazon.Lambda.DurableExecution.Tests;
+
+public class AssemblyLoadTests
+{
+    [Fact]
+    public void DurableExecutionAssembly_Loads()
+    {
+        var assembly = typeof(AssemblyMarker).Assembly;
+        Assert.Equal("Amazon.Lambda.DurableExecution", assembly.GetName().Name);
+    }
+}

--- a/buildtools/build.proj
+++ b/buildtools/build.proj
@@ -215,6 +215,7 @@
         <Exec Command="dotnet test -c $(Configuration)" WorkingDirectory="..\Libraries\test\SnapshotRestore.Registry.Tests"/>
         <Exec Command="dotnet test -c $(Configuration)" WorkingDirectory="..\Libraries\test\Amazon.Lambda.RuntimeSupport.Tests\Amazon.Lambda.RuntimeSupport.UnitTests"/>
         <Exec Command="dotnet test -c $(Configuration)" WorkingDirectory="..\Libraries\test\Amazon.Lambda.Annotations.SourceGenerators.Tests"/>
+        <Exec Command="dotnet test -c $(Configuration)" WorkingDirectory="..\Libraries\test\Amazon.Lambda.DurableExecution.Tests"/>
     </Target>
     <Target Name="run-integ-tests">
         <Exec Command="dotnet test -c $(Configuration) --logger &quot;console;verbosity=detailed&quot;" WorkingDirectory="..\Libraries\test\Amazon.Lambda.RuntimeSupport.Tests\Amazon.Lambda.RuntimeSupport.IntegrationTests"/>


### PR DESCRIPTION
Stacked PRs:
 * #2363
 * #2360
 * __->__#2359


--- --- ---

### Add Amazon.Lambda.DurableExecution project scaffolding


Establishes the package metadata for the durable execution SDK:
src project (net8.0, trimmable, signed) and the matching test project
with InternalsVisibleTo wired up. No public API is added yet — a
single sanity test verifies the assembly loads.

Subsequent PRs will add the actual SDK contents on top of this scaffolding.

build

PR comments

PR comments