### PR TITLE
Adds retry support to the Amazon.Lambda.DurableExecution

### DIFF
--- a/Docs/durable-execution-design.md
+++ b/Docs/durable-execution-design.md
@@ -1,0 +1,2074 @@
+# .NET Lambda Durable Execution SDK Design
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Motivation](#motivation)
+- [How Durable Execution Works](#how-durable-execution-works)
+- [User Experience](#user-experience)
+  - [Quick Start](#quick-start)
+  - [Steps](#steps)
+  - [Wait Operations](#wait-operations)
+  - [Callbacks](#callbacks)
+  - [Invoke (Chained Functions)](#invoke-chained-functions)
+  - [Parallel Execution](#parallel-execution)
+  - [Map Operations](#map-operations)
+  - [Child Contexts](#child-contexts)
+  - [Error Handling & Retry](#error-handling--retry)
+  - [Logging](#logging)
+- [Internals](#internals)
+- [API Reference](#api-reference)
+  - [IDurableContext](#idurablecontext)
+  - [Configuration Types](#configuration-types)
+  - [Result Types](#result-types)
+  - [Exception Types](#exception-types)
+- [Serialization](#serialization)
+- [Integration with Existing Libraries](#integration-with-existing-libraries)
+- [Testing](#testing)
+- [Local development (Test Tool v2 and Aspire)](#local-development-test-tool-v2-and-aspire)
+- [Requirements & Constraints](#requirements--constraints)
+- [Package Structure](#package-structure)
+- [Implementation plan](#implementation-plan)
+- [Cross-SDK API comparison](#cross-sdk-api-comparison)
+- [Common Patterns](#common-patterns)
+
+---
+
+## Overview
+
+Lambda Durable Functions let you write multi-step workflows that persist state automatically. They can run for days or months, survive failures, and you only pay for actual compute time.
+
+This doc covers the **.NET Durable Execution SDK** (`Amazon.Lambda.DurableExecution`). SDKs already exist for [Python](https://github.com/aws/aws-durable-execution-sdk-python) and [JavaScript/TypeScript](https://github.com/aws/aws-durable-execution-sdk-js).
+
+Related: [GitHub Issue #2216](https://github.com/aws/aws-lambda-dotnet/issues/2216)
+
+---
+
+## Motivation
+
+### The problem
+
+Today, building multi-step Lambda workflows in .NET requires one of:
+
+1. **Step Functions** -- a separate service with its own state machine language (ASL), adding latency between steps and forcing you to learn a second programming model.
+2. **Manual state management** -- rolling your own checkpointing with DynamoDB or S3, plus retry logic, idempotency keys, and resumption code.
+3. **Event-driven choreography** -- chaining functions through SQS/SNS/EventBridge, scattering a single workflow's logic across half a dozen Lambda functions.
+
+All three push infrastructure concerns into your business logic. The code gets harder to read and test, and nobody wants to inherit it.
+
+### What durable functions do instead
+
+With this SDK, you write sequential code and the runtime handles persistence:
+- Checkpoints each step's result
+- Suspends when waiting (no compute charges while idle)
+- Resumes from the last checkpoint on the next invocation
+- Retries failed steps with configurable backoff
+- Waits for callbacks from external systems
+
+Your function reads like a normal async method. The SDK deals with state, replay, and recovery.
+
+### Why build a .NET SDK
+
+.NET has a large Lambda user base, especially in enterprise shops running order processing, document pipelines, and (increasingly) AI agent workflows. Today those teams either use Step Functions or build custom state machines. A native .NET SDK removes that tradeoff.
+
+---
+
+## How Durable Execution Works
+
+### The replay model
+
+Durable functions use a replay-based execution model. Every invocation runs your code from the top, but previously completed steps return their cached result instead of re-executing.
+
+1. Lambda invokes your function with a `DurableExecutionInvocationInput` containing:
+   - `DurableExecutionArn` -- unique execution identifier
+   - `CheckpointToken` -- for optimistic concurrency
+   - `InitialExecutionState` -- previously checkpointed operations
+
+2. Your function code runs **from the beginning** on every invocation.
+
+3. When a **step** is encountered:
+   - Previously completed → return cached result (no re-execution)
+   - New → execute it, checkpoint the result, continue
+
+4. When a **wait** is encountered:
+   - Already elapsed → continue
+   - Still pending → return `PENDING`, Lambda terminates, service re-invokes later
+
+5. The function returns one of:
+   - `SUCCEEDED` -- workflow completed
+   - `FAILED` -- workflow failed
+   - `PENDING` -- workflow suspended (waiting for time or callback)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ First Invocation (t=0s)                                         │
+│                                                                 │
+│  handler(event, context)                                        │
+│    │                                                            │
+│    ├─► context.StepAsync(FetchData) → executes, checkpoints     │
+│    │                                                            │
+│    ├─► context.WaitAsync(30 seconds) → returns PENDING          │
+│    │                                                            │
+│    └── (Lambda terminates, environment recyclable)              │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│ Second Invocation (t=30s)                                       │
+│                                                                 │
+│  handler(event, context)                                        │
+│    │                                                            │
+│    ├─► context.StepAsync(FetchData) → returns cached result     │
+│    │                                                            │
+│    ├─► context.WaitAsync(30 seconds) → already elapsed, skip    │
+│    │                                                            │
+│    ├─► context.StepAsync(ProcessData) → executes, checkpoints   │
+│    │                                                            │
+│    └── return result → SUCCEEDED                                │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## User Experience
+
+### Quick Start
+
+#### Installation
+
+```shell
+dotnet add package Amazon.Lambda.DurableExecution
+```
+
+#### Minimal Example
+
+```csharp
+using Amazon.Lambda.Annotations;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace MyDurableFunction;
+
+public class Function
+{
+    [LambdaFunction]
+    [DurableExecution]
+    public async Task<OrderResult> Handler(OrderEvent input, IDurableContext context)
+    {
+        // Step 1: Validate the order (checkpointed automatically)
+        var validation = await context.StepAsync(
+            async () => await ValidateOrder(input.OrderId),
+            name: "validate_order");
+
+        if (!validation.IsValid)
+            return new OrderResult { Status = "rejected" };
+
+        // Step 2: Wait for processing (Lambda is NOT running during this time)
+        await context.WaitAsync(TimeSpan.FromSeconds(30), name: "processing_delay");
+
+        // Step 3: Process the order
+        var result = await context.StepAsync(
+            async () => await ProcessOrder(input.OrderId),
+            name: "process_order");
+
+        return new OrderResult { Status = "approved", OrderId = result.OrderId };
+    }
+
+    private async Task<ValidationResult> ValidateOrder(string orderId) { /* ... */ }
+    private async Task<ProcessResult> ProcessOrder(string orderId) { /* ... */ }
+}
+```
+
+Things to notice:
+- `[LambdaFunction]` + `[DurableExecution]` triggers source generation, so you don't wire up the handler yourself
+- Each `StepAsync` call checkpoints its result automatically
+- `WaitAsync` suspends the function -- Lambda is not running (or billing you) during the wait
+- On replay, completed steps return their cached result without re-executing
+- The generated wrapper handles checkpoint batching and cleanup
+
+#### Manual Handler (Without Annotations)
+
+If you don't use `Amazon.Lambda.Annotations`, use `DurableFunction.WrapAsync` — a static helper (inspired by [OpenTelemetry's `AWSLambdaWrapper.TraceAsync`](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.AWSLambda#lambda-function)) that handles the entire durable execution envelope for you:
+
+```csharp
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace MyDurableFunction;
+
+public class Function
+{
+    public Task<DurableExecutionInvocationOutput> FunctionHandler(
+        DurableExecutionInvocationInput invocationInput, ILambdaContext context)
+        => DurableFunction.WrapAsync<OrderEvent, OrderResult>(MyWorkflow, invocationInput, context);
+
+    private async Task<OrderResult> MyWorkflow(OrderEvent input, IDurableContext context)
+    {
+        var validation = await context.StepAsync(
+            async () => await ValidateOrder(input.OrderId),
+            name: "validate_order");
+
+        if (!validation.IsValid)
+            return new OrderResult { Status = "rejected" };
+
+        await context.WaitAsync(TimeSpan.FromSeconds(30), name: "processing_delay");
+
+        var result = await context.StepAsync(
+            async () => await ProcessOrder(input.OrderId),
+            name: "process_order");
+
+        return new OrderResult { Status = "approved", OrderId = result.OrderId };
+    }
+
+    private async Task<ValidationResult> ValidateOrder(string orderId) { /* ... */ }
+    private async Task<ProcessResult> ProcessOrder(string orderId) { /* ... */ }
+}
+```
+
+`DurableFunction.WrapAsync` handles all the plumbing:
+- Hydrates `ExecutionState` from `invocationInput.InitialExecutionState`
+- Extracts the user payload from the service envelope
+- Runs the workflow through `DurableExecutionHandler.RunAsync`
+- Constructs and returns the `DurableExecutionInvocationOutput` envelope (status mapping, JSON serialization)
+- Sets execution environment tracking
+
+For workflows that return no value, use the single-type-parameter overload:
+
+```csharp
+public Task<DurableExecutionInvocationOutput> FunctionHandler(
+    DurableExecutionInvocationInput invocationInput, ILambdaContext context)
+    => DurableFunction.WrapAsync<OrderEvent>(MyWorkflow, invocationInput, context);
+
+private async Task MyWorkflow(OrderEvent input, IDurableContext context)
+{
+    await context.StepAsync(async () => await SendNotification(input.UserId), name: "notify");
+    await context.WaitAsync(TimeSpan.FromHours(1), name: "cooldown");
+    await context.StepAsync(async () => await Cleanup(input.UserId), name: "cleanup");
+}
+```
+
+You'd also need to manually configure the CloudFormation template with `DurableConfig` and managed policies:
+
+```json
+{
+  "Resources": {
+    "MyFunction": {
+      "Type": "AWS::Serverless::Function",
+      "Properties": {
+        "Handler": "MyDurableFunction::MyDurableFunction.Function::FunctionHandler",
+        "Policies": [
+          "AWSLambdaBasicExecutionRole",
+          "AWSLambdaBasicDurableExecutionRolePolicy"
+        ],
+        "DurableConfig": {
+          "Enabled": true
+        }
+      }
+    }
+  }
+}
+```
+
+##### What WrapAsync does internally
+
+For reference, here's the expanded version of what `DurableFunction.WrapAsync` eliminates — this is effectively what the source generator produces for the Annotations path:
+
+```csharp
+public async Task<DurableExecutionInvocationOutput> FunctionHandler(
+    DurableExecutionInvocationInput invocationInput,
+    ILambdaContext lambdaContext)
+{
+    // 1. Hydrate execution state from previously checkpointed operations
+    var state = new ExecutionState();
+    state.LoadFromCheckpoint(invocationInput.InitialExecutionState);
+
+    // 2. Extract user payload from the service envelope (internal)
+    var userPayload = ExtractUserPayload<OrderEvent>(invocationInput);
+
+    // 3. Run the user's workflow via DurableExecutionHandler.RunAsync
+    var result = await DurableExecutionHandler.RunAsync(
+        state,
+        async (durableContext) => await MyWorkflow(userPayload, durableContext),
+        invocationInput.DurableExecutionArn);
+
+    // 4. Construct and return the service output envelope
+    return new DurableExecutionInvocationOutput
+    {
+        Status = result.Status,
+        Result = result.Status == InvocationStatus.Succeeded
+            ? JsonSerializer.Serialize(result.Result)
+            : null,
+        ErrorMessage = result.Message
+    };
+}
+```
+
+Key differences between `WrapAsync` and the Annotations approach:
+- `WrapAsync` still requires you to define the Lambda entry point signature (`DurableExecutionInvocationInput` → `DurableExecutionInvocationOutput`)
+- You configure `DurableConfig` + managed policies in your CloudFormation template manually (not generated)
+- No `[LambdaFunction]` or `[DurableExecution]` attributes needed
+
+With `[LambdaFunction] + [DurableExecution]`, even the entry point and CloudFormation config are generated at compile time — you just write the workflow method.
+
+---
+
+### Steps
+
+> **Implementations:** [Python](https://github.com/aws/aws-durable-execution-sdk-python/blob/main/src/aws_durable_execution_sdk_python/operation/step.py) | [JavaScript](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts)
+
+A step runs your code and checkpoints the result. On replay, the cached result comes back without re-executing. Each step function receives an `IStepContext` with a step-scoped logger and attempt metadata.
+
+```csharp
+// Basic step
+var result = await context.StepAsync(async (step) => await CallExternalApi());
+
+// Named step (recommended for debugging/testing)
+var user = await context.StepAsync(
+    async (step) => await FetchUser(userId),
+    name: "fetch_user");
+
+// Using the step-scoped logger (includes step name, attempt number, operation ID)
+var order = await context.StepAsync(
+    async (step) =>
+    {
+        step.Logger.LogInformation("Fetching order {OrderId}", orderId);
+        return await orderService.GetOrder(orderId);
+    },
+    name: "get_order");
+
+// Step with configuration
+var payment = await context.StepAsync(
+    async (step) => await chargeCard(amount),
+    name: "charge_card",
+    config: new StepConfig
+    {
+        Semantics = StepSemantics.AtMostOncePerRetry,
+        RetryStrategy = RetryStrategy.Exponential(maxAttempts: 3, initialDelay: TimeSpan.FromSeconds(1))
+    });
+```
+
+#### Step Semantics
+
+| Semantics | Behavior | Use Case |
+|-----------|----------|----------|
+| `AtLeastOncePerRetry` (default) | Step re-executes on each retry | Idempotent operations (calculations, reads) |
+| `AtMostOncePerRetry` | Step executes at most once per retry | Side effects (payments, emails, writes) |
+
+---
+
+### Wait Operations
+
+> **Implementations:** [Python](https://github.com/aws/aws-durable-execution-sdk-python/blob/main/src/aws_durable_execution_sdk_python/operation/wait.py) | [JavaScript](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.ts)
+
+Waits suspend the function without consuming compute time. Lambda can recycle the execution environment.
+
+```csharp
+// Wait for a specific duration
+await context.WaitAsync(TimeSpan.FromSeconds(30));
+await context.WaitAsync(TimeSpan.FromMinutes(5), name: "cooldown");
+await context.WaitAsync(TimeSpan.FromHours(24), name: "daily_check");
+await context.WaitAsync(TimeSpan.FromDays(7), name: "weekly_reminder");
+```
+
+> **Validation:** The duration must be at least 1 second. Values less than 1 second throw `ArgumentOutOfRangeException`. Sub-second precision is truncated to whole seconds (the underlying service operates at second granularity).
+
+---
+
+### Callbacks
+
+> **Implementations:** [Python](https://github.com/aws/aws-durable-execution-sdk-python/blob/main/src/aws_durable_execution_sdk_python/operation/callback.py) | [JavaScript](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts)
+
+Callbacks let your workflow pause until an external system responds (human approval, a webhook, a third-party API).
+
+#### Create a Callback (Advanced)
+
+```csharp
+// Create a callback and get the callback ID
+var callback = await context.CreateCallbackAsync<ApprovalResult>(
+    name: "approval_callback",
+    config: new CallbackConfig
+    {
+        Timeout = TimeSpan.FromHours(24),
+        HeartbeatTimeout = TimeSpan.FromHours(2)
+    });
+
+// Send the callback ID to an external system
+await context.StepAsync(
+    async () => await SendApprovalEmail(callback.CallbackId, recipientEmail),
+    name: "send_approval_email");
+
+// Wait for the external system to respond
+var result = await callback.GetResultAsync();
+```
+
+#### Wait For Callback (Simple)
+
+```csharp
+// Combined pattern: create callback, submit to external system, wait for result
+var approval = await context.WaitForCallbackAsync<ApprovalResult>(
+    async (callbackId, ctx) =>
+    {
+        await SendApprovalEmail(callbackId, managerEmail);
+    },
+    name: "wait_for_approval",
+    config: new WaitForCallbackConfig
+    {
+        Timeout = TimeSpan.FromHours(24),
+        RetryStrategy = RetryStrategy.Exponential(maxAttempts: 3)
+    });
+
+if (approval.Approved)
+{
+    await context.StepAsync(async () => await ExecutePlan(), name: "execute");
+}
+```
+
+**Example `SendApprovalEmail` stub:**
+```csharp
+private async Task SendApprovalEmail(string callbackId, string recipientEmail)
+{
+    // Include the callbackId in the approval link so the external system
+    // can complete the callback via the AWS API
+    var approvalLink = $"https://my-app.example.com/approve?callbackId={callbackId}";
+    await emailService.SendAsync(recipientEmail, "Approval Required", $"Please approve: {approvalLink}");
+}
+```
+
+**External system completes the callback via AWS API:**
+```bash
+aws lambda send-durable-execution-callback-success \
+  --function-name my-function:1 \
+  --callback-id "cb-12345" \
+  --payload '{"approved": true, "approver": "jane@example.com"}'
+```
+
+---
+
+### Invoke (Chained Functions)
+
+> **Implementations:** [Python](https://github.com/aws/aws-durable-execution-sdk-python/blob/main/src/aws_durable_execution_sdk_python/operation/invoke.py) | [JavaScript](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts)
+
+Call another durable function. The invocation is checkpointed, so it survives failures and won't double-fire.
+
+```csharp
+// Invoke another durable function
+var paymentResult = await context.InvokeAsync<PaymentRequest, PaymentResult>(
+    functionName: "arn:aws:lambda:us-east-1:123456789012:function:payment-processor:prod",
+    payload: new PaymentRequest { Amount = 100, Currency = "USD" },
+    name: "process_payment",
+    config: new InvokeConfig
+    {
+        Timeout = TimeSpan.FromMinutes(5)
+    });
+```
+
+> **Note:** Durable function invocations require **qualified identifiers** — include a version number, alias, or `$LATEST`:
+> - ✅ `arn:aws:lambda:us-east-1:123456789012:function:payment-processor:prod` (alias)
+> - ✅ `arn:aws:lambda:us-east-1:123456789012:function:payment-processor:42` (version)  
+> - ✅ `arn:aws:lambda:us-east-1:123456789012:function:payment-processor:$LATEST`
+> - ❌ `arn:aws:lambda:us-east-1:123456789012:function:payment-processor` (unqualified — not supported)
+
+---
+
+### Parallel Execution
+
+> **Implementations:** [Python](https://github.com/aws/aws-durable-execution-sdk-python/blob/main/src/aws_durable_execution_sdk_python/operation/parallel.py) | [JavaScript](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js/src/handlers/parallel-handler/parallel-handler.ts)
+
+Run independent operations concurrently. The JS SDK uses a `DurablePromise` pattern where operations are deferred until awaited; in .NET that isn't necessary because `ParallelAsync` and `MapAsync` cover the same use case idiomatically. `Task`-returning methods start immediately and `await` retrieves the result, so there's no gap to fill with a lazy wrapper.
+
+> **Prefer `ParallelAsync` over `Task.WhenAll`:** While `Task.WhenAll` works correctly with durable operations (operation IDs are allocated deterministically), it bypasses completion policies, concurrency limits, branch naming, and `IBatchResult` structured output. Always use `ParallelAsync` or `MapAsync` for concurrent durable operations. A future Roslyn analyzer (DE004) will flag `Task.WhenAll` usage with durable tasks and suggest `ParallelAsync` as a replacement.
+
+```csharp
+// Run multiple operations in parallel
+var results = await context.ParallelAsync(
+    new Func<IDurableContext, Task<object>>[]
+    {
+        async (ctx) => await ctx.StepAsync(async () => await FetchUserData(userId), name: "fetch_user"),
+        async (ctx) => await ctx.StepAsync(async () => await FetchOrderHistory(userId), name: "fetch_orders"),
+        async (ctx) => await ctx.StepAsync(async () => await FetchPreferences(userId), name: "fetch_prefs"),
+    },
+    name: "parallel_fetch",
+    config: new ParallelConfig
+    {
+        MaxConcurrency = 3,
+        CompletionConfig = CompletionConfig.AllSuccessful()
+    });
+
+// Access individual results
+var userData = results.GetResults()[0];
+var orderHistory = results.GetResults()[1];
+var preferences = results.GetResults()[2];
+```
+
+#### Named Parallel Branches
+
+For better observability, you can name individual branches (matching the JS SDK pattern):
+
+```csharp
+// Named branches for easier debugging and testing
+var results = await context.ParallelAsync(
+    new NamedBranch<object>[]
+    {
+        new("fetch_user", async (ctx) => await ctx.StepAsync(async () => await FetchUserData(userId))),
+        new("fetch_orders", async (ctx) => await ctx.StepAsync(async () => await FetchOrderHistory(userId))),
+        new("fetch_prefs", async (ctx) => await ctx.StepAsync(async () => await FetchPreferences(userId))),
+    },
+    name: "parallel_fetch");
+
+// In tests, you can find specific branches by name
+var fetchUserBranch = result.GetOperation("fetch_user");
+```
+
+#### Completion Configurations
+
+`ParallelAsync` and `MapAsync` accept a `CompletionConfig` to control when the overall operation is considered complete:
+
+```csharp
+// All must succeed (default)
+CompletionConfig.AllSuccessful()
+
+// Complete when any one succeeds
+CompletionConfig.FirstSuccessful()
+
+// Complete when all finish (regardless of success/failure)
+CompletionConfig.AllCompleted()
+
+// Custom: succeed if at least 3 succeed, tolerate up to 2 failures
+new CompletionConfig
+{
+    MinSuccessful = 3,
+    ToleratedFailureCount = 2
+}
+```
+
+---
+
+### Map Operations
+
+> **Implementations:** [Python](https://github.com/aws/aws-durable-execution-sdk-python/blob/main/src/aws_durable_execution_sdk_python/operation/map.py) | [JavaScript](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js/src/handlers/map-handler/map-handler.ts)
+
+Process a collection in parallel with configurable concurrency. The `items` parameter accepts any `IReadOnlyList<T>` (arrays, lists, etc.).
+
+```csharp
+var orders = new[] { "order-1", "order-2", "order-3", "order-4", "order-5" };
+
+var results = await context.MapAsync(
+    items: orders, // IReadOnlyList<string>
+    func: async (ctx, orderId, index, allItems) =>
+    {
+        return await ctx.StepAsync(
+            async () => await ProcessOrder(orderId),
+            name: $"process_order_{index}");
+    },
+    name: "process_all_orders",
+    config: new MapConfig
+    {
+        MaxConcurrency = 3,
+        CompletionConfig = CompletionConfig.AllSuccessful(),
+        ItemNamer = (orderId, index) => $"Order-{orderId}"  // Readable names for observability
+    });
+
+// Check results
+results.ThrowIfError(); // Throws if any item failed
+var processedOrders = results.GetResults();
+```
+
+---
+
+### Child Contexts
+
+> **Implementations:** [Python](https://github.com/aws/aws-durable-execution-sdk-python/blob/main/src/aws_durable_execution_sdk_python/operation/child.py) | [JavaScript](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts)
+
+Child contexts group related durable operations into a sub-workflow. Use them when you need waits or multiple steps inside a logical unit (you cannot nest durable calls inside a step directly).
+
+```csharp
+// Group operations into a child context
+var enrichedData = await context.RunInChildContextAsync(
+    async (childCtx) =>
+    {
+        var validated = await childCtx.StepAsync(
+            async () => await Validate(data),
+            name: "validate");
+
+        await childCtx.WaitAsync(TimeSpan.FromSeconds(1), name: "rate_limit");
+
+        var enriched = await childCtx.StepAsync(
+            async () => await Enrich(validated),
+            name: "enrich");
+
+        return enriched;
+    },
+    name: "validation_phase");
+
+// Use the enriched data in a subsequent step
+var finalResult = await context.StepAsync(
+    async () => await SubmitEnrichedData(enrichedData),
+    name: "submit");
+```
+
+> **Why child contexts?** You cannot nest durable operations inside a step. Steps are leaf operations. If you need multiple durable operations grouped together, use a child context.
+
+---
+
+### Error Handling & Retry
+
+> **Implementations:** [Python](https://github.com/aws/aws-durable-execution-sdk-python/blob/main/src/aws_durable_execution_sdk_python/retries.py) | [JavaScript](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js/src/utils/retry/retry-config/index.ts)
+
+#### Retry Strategies
+
+```csharp
+// Exponential backoff with jitter
+var result = await context.StepAsync(
+    async () => await CallUnreliableApi(),
+    name: "api_call",
+    config: new StepConfig
+    {
+        RetryStrategy = RetryStrategy.Exponential(
+            maxAttempts: 5,
+            initialDelay: TimeSpan.FromSeconds(1),
+            maxDelay: TimeSpan.FromSeconds(60),
+            backoffRate: 2.0,
+            jitter: JitterStrategy.Full)
+    });
+
+// Using presets
+var result = await context.StepAsync(
+    async () => await CallApi(),
+    name: "api_call",
+    config: new StepConfig
+    {
+        RetryStrategy = RetryStrategy.Default  // 6 attempts, 2x backoff, 5s initial, Full jitter
+    });
+
+// Available presets:
+// RetryStrategy.None       — maxAttempts: 1 (no retry)
+// RetryStrategy.Default    — 6 attempts, 2x backoff, 5s initial delay, Full jitter
+// RetryStrategy.Transient  — 3 attempts, 2x backoff, 1s initial delay, Full jitter
+
+// Custom retry strategy
+var result = await context.StepAsync(
+    async () => await CallApi(),
+    name: "api_call",
+    config: new StepConfig
+    {
+        RetryStrategy = new CustomRetryStrategy((exception, attemptCount) =>
+        {
+            // Only retry transient errors
+            if (exception is HttpRequestException httpEx && httpEx.StatusCode >= 500)
+                return RetryDecision.RetryAfter(TimeSpan.FromSeconds(Math.Pow(2, attemptCount)));
+
+            return RetryDecision.DoNotRetry();
+        })
+    });
+
+// Retry with specific exception types
+var result = await context.StepAsync(
+    async () => await CallApi(),
+    name: "api_call",
+    config: new StepConfig
+    {
+        RetryStrategy = RetryStrategy.Exponential(
+            maxAttempts: 3,
+            retryableExceptions: new[] { typeof(TimeoutException), typeof(HttpRequestException) })
+    });
+
+// Retry with message pattern matching (regex)
+var result = await context.StepAsync(
+    async () => await CallApi(),
+    name: "api_call",
+    config: new StepConfig
+    {
+        RetryStrategy = RetryStrategy.Exponential(
+            maxAttempts: 3,
+            retryableExceptions: new[] { typeof(HttpRequestException) },
+            retryableMessagePatterns: new[] { "timeout", "throttl", "5\\d{2}" })
+    });
+```
+
+#### Jitter Strategies
+
+Jitter prevents thundering-herd scenarios where multiple retrying clients converge on the same backoff schedule. The SDK supports three jitter strategies:
+
+```csharp
+public enum JitterStrategy
+{
+    /// No randomization — delay is exactly the calculated backoff value.
+    None,
+
+    /// Random delay between 0 and the calculated backoff value (recommended).
+    Full,
+
+    /// Random delay between 50% and 100% of the calculated backoff value.
+    Half
+}
+```
+
+The default jitter for `RetryStrategy.Exponential()` is `JitterStrategy.Full`. All built-in presets (`RetryStrategy.Default`, `RetryStrategy.Transient`) also use `JitterStrategy.Full`. Use `JitterStrategy.None` only when you need deterministic retry timing (e.g., for testing).
+
+#### Retry Strategy Interface
+
+```csharp
+public interface IRetryStrategy
+{
+    RetryDecision ShouldRetry(Exception exception, int attemptNumber);
+}
+
+public record RetryDecision
+{
+    public bool ShouldRetry { get; }
+    public TimeSpan Delay { get; }
+
+    public static RetryDecision DoNotRetry() => new() { ShouldRetry = false };
+    public static RetryDecision RetryAfter(TimeSpan delay) => new() { ShouldRetry = true, Delay = delay };
+}
+```
+
+`IRetryStrategy` supports implicit conversion from `Func<Exception, int, RetryDecision>`, enabling inline lambdas:
+
+```csharp
+config: new StepConfig
+{
+    RetryStrategy = (ex, attempt) =>
+        attempt < 3 && ex is HttpRequestException
+            ? RetryDecision.RetryAfter(TimeSpan.FromSeconds(Math.Pow(2, attempt)))
+            : RetryDecision.DoNotRetry()
+}
+```
+
+#### Saga Pattern (Compensating Transactions)
+
+```csharp
+[DurableExecution]
+public async Task<BookingResult> Handler(BookingRequest input, IDurableContext context)
+{
+    var compensations = new List<(string Name, Func<Task> Action)>();
+
+    try
+    {
+        var flight = await context.StepAsync(
+            async () => await BookFlight(input),
+            name: "book_flight");
+        compensations.Add(("cancel_flight", async () => await CancelFlight(flight.Id)));
+
+        var hotel = await context.StepAsync(
+            async () => await BookHotel(input),
+            name: "book_hotel");
+        compensations.Add(("cancel_hotel", async () => await CancelHotel(hotel.Id)));
+
+        var car = await context.StepAsync(
+            async () => await BookCar(input),
+            name: "book_car");
+        compensations.Add(("cancel_car", async () => await CancelCar(car.Id)));
+
+        return new BookingResult { Status = "confirmed" };
+    }
+    catch (Exception ex)
+    {
+        // Execute compensations in reverse order
+        foreach (var (name, action) in compensations.AsEnumerable().Reverse())
+        {
+            await context.StepAsync(action, name: name);
+        }
+        return new BookingResult { Status = "cancelled", Error = ex.Message };
+    }
+}
+```
+
+---
+
+### Logging
+
+> **Implementations:** [Python](https://github.com/aws/aws-durable-execution-sdk-python/blob/main/src/aws_durable_execution_sdk_python/logger.py) | [JavaScript](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js/src/utils/logger/logger.ts)
+
+`context.Logger` is replay-aware: it suppresses duplicate messages that would otherwise repeat on every invocation. Use it instead of `Console.WriteLine`.
+
+> **Implementation note:** The replay-aware logger is implemented entirely in the durable execution SDK. During replay, the SDK tracks which operations are being restored from checkpoint state vs. executing for the first time, and suppresses log output for replayed operations. No changes to `Amazon.Lambda.RuntimeSupport` or the Lambda Runtime API are required.
+
+```csharp
+[DurableExecution]
+public async Task<string> Handler(MyEvent input, IDurableContext context)
+{
+    // ✅ Replay-safe: only logs once even during replay
+    context.Logger.LogInformation("Starting workflow for {OrderId}", input.OrderId);
+
+    var result = await context.StepAsync(
+        async () => await ProcessData(input.Data),
+        name: "process_data");
+
+    // ✅ Replay-safe
+    context.Logger.LogInformation("Processing complete: {Result}", result);
+
+    // ❌ NOT replay-safe: will log on every replay
+    Console.WriteLine("This will repeat!");
+
+    return result;
+}
+```
+
+The logger integrates with `Microsoft.Extensions.Logging`:
+
+```csharp
+// context.Logger implements ILogger
+context.Logger.LogDebug("Debug info");
+context.Logger.LogInformation("Info message");
+context.Logger.LogWarning("Warning: {Detail}", detail);
+context.Logger.LogError(exception, "Error occurred");
+```
+
+#### Custom Logger Configuration
+
+You can swap the logger or disable replay-aware filtering (e.g., to see logs during replay for debugging):
+
+```csharp
+// Use a custom logger (e.g., Serilog, AWS Lambda Powertools)
+context.ConfigureLogger(new LoggerConfig
+{
+    CustomLogger = myCustomLogger,
+    ModeAware = true  // true = suppress during replay (default), false = always log
+});
+
+// Disable replay-aware filtering to see ALL logs (useful for debugging)
+context.ConfigureLogger(new LoggerConfig { ModeAware = false });
+```
+
+---
+
+## Internals
+
+### AWS APIs used
+
+| API | Purpose |
+|-----|---------|
+| `CheckpointDurableExecution` | Persist operation state (step results, waits, etc.) |
+| `GetDurableExecutionState` | Retrieve previously checkpointed state on replay |
+| `SendDurableExecutionCallbackSuccess` | External systems signal callback completion |
+| `SendDurableExecutionCallbackFailure` | External systems signal callback failure |
+| `SendDurableExecutionCallbackHeartbeat` | External systems send heartbeat signals |
+
+### How suspension works internally
+
+This follows the same pattern as the JavaScript SDK's `Promise.race`. The .NET equivalent is `Task.WhenAny`.
+
+When `RunAsync` starts, it kicks off two tasks in parallel: user code and a termination signal (a `TaskCompletionSource` that starts unresolved). Whoever finishes first wins:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  DurableExecutionHandler.RunAsync                                    │
+│                                                                      │
+│  var userTask = userHandler(context);                                │
+│  var terminationTask = terminationManager.TerminationTask;           │
+│                                                                      │
+│  var winner = await Task.WhenAny(userTask, terminationTask);         │
+│                                                                      │
+│  ┌─── userTask ───────────────────┐  ┌─── terminationTask ────────┐ │
+│  │ StepAsync("fetch") → execute   │  │ (unresolved TCS - waiting) │ │
+│  │ WaitAsync("delay") → ...       │  │                            │ │
+│  │   calls Terminate() ──────────────► SetResult() → resolves!    │ │
+│  │   awaits forever (blocked)     │  │                            │ │
+│  └────────────────────────────────┘  └────────────────────────────┘ │
+│                                                                      │
+│  winner == terminationTask → return PENDING                          │
+│  (userTask is abandoned, GC collects it)                             │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+The `TerminationManager` is a thin wrapper around `TaskCompletionSource<TerminationResult>`:
+- `TerminationTask` -- a Task that hangs forever until `Terminate()` is called
+- `Terminate(reason)` -- resolves the TCS, causing the race to pick termination
+
+When user code hits a pending wait or callback:
+1. It checkpoints the operation state
+2. Calls `terminationManager.Terminate(WaitScheduled)`
+3. Awaits a new never-completing `TaskCompletionSource` (blocks itself permanently)
+4. `Task.WhenAny` sees the termination task resolved and picks it as the winner
+5. `RunAsync` returns PENDING; Lambda terminates; the abandoned user task is GC'd
+
+### Lifecycle and cleanup
+
+`RunAsync` manages the full lifecycle internally. When the handler completes (SUCCEEDED/FAILED) or suspends (PENDING), `RunAsync` stops the background checkpoint batcher, flushes any pending checkpoint operations, and disposes internal state. Users never call `Dispose` or wrap anything in `await using`.
+
+---
+
+## API Reference
+
+### DurableFunction
+
+Static helper for the non-Annotations handler path. Wraps a workflow function, handling all envelope translation between `DurableExecutionInvocationInput`/`DurableExecutionInvocationOutput` and user types.
+
+```csharp
+/// <summary>
+/// Static helper that wraps a durable workflow function, handling all envelope
+/// translation between DurableExecutionInvocationInput/Output and user types.
+/// Inspired by OpenTelemetry.Instrumentation.AWSLambda's AWSLambdaWrapper.TraceAsync pattern.
+/// </summary>
+public static class DurableFunction
+{
+    /// <summary>
+    /// Wrap a workflow that takes typed input and returns typed output.
+    /// </summary>
+    public static Task<DurableExecutionInvocationOutput> WrapAsync<TInput, TOutput>(
+        Func<TInput, IDurableContext, Task<TOutput>> workflow,
+        DurableExecutionInvocationInput invocationInput,
+        ILambdaContext lambdaContext);
+
+    /// <summary>
+    /// Wrap a workflow that takes typed input and returns no value.
+    /// </summary>
+    public static Task<DurableExecutionInvocationOutput> WrapAsync<TInput>(
+        Func<TInput, IDurableContext, Task> workflow,
+        DurableExecutionInvocationInput invocationInput,
+        ILambdaContext lambdaContext);
+}
+```
+
+### IDurableContext
+
+> **Implementations:** [Python](https://github.com/aws/aws-durable-execution-sdk-python/blob/main/src/aws_durable_execution_sdk_python/context.py) | [JavaScript](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts)
+
+The primary interface developers interact with:
+
+```csharp
+public interface IDurableContext
+{
+    /// <summary>
+    /// Replay-safe logger. Messages are de-duplicated during replay.
+    /// </summary>
+    ILogger Logger { get; }
+
+    /// <summary>
+    /// Metadata about the current durable execution.
+    /// </summary>
+    IExecutionContext ExecutionContext { get; }
+
+    /// <summary>
+    /// The underlying Lambda context.
+    /// </summary>
+    ILambdaContext LambdaContext { get; }
+
+    /// <summary>
+    /// Execute a step with automatic checkpointing.
+    /// The IStepContext provides a step-scoped logger with operation metadata
+    /// (step name, attempt number, operation ID) and the current attempt number.
+    /// </summary>
+    Task<T> StepAsync<T>(
+        Func<IStepContext, Task<T>> func,
+        string? name = null,
+        StepConfig? config = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Execute a step that returns no value.
+    /// </summary>
+    Task StepAsync(
+        Func<IStepContext, Task> func,
+        string? name = null,
+        StepConfig? config = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Suspend execution for the specified duration.
+    /// Throws ArgumentOutOfRangeException if duration is less than 1 second.
+    /// </summary>
+    Task WaitAsync(
+        TimeSpan duration,
+        string? name = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create a callback for external system integration.
+    /// </summary>
+    Task<ICallback<T>> CreateCallbackAsync<T>(
+        string? name = null,
+        CallbackConfig? config = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Wait for an external system to respond via callback.
+    /// </summary>
+    Task<T> WaitForCallbackAsync<T>(
+        Func<string, ICallbackContext, Task> submitter,
+        string? name = null,
+        WaitForCallbackConfig? config = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Invoke another durable function.
+    /// </summary>
+    Task<TResult> InvokeAsync<TPayload, TResult>(
+        string functionName,
+        TPayload payload,
+        string? name = null,
+        InvokeConfig? config = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Execute multiple operations in parallel (unnamed branches).
+    /// </summary>
+    Task<IBatchResult<T>> ParallelAsync<T>(
+        IReadOnlyList<Func<IDurableContext, Task<T>>> functions,
+        string? name = null,
+        ParallelConfig? config = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Execute multiple named operations in parallel. Named branches appear in
+    /// execution traces and can be inspected by name in tests.
+    /// </summary>
+    Task<IBatchResult<T>> ParallelAsync<T>(
+        IReadOnlyList<DurableBranch<T>> branches,
+        string? name = null,
+        ParallelConfig? config = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Process a collection of items in parallel.
+    /// </summary>
+    Task<IBatchResult<TResult>> MapAsync<TItem, TResult>(
+        IReadOnlyList<TItem> items,
+        Func<IDurableContext, TItem, int, IReadOnlyList<TItem>, Task<TResult>> func,
+        string? name = null,
+        MapConfig? config = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Run operations in an isolated child context.
+    /// </summary>
+    Task<T> RunInChildContextAsync<T>(
+        Func<IDurableContext, Task<T>> func,
+        string? name = null,
+        ChildContextConfig? config = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Poll until a condition is met.
+    /// </summary>
+    Task<TState> WaitForConditionAsync<TState>(
+        Func<TState, IConditionCheckContext, Task<TState>> check,
+        WaitForConditionConfig<TState> config,
+        string? name = null,
+        CancellationToken cancellationToken = default);
+}
+```
+
+#### Supporting Types
+
+```csharp
+/// <summary>
+/// Context passed to step functions. Provides step-scoped logging and metadata.
+/// </summary>
+public interface IStepContext
+{
+    /// <summary>
+    /// Logger scoped to this step. Includes step name, operation ID, and attempt
+    /// number in structured log metadata automatically.
+    /// </summary>
+    ILogger Logger { get; }
+
+    /// <summary>
+    /// The current retry attempt number (1-based).
+    /// </summary>
+    int AttemptNumber { get; }
+
+    /// <summary>
+    /// The deterministic operation ID for this step.
+    /// </summary>
+    string OperationId { get; }
+}
+
+/// <summary>
+/// A named branch for parallel execution. Named branches appear in execution
+/// traces and can be inspected by name in the test runner.
+/// </summary>
+public record DurableBranch<T>(string Name, Func<IDurableContext, Task<T>> Func);
+```
+
+#### CancellationToken behavior
+
+All methods accept a `CancellationToken` that follows standard .NET semantics: cancellation throws `OperationCanceledException` and the execution fails. Cancellation does **not** trigger suspension — those are separate concepts. The durable execution service handles timeout scenarios automatically: if Lambda terminates mid-execution, the next invocation simply replays from the last checkpoint. For advanced users who want to suspend gracefully before timeout, check `context.LambdaContext.RemainingTime` and return early.
+
+### Configuration Types
+
+> **Implementations:** [Python](https://github.com/aws/aws-durable-execution-sdk-python/blob/main/src/aws_durable_execution_sdk_python/config.py) | JavaScript: [step](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js/src/types/step.ts) &#124; [batch](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js/src/types/batch.ts)
+
+```csharp
+/// <summary>
+/// Configuration for step execution.
+/// </summary>
+public class StepConfig
+{
+    /// <summary>
+    /// Retry strategy for failed steps. Default is no retry.
+    /// Accepts IRetryStrategy implementations (RetryStrategy.Exponential, etc.)
+    /// or an inline function via implicit conversion from
+    /// Func&lt;Exception, int, RetryDecision&gt;.
+    /// </summary>
+    public IRetryStrategy? RetryStrategy { get; set; }
+
+    /// <summary>
+    /// Execution semantics. Default is AtLeastOncePerRetry.
+    /// </summary>
+    public StepSemantics Semantics { get; set; } = StepSemantics.AtLeastOncePerRetry;
+
+    /// <summary>
+    /// Custom serializer for the step result. Default is System.Text.Json.
+    /// </summary>
+    public ICheckpointSerializer? Serializer { get; set; }
+}
+
+public enum StepSemantics
+{
+    /// <summary>
+    /// Step re-executes on each retry attempt. Safe for idempotent operations.
+    /// </summary>
+    AtLeastOncePerRetry,
+
+    /// <summary>
+    /// Step executes at most once per retry attempt. Use for side effects.
+    /// </summary>
+    AtMostOncePerRetry
+}
+
+/// <summary>
+/// Configuration for callback operations.
+/// </summary>
+public class CallbackConfig
+{
+    /// <summary>
+    /// Maximum time to wait for callback response. Default (TimeSpan.Zero) means no timeout.
+    /// </summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
+    /// Maximum time between heartbeat signals before timeout. Default (TimeSpan.Zero) means no heartbeat timeout.
+    /// </summary>
+    public TimeSpan HeartbeatTimeout { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
+    /// Custom serializer for callback result.
+    /// </summary>
+    public ICheckpointSerializer? Serializer { get; set; }
+}
+
+/// <summary>
+/// Configuration for wait-for-callback operations.
+/// </summary>
+public class WaitForCallbackConfig : CallbackConfig
+{
+    /// <summary>
+    /// Retry strategy for the submitter function.
+    /// </summary>
+    public IRetryStrategy? RetryStrategy { get; set; }
+}
+
+/// <summary>
+/// Configuration for invoke operations.
+/// </summary>
+public class InvokeConfig
+{
+    /// <summary>
+    /// Maximum time to wait for the invoked function. Default (TimeSpan.Zero) means no timeout.
+    /// </summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
+    /// Custom serializer for the payload.
+    /// </summary>
+    public ICheckpointSerializer? PayloadSerializer { get; set; }
+
+    /// <summary>
+    /// Custom serializer for the result.
+    /// </summary>
+    public ICheckpointSerializer? ResultSerializer { get; set; }
+}
+
+/// <summary>
+/// Controls how branches are represented in the checkpoint graph.
+/// </summary>
+public enum NestingType
+{
+    /// <summary>
+    /// Each branch creates a full isolated CONTEXT operation. Higher observability
+    /// in execution traces but more checkpoint operations (default).
+    /// </summary>
+    Nested,
+
+    /// <summary>
+    /// Branches use virtual contexts sharing the parent. Reduces checkpoint cost
+    /// by ~30% at the expense of less granular execution traces.
+    /// </summary>
+    Flat
+}
+
+/// <summary>
+/// Configuration for parallel execution.
+/// </summary>
+public class ParallelConfig
+{
+    /// <summary>
+    /// Maximum concurrent branches. Null = unlimited.
+    /// </summary>
+    public int? MaxConcurrency { get; set; }
+
+    /// <summary>
+    /// When to consider the operation complete.
+    /// </summary>
+    public CompletionConfig CompletionConfig { get; set; } = CompletionConfig.AllSuccessful();
+
+    /// <summary>
+    /// How branches are represented in the checkpoint graph.
+    /// Nested = full isolated context per branch (default).
+    /// Flat = virtual contexts sharing parent (~30% fewer checkpoint operations).
+    /// </summary>
+    public NestingType NestingType { get; set; } = NestingType.Nested;
+}
+
+/// <summary>
+/// Configuration for map operations.
+/// </summary>
+public class MapConfig
+{
+    /// <summary>
+    /// Maximum concurrent items. Null = unlimited.
+    /// </summary>
+    public int? MaxConcurrency { get; set; }
+
+    /// <summary>
+    /// When to consider the operation complete.
+    /// </summary>
+    public CompletionConfig CompletionConfig { get; set; } = CompletionConfig.AllSuccessful();
+
+    /// <summary>
+    /// How item branches are represented in the checkpoint graph.
+    /// </summary>
+    public NestingType NestingType { get; set; } = NestingType.Nested;
+
+    /// <summary>
+    /// Optional batching configuration for grouping items before processing.
+    /// When set, items are grouped into batches and each batch is processed as a unit.
+    /// Reduces checkpoint overhead for large collections.
+    /// </summary>
+    public ItemBatcher? Batcher { get; set; }
+
+    /// <summary>
+    /// Optional function to generate a custom name for each item's branch.
+    /// Improves observability in execution traces. Receives the item and its index.
+    /// If null, branches are named by index (e.g., "0", "1", "2").
+    /// </summary>
+    public Func<object, int, string>? ItemNamer { get; set; }
+}
+
+/// <summary>
+/// Groups items into batches for map operations to reduce checkpoint overhead.
+/// At least one of MaxItemsPerBatch or MaxBytesPerBatch must be set.
+/// </summary>
+public class ItemBatcher
+{
+    /// <summary>
+    /// Maximum number of items per batch. Null = no count limit.
+    /// </summary>
+    public int? MaxItemsPerBatch { get; set; }
+
+    /// <summary>
+    /// Maximum serialized size (bytes) per batch. Null = no size limit.
+    /// </summary>
+    public int? MaxBytesPerBatch { get; set; }
+}
+
+/// <summary>
+/// Defines completion criteria for parallel/map operations.
+/// </summary>
+public class CompletionConfig
+{
+    public int? MinSuccessful { get; set; }
+    public int? ToleratedFailureCount { get; set; }
+    public double? ToleratedFailurePercentage { get; set; }
+
+    public static CompletionConfig AllSuccessful() => new() { ToleratedFailureCount = 0 };
+    public static CompletionConfig FirstSuccessful() => new() { MinSuccessful = 1 };
+    public static CompletionConfig AllCompleted() => new();
+}
+
+/// <summary>
+/// Configuration for child context operations.
+/// </summary>
+public class ChildContextConfig
+{
+    /// <summary>
+    /// Custom serializer for the child context's return value.
+    /// </summary>
+    public ICheckpointSerializer? Serializer { get; set; }
+
+    /// <summary>
+    /// Operation sub-type label for observability (e.g., in test runner output).
+    /// </summary>
+    public string? SubType { get; set; }
+
+    /// <summary>
+    /// Optional function to transform exceptions from the child context before
+    /// surfacing them to the parent. Useful for wrapping low-level errors into
+    /// domain-specific exceptions.
+    /// </summary>
+    public Func<Exception, Exception>? ErrorMapping { get; set; }
+}
+
+/// <summary>
+/// Configuration for wait-for-condition (polling).
+/// </summary>
+public class WaitForConditionConfig<TState>
+{
+    /// <summary>
+    /// Initial state passed to the first check invocation.
+    /// </summary>
+    public required TState InitialState { get; set; }
+
+    /// <summary>
+    /// Strategy controlling how long to wait between checks.
+    /// </summary>
+    public required IWaitStrategy<TState> WaitStrategy { get; set; }
+}
+```
+
+### Result Types
+
+```csharp
+/// <summary>
+/// Result of a parallel or map operation.
+/// </summary>
+public interface IBatchResult<T>
+{
+    /// <summary>
+    /// All items (succeeded and failed).
+    /// </summary>
+    IReadOnlyList<IBatchItem<T>> All { get; }
+
+    /// <summary>
+    /// Only successful items.
+    /// </summary>
+    IReadOnlyList<IBatchItem<T>> Succeeded { get; }
+
+    /// <summary>
+    /// Only failed items.
+    /// </summary>
+    IReadOnlyList<IBatchItem<T>> Failed { get; }
+
+    /// <summary>
+    /// Get all successful results. Throws if any failed.
+    /// </summary>
+    IReadOnlyList<T> GetResults();
+
+    /// <summary>
+    /// Throw an exception if any item failed.
+    /// </summary>
+    void ThrowIfError();
+
+    /// <summary>
+    /// Why the operation completed.
+    /// </summary>
+    CompletionReason CompletionReason { get; }
+}
+
+public interface IBatchItem<T>
+{
+    int Index { get; }
+    BatchItemStatus Status { get; }
+    T? Result { get; }
+    DurableExecutionException? Error { get; }
+}
+
+public enum BatchItemStatus { Succeeded, Failed, Cancelled }
+public enum CompletionReason { AllCompleted, MinSuccessfulReached, FailureToleranceExceeded }
+
+/// <summary>
+/// Represents a pending callback.
+/// </summary>
+public interface ICallback<T>
+{
+    /// <summary>
+    /// The callback ID to send to external systems.
+    /// </summary>
+    string CallbackId { get; }
+
+    /// <summary>
+    /// Wait for and return the callback result.
+    /// Suspends execution until the result is available.
+    /// </summary>
+    Task<T?> GetResultAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Metadata about the current execution.
+/// </summary>
+public interface IExecutionContext
+{
+    /// <summary>
+    /// The ARN of the current durable execution.
+    /// </summary>
+    string DurableExecutionArn { get; }
+}
+```
+
+### Exception Types
+
+> **Implementations:** [Python](https://github.com/aws/aws-durable-execution-sdk-python/blob/main/src/aws_durable_execution_sdk_python/exceptions.py) | [JavaScript](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js/src/errors/durable-error/durable-error.ts)
+
+```csharp
+/// <summary>
+/// Base exception for all durable execution errors.
+/// </summary>
+public class DurableExecutionException : Exception { }
+
+/// <summary>
+/// Thrown when user code inside a step fails (after retries exhausted).
+/// Contains the original error details from the checkpoint.
+/// </summary>
+public class StepException : DurableExecutionException
+{
+    public string? ErrorType { get; }
+    public string? ErrorData { get; }
+    public IReadOnlyList<string>? StackTrace { get; }
+}
+
+/// <summary>
+/// Thrown when a callback fails or times out.
+/// </summary>
+public class CallbackException : DurableExecutionException
+{
+    public string? CallbackId { get; }
+    public bool IsTimeout { get; }
+}
+
+/// <summary>
+/// Thrown when an invoked function fails.
+/// </summary>
+public class InvokeException : DurableExecutionException
+{
+    public string? FunctionName { get; }
+    public string? ErrorType { get; }
+    public string? ErrorData { get; }
+}
+
+/// <summary>
+/// Thrown when a child context operation fails.
+/// </summary>
+public class ChildContextException : DurableExecutionException
+{
+    public string? SubType { get; }
+}
+
+/// <summary>
+/// Thrown when a wait-for-condition operation exhausts all attempts
+/// without the condition being met.
+/// </summary>
+public class WaitForConditionException : DurableExecutionException
+{
+    public int AttemptsExhausted { get; }
+}
+
+/// <summary>
+/// Thrown when the operation sequence during replay does not match
+/// the previously checkpointed history. Indicates non-deterministic code.
+/// </summary>
+public class NonDeterministicException : DurableExecutionException
+{
+    public string? ExpectedOperationId { get; }
+    public string? ActualOperationId { get; }
+}
+
+/// <summary>
+/// Thrown when a step is interrupted mid-execution (e.g., Lambda timeout or
+/// runtime termination). The step did not complete and its result was not
+/// checkpointed. On the next invocation, the step will re-execute from scratch.
+/// </summary>
+public class StepInterruptedException : DurableExecutionException
+{
+    public string? StepName { get; }
+    public int AttemptNumber { get; }
+}
+
+/// <summary>
+/// Thrown when checkpoint serialization or deserialization fails.
+/// </summary>
+public class SerializationException : DurableExecutionException { }
+
+/// <summary>
+/// Thrown when input validation fails.
+/// </summary>
+public class DurableValidationException : DurableExecutionException { }
+
+/// <summary>
+/// Thrown when the checkpoint API call fails.
+/// </summary>
+public class CheckpointException : DurableExecutionException
+{
+    public bool IsRetriable { get; }
+}
+```
+
+---
+
+## Serialization
+
+> **Implementations:** [Python](https://github.com/aws/aws-durable-execution-sdk-python/blob/main/src/aws_durable_execution_sdk_python/serdes.py) | [JavaScript](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js/src/utils/serdes/serdes.ts)
+
+### Default behavior
+
+Step results are serialized to JSON (via `System.Text.Json`) before checkpointing. Your return types need to be JSON-serializable.
+
+```csharp
+// ✅ GOOD: JSON-serializable types
+public record OrderResult(string OrderId, decimal Total, bool IsCompleted);
+
+// ❌ BAD: Non-serializable types
+public class BadResult
+{
+    public Stream DataStream { get; set; }      // Not serializable
+    public HttpClient Client { get; set; }      // Not serializable
+}
+```
+
+### Custom Serialization
+
+Implement `ICheckpointSerializer<T>` for custom serialization:
+
+```csharp
+public interface ICheckpointSerializer<T>
+{
+    string Serialize(T value, SerializationContext context);
+    T Deserialize(string data, SerializationContext context);
+}
+
+public record SerializationContext(string OperationId, string DurableExecutionArn);
+```
+
+Usage:
+
+```csharp
+var result = await context.StepAsync(
+    async () => await GetLargeData(),
+    name: "get_data",
+    config: new StepConfig
+    {
+        Serializer = new CompressedJsonSerializer<LargeData>()
+    });
+```
+
+### Class library vs. executable output
+
+All samples in this doc use the class library pattern (no `Main` method). This is the default for Lambda functions. To turn a durable function project into an executable (required for NativeAOT or custom runtimes):
+
+**With Annotations** — add the global attribute to auto-generate a `Main` method:
+```csharp
+[assembly: LambdaGlobalProperties(GenerateMain = true)]
+```
+
+**Without Annotations** — provide your own `Main` method:
+```csharp
+public static async Task Main(string[] args)
+{
+    using var bootstrap = new LambdaBootstrap(
+        new Function().FunctionHandler,
+        new DefaultLambdaJsonSerializer());
+    await bootstrap.RunAsync();
+}
+```
+
+Both approaches produce a self-contained executable that the Lambda custom runtime can invoke.
+
+### NativeAOT compatibility
+
+The SDK is AOT-friendly but does not require AOT. The default JSON serialization uses reflection (standard `System.Text.Json` behavior), which works in JIT mode. For NativeAOT deployments, provide a `JsonSerializerContext` via the `ICheckpointSerializer<T>` interface — this avoids all runtime reflection and is fully trim-safe. The SDK itself avoids `Activator.CreateInstance`, `Type.GetType()`, and other reflection patterns, and uses `[DynamicallyAccessedMembers]` trimming annotations where needed.
+
+```csharp
+// Default: works with reflection (JIT mode)
+var result = await context.StepAsync<Order>(async () => await GetOrder());
+
+// AOT mode: user provides serialization context
+var result = await context.StepAsync(
+    async () => await GetOrder(),
+    config: new StepConfig { Serializer = new JsonCheckpointSerializer<Order>(MyJsonContext.Default.Order) });
+```
+
+### Large payload and checkpoint overflow
+
+The durable execution service imposes size limits:
+
+- **256 KB** per individual operation checkpoint
+- **6 MB** maximum Lambda response payload
+
+The SDK handles overflow transparently:
+
+**Step results exceeding 256 KB:** When a step's serialized result exceeds the checkpoint size limit, the SDK splits the checkpoint into a START operation (before execution) and a separate result checkpoint (after execution). On replay, the SDK fetches the result via the paginated `GetDurableExecutionState` API rather than reading it inline from the operation record.
+
+**Batch results (map/parallel) exceeding limits:** For large map/parallel operations, the SDK generates a compact summary for the parent operation's checkpoint. The summary includes item count, success/failure counts, and completion reason — but not individual item results. During replay, the SDK sets `ReplayChildren = true` on the state request, which causes the service to return child operation records so full results can be reconstructed.
+
+**Lambda response exceeding 6 MB:** If the final orchestration result exceeds the response payload limit, the SDK checkpoints the result before returning the `DurableExecutionInvocationOutput`. The service reads the result from the checkpoint rather than from the response body.
+
+**Guidance for very large results:** For results that are inherently large (multi-MB payloads), use a custom `ICheckpointSerializer<T>` that offloads to external storage (S3, DynamoDB) and returns a reference. This keeps checkpoint sizes small and avoids pagination overhead:
+
+```csharp
+public class S3BackedSerializer<T> : ICheckpointSerializer<T>
+{
+    public string Serialize(T value, SerializationContext context)
+    {
+        var key = $"results/{context.DurableExecutionArn}/{context.OperationId}";
+        // Upload to S3, return the key as the checkpoint value
+        _s3Client.PutObject(new PutObjectRequest { BucketName = _bucket, Key = key, ... });
+        return key;
+    }
+
+    public T Deserialize(string data, SerializationContext context)
+    {
+        // Download from S3 using the stored key
+        var response = _s3Client.GetObject(new GetObjectRequest { BucketName = _bucket, Key = data });
+        return JsonSerializer.Deserialize<T>(response.ResponseStream);
+    }
+}
+```
+
+---
+
+## Integration with Existing Libraries
+
+### Amazon.Lambda.Core
+
+The SDK uses existing Lambda core interfaces:
+- `ILambdaContext` -- available via `context.LambdaContext`
+- `ILambdaSerializer` -- used for event deserialization
+
+### Amazon.Lambda.RuntimeSupport
+
+The durable execution handler integrates with the existing runtime support bootstrap:
+
+```csharp
+// The [DurableExecution] attribute signals that the handler
+// receives DurableExecutionInvocationInput and returns DurableExecutionInvocationOutput
+// The SDK handles the translation to/from the user's handler signature
+```
+
+### Amazon.Lambda.Annotations (optional)
+
+`Amazon.Lambda.Annotations` is an **optional** dependency. Users can write durable functions without it (see [Manual Handler](#manual-handler-without-annotations) above), but adding Annotations to the project reduces boilerplate significantly.
+
+When both packages are referenced, the Annotations source generator detects `[DurableExecution]` by fully-qualified name and at compile time:
+
+1. Generates a handler wrapper that translates `DurableExecutionInvocationInput` to/from your types
+2. Manages context lifecycle (creation, checkpoint batching, cleanup)
+3. Adds `DurableConfig` to the CloudFormation template
+4. Adds the `AWSLambdaBasicDurableExecutionRolePolicy` managed policy
+
+```csharp
+public class Functions
+{
+    [LambdaFunction]
+    [DurableExecution(ExecutionTimeout = 3600, RetentionPeriodInDays = 7)]
+    public async Task<OrderResult> ProcessOrder(
+        [FromBody] OrderRequest request,
+        IDurableContext context)
+    {
+        var validated = await context.StepAsync(
+            async (step) => await Validate(request),
+            name: "validate");
+        // ...
+    }
+}
+```
+
+#### Custom Lambda Client
+
+For VPC endpoints, custom retry policies, or testing with mocked clients, inject a custom `IAmazonLambda` client via the `[DurableExecution]` attribute:
+
+```csharp
+public class Functions
+{
+    private readonly IAmazonLambda _lambdaClient;
+
+    public Functions(IAmazonLambda lambdaClient)
+    {
+        _lambdaClient = lambdaClient;
+    }
+
+    [LambdaFunction]
+    [DurableExecution(LambdaClientFactory = nameof(_lambdaClient))]
+    public async Task<OrderResult> ProcessOrder(
+        [FromBody] OrderRequest request,
+        IDurableContext context)
+    {
+        // ...
+    }
+}
+```
+
+When no `LambdaClientFactory` is specified, the generated code creates a default `AmazonLambdaClient`. For the manual handler path, pass the client directly to `DurableExecutionHandler.RunAsync`.
+
+> **Dependency boundaries:** `Amazon.Lambda.Annotations` has **no dependency** on the AWS SDK or on `Amazon.Lambda.DurableExecution`. The Annotations source generator references durable execution types by fully-qualified name strings only — it never takes a compile-time dependency on the durable package. The `[DurableExecution]` attribute is defined in `Amazon.Lambda.DurableExecution`, and the generated code resolves against the user's project references. There is only one source generator (Annotations) — no coordination between multiple generators is needed.
+
+### AWSSDK.Lambda
+
+The `Amazon.Lambda.DurableExecution` package depends on the AWS SDK for .NET Lambda client to make checkpoint API calls. This dependency is confined to the durable execution package — `Amazon.Lambda.Annotations` does not depend on the AWS SDK.
+
+
+- `CheckpointDurableExecutionAsync`
+- `GetDurableExecutionStateAsync`
+
+---
+
+## Testing (customer-facing package)
+
+> **Implementations:** [JavaScript (local runner)](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/local-durable-test-runner.ts) | [JavaScript (cloud runner)](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/cloud-durable-test-runner.ts)
+
+We ship a separate NuGet package (`Amazon.Lambda.DurableExecution.Testing`) that lets developers test their durable functions locally without deploying to AWS.
+
+**Why this needs to exist:** A durable function requires multiple Lambda invocations to complete (invoke → PENDING → wait → re-invoke → SUCCEEDED). You can't test that with a normal unit test because there's no Lambda service orchestrating the re-invocations. The test runner simulates this loop in-process: it calls your handler, gets PENDING, marks waits as elapsed, calls your handler again with the prior checkpoint state, and repeats until the workflow completes.
+
+```csharp
+var runner = new DurableTestRunner<OrderEvent, OrderResult>(
+    handler: new Function().Handler,
+    options: new TestRunnerOptions
+    {
+        SkipTime = true,      // Waits complete instantly (no real delays)
+        MaxInvocations = 10   // Safety limit to prevent infinite loops
+    });
+
+var result = await runner.RunAsync(
+    input: new OrderEvent { OrderId = "order-123" },
+    timeout: TimeSpan.FromSeconds(30));
+
+Assert.Equal(InvocationStatus.Succeeded, result.Status);
+Assert.Equal("approved", result.Result.Status);
+
+// Inspect individual steps
+var validateStep = result.GetStep("validate_order");
+Assert.True(validateStep.GetResult<ValidationResult>().IsValid);
+```
+
+The Python and JS SDKs both ship equivalent test runner packages.
+
+### Cloud Test Runner
+
+For integration testing against deployed functions, the testing package also ships a `CloudDurableTestRunner` with the same API as the local runner. This lets developers run the exact same assertions against a real Lambda function:
+
+```csharp
+var runner = new CloudDurableTestRunner<OrderEvent, OrderResult>(
+    functionArn: "arn:aws:lambda:us-east-1:123456789012:function:process-order:$LATEST");
+
+var result = await runner.RunAsync(
+    input: new OrderEvent { OrderId = "order-123" },
+    timeout: TimeSpan.FromSeconds(60));
+
+Assert.Equal(InvocationStatus.Succeeded, result.Status);
+var validateStep = result.GetStep("validate_order");
+Assert.True(validateStep.GetResult<ValidationResult>().IsValid);
+```
+
+The cloud runner invokes the deployed function and polls `GetDurableExecutionState` until the execution reaches a terminal state, then reconstructs the same `TestResult` structure as the local runner.
+
+### Function Registration for Invoke Testing
+
+To test workflows that use `InvokeAsync` without deploying, register sibling functions with the local test runner:
+
+```csharp
+var paymentHandler = new PaymentFunction().Handler;
+
+var runner = new DurableTestRunner<OrderEvent, OrderResult>(
+    handler: new OrderFunction().Handler,
+    options: new TestRunnerOptions { SkipTime = true });
+
+runner.RegisterFunction("process-payment", paymentHandler);
+runner.RegisterFunction(
+    "arn:aws:lambda:us-east-1:123:function:process-payment:$LATEST",
+    paymentHandler);
+
+var result = await runner.RunAsync(input: new OrderEvent { OrderId = "123" });
+```
+
+When the workflow calls `context.InvokeAsync("process-payment", payload)`, the test runner routes to the registered handler instead of making an AWS API call.
+
+---
+
+## Local development (Test Tool v2 and Aspire)
+
+The Lambda Test Tool v2 and the Aspire Lambda integration currently emulate single-invocation Lambda functions. Durable functions require a multi-invocation loop that neither tool supports today. To add support, the local emulator needs three things:
+
+### Checkpoint API endpoints
+
+The SDK calls these during execution. The emulator would serve them locally with in-memory storage:
+
+- `POST /checkpoint-durable-execution` -- store step results, wait records
+- `GET /durable-execution-state` -- return accumulated state for replay
+
+### An orchestration loop
+
+When the function returns `PENDING`, the emulator needs to:
+- Parse the checkpoint to determine what's pending (timer, callback, retry)
+- Wait for that condition (or skip it in fast mode)
+- Re-invoke the function with the accumulated `DurableExecutionInvocationInput`
+- Repeat until `SUCCEEDED` or `FAILED`
+
+### Callback delivery
+
+An endpoint that external tools (or the developer via the UI) can call to deliver callback results:
+
+- `POST /send-durable-execution-callback-success`
+- This triggers a re-invocation of the waiting execution
+
+### How this relates to the testing SDK
+
+The `DurableTestRunner` in the testing package implements the same orchestration loop programmatically. The test tool / Aspire enhancement would reuse this engine and wrap it in a web UI or Aspire dashboard, giving developers a visual way to see execution state, deliver callbacks manually, skip timers, and inspect checkpoint history.
+
+### Priority
+
+This is post-v1 work. For the initial release, developers test durable functions using the programmatic `DurableTestRunner` or by deploying to AWS. Test tool and Aspire support are a fast-follow once the core SDK is stable.
+
+---
+
+## Requirements & Constraints
+
+- **Target framework:** `net8.0` only. .NET 6 is EOL and not supported. Durable functions are a new feature — adopters will be on the latest managed runtime. Targeting .NET 8 gives access to `required` properties, improved `System.Text.Json` source generation, and better NativeAOT support.
+- **Lambda runtime:** Requires the managed .NET 8 runtime or a custom runtime (`provided.al2023`) for NativeAOT deployments.
+- **Durable execution service:** The function must be configured with `DurableConfig` (handled automatically by the `[DurableExecution]` source generator).
+- **Qualified function identifiers:** `InvokeAsync` requires a version number, alias, or `$LATEST` — unqualified ARNs are not supported for durable invocations.
+- **Serializable results:** All step return types must be JSON-serializable (or use a custom `ICheckpointSerializer<T>`).
+
+---
+
+## Package Structure
+
+### Amazon.Lambda.DurableExecution (Runtime)
+
+The core SDK that runs in Lambda. Minimal dependencies.
+
+**Dependencies:**
+- `Amazon.Lambda.Core` (existing)
+- `AWSSDK.Lambda` (for checkpoint/state APIs)
+- `Microsoft.Extensions.Logging.Abstractions` (for ILogger)
+
+### Amazon.Lambda.DurableExecution.Testing (Dev-only)
+
+Test runner and helpers for local/cloud testing.
+
+**Dependencies:**
+- `Amazon.Lambda.DurableExecution`
+- `Amazon.Lambda.TestUtilities` (existing)
+
+### Blueprints (`dotnet new` Templates)
+
+New `dotnet new` templates ship as part of the existing `Amazon.Lambda.Templates` NuGet package (same as all other Lambda blueprints in this repo under `Blueprints/BlueprintDefinitions/`).
+
+**Templates to ship:**
+
+| Template short name | Description |
+|---------------------|-------------|
+| `lambda.DurableFunction` | Minimal durable function with a single step and wait. Includes test project with `DurableTestRunner`. |
+| `lambda.DurableFunction.Agentic` | GenAI agentic loop pattern (invoke model → check tool call → execute tool → repeat). |
+| `lambda.DurableFunction.HumanInTheLoop` | Callback-based human approval workflow. |
+
+Each template includes:
+- `.csproj` with correct NuGet references (`Amazon.Lambda.DurableExecution`, `Amazon.Lambda.Annotations`)
+- Handler class with `[LambdaFunction]` + `[DurableExecution]` attributes
+- `serverless.template` (auto-generated by source generator on build)
+- Test project with `DurableTestRunner` and a passing test
+- `aws-lambda-tools-defaults.json` for deployment via `dotnet lambda deploy-function`
+
+Running `dotnet new lambda.DurableFunction` should produce a buildable, testable, deployable project in under 30 seconds.
+
+---
+
+## Implementation plan
+
+| Workstream | Scope | Estimate |
+|------------|-------|----------|
+| **Durable execution runtime** | Core SDK: replay engine, all context operations (step, wait, callback, invoke, parallel, map), checkpoint batching, retry, logging | ~5-6 weeks |
+| **Annotations / source generator** | `[DurableExecution]` attribute, handler wrapper codegen, CloudFormation DurableConfig + IAM policy generation | ~2 weeks |
+| **Testing SDK** | Local test runner (in-memory, time-skipping), cloud test runner, step inspection API | ~1.5 weeks |
+| **Blueprints, docs, examples** | `dotnet new` project templates, developer guide, API reference, sample projects | ~2 weeks |
+| **Roslyn analyzers** (P1 follow-up) | Static analysis detecting non-determinism, nesting violations, closure mutations | ~2 weeks |
+
+**Total: ~10-11 weeks (1 engineer familiar with the Python/JS SDKs)** + Roslyn analyzers as follow-up
+
+### Roslyn Analyzers (P1 Follow-up)
+
+> **Reference implementation:** JavaScript ESLint plugin — [no-non-deterministic-outside-step](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js-eslint-plugin/src/rules/no-non-deterministic-outside-step/no-non-deterministic-outside-step.ts) | [no-nested-durable-operations](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js-eslint-plugin/src/rules/no-nested-durable-operations/no-nested-durable-operations.ts) | [no-closure-in-durable-operations](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js-eslint-plugin/src/rules/no-closure-in-durable-operations/no-closure-in-durable-operations.ts)
+
+Ship as a separate NuGet package: `Amazon.Lambda.DurableExecution.Analyzers`
+
+The JavaScript SDK ships an ESLint plugin (`@aws/durable-execution-sdk-js-eslint-plugin`) with three rules that catch the most common durable execution mistakes at author time. The .NET equivalent uses Roslyn diagnostic analyzers:
+
+| Diagnostic ID | Severity | Rule | Rationale |
+|---------------|----------|------|-----------|
+| DE001 | Warning | `DateTime.Now`, `DateTime.UtcNow`, `Guid.NewGuid()`, `Random.Next()`, `Random.Shared`, `Environment.TickCount` used outside a `StepAsync` body | Non-deterministic values produce different results on replay, breaking checkpoint consistency |
+| DE002 | Error | Calling `context.StepAsync`, `WaitAsync`, `ParallelAsync`, `MapAsync`, `InvokeAsync`, `RunInChildContextAsync`, `CreateCallbackAsync`, or `WaitForCallbackAsync` inside a `StepAsync` lambda | Steps are leaf operations — nesting durable operations inside a step produces unpredictable behavior |
+| DE003 | Warning | Mutable variable captured by a `StepAsync` lambda and written to inside the lambda body | On replay the step returns cached result without executing, so the write never happens — the outer variable has stale state |
+| DE004 | Info | `Task.WhenAll` or `Task.WhenAny` called with tasks returned by durable context methods | Suggest using `ParallelAsync` for completion policies, nesting control, and observability |
+
+These analyzers run at compile time in the IDE (IntelliSense squiggles) and during `dotnet build`, preventing the most confusing class of runtime failures.
+
+---
+
+## Cross-SDK API comparison
+
+All three SDKs expose the same core operations. The differences are naming conventions, parameter ordering, and concurrency model.
+
+| Operation | .NET | Python | JavaScript |
+|-----------|------|--------|------------|
+| Step | `context.StepAsync(func, name?, config?)` | `context.step(func, name?, config?)` | `context.step(name?, fn, config?)` → `DurablePromise<T>` |
+| Wait | `context.WaitAsync(duration, name?)` | `context.wait(duration, name?)` | `context.wait(name?, duration)` → `DurablePromise<void>` |
+| Create callback | `context.CreateCallbackAsync<T>(name?, config?)` | `context.create_callback(name?, config?)` | `context.createCallback(name?, config?)` |
+| Wait for callback | `context.WaitForCallbackAsync<T>(submitter, name?, config?)` | `context.wait_for_callback(submitter, name?, config?)` | `context.waitForCallback(name?, submitter, config?)` |
+| Invoke | `context.InvokeAsync<P,R>(funcName, payload, name?, config?)` | `context.invoke(func_name, payload, name?, config?)` | `context.invoke(name?, funcId, input, config?)` → `DurablePromise<T>` |
+| Parallel | `context.ParallelAsync<T>(functions, name?, config?)` | `context.parallel(functions, name?, config?)` | `context.parallel(name?, branches, config?)` |
+| Map | `context.MapAsync<TItem,TResult>(items, func, name?, config?)` | `context.map(inputs, func, name?, config?)` | `context.map(name?, items, mapFunc, config?)` |
+| Child context | `context.RunInChildContextAsync<T>(func, name?, config?)` | `context.run_in_child_context(func, name?, config?)` | `context.runInChildContext(name?, fn, config?)` |
+| Wait for condition | `context.WaitForConditionAsync<T>(check, config, name?)` | `context.wait_for_condition(check, config, name?)` | `context.waitForCondition(name?, checkFunc, config?)` |
+| Logger | `context.Logger` (ILogger) | `context.logger` (Logger) | `context.logger` (DurableContextLogger) |
+| Lambda context | `context.LambdaContext` | `context.lambda_context` | `context.lambdaContext` |
+| Execution context | `context.ExecutionContext` | `context.execution_context` | *(via logger metadata)* |
+| Promise combinators | `CompletionConfig` on `ParallelAsync` | `CompletionConfig` on `parallel`/`map` | `context.promise.all/allSettled/any/race` |
+| Configure logger | `context.ConfigureLogger(config)` | `context.set_logger(logger)` | `context.configureLogger(config)` |
+| Cancellation | `CancellationToken` on all methods | *(N/A)* | *(N/A)* |
+| Jitter strategy | `JitterStrategy` enum on `Exponential()` | `jitter_strategy` on `RetryStrategyConfig` | `jitter` on `createRetryStrategy()` |
+| Retry presets | `RetryStrategy.None/Default/Transient` | `RetryPresets.none()/default()/transient()` | `retryPresets.default/linear/noRetry` |
+| Nesting type | `NestingType` on `ParallelConfig`/`MapConfig` | `NestingType` on parallel/map config | `NestingType` on parallel/map config |
+| Item batching | `ItemBatcher` on `MapConfig` | `ItemBatcher` on `MapConfig` | *(checkpoint manager handles batching)* |
+| Item namer | `ItemNamer` on `MapConfig` | Item naming function on `MapConfig` | `itemNamer` on `MapConfig` |
+| Error mapping | `ErrorMapping` on `ChildContextConfig` | *(typed exception wrapping)* | `errorMapping` on child context config |
+| Message-based retry filter | `retryableMessagePatterns` (regex) | `retryable_errors` (regex) | `retryableErrors` (RegExp[]) |
+| Step context / scoped logger | `IStepContext` with `Logger`, `AttemptNumber` | `StepContext` with `logger` | `ctx` with `logger` in step callback |
+| Named parallel branches | `DurableBranch<T>(name, func)` | Function `__name__` | `{ name, func }` objects |
+| Inline retry lambda | `Func<Exception, int, RetryDecision>` | `Callable[[Exception, int], RetryDecision]` | `(error, attempt) => RetryDecision` |
+| Static analysis | Roslyn analyzers (P1 follow-up) | *(N/A)* | ESLint plugin (3 rules) |
+| Cloud test runner | `CloudDurableTestRunner<TIn,TOut>` | `pytest --runner-mode=cloud` | `CloudDurableTestRunner` |
+
+**Key differences:**
+
+- **Concurrency model:** JS returns `DurablePromise<T>` (lazy, deferred until awaited). Python is synchronous (blocks the thread). .NET returns `Task<T>` (standard async/await). Note: `Task.WhenAll` works with durable operations but `ParallelAsync`/`MapAsync` are preferred for completion policies and observability.
+- **Name parameter position:** JS puts `name` first; Python and .NET put it after the function/duration.
+- **Parallel semantics in JS:** JS uses `context.promise.all/any/race/allSettled` to combine DurablePromises. .NET and Python use `CompletionConfig` on the `Parallel`/`Map` operations instead.
+- **.NET-only:** `CancellationToken` on every method (standard .NET pattern).
+- **Jitter default:** All three SDKs default to full jitter on retry strategies.
+
+---
+
+## Common Patterns
+
+### GenAI Agentic Loop
+
+```csharp
+[DurableExecution]
+public async Task<string> AgentHandler(AgentRequest input, IDurableContext context)
+{
+    var messages = new List<Message>
+    {
+        new Message { Role = "user", Content = input.Prompt }
+    };
+
+    while (true)
+    {
+        var response = await context.StepAsync(
+            async (step) => await InvokeModel(messages),
+            name: "invoke_model");
+
+        if (response.ToolCall == null)
+            return response.Content;
+
+        var toolResult = await context.StepAsync(
+            async (step) => await ExecuteTool(response.ToolCall),
+            name: $"tool_{response.ToolCall.Name}");
+
+        messages.Add(new Message { Role = "assistant", Content = toolResult });
+    }
+}
+```
+
+### Human-in-the-Loop
+
+```csharp
+[DurableExecution]
+public async Task<ReviewResult> ReviewHandler(ReviewRequest input, IDurableContext context)
+{
+    var analysis = await context.StepAsync(
+        async (step) => await AnalyzeDocument(input.DocumentUrl),
+        name: "analyze_document");
+
+    context.Logger.LogInformation("Analysis complete, requesting human review");
+
+    var review = await context.WaitForCallbackAsync<HumanReview>(
+        async (callbackId, ctx) =>
+        {
+            await NotifyReviewer(input.ReviewerEmail, callbackId, analysis);
+        },
+        name: "human_review",
+        config: new WaitForCallbackConfig
+        {
+            Timeout = TimeSpan.FromDays(7),
+            HeartbeatTimeout = TimeSpan.FromHours(24)
+        });
+
+    if (review.Approved)
+    {
+        await context.StepAsync(
+            async (step) => await PublishDocument(input.DocumentUrl),
+            name: "publish");
+    }
+
+    return new ReviewResult { Status = review.Approved ? "published" : "rejected" };
+}
+```
+
+### Scheduled Pipeline with Retries
+
+```csharp
+[DurableExecution]
+public async Task<PipelineResult> DataPipeline(PipelineInput input, IDurableContext context)
+{
+    // Extract
+    var rawData = await context.StepAsync(
+        async (step) => await ExtractFromSource(input.SourceId),
+        name: "extract",
+        config: new StepConfig
+        {
+            RetryStrategy = RetryStrategy.Exponential(maxAttempts: 5, initialDelay: TimeSpan.FromSeconds(2))
+        });
+
+    // Transform (fan-out)
+    var transformed = await context.MapAsync(
+        items: rawData.Chunks,
+        func: async (ctx, chunk, index, _) =>
+        {
+            return await ctx.StepAsync(
+                async (step) => await TransformChunk(chunk),
+                name: $"transform_{index}");
+        },
+        name: "transform_all",
+        config: new MapConfig { MaxConcurrency = 10 });
+
+    transformed.ThrowIfError();
+
+    // Load
+    var loadResult = await context.StepAsync(
+        async (step) => await LoadToDestination(transformed.GetResults()),
+        name: "load",
+        config: new StepConfig
+        {
+            Semantics = StepSemantics.AtMostOncePerRetry
+        });
+
+    // Wait before next run
+    await context.WaitAsync(TimeSpan.FromHours(1), name: "schedule_delay");
+
+    return new PipelineResult { RecordsProcessed = loadResult.Count };
+}
+```
+
+---
+
+## References
+
+- [AWS Blog: Build multi-step applications and AI workflows with AWS Lambda durable functions](https://aws.amazon.com/blogs/aws/build-multi-step-applications-and-ai-workflows-with-aws-lambda-durable-functions/)
+- [AWS Documentation: Lambda Durable Functions](https://docs.aws.amazon.com/lambda/latest/dg/durable-functions.html)
+- [Python SDK Repository](https://github.com/aws/aws-durable-execution-sdk-python)
+- [JavaScript/TypeScript SDK Repository](https://github.com/aws/aws-durable-execution-sdk-js)
+- [GitHub Issue #2216: .NET Durable Functions Support](https://github.com/aws/aws-lambda-dotnet/issues/2216)
+- [Existing .NET Annotations Design Doc](lambda-annotations-design.md)

--- a/Libraries/src/Amazon.Lambda.DurableExecution/DurableExecutionException.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/DurableExecutionException.cs
@@ -47,3 +47,23 @@ public class StepException : DurableExecutionException
     /// <summary>Creates a <see cref="StepException"/> wrapping an inner exception.</summary>
     public StepException(string message, Exception innerException) : base(message, innerException) { }
 }
+
+/// <summary>
+/// Thrown when a step under <see cref="StepSemantics.AtMostOncePerRetry"/> is
+/// detected to have been interrupted mid-execution on a prior invocation
+/// (replay sees a <c>STARTED</c> checkpoint with no terminal record).
+/// </summary>
+/// <remarks>
+/// Surfaces in <see cref="IRetryStrategy.ShouldRetry"/> so user-supplied
+/// strategies can distinguish "my code threw" from "a previous attempt
+/// crashed before it could record a result".
+/// </remarks>
+public class StepInterruptedException : StepException
+{
+    /// <summary>Creates an empty <see cref="StepInterruptedException"/>.</summary>
+    public StepInterruptedException() { }
+    /// <summary>Creates a <see cref="StepInterruptedException"/> with the given message.</summary>
+    public StepInterruptedException(string message) : base(message) { }
+    /// <summary>Creates a <see cref="StepInterruptedException"/> wrapping an inner exception.</summary>
+    public StepInterruptedException(string message, Exception innerException) : base(message, innerException) { }
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/DurableFunction.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/DurableFunction.cs
@@ -155,8 +155,7 @@ public static class DurableFunction
     ///
     /// State-hydration errors (<c>GetExecutionStateAsync</c>) propagate as
     /// <see cref="DurableExecutionException"/> too, but they are NOT caught here — they
-    /// flow up to the host so Lambda retries, matching Python's <c>GetExecutionStateError</c>
-    /// (which extends <c>InvocationError</c>).
+    /// flow up to the host so Lambda retries.
     ///
     /// User-code SDK errors (e.g. an SDK call inside a Step body) are caught by
     /// <c>StepRunner</c> and surfaced as <c>StepException</c> for the workflow's normal

--- a/Libraries/src/Amazon.Lambda.DurableExecution/IRetryStrategy.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/IRetryStrategy.cs
@@ -1,0 +1,39 @@
+namespace Amazon.Lambda.DurableExecution;
+
+/// <summary>
+/// Determines whether a failed step should be retried and with what delay.
+/// </summary>
+public interface IRetryStrategy
+{
+    /// <summary>
+    /// Evaluates whether the given exception warrants a retry.
+    /// </summary>
+    /// <param name="exception">The exception that caused the step to fail.</param>
+    /// <param name="attemptNumber">The 1-based attempt number that just failed.</param>
+    /// <returns>A decision indicating whether to retry and the delay before the next attempt.</returns>
+    RetryDecision ShouldRetry(Exception exception, int attemptNumber);
+}
+
+/// <summary>
+/// The outcome of a retry evaluation.
+/// </summary>
+public readonly struct RetryDecision
+{
+    /// <summary>Whether the step should be retried.</summary>
+    public bool ShouldRetry { get; }
+
+    /// <summary>The delay before the next retry attempt.</summary>
+    public TimeSpan Delay { get; }
+
+    private RetryDecision(bool shouldRetry, TimeSpan delay)
+    {
+        ShouldRetry = shouldRetry;
+        Delay = delay;
+    }
+
+    /// <summary>Indicates the step should not be retried.</summary>
+    public static RetryDecision DoNotRetry() => new(false, TimeSpan.Zero);
+
+    /// <summary>Indicates the step should be retried after the specified delay.</summary>
+    public static RetryDecision RetryAfter(TimeSpan delay) => new(true, delay);
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/CheckpointBatcher.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/CheckpointBatcher.cs
@@ -11,13 +11,12 @@ namespace Amazon.Lambda.DurableExecution.Internal;
 /// call awaits the flush of its containing batch (sync semantics).
 /// </summary>
 /// <remarks>
-/// TODO: when Map / Parallel / ChildContext / WaitForCondition land — or when
-/// AtLeastOncePerRetry step START gets a non-blocking variant — they will need
-/// a fire-and-forget overload like
-/// <c>Task EnqueueAsync(SdkOperationUpdate update, bool sync)</c> where
-/// <c>sync=false</c> returns as soon as the item is queued. Java's
-/// <c>sendOperationUpdate</c> vs <c>sendOperationUpdateAsync</c> is the model.
-/// Today every call site is sync, so the API stays minimal.
+/// Fire-and-forget semantics are achieved by simply not awaiting the returned
+/// Task. Errors still surface deterministically via <c>_terminalError</c>: the
+/// next sync <see cref="EnqueueAsync"/> or <see cref="DrainAsync"/> rethrows.
+/// Callers using fire-and-forget should observe the discarded Task's exception
+/// (see <c>StepOperation.FireAndForget</c>) so it doesn't trip the runtime's
+/// <c>UnobservedTaskException</c> event.
 /// </remarks>
 internal sealed class CheckpointBatcher : IAsyncDisposable
 {

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/CheckpointBatcherConfig.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/CheckpointBatcherConfig.cs
@@ -24,12 +24,10 @@ internal sealed class CheckpointBatcherConfig
     /// <remarks>
     /// TODO: not enforced today. The worker only checks <see cref="MaxBatchOperations"/>;
     /// a single oversized item (or a batch whose serialized size exceeds 750 KB)
-    /// will be sent to the service and rejected there. Java/JS/Python all
-    /// pre-flight this on the in-flight batch and split before the next add.
-    /// Wire this in alongside the async-flush operations (Map / Parallel /
-    /// child-context) since those are the scenarios that can actually fill a
-    /// batch — today every batch is 1 item with <see cref="FlushInterval"/>
-    /// = Zero, so the gap is latent.
+    /// will be sent to the service and rejected there. Wire this in alongside
+    /// the async-flush operations (Map / Parallel / child-context) since those
+    /// are the scenarios that can actually fill a batch — today every batch is
+    /// 1 item with <see cref="FlushInterval"/> = Zero, so the gap is latent.
     /// </remarks>
     internal int MaxBatchBytes { get; init; } = 750 * 1024;
 }

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/ExecutionState.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/ExecutionState.cs
@@ -6,7 +6,6 @@ namespace Amazon.Lambda.DurableExecution.Internal;
 /// <see cref="CheckpointBatcher"/>; this type is the inbound side only.
 /// </summary>
 /// <remarks>
-/// Replay tracking mirrors the Python / Java / JavaScript reference SDKs:
 /// <list type="bullet">
 ///   <item>At construction the workflow is "replaying" if and only if any user-replayable
 ///       op is present. The service always sends one <c>EXECUTION</c>-type op
@@ -41,11 +40,15 @@ internal sealed class ExecutionState
             AddOperations(initialState.Operations);
         }
 
-        // Only user-replayable ops put us into replay mode. The service-side
-        // EXECUTION op (input payload bookkeeping) is always present and must
-        // not count — see Python execution.py:258 / Java ExecutionManager:81 /
-        // JS execution-context.ts:62 for the same rule.
-        (_isReplaying, _remainingReplayOps) = ScanReplayable();
+        // We're "replaying" when there are completed ops (SUCCEEDED, FAILED,
+        // CANCELLED, STOPPED) we need to re-derive before resuming live work.
+        // The service-side EXECUTION op (input payload bookkeeping) is always
+        // present and doesn't count. If the only ops are in-progress
+        // (READY/PENDING/STARTED), there's nothing to re-derive — the next
+        // user call IS the next thing to run — so IsReplaying starts false.
+        var (_, terminalCount) = ScanReplayable();
+        _remainingReplayOps = terminalCount;
+        _isReplaying = terminalCount > 0;
     }
 
     public void AddOperations(IEnumerable<Operation> operations)
@@ -91,8 +94,11 @@ internal sealed class ExecutionState
 
     public void ValidateReplayConsistency(string operationId, string expectedType, string? expectedName)
     {
-        if (!_isReplaying) return;
-
+        // Independent of IsReplaying: as long as a checkpoint record exists
+        // for this id, its type/name must match what user code is asking for.
+        // If the only checkpointed ops are in-progress (PENDING/READY/STARTED),
+        // IsReplaying is false but the records still exist and code drift can
+        // still produce a mismatch.
         if (!_operations.TryGetValue(operationId, out var op)) return;
 
         if (op.Type != null && op.Type != expectedType)

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/OperationIdGenerator.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/OperationIdGenerator.cs
@@ -8,11 +8,10 @@ namespace Amazon.Lambda.DurableExecution.Internal;
 /// <summary>
 /// Generates deterministic operation IDs for durable operations. Each call
 /// increments an internal counter and SHA-256 hashes <c>"&lt;parentId&gt;-&lt;counter&gt;"</c>
-/// (or just <c>"&lt;counter&gt;"</c> at the root). Hashing matches the wire format
-/// used by the Java/JS/Python SDKs so the same workflow position produces a
-/// stable, opaque ID across replays — and the human-readable step name is
-/// carried separately on <c>OperationUpdate.Name</c>, so renaming a step does
-/// not break replay correlation.
+/// (or just <c>"&lt;counter&gt;"</c> at the root). The same workflow position
+/// produces a stable, opaque ID across replays — and the human-readable step
+/// name is carried separately on <c>OperationUpdate.Name</c>, so renaming a
+/// step does not break replay correlation.
 /// </summary>
 internal sealed class OperationIdGenerator
 {
@@ -46,7 +45,7 @@ internal sealed class OperationIdGenerator
 
     /// <summary>
     /// Generates the next operation ID. The counter is pre-incremented so the
-    /// first ID is <c>hash("1")</c>, matching the reference SDKs.
+    /// first ID is <c>hash("1")</c>.
     /// </summary>
     /// <remarks>
     /// Uses <see cref="Interlocked.Increment(ref int)"/> so concurrent callers
@@ -55,7 +54,7 @@ internal sealed class OperationIdGenerator
     /// <c>MapAsync</c> branches that fan out before awaiting) cannot collide
     /// on the same ID. Determinism still requires that calls happen in a
     /// deterministic order — atomicity prevents duplicate IDs but not
-    /// reordering between replays. Matches Java's <c>AtomicInteger.incrementAndGet</c>.
+    /// reordering between replays.
     /// </remarks>
     public string NextId()
     {

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/StepOperation.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/StepOperation.cs
@@ -109,9 +109,13 @@ internal sealed class StepOperation<T> : DurableOperation<T>
     }
 
     /// <summary>
-    /// PENDING means a retry was scheduled (RETRY checkpoint). If
-    /// NextAttemptTimestamp is in the future, re-suspend; otherwise the timer
-    /// has fired and we run the next attempt.
+    /// PENDING means a retry was scheduled (RETRY checkpoint). The service's
+    /// transition to READY when the timer fires is the authoritative "timer
+    /// fired" signal; we still get re-invoked in PENDING only if the service
+    /// re-invokes slightly early. The wall-clock check below is a safety net
+    /// for that case — clock skew can't cause a missed retry because if our
+    /// clock is fast we just run early, and if it's slow we re-suspend and
+    /// the service's READY transition takes over.
     /// </summary>
     private Task<T> ReplayPending(Operation pending, CancellationToken cancellationToken)
     {

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/StepOperation.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/StepOperation.cs
@@ -5,20 +5,27 @@ using Amazon.Lambda.Core;
 using Microsoft.Extensions.Logging;
 using SdkErrorObject = Amazon.Lambda.Model.ErrorObject;
 using SdkOperationUpdate = Amazon.Lambda.Model.OperationUpdate;
+using SdkStepOptions = Amazon.Lambda.Model.StepOptions;
 
 namespace Amazon.Lambda.DurableExecution.Internal;
 
 /// <summary>
-/// Durable step operation. Runs the user's function once across the lifetime
-/// of a durable execution, persisting its result so subsequent invocations
-/// replay the cached value without re-executing.
+/// Durable step operation. Runs the user's function (with retry support),
+/// persisting its result so subsequent invocations replay the cached value
+/// without re-executing.
 /// </summary>
 /// <remarks>
-/// Replay semantics — example: <c>await ctx.StepAsync(ChargeCard, "charge")</c>
+/// Replay branches — example: <c>await ctx.StepAsync(ChargeCard, "charge")</c>
 /// <list type="bullet">
-///   <item>Fresh: no prior state → run func → emit SUCCEED → return result.</item>
-///   <item>Replay (SUCCEEDED): return cached result; func is NOT re-executed.</item>
-///   <item>Replay (FAILED): re-throw the recorded exception.</item>
+///   <item><b>Fresh</b>: no prior state → run func → emit SUCCEED → return.</item>
+///   <item><b>SUCCEEDED</b>: return cached result; func is NOT re-executed.</item>
+///   <item><b>FAILED</b>: re-throw the recorded exception.</item>
+///   <item><b>PENDING</b> (retry timer not yet fired): re-suspend without
+///       running func; service re-invokes once <c>NextAttemptTimestamp</c> elapses.</item>
+///   <item><b>STARTED</b> + AtMostOncePerRetry: crash recovery — treat as a
+///       failed attempt, route through retry strategy.</item>
+///   <item><b>READY</b>: service has post-PENDING re-invoked us; the retry
+///       timer fired and the next attempt is up. Run it.</item>
 /// </list>
 /// Serialization is delegated to the <see cref="ILambdaSerializer"/> registered on
 /// <see cref="ILambdaContext.Serializer"/>. AOT-safe and reflection-based callers
@@ -55,7 +62,7 @@ internal sealed class StepOperation<T> : DurableOperation<T>
     protected override string OperationType => OperationTypes.Step;
 
     protected override Task<T> StartAsync(CancellationToken cancellationToken)
-        => ExecuteFunc(cancellationToken);
+        => ExecuteFunc(attemptNumber: 1, cancellationToken);
 
     protected override Task<T> ReplayAsync(Operation existing, CancellationToken cancellationToken)
     {
@@ -71,31 +78,126 @@ internal sealed class StepOperation<T> : DurableOperation<T>
                 // user's catch-block flow matches the original execution.
                 throw CreateStepException(existing);
 
+            case OperationStatuses.Pending:
+                return ReplayPending(existing, cancellationToken);
+
+            case OperationStatuses.Started:
+                return ReplayStarted(existing, cancellationToken);
+
+            case OperationStatuses.Ready:
+                return ReplayReady(existing, cancellationToken);
+
             default:
-                // STARTED/READY/PENDING from a prior invocation — no retry logic
-                // in this commit, so fall through and execute fresh. (Future work
-                // on retries will replace this default with explicit arms.)
-                return ExecuteFunc(cancellationToken);
+                // CANCELLED / STOPPED / unrecognized status. Re-running the
+                // step would re-execute side effects and silently mask a
+                // service-state we don't know how to interpret. Fail loud.
+                throw new NonDeterministicExecutionException(
+                    $"Step operation '{Name ?? OperationId}' has unexpected status '{existing.Status}' on replay.");
         }
     }
 
-    private async Task<T> ExecuteFunc(CancellationToken cancellationToken)
+    /// <summary>
+    /// READY means the service has post-PENDING re-invoked us — the retry
+    /// timer fired and the step is eligible to run its next attempt. No
+    /// timer check is needed (the service has already decided we're up);
+    /// just advance the attempt counter and execute.
+    /// </summary>
+    private Task<T> ReplayReady(Operation ready, CancellationToken cancellationToken)
+    {
+        var attemptNumber = (ready.StepDetails?.Attempt ?? 0) + 1;
+        return ExecuteFunc(attemptNumber, cancellationToken);
+    }
+
+    /// <summary>
+    /// PENDING means a retry was scheduled (RETRY checkpoint). If
+    /// NextAttemptTimestamp is in the future, re-suspend; otherwise the timer
+    /// has fired and we run the next attempt.
+    /// </summary>
+    private Task<T> ReplayPending(Operation pending, CancellationToken cancellationToken)
+    {
+        var nextAttemptTs = pending.StepDetails?.NextAttemptTimestamp;
+        var attemptNumber = (pending.StepDetails?.Attempt ?? 0) + 1;
+
+        if (nextAttemptTs is { } scheduledMs &&
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() < scheduledMs)
+        {
+            // Retry timer hasn't fired yet — re-suspend so we don't bill compute
+            // while the timer ticks. Service re-invokes once the timer elapses.
+            return Termination.SuspendAndAwait<T>(
+                TerminationReason.RetryScheduled, $"retry:{Name ?? OperationId}");
+        }
+
+        return ExecuteFunc(attemptNumber, cancellationToken);
+    }
+
+    /// <summary>
+    /// STARTED means a START checkpoint was written but no SUCCEED/FAIL exists.
+    /// For AtMostOncePerRetry this signals a crash mid-step — treat as failure
+    /// and route through retry. For AtLeastOncePerRetry just re-execute.
+    /// </summary>
+    private Task<T> ReplayStarted(Operation started, CancellationToken cancellationToken)
+    {
+        var attemptNumber = (started.StepDetails?.Attempt ?? 0) + 1;
+
+        if (_config?.Semantics == StepSemantics.AtMostOncePerRetry)
+        {
+            // Re-running func would risk a duplicate side effect (e.g. double
+            // charge). Treat the lost result as a failure; let the retry
+            // strategy decide whether to try again or give up.
+            //
+            // Surface as StepInterruptedException so user strategies can
+            // distinguish "my code threw" from "a prior attempt crashed before
+            // recording a terminal record".
+            var error = started.StepDetails?.Error;
+            var ex = error != null
+                ? new StepInterruptedException(error.ErrorMessage ?? "Step failed on previous attempt") { ErrorType = error.ErrorType }
+                : new StepInterruptedException("Step result lost during AtMostOncePerRetry replay");
+            return HandleStepFailureAsync(ex, attemptNumber, cancellationToken);
+        }
+
+        return ExecuteFunc(attemptNumber, cancellationToken);
+    }
+
+    private async Task<T> ExecuteFunc(int attemptNumber, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        // TODO: emit a STEP_STARTED checkpoint (action = "START") here when retries
-        // and/or AtMostOncePerRetry semantics land. AtMostOncePerRetry needs the
-        // START to be sync-flushed before user code runs (so replay can detect
-        // "we already attempted this and must not re-run"). AtLeastOncePerRetry
-        // wants it fire-and-forget for telemetry (attempt timing, retry count in
-        // history). Both require the async-flush overload in CheckpointBatcher
-        // (see TODO in CheckpointBatcher.cs). Today neither feature is wired up,
-        // so the START is intentionally omitted — SUCCEED alone is sufficient
-        // for replay correctness in the AtLeastOncePerRetry-only world this PR
-        // ships. Java SDK precedent: StepOperation.checkpointStarted().
+        // Emit a START checkpoint before running user code, unless we're already
+        // resuming a STARTED record (which means an earlier attempt wrote it).
+        //
+        // AtMostOncePerRetry: SYNC flush. If Lambda crashes before SUCCEED is
+        // flushed, ReplayStarted routes through retry instead of re-executing.
+        // A queued-but-unflushed START is indistinguishable from "never ran" if
+        // we die, so the sync flush is correctness-load-bearing here.
+        //
+        // AtLeastOncePerRetry (default): FIRE-AND-FORGET. Replay correctness
+        // doesn't depend on the START — SUCCEED alone is sufficient — so this
+        // is purely telemetry (attempt timing, retry count visible in history).
+        if (State.GetOperation(OperationId)?.Status != OperationStatuses.Started)
+        {
+            var startUpdate = new SdkOperationUpdate
+            {
+                Id = OperationId,
+                Type = OperationTypes.Step,
+                Action = OperationAction.START,
+                SubType = OperationSubTypes.Step,
+                Name = Name
+            };
+
+            if (_config?.Semantics == StepSemantics.AtMostOncePerRetry)
+            {
+                await EnqueueAsync(startUpdate, cancellationToken);
+            }
+            else
+            {
+                FireAndForget(EnqueueAsync(startUpdate, cancellationToken));
+            }
+        }
+
+
         try
         {
-            var stepContext = new StepContext(OperationId, attemptNumber: 1, _logger);
+            var stepContext = new StepContext(OperationId, attemptNumber, _logger);
             var result = await _func(stepContext);
 
             await EnqueueAsync(new SdkOperationUpdate
@@ -103,7 +205,7 @@ internal sealed class StepOperation<T> : DurableOperation<T>
                 Id = OperationId,
                 Type = OperationTypes.Step,
                 Action = OperationAction.SUCCEED,
-                SubType = "Step",
+                SubType = OperationSubTypes.Step,
                 Name = Name,
                 Payload = SerializeResult(result)
             }, cancellationToken);
@@ -116,24 +218,64 @@ internal sealed class StepOperation<T> : DurableOperation<T>
         }
         catch (Exception ex)
         {
-            // No retry logic in this commit: any thrown exception becomes a
-            // FAIL checkpoint and is re-thrown as a StepException. On replay,
-            // the FAILED branch above will re-throw without re-executing.
-            await EnqueueAsync(new SdkOperationUpdate
-            {
-                Id = OperationId,
-                Type = OperationTypes.Step,
-                Action = OperationAction.FAIL,
-                SubType = "Step",
-                Name = Name,
-                Error = ToSdkError(ex)
-            }, cancellationToken);
-
-            throw new StepException(ex.Message, ex)
-            {
-                ErrorType = ex.GetType().FullName
-            };
+            // Funnel into the retry/fail decision tree. May checkpoint RETRY and
+            // suspend (Pending), or checkpoint FAIL and rethrow to user.
+            return await HandleStepFailureAsync(ex, attemptNumber, cancellationToken);
         }
+    }
+
+    /// <summary>
+    /// Funnels a step failure into the retry/fail decision. May checkpoint
+    /// RETRY and suspend (Pending), or checkpoint FAIL and rethrow.
+    /// </summary>
+    private async Task<T> HandleStepFailureAsync(Exception ex, int attemptNumber, CancellationToken cancellationToken)
+    {
+        var retryStrategy = _config?.RetryStrategy;
+        if (retryStrategy != null)
+        {
+            var decision = retryStrategy.ShouldRetry(ex, attemptNumber);
+            if (decision.ShouldRetry)
+            {
+                // Service requires NextAttemptDelaySeconds >= 1. Built-in
+                // strategies already produce >=1s delays; this guard only
+                // matters for user-supplied IRetryStrategy / FromDelegate.
+                var requestedSeconds = decision.Delay.TotalSeconds;
+                var delaySeconds = (int)Math.Max(1, Math.Ceiling(requestedSeconds));
+                if (requestedSeconds < 1)
+                {
+                    _logger.LogWarning(
+                        "Retry delay for step '{StepName}' attempt {Attempt} was {Requested:F3}s (< 1s); coerced to {Coerced}s.",
+                        Name ?? OperationId, attemptNumber, requestedSeconds, delaySeconds);
+                }
+                await EnqueueAsync(new SdkOperationUpdate
+                {
+                    Id = OperationId,
+                    Type = OperationTypes.Step,
+                    Action = OperationAction.RETRY,
+                    SubType = OperationSubTypes.Step,
+                    Name = Name,
+                    Error = ToSdkError(ex),
+                    StepOptions = new SdkStepOptions { NextAttemptDelaySeconds = delaySeconds }
+                }, cancellationToken);
+                return await Termination.SuspendAndAwait<T>(
+                    TerminationReason.RetryScheduled, $"retry:{Name ?? OperationId}");
+            }
+        }
+
+        await EnqueueAsync(new SdkOperationUpdate
+        {
+            Id = OperationId,
+            Type = OperationTypes.Step,
+            Action = OperationAction.FAIL,
+            SubType = OperationSubTypes.Step,
+            Name = Name,
+            Error = ToSdkError(ex)
+        }, cancellationToken);
+
+        throw new StepException(ex.Message, ex)
+        {
+            ErrorType = ex.GetType().FullName
+        };
     }
 
     private T DeserializeResult(string? serialized)
@@ -168,4 +310,20 @@ internal sealed class StepOperation<T> : DurableOperation<T>
         ErrorMessage = ex.Message,
         StackTrace = ex.StackTrace?.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).ToList()
     };
+
+    /// <summary>
+    /// Discards a Task but observes any exception so it doesn't surface as an
+    /// <c>UnobservedTaskException</c>. Used for fire-and-forget START checkpoints
+    /// under AtLeastOncePerRetry semantics. The actual error still propagates
+    /// via <c>CheckpointBatcher._terminalError</c>: the next sync EnqueueAsync
+    /// or DrainAsync will rethrow with the original cause.
+    /// </summary>
+    private static void FireAndForget(Task task)
+    {
+        _ = task.ContinueWith(
+            static t => _ = t.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
 }

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/TerminationManager.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/TerminationManager.cs
@@ -6,6 +6,7 @@ namespace Amazon.Lambda.DurableExecution.Internal;
 internal enum TerminationReason
 {
     WaitScheduled,
+    RetryScheduled,
     CallbackPending,
     InvokePending,
     CheckpointFailed

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/WaitOperation.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/WaitOperation.cs
@@ -49,7 +49,7 @@ internal sealed class WaitOperation : DurableOperation<object?>
             Id = OperationId,
             Type = OperationTypes.Wait,
             Action = OperationAction.START,
-            SubType = "Wait",
+            SubType = OperationSubTypes.Wait,
             Name = Name,
             WaitOptions = new SdkWaitOptions { WaitSeconds = _waitSeconds }
         }, cancellationToken);

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Operation.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Operation.cs
@@ -168,6 +168,30 @@ public static class OperationTypes
 }
 
 /// <summary>
+/// Wire-format <see cref="Operation.SubType"/> string constants. SubType is a
+/// finer-grained classifier sent alongside <see cref="Operation.Type"/> for
+/// observability — the values are PascalCase ("Step", "Wait") and distinct
+/// from the uppercase <see cref="OperationTypes"/> values.
+/// </summary>
+public static class OperationSubTypes
+{
+    /// <summary>Step sub-type.</summary>
+    public const string Step = "Step";
+
+    /// <summary>Wait sub-type.</summary>
+    public const string Wait = "Wait";
+
+    /// <summary>Callback sub-type.</summary>
+    public const string Callback = "Callback";
+
+    /// <summary>Chained-invoke sub-type.</summary>
+    public const string ChainedInvoke = "ChainedInvoke";
+
+    /// <summary>Child-context sub-type.</summary>
+    public const string Context = "Context";
+}
+
+/// <summary>
 /// Wire-format <see cref="Operation.Status"/> string constants.
 /// Plural name avoids collision with <c>Amazon.Lambda.OperationStatus</c>.
 /// </summary>

--- a/Libraries/src/Amazon.Lambda.DurableExecution/RetryStrategy.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/RetryStrategy.cs
@@ -1,0 +1,201 @@
+using System.Text.RegularExpressions;
+
+namespace Amazon.Lambda.DurableExecution;
+
+/// <summary>
+/// Jitter strategy for exponential backoff to prevent thundering-herd scenarios.
+/// </summary>
+public enum JitterStrategy
+{
+    /// <summary>No randomization — delay is exactly the calculated backoff value.</summary>
+    None,
+    /// <summary>Random delay between 0 and the calculated backoff value (recommended).</summary>
+    Full,
+    /// <summary>Random delay between 50% and 100% of the calculated backoff value.</summary>
+    Half
+}
+
+/// <summary>
+/// Controls whether a step re-executes if the Lambda is re-invoked mid-attempt.
+/// </summary>
+public enum StepSemantics
+{
+    /// <summary>
+    /// Default. The step may re-execute if the Lambda is re-invoked during execution.
+    /// Use for idempotent operations.
+    /// </summary>
+    AtLeastOncePerRetry,
+
+    /// <summary>
+    /// The step executes at most once per retry attempt. A START checkpoint is written
+    /// before execution; on replay with an existing START, the SDK skips re-execution
+    /// and proceeds to the retry handler.
+    /// </summary>
+    AtMostOncePerRetry
+}
+
+/// <summary>
+/// Factory methods for common retry strategies.
+/// </summary>
+public static class RetryStrategy
+{
+    /// <summary>6 attempts, 2x backoff, 5s initial delay, 60s max, Full jitter.</summary>
+    public static IRetryStrategy Default { get; } = Exponential(
+        maxAttempts: 6,
+        initialDelay: TimeSpan.FromSeconds(5),
+        maxDelay: TimeSpan.FromSeconds(60),
+        backoffRate: 2.0,
+        jitter: JitterStrategy.Full);
+
+    /// <summary>3 attempts, 2x backoff, 1s initial delay, 5s max, Half jitter.</summary>
+    public static IRetryStrategy Transient { get; } = Exponential(
+        maxAttempts: 3,
+        initialDelay: TimeSpan.FromSeconds(1),
+        maxDelay: TimeSpan.FromSeconds(5),
+        backoffRate: 2.0,
+        jitter: JitterStrategy.Half);
+
+    /// <summary>No retry — 1 attempt only.</summary>
+    public static IRetryStrategy None { get; } = Exponential(maxAttempts: 1);
+
+    /// <summary>
+    /// Creates an exponential backoff retry strategy.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="maxAttempts"/> &lt; 1, <paramref name="backoffRate"/> &lt; 1,
+    /// <paramref name="initialDelay"/> is non-positive, <paramref name="maxDelay"/> is non-positive,
+    /// or <paramref name="initialDelay"/> &gt; <paramref name="maxDelay"/>.
+    /// </exception>
+    public static IRetryStrategy Exponential(
+        int maxAttempts = 3,
+        TimeSpan? initialDelay = null,
+        TimeSpan? maxDelay = null,
+        double backoffRate = 2.0,
+        JitterStrategy jitter = JitterStrategy.Full,
+        Type[]? retryableExceptions = null,
+        string[]? retryableMessagePatterns = null)
+    {
+        return new ExponentialRetryStrategy(
+            maxAttempts,
+            initialDelay ?? TimeSpan.FromSeconds(5),
+            maxDelay ?? TimeSpan.FromSeconds(300),
+            backoffRate,
+            jitter,
+            retryableExceptions,
+            retryableMessagePatterns);
+    }
+
+    /// <summary>
+    /// Creates a retry strategy from a delegate.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="strategy"/> is null.</exception>
+    public static IRetryStrategy FromDelegate(Func<Exception, int, RetryDecision> strategy)
+    {
+        if (strategy == null) throw new ArgumentNullException(nameof(strategy));
+        return new DelegateRetryStrategy(strategy);
+    }
+}
+
+internal sealed class ExponentialRetryStrategy : IRetryStrategy
+{
+    private readonly int _maxAttempts;
+    private readonly TimeSpan _initialDelay;
+    private readonly TimeSpan _maxDelay;
+    private readonly double _backoffRate;
+    private readonly JitterStrategy _jitter;
+    private readonly Type[]? _retryableExceptions;
+    private readonly Regex[]? _retryableMessagePatterns;
+
+    public ExponentialRetryStrategy(
+        int maxAttempts,
+        TimeSpan initialDelay,
+        TimeSpan maxDelay,
+        double backoffRate,
+        JitterStrategy jitter,
+        Type[]? retryableExceptions,
+        string[]? retryableMessagePatterns)
+    {
+        if (maxAttempts < 1)
+            throw new ArgumentOutOfRangeException(nameof(maxAttempts), maxAttempts, "must be >= 1");
+        if (initialDelay <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(initialDelay), initialDelay, "must be > 0");
+        if (maxDelay <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(maxDelay), maxDelay, "must be > 0");
+        if (initialDelay > maxDelay)
+            throw new ArgumentOutOfRangeException(nameof(initialDelay), initialDelay, $"must be <= maxDelay ({maxDelay})");
+        if (backoffRate < 1.0 || double.IsNaN(backoffRate) || double.IsInfinity(backoffRate))
+            throw new ArgumentOutOfRangeException(nameof(backoffRate), backoffRate, "must be a finite value >= 1.0");
+
+        _maxAttempts = maxAttempts;
+        _initialDelay = initialDelay;
+        _maxDelay = maxDelay;
+        _backoffRate = backoffRate;
+        _jitter = jitter;
+        _retryableExceptions = retryableExceptions;
+        _retryableMessagePatterns = retryableMessagePatterns?
+            .Select(p => new Regex(p, RegexOptions.Compiled))
+            .ToArray();
+    }
+
+    public RetryDecision ShouldRetry(Exception exception, int attemptNumber)
+    {
+        if (attemptNumber >= _maxAttempts)
+            return RetryDecision.DoNotRetry();
+
+        if (!IsRetryable(exception))
+            return RetryDecision.DoNotRetry();
+
+        var delay = CalculateDelay(attemptNumber);
+        return RetryDecision.RetryAfter(delay);
+    }
+
+    private bool IsRetryable(Exception exception)
+    {
+        if (_retryableExceptions == null && _retryableMessagePatterns == null)
+            return true;
+
+        if (_retryableExceptions != null)
+        {
+            var exType = exception.GetType();
+            if (_retryableExceptions.Any(t => t.IsAssignableFrom(exType)))
+                return true;
+        }
+
+        if (_retryableMessagePatterns != null)
+        {
+            var message = exception.Message;
+            if (_retryableMessagePatterns.Any(p => p.IsMatch(message)))
+                return true;
+        }
+
+        return false;
+    }
+
+    internal TimeSpan CalculateDelay(int attemptNumber)
+    {
+        var baseDelay = _initialDelay.TotalSeconds * Math.Pow(_backoffRate, attemptNumber - 1);
+        var cappedDelay = Math.Min(baseDelay, _maxDelay.TotalSeconds);
+
+        var finalDelay = _jitter switch
+        {
+            JitterStrategy.Full => Random.Shared.NextDouble() * cappedDelay,
+            JitterStrategy.Half => cappedDelay * (0.5 + 0.5 * Random.Shared.NextDouble()),
+            _ => cappedDelay
+        };
+
+        return TimeSpan.FromSeconds(Math.Max(1, Math.Ceiling(finalDelay)));
+    }
+}
+
+internal sealed class DelegateRetryStrategy : IRetryStrategy
+{
+    private readonly Func<Exception, int, RetryDecision> _strategy;
+
+    public DelegateRetryStrategy(Func<Exception, int, RetryDecision> strategy)
+    {
+        _strategy = strategy ?? throw new ArgumentNullException(nameof(strategy));
+    }
+
+    public RetryDecision ShouldRetry(Exception exception, int attemptNumber)
+        => _strategy(exception, attemptNumber);
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/RetryStrategy.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/RetryStrategy.cs
@@ -133,7 +133,7 @@ internal sealed class ExponentialRetryStrategy : IRetryStrategy
         _jitter = jitter;
         _retryableExceptions = retryableExceptions;
         _retryableMessagePatterns = retryableMessagePatterns?
-            .Select(p => new Regex(p, RegexOptions.Compiled))
+            .Select(p => new Regex(p))
             .ToArray();
     }
 

--- a/Libraries/src/Amazon.Lambda.DurableExecution/StepConfig.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/StepConfig.cs
@@ -5,9 +5,14 @@ namespace Amazon.Lambda.DurableExecution;
 /// </summary>
 public sealed class StepConfig
 {
-    // TODO: Retry support is deferred to a follow-up PR. When added, this is
-    // where RetryStrategy and Semantics (AtLeastOncePerRetry / AtMostOncePerRetry)
-    // will live. The follow-up needs to use service-mediated retries (checkpoint
-    // a RETRY operation + suspend the Lambda) rather than an in-process Task.Delay
-    // loop, to avoid billing Lambda compute time during retry backoff.
+    /// <summary>
+    /// Retry strategy for failed steps. When null (default), failures are not retried.
+    /// </summary>
+    public IRetryStrategy? RetryStrategy { get; set; }
+
+    /// <summary>
+    /// Controls whether a step may re-execute if the Lambda is re-invoked mid-attempt.
+    /// Default is <see cref="StepSemantics.AtLeastOncePerRetry"/>.
+    /// </summary>
+    public StepSemantics Semantics { get; set; } = StepSemantics.AtLeastOncePerRetry;
 }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/AtMostOnceCrashReplayTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/AtMostOnceCrashReplayTest.cs
@@ -1,0 +1,81 @@
+using System.Linq;
+using System.Text;
+using Amazon.Lambda.Model;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Amazon.Lambda.DurableExecution.IntegrationTests;
+
+public class AtMostOnceCrashReplayTest
+{
+    private readonly ITestOutputHelper _output;
+    public AtMostOnceCrashReplayTest(ITestOutputHelper output) => _output = output;
+
+    /// <summary>
+    /// Validates the AtMostOncePerRetry crash-recovery wire path: the Lambda
+    /// process is killed mid-step on attempt 1 (after START flush, before
+    /// SUCCEED). On re-invocation the SDK sees a STARTED checkpoint with no
+    /// terminal record and routes through the retry strategy rather than
+    /// re-executing the step. Attempt 2 succeeds.
+    ///
+    /// This is the only path that exercises the StepInterruptedException
+    /// synthesis — the unit-test analogue
+    /// (StepAsync_AtMostOnce_StartedReplay_TriggersRetryHandler) fakes the
+    /// STARTED state in-memory and never proves the service actually delivers
+    /// it on a real crash.
+    /// </summary>
+    [Fact]
+    public async Task AtMostOnce_StepCrashesMidExecution_RecoversViaRetry()
+    {
+        await using var deployment = await DurableFunctionDeployment.CreateAsync(
+            DurableFunctionDeployment.FindTestFunctionDir("AtMostOnceCrashFunction"),
+            "amocrash", _output);
+
+        var (invokeResponse, executionName) = await deployment.InvokeAsync("""{"orderId": "x"}""");
+        var responsePayload = Encoding.UTF8.GetString(invokeResponse.Payload.ToArray());
+        _output.WriteLine($"Response: {responsePayload}");
+
+        var arn = await deployment.FindDurableExecutionArnByNameAsync(executionName, TimeSpan.FromSeconds(60));
+        Assert.NotNull(arn);
+
+        // 2s retry delay + initial-attempt cold-start + recovery invoke. Generous headroom.
+        var status = await deployment.PollForCompletionAsync(arn!, TimeSpan.FromSeconds(120));
+        Assert.Equal("SUCCEEDED", status, ignoreCase: true);
+
+        var history = await deployment.WaitForHistoryAsync(
+            arn!,
+            h => (h.Events?.Any(e => e.StepSucceededDetails != null && e.Name == "crash_then_recover") ?? false),
+            TimeSpan.FromSeconds(60));
+        var events = history.Events ?? new List<Event>();
+
+        // Attempt 1 was crashed (no SUCCEED), attempt 2 recovered.
+        // We expect exactly one StepSucceeded carrying "recovered on attempt 2".
+        var succeeded = events.SingleOrDefault(e => e.StepSucceededDetails != null && e.Name == "crash_then_recover");
+        Assert.NotNull(succeeded);
+        Assert.Equal("\"recovered on attempt 2\"", succeeded!.StepSucceededDetails.Result?.Payload);
+
+        // Two StepStarted events: one per invocation.
+        Assert.True(
+            events.Count(e => e.EventType == EventType.StepStarted) >= 2,
+            "Expected at least 2 StepStarted events (attempt 1 crashed, attempt 2 recovered).");
+
+        // The crash-recovery branch records the synthesized StepInterruptedException
+        // as a StepFailed event for attempt 1, with a message identifying the lost
+        // attempt rather than a user exception type.
+        var failures = events
+            .Where(e => e.StepFailedDetails != null && e.Name == "crash_then_recover")
+            .Select(e => e.StepFailedDetails.Error?.Payload?.ErrorMessage ?? string.Empty)
+            .ToList();
+        Assert.NotEmpty(failures);
+        Assert.Contains(failures, m => m.Contains("Step result lost", StringComparison.OrdinalIgnoreCase)
+                                    || m.Contains("interrupted", StringComparison.OrdinalIgnoreCase)
+                                    || m.Contains("previous attempt", StringComparison.OrdinalIgnoreCase));
+
+        // The execution actually crossed at least one invocation boundary
+        // (otherwise replay wasn't exercised at all).
+        var invocations = events.Where(e => e.InvocationCompletedDetails != null).ToList();
+        Assert.True(
+            invocations.Count >= 2,
+            $"Expected at least 2 InvocationCompleted events (proves crash + replay), got {invocations.Count}");
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/DurableFunctionDeployment.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/DurableFunctionDeployment.cs
@@ -263,8 +263,16 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
             {
                 last = await GetHistoryAsync(durableExecutionArn, includeExecutionData);
                 var eventCount = last.Events?.Count ?? 0;
-                _output.WriteLine($"[WaitForHistory] attempt {attempt}: {eventCount} events");
-                if (predicate(last)) return last;
+                var typeCounts = last.Events?
+                    .GroupBy(e => e.EventType?.Value ?? "<null>")
+                    .Select(g => $"{g.Key}:{g.Count()}")
+                    .OrderBy(s => s);
+                _output.WriteLine($"[WaitForHistory] attempt {attempt}: {eventCount} events [{string.Join(",", typeCounts ?? Enumerable.Empty<string>())}]");
+                if (predicate(last))
+                {
+                    DumpEvents(last);
+                    return last;
+                }
             }
             catch (Exception ex)
             {
@@ -274,7 +282,19 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
         }
 
         _output.WriteLine($"[WaitForHistory] gave up after {attempt} attempts; returning last response with {last?.Events?.Count ?? 0} events");
+        if (last != null) DumpEvents(last);
         return last ?? throw new TimeoutException($"GetDurableExecutionHistory never succeeded within {timeout.TotalSeconds}s");
+    }
+
+    private void DumpEvents(GetDurableExecutionHistoryResponse history)
+    {
+        var events = history.Events ?? new List<Event>();
+        _output.WriteLine($"[WaitForHistory] event dump ({events.Count} total):");
+        for (int i = 0; i < events.Count; i++)
+        {
+            var e = events[i];
+            _output.WriteLine($"  [{i}] type={e.EventType?.Value ?? "<null>"} name={e.Name ?? "<null>"} ts={e.EventTimestamp:O}");
+        }
     }
 
     public string? ExtractDurableExecutionArn(string responsePayload)
@@ -375,14 +395,18 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
         var stdout = await stdoutTask;
         var stderr = await stderrTask;
 
-        if (!string.IsNullOrWhiteSpace(stdout))
-            _output.WriteLine($"stdout: {stdout[..Math.Min(stdout.Length, 1000)]}");
-
         if (process.ExitCode != 0)
         {
+            // Dump the FULL streams on failure — diagnosing build errors with
+            // truncated output is painful, and these only fire on test failure.
+            _output.WriteLine($"stdout: {stdout}");
             _output.WriteLine($"stderr: {stderr}");
-            throw new Exception($"{fileName} failed (exit {process.ExitCode}): {stderr}");
+            var detail = !string.IsNullOrWhiteSpace(stderr) ? stderr : stdout;
+            throw new Exception($"{fileName} failed (exit {process.ExitCode}): {detail}");
         }
+
+        if (!string.IsNullOrWhiteSpace(stdout))
+            _output.WriteLine($"stdout: {stdout[..Math.Min(stdout.Length, 1000)]}");
     }
 
     public async ValueTask DisposeAsync()

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/LongRetryChainTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/LongRetryChainTest.cs
@@ -1,0 +1,77 @@
+using System.Linq;
+using System.Text;
+using Amazon.Lambda.Model;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Amazon.Lambda.DurableExecution.IntegrationTests;
+
+public class LongRetryChainTest
+{
+    private readonly ITestOutputHelper _output;
+    public LongRetryChainTest(ITestOutputHelper output) => _output = output;
+
+    /// <summary>
+    /// Long retry chain across many invocations: step fails 5 times before
+    /// succeeding on attempt 6. Validates that StepDetails.Attempt increments
+    /// monotonically across invocations (no off-by-one, no skipped attempts)
+    /// and that IStepContext.AttemptNumber on the user side matches the wire
+    /// value on each attempt.
+    /// </summary>
+    [Fact]
+    public async Task FailsFiveTimesThenSucceeds_AttemptCounterIsMonotonic()
+    {
+        await using var deployment = await DurableFunctionDeployment.CreateAsync(
+            DurableFunctionDeployment.FindTestFunctionDir("LongRetryChainFunction"),
+            "longretry", _output);
+
+        var (invokeResponse, executionName) = await deployment.InvokeAsync("""{"orderId": "x"}""");
+        var responsePayload = Encoding.UTF8.GetString(invokeResponse.Payload.ToArray());
+        _output.WriteLine($"Response: {responsePayload}");
+
+        var arn = await deployment.FindDurableExecutionArnByNameAsync(executionName, TimeSpan.FromSeconds(60));
+        Assert.NotNull(arn);
+
+        // Total retry delay budget: 1+2+3+4+5 = 15s. Allow generous headroom.
+        var status = await deployment.PollForCompletionAsync(arn!, TimeSpan.FromSeconds(180));
+        Assert.Equal("SUCCEEDED", status, ignoreCase: true);
+
+        var history = await deployment.WaitForHistoryAsync(
+            arn!,
+            h => (h.Events?.Count(e => e.EventType == EventType.StepStarted) ?? 0) >= 6
+              && (h.Events?.Any(e => e.StepSucceededDetails != null) ?? false),
+            TimeSpan.FromSeconds(60));
+        var events = history.Events ?? new List<Event>();
+
+        // Six attempts total: five failures + one success.
+        Assert.Equal(6, events.Count(e => e.EventType == EventType.StepStarted));
+        Assert.Equal(5, events.Count(e => e.StepFailedDetails != null && e.Name == "long_retry_step"));
+        var succeeded = events.SingleOrDefault(e => e.StepSucceededDetails != null && e.Name == "long_retry_step");
+        Assert.NotNull(succeeded);
+
+        // The user-facing AttemptNumber on the final (winning) attempt was 6 —
+        // proves IStepContext.AttemptNumber tracks the wire attempt counter
+        // across invocations, not just within a single invocation.
+        Assert.Equal("\"ok on attempt 6\"", succeeded!.StepSucceededDetails.Result?.Payload);
+
+        // Each failure carries a unique per-attempt message — confirms the user-side
+        // counter incremented exactly once per invocation, no duplicates or skips.
+        var failureMessages = events
+            .Where(e => e.StepFailedDetails != null && e.Name == "long_retry_step")
+            .Select(e => e.StepFailedDetails.Error?.Payload?.ErrorMessage ?? string.Empty)
+            .ToList();
+        Assert.Equal(5, failureMessages.Count);
+        for (int i = 1; i <= 5; i++)
+        {
+            Assert.Contains(failureMessages, m => m.Contains($"attempt {i}"));
+        }
+
+        // The chain was executed across multiple invocations (proves the
+        // service actually re-invoked us between retries instead of holding
+        // a single Lambda alive through all six attempts).
+        var invocations = events.Where(e => e.InvocationCompletedDetails != null).ToList();
+        Assert.True(
+            invocations.Count >= 5,
+            $"Expected at least 5 InvocationCompleted events (one per retry boundary), got {invocations.Count}");
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/LongerWaitTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/LongerWaitTest.cs
@@ -30,10 +30,13 @@ public class LongerWaitTest
 
         var history = await deployment.WaitForHistoryAsync(
             arn!,
-            h => (h.Events?.Count(e => e.StepSucceededDetails != null) ?? 0) >= 2
+            h => (h.Events?.Count(e => e.EventType == EventType.StepStarted) ?? 0) >= 2
+              && (h.Events?.Count(e => e.StepSucceededDetails != null) ?? 0) >= 2
               && (h.Events?.Any(e => e.WaitSucceededDetails != null) ?? false),
             TimeSpan.FromSeconds(60));
         var events = history.Events ?? new List<Event>();
+
+        Assert.Equal(2, events.Count(e => e.EventType == EventType.StepStarted));
 
         // Steps before and after the wait both ran, with the post-wait step seeing
         // the pre-wait step's value via replay.

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/MultipleStepsTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/MultipleStepsTest.cs
@@ -32,9 +32,12 @@ public class MultipleStepsTest
         // all events are indexed. Wait until we see all 5 step-succeeded events.
         var history = await deployment.WaitForHistoryAsync(
             arn!,
-            h => (h.Events?.Count(e => e.StepSucceededDetails != null) ?? 0) >= 5,
+            h => (h.Events?.Count(e => e.EventType == EventType.StepStarted) ?? 0) >= 5
+              && (h.Events?.Count(e => e.StepSucceededDetails != null) ?? 0) >= 5,
             TimeSpan.FromSeconds(60));
         var events = history.Events ?? new List<Event>();
+
+        Assert.Equal(5, events.Count(e => e.EventType == EventType.StepStarted));
 
         // Each step ran exactly once (no replay-induced duplicates) in declaration order,
         // and each step's output chained from the previous one.

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/ReplayDeterminismTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/ReplayDeterminismTest.cs
@@ -31,9 +31,12 @@ public class ReplayDeterminismTest
         // History is eventually consistent — wait until both step-succeeded events are visible.
         var history = await deployment.WaitForHistoryAsync(
             arn!,
-            h => (h.Events?.Count(e => e.StepSucceededDetails != null) ?? 0) >= 2,
+            h => (h.Events?.Count(e => e.EventType == EventType.StepStarted) ?? 0) >= 2
+              && (h.Events?.Count(e => e.StepSucceededDetails != null) ?? 0) >= 2,
             TimeSpan.FromSeconds(60));
         var events = history.Events ?? new List<Event>();
+
+        Assert.Equal(2, events.Count(e => e.EventType == EventType.StepStarted));
 
         // Each step succeeded exactly once — generate_id was NOT re-executed on replay
         // (a duplicate would show up as two succeeded events for the same name).

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/RetryExhaustionTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/RetryExhaustionTest.cs
@@ -1,0 +1,80 @@
+using System.Linq;
+using System.Text;
+using Amazon.Lambda.Model;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Amazon.Lambda.DurableExecution.IntegrationTests;
+
+public class RetryExhaustionTest
+{
+    private readonly ITestOutputHelper _output;
+    public RetryExhaustionTest(ITestOutputHelper output) => _output = output;
+
+    /// <summary>
+    /// End-to-end retry exhaustion: step always throws, maxAttempts=3.
+    /// Validates that the SDK records exactly three StepStarted/StepFailed pairs,
+    /// the final attempt produces a FAIL checkpoint (not RETRY), and the workflow
+    /// terminates FAILED with the original exception surfaced through the
+    /// execution-level error.
+    /// </summary>
+    [Fact]
+    public async Task AlwaysFailsStep_ExhaustsRetries_TerminatesFailed()
+    {
+        await using var deployment = await DurableFunctionDeployment.CreateAsync(
+            DurableFunctionDeployment.FindTestFunctionDir("RetryExhaustionFunction"),
+            "rexhaust", _output);
+
+        var (invokeResponse, executionName) = await deployment.InvokeAsync("""{"orderId": "x"}""");
+        var responsePayload = Encoding.UTF8.GetString(invokeResponse.Payload.ToArray());
+        _output.WriteLine($"Response: {responsePayload}");
+
+        // Failed workflows return null payload synchronously; locate the execution by name.
+        var arn = await deployment.FindDurableExecutionArnByNameAsync(executionName, TimeSpan.FromSeconds(60));
+        Assert.NotNull(arn);
+
+        // 2s + 4s of retry delays + 3x execution overhead. Generous headroom for scheduling.
+        var status = await deployment.PollForCompletionAsync(arn!, TimeSpan.FromSeconds(120));
+        Assert.Equal("FAILED", status, ignoreCase: true);
+
+        // Execution-level error is the original exception from the final attempt.
+        var execution = await deployment.GetExecutionAsync(arn!);
+        Assert.NotNull(execution.Error);
+        Assert.Contains("attempt 3", execution.Error.ErrorMessage);
+
+        var history = await deployment.WaitForHistoryAsync(
+            arn!,
+            h => (h.Events?.Count(e => e.EventType == EventType.StepStarted) ?? 0) >= 3
+              && (h.Events?.Count(e => e.StepFailedDetails != null) ?? 0) >= 3,
+            TimeSpan.FromSeconds(60));
+        var events = history.Events ?? new List<Event>();
+
+        // Three attempts ran in total — no extra (off-by-one) and no truncation.
+        Assert.Equal(3, events.Count(e => e.EventType == EventType.StepStarted));
+
+        // Three failures recorded; no successes.
+        Assert.Equal(3, events.Count(e => e.StepFailedDetails != null && e.Name == "always_fails_step"));
+        Assert.Empty(events.Where(e => e.StepSucceededDetails != null));
+
+        // Each recorded failure carries the right per-attempt message.
+        var failures = events
+            .Where(e => e.StepFailedDetails != null && e.Name == "always_fails_step")
+            .Select(e => e.StepFailedDetails.Error?.Payload?.ErrorMessage ?? string.Empty)
+            .ToList();
+        Assert.Contains(failures, m => m.Contains("attempt 1"));
+        Assert.Contains(failures, m => m.Contains("attempt 2"));
+        Assert.Contains(failures, m => m.Contains("attempt 3"));
+
+        // Service honored the retry delays. No-jitter exponential backoff at 2s/4s
+        // means the gap between the first and last StepStarted is >= 6s.
+        var startedTimestamps = events
+            .Where(e => e.EventType == EventType.StepStarted && e.EventTimestamp.HasValue)
+            .OrderBy(e => e.EventTimestamp!.Value)
+            .Select(e => e.EventTimestamp!.Value)
+            .ToList();
+        var totalGap = startedTimestamps[^1] - startedTimestamps[0];
+        _output.WriteLine($"Time between first and last attempt: {totalGap.TotalSeconds:F1}s");
+        Assert.True(totalGap >= TimeSpan.FromSeconds(6),
+            $"Service did not honor retry delays: {totalGap.TotalSeconds:F1}s gap (expected >= 6s)");
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/RetryTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/RetryTest.cs
@@ -1,0 +1,78 @@
+using System.Linq;
+using System.Text;
+using Amazon.Lambda.Model;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Amazon.Lambda.DurableExecution.IntegrationTests;
+
+public class RetryTest
+{
+    private readonly ITestOutputHelper _output;
+    public RetryTest(ITestOutputHelper output) => _output = output;
+
+    /// <summary>
+    /// End-to-end retry: step throws on attempts 1 and 2, succeeds on attempt 3.
+    /// Validates that the service honors the RETRY checkpoint, schedules the
+    /// requested delay, and re-invokes the Lambda — none of which the unit
+    /// tests can prove (they fake state transitions in-memory).
+    /// </summary>
+    [Fact]
+    public async Task FlakyStep_RetriesAndSucceedsOnThirdAttempt()
+    {
+        await using var deployment = await DurableFunctionDeployment.CreateAsync(
+            DurableFunctionDeployment.FindTestFunctionDir("RetryFunction"),
+            "retry", _output);
+
+        var (invokeResponse, executionName) = await deployment.InvokeAsync("""{"orderId": "x"}""");
+        var responsePayload = Encoding.UTF8.GetString(invokeResponse.Payload.ToArray());
+        _output.WriteLine($"Response: {responsePayload}");
+
+        // Initial invoke returns when the SDK suspends after the first failure.
+        // The execution continues asynchronously via service-driven re-invokes.
+        var arn = await deployment.FindDurableExecutionArnByNameAsync(executionName, TimeSpan.FromSeconds(60));
+        Assert.NotNull(arn);
+
+        // Total expected wall time: 2s + 4s of retry delay + execution overhead.
+        // Allow generous headroom for service scheduling latency.
+        var status = await deployment.PollForCompletionAsync(arn!, TimeSpan.FromSeconds(120));
+        Assert.Equal("SUCCEEDED", status, ignoreCase: true);
+
+        var history = await deployment.WaitForHistoryAsync(
+            arn!,
+            h => (h.Events?.Count(e => e.EventType == EventType.StepStarted) ?? 0) >= 3
+              && (h.Events?.Any(e => e.StepSucceededDetails != null) ?? false),
+            TimeSpan.FromSeconds(60));
+        var events = history.Events ?? new List<Event>();
+
+        // Three attempts ran (attempts 1, 2, 3).
+        Assert.Equal(3, events.Count(e => e.EventType == EventType.StepStarted));
+
+        // Two failed attempts recorded retry metadata; the final attempt succeeded.
+        Assert.Equal(2, events.Count(e => e.StepFailedDetails != null && e.Name == "flaky_step"));
+        var succeeded = events.SingleOrDefault(e => e.StepSucceededDetails != null && e.Name == "flaky_step");
+        Assert.NotNull(succeeded);
+        Assert.Equal("\"ok on attempt 3\"", succeeded!.StepSucceededDetails.Result?.Payload);
+
+        // The two recorded failure messages reflect the per-attempt exception.
+        var failures = events
+            .Where(e => e.StepFailedDetails != null && e.Name == "flaky_step")
+            .Select(e => e.StepFailedDetails.Error?.Payload?.ErrorMessage ?? string.Empty)
+            .ToList();
+        Assert.Contains(failures, m => m.Contains("attempt 1"));
+        Assert.Contains(failures, m => m.Contains("attempt 2"));
+
+        // Timing check: the service must have actually waited between attempts.
+        // With initialDelay=2s, backoffRate=2.0, no jitter: delays are 2s and 4s.
+        // The gap between the first and last StepStarted should be >= 6s.
+        var startedTimestamps = events
+            .Where(e => e.EventType == EventType.StepStarted && e.EventTimestamp.HasValue)
+            .OrderBy(e => e.EventTimestamp!.Value)
+            .Select(e => e.EventTimestamp!.Value)
+            .ToList();
+        var totalGap = startedTimestamps[^1] - startedTimestamps[0];
+        _output.WriteLine($"Time between first and last attempt: {totalGap.TotalSeconds:F1}s");
+        Assert.True(totalGap >= TimeSpan.FromSeconds(6),
+            $"Service did not honor retry delays: {totalGap.TotalSeconds:F1}s gap (expected >= 6s)");
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/StepFailsTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/StepFailsTest.cs
@@ -36,9 +36,12 @@ public class StepFailsTest
 
         var history = await deployment.WaitForHistoryAsync(
             arn!,
-            h => h.Events?.Any(e => e.StepFailedDetails != null) ?? false,
+            h => (h.Events?.Any(e => e.EventType == EventType.StepStarted) ?? false)
+              && (h.Events?.Any(e => e.StepFailedDetails != null) ?? false),
             TimeSpan.FromSeconds(60));
         var events = history.Events ?? new List<Event>();
+
+        Assert.Equal(1, events.Count(e => e.EventType == EventType.StepStarted));
 
         // The failing step recorded a StepFailed event with the exception message.
         var stepFailed = events.FirstOrDefault(e => e.StepFailedDetails != null && e.Name == "fail_step");

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/StepWaitStepTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/StepWaitStepTest.cs
@@ -32,10 +32,13 @@ public class StepWaitStepTest
 
         var history = await deployment.WaitForHistoryAsync(
             arn!,
-            h => (h.Events?.Count(e => e.StepSucceededDetails != null) ?? 0) >= 2
+            h => (h.Events?.Count(e => e.EventType == EventType.StepStarted) ?? 0) >= 2
+              && (h.Events?.Count(e => e.StepSucceededDetails != null) ?? 0) >= 2
               && (h.Events?.Any(e => e.WaitSucceededDetails != null) ?? false),
             TimeSpan.FromSeconds(60));
         var events = history.Events ?? new List<Event>();
+
+        Assert.Equal(2, events.Count(e => e.EventType == EventType.StepStarted));
 
         // Both steps ran in order and produced the expected chained outputs.
         var stepResults = events

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/AtMostOnceCrashFunction/AtMostOnceCrashFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/AtMostOnceCrashFunction/AtMostOnceCrashFunction.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>bootstrap</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/AtMostOnceCrashFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/AtMostOnceCrashFunction/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/provided:al2023
+
+RUN dnf install -y libicu
+
+COPY bin/publish/ ${LAMBDA_TASK_ROOT}
+
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/AtMostOnceCrashFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/AtMostOnceCrashFunction/Function.cs
@@ -1,0 +1,69 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace DurableExecutionTestFunction;
+
+/// <summary>
+/// Exercises the AtMostOncePerRetry crash-recovery path end-to-end.
+///
+/// On attempt 1 the step kills the Lambda process AFTER the START checkpoint
+/// has been flushed but BEFORE any SUCCEED checkpoint can be written. The
+/// service re-invokes us; replay sees STARTED with no terminal record, so the
+/// SDK routes through the retry strategy with a synthesized
+/// StepInterruptedException. Attempt 2 succeeds normally.
+///
+/// The per-attempt counter is read from the input payload — the durable
+/// service preserves it across re-invokes so we can drive deterministic crash
+/// behavior on attempt 1 only.
+/// </summary>
+public class Function
+{
+    public static async Task Main(string[] args)
+    {
+        var handler = new Function();
+        var serializer = new DefaultLambdaJsonSerializer();
+        using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<DurableExecutionInvocationInput, DurableExecutionInvocationOutput>(handler.Handler, serializer);
+        using var bootstrap = new LambdaBootstrap(handlerWrapper);
+        await bootstrap.RunAsync();
+    }
+
+    public Task<DurableExecutionInvocationOutput> Handler(
+        DurableExecutionInvocationInput input, ILambdaContext context)
+        => DurableFunction.WrapAsync<TestEvent, TestResult>(Workflow, input, context);
+
+    private async Task<TestResult> Workflow(TestEvent input, IDurableContext context)
+    {
+        var result = await context.StepAsync<string>(
+            async (ctx) =>
+            {
+                await Task.CompletedTask;
+                if (ctx.AttemptNumber == 1)
+                {
+                    // Hard process exit AFTER the SDK has flushed the START
+                    // checkpoint (sync flush is part of the AtMostOncePerRetry
+                    // contract). The service will see a STARTED record with no
+                    // terminal counterpart on the next invocation.
+                    Environment.Exit(137);
+                }
+                return $"recovered on attempt {ctx.AttemptNumber}";
+            },
+            name: "crash_then_recover",
+            config: new StepConfig
+            {
+                Semantics = StepSemantics.AtMostOncePerRetry,
+                RetryStrategy = RetryStrategy.Exponential(
+                    maxAttempts: 3,
+                    initialDelay: TimeSpan.FromSeconds(2),
+                    maxDelay: TimeSpan.FromSeconds(5),
+                    backoffRate: 2.0,
+                    jitter: JitterStrategy.None)
+            });
+
+        return new TestResult { Status = "completed", Data = result };
+    }
+}
+
+public class TestEvent { public string? OrderId { get; set; } }
+public class TestResult { public string? Status { get; set; } public string? Data { get; set; } }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/LongRetryChainFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/LongRetryChainFunction/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/provided:al2023
+
+RUN dnf install -y libicu
+
+COPY bin/publish/ ${LAMBDA_TASK_ROOT}
+
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/LongRetryChainFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/LongRetryChainFunction/Function.cs
@@ -1,0 +1,57 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace DurableExecutionTestFunction;
+
+/// <summary>
+/// Five-failure retry chain: the step throws on attempts 1-5 and succeeds on
+/// attempt 6. The result payload echoes ctx.AttemptNumber on each attempt so
+/// the integration test can verify the SDK's user-facing attempt counter
+/// matches the wire-format StepDetails.Attempt value across multiple
+/// invocations.
+/// </summary>
+public class Function
+{
+    public static async Task Main(string[] args)
+    {
+        var handler = new Function();
+        var serializer = new DefaultLambdaJsonSerializer();
+        using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<DurableExecutionInvocationInput, DurableExecutionInvocationOutput>(handler.Handler, serializer);
+        using var bootstrap = new LambdaBootstrap(handlerWrapper);
+        await bootstrap.RunAsync();
+    }
+
+    public Task<DurableExecutionInvocationOutput> Handler(
+        DurableExecutionInvocationInput input, ILambdaContext context)
+        => DurableFunction.WrapAsync<TestEvent, TestResult>(Workflow, input, context);
+
+    private async Task<TestResult> Workflow(TestEvent input, IDurableContext context)
+    {
+        var result = await context.StepAsync<string>(
+            async (ctx) =>
+            {
+                await Task.CompletedTask;
+                if (ctx.AttemptNumber < 6)
+                    throw new InvalidOperationException($"flake on attempt {ctx.AttemptNumber}");
+                return $"ok on attempt {ctx.AttemptNumber}";
+            },
+            name: "long_retry_step",
+            config: new StepConfig
+            {
+                // Short delays so the test wall time stays manageable: 1s, 2s, 3s, 4s, 5s.
+                RetryStrategy = RetryStrategy.Exponential(
+                    maxAttempts: 6,
+                    initialDelay: TimeSpan.FromSeconds(1),
+                    maxDelay: TimeSpan.FromSeconds(5),
+                    backoffRate: 1.5,
+                    jitter: JitterStrategy.None)
+            });
+
+        return new TestResult { Status = "completed", Data = result };
+    }
+}
+
+public class TestEvent { public string? OrderId { get; set; } }
+public class TestResult { public string? Status { get; set; } public string? Data { get; set; } }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/LongRetryChainFunction/LongRetryChainFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/LongRetryChainFunction/LongRetryChainFunction.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>bootstrap</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/RetryExhaustionFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/RetryExhaustionFunction/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/provided:al2023
+
+RUN dnf install -y libicu
+
+COPY bin/publish/ ${LAMBDA_TASK_ROOT}
+
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/RetryExhaustionFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/RetryExhaustionFunction/Function.cs
@@ -1,0 +1,47 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace DurableExecutionTestFunction;
+
+public class Function
+{
+    public static async Task Main(string[] args)
+    {
+        var handler = new Function();
+        var serializer = new DefaultLambdaJsonSerializer();
+        using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<DurableExecutionInvocationInput, DurableExecutionInvocationOutput>(handler.Handler, serializer);
+        using var bootstrap = new LambdaBootstrap(handlerWrapper);
+        await bootstrap.RunAsync();
+    }
+
+    public Task<DurableExecutionInvocationOutput> Handler(
+        DurableExecutionInvocationInput input, ILambdaContext context)
+        => DurableFunction.WrapAsync<TestEvent, TestResult>(Workflow, input, context);
+
+    private async Task<TestResult> Workflow(TestEvent input, IDurableContext context)
+    {
+        var result = await context.StepAsync<string>(
+            async (ctx) =>
+            {
+                await Task.CompletedTask;
+                throw new InvalidOperationException($"always-fails attempt {ctx.AttemptNumber}");
+            },
+            name: "always_fails_step",
+            config: new StepConfig
+            {
+                RetryStrategy = RetryStrategy.Exponential(
+                    maxAttempts: 3,
+                    initialDelay: TimeSpan.FromSeconds(2),
+                    maxDelay: TimeSpan.FromSeconds(10),
+                    backoffRate: 2.0,
+                    jitter: JitterStrategy.None)
+            });
+
+        return new TestResult { Status = "completed", Data = result };
+    }
+}
+
+public class TestEvent { public string? OrderId { get; set; } }
+public class TestResult { public string? Status { get; set; } public string? Data { get; set; } }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/RetryExhaustionFunction/RetryExhaustionFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/RetryExhaustionFunction/RetryExhaustionFunction.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>bootstrap</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/RetryFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/RetryFunction/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/provided:al2023
+
+RUN dnf install -y libicu
+
+COPY bin/publish/ ${LAMBDA_TASK_ROOT}
+
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/RetryFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/RetryFunction/Function.cs
@@ -1,0 +1,49 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace DurableExecutionTestFunction;
+
+public class Function
+{
+    public static async Task Main(string[] args)
+    {
+        var handler = new Function();
+        var serializer = new DefaultLambdaJsonSerializer();
+        using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<DurableExecutionInvocationInput, DurableExecutionInvocationOutput>(handler.Handler, serializer);
+        using var bootstrap = new LambdaBootstrap(handlerWrapper);
+        await bootstrap.RunAsync();
+    }
+
+    public Task<DurableExecutionInvocationOutput> Handler(
+        DurableExecutionInvocationInput input, ILambdaContext context)
+        => DurableFunction.WrapAsync<TestEvent, TestResult>(Workflow, input, context);
+
+    private async Task<TestResult> Workflow(TestEvent input, IDurableContext context)
+    {
+        var result = await context.StepAsync<string>(
+            async (ctx) =>
+            {
+                await Task.CompletedTask;
+                if (ctx.AttemptNumber < 3)
+                    throw new InvalidOperationException($"flake on attempt {ctx.AttemptNumber}");
+                return $"ok on attempt {ctx.AttemptNumber}";
+            },
+            name: "flaky_step",
+            config: new StepConfig
+            {
+                RetryStrategy = RetryStrategy.Exponential(
+                    maxAttempts: 3,
+                    initialDelay: TimeSpan.FromSeconds(2),
+                    maxDelay: TimeSpan.FromSeconds(10),
+                    backoffRate: 2.0,
+                    jitter: JitterStrategy.None)
+            });
+
+        return new TestResult { Status = "completed", Data = result };
+    }
+}
+
+public class TestEvent { public string? OrderId { get; set; } }
+public class TestResult { public string? Status { get; set; } public string? Data { get; set; } }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/RetryFunction/RetryFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/RetryFunction/RetryFunction.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>bootstrap</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/DurableContextTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/DurableContextTests.cs
@@ -620,4 +620,306 @@ public class DurableContextTests
         public string? Name { get; set; }
         public int Age { get; set; }
     }
+
+    #region StepAsync Retry Tests
+
+    [Fact]
+    public async Task StepAsync_FailsWithRetryStrategy_CheckpointsRetryAndSuspends()
+    {
+        var tm = new TerminationManager();
+        var state = new ExecutionState();
+        state.LoadFromCheckpoint(null);
+        var idGen = new OperationIdGenerator();
+        var lambdaContext = CreateLambdaContext();
+        var recorder = new RecordingBatcher();
+        var context = new DurableContext(state, tm, idGen, "arn:test", lambdaContext, recorder.Batcher);
+
+        var stepTask = context.StepAsync<string>(
+            async (_) => { await Task.CompletedTask; throw new InvalidOperationException("transient"); },
+            name: "flaky_step",
+            config: new StepConfig
+            {
+                RetryStrategy = RetryStrategy.Exponential(
+                    maxAttempts: 3,
+                    initialDelay: TimeSpan.FromSeconds(5),
+                    jitter: JitterStrategy.None)
+            });
+
+        await Task.Delay(50);
+
+        Assert.True(tm.IsTerminated);
+        Assert.False(stepTask.IsCompleted);
+
+        // Fresh attempt 1 emits a fire-and-forget START (telemetry under
+        // AtLeastOncePerRetry), then a RETRY when the user code throws and
+        // the retry strategy decides to retry.
+        var checkpoints = recorder.Flushed;
+        Assert.Equal(2, checkpoints.Count);
+        Assert.Equal("START", checkpoints[0].Action);
+        Assert.Equal("RETRY", checkpoints[1].Action);
+        Assert.Equal(IdAt(1), checkpoints[1].Id);
+        Assert.Equal(5, checkpoints[1].StepOptions.NextAttemptDelaySeconds);
+    }
+
+    [Fact]
+    public async Task StepAsync_FailsNoRetryStrategy_CheckpointsFail()
+    {
+        var context = CreateContext();
+
+        var ex = await Assert.ThrowsAsync<StepException>(() =>
+            context.StepAsync<string>(
+                async (_) => { await Task.CompletedTask; throw new InvalidOperationException("permanent"); },
+                name: "fail_step"));
+
+        Assert.Equal("permanent", ex.Message);
+    }
+
+    [Fact]
+    public async Task StepAsync_RetryExhausted_CheckpointsFail()
+    {
+        var state = new ExecutionState();
+        state.LoadFromCheckpoint(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Step,
+                    Status = OperationStatuses.Pending,
+                    StepDetails = new StepDetails
+                    {
+                        Attempt = 2,
+                        NextAttemptTimestamp = DateTimeOffset.UtcNow.AddSeconds(-10).ToUnixTimeMilliseconds()
+                    }
+                }
+            }
+        });
+        var tm = new TerminationManager();
+        var idGen = new OperationIdGenerator();
+        var lambdaContext = CreateLambdaContext();
+        var recorder = new RecordingBatcher();
+        var context = new DurableContext(state, tm, idGen, "arn:test", lambdaContext, recorder.Batcher);
+
+        // Attempt 3 (last one) — should fail after this
+        var ex = await Assert.ThrowsAsync<StepException>(() =>
+            context.StepAsync<string>(
+                async (_) => { await Task.CompletedTask; throw new InvalidOperationException("still failing"); },
+                name: "exhaust_step",
+                config: new StepConfig
+                {
+                    RetryStrategy = RetryStrategy.Exponential(maxAttempts: 3, jitter: JitterStrategy.None)
+                }));
+
+        Assert.Equal("still failing", ex.Message);
+
+        // Fresh attempt 3 emits a fire-and-forget START (telemetry under
+        // AtLeastOncePerRetry), then a FAIL after the retry strategy gives up.
+        var checkpoints = recorder.Flushed;
+        Assert.Equal(2, checkpoints.Count);
+        Assert.Equal("START", checkpoints[0].Action);
+        Assert.Equal("FAIL", checkpoints[1].Action);
+    }
+
+    [Fact]
+    public async Task StepAsync_PendingWithFutureTimestamp_Suspends()
+    {
+        var futureMs = DateTimeOffset.UtcNow.AddSeconds(300).ToUnixTimeMilliseconds();
+        var tm = new TerminationManager();
+        var state = new ExecutionState();
+        state.LoadFromCheckpoint(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Step,
+                    Status = OperationStatuses.Pending,
+                    StepDetails = new StepDetails
+                    {
+                        Attempt = 1,
+                        NextAttemptTimestamp = futureMs
+                    }
+                }
+            }
+        });
+        var idGen = new OperationIdGenerator();
+        var lambdaContext = CreateLambdaContext();
+        var recorder = new RecordingBatcher();
+        var context = new DurableContext(state, tm, idGen, "arn:test", lambdaContext, recorder.Batcher);
+
+        var stepTask = context.StepAsync<string>(
+            async (_) => { await Task.CompletedTask; return "should not run"; },
+            name: "pending_step",
+            config: new StepConfig { RetryStrategy = RetryStrategy.Default });
+
+        await Task.Delay(50);
+
+        Assert.True(tm.IsTerminated);
+        Assert.False(stepTask.IsCompleted);
+        Assert.Empty(recorder.Flushed);
+    }
+
+    [Fact]
+    public async Task StepAsync_PendingWithPastTimestamp_ReExecutes()
+    {
+        var pastMs = DateTimeOffset.UtcNow.AddSeconds(-10).ToUnixTimeMilliseconds();
+        var state = new ExecutionState();
+        state.LoadFromCheckpoint(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Step,
+                    Status = OperationStatuses.Pending,
+                    StepDetails = new StepDetails
+                    {
+                        Attempt = 1,
+                        NextAttemptTimestamp = pastMs
+                    }
+                }
+            }
+        });
+        var tm = new TerminationManager();
+        var idGen = new OperationIdGenerator();
+        var lambdaContext = CreateLambdaContext();
+        var context = new DurableContext(state, tm, idGen, "arn:test", lambdaContext);
+
+        var result = await context.StepAsync<string>(
+            async (ctx) =>
+            {
+                await Task.CompletedTask;
+                Assert.Equal(2, ctx.AttemptNumber);
+                return "retry success";
+            },
+            name: "retry_step",
+            config: new StepConfig { RetryStrategy = RetryStrategy.Default });
+
+        Assert.Equal("retry success", result);
+    }
+
+    [Fact]
+    public async Task StepAsync_ReadyReplay_AdvancesAttemptAndExecutes()
+    {
+        // READY = service has post-PENDING re-invoked us; the retry timer
+        // already fired so no timestamp check is needed. Just advance the
+        // attempt counter and run.
+        var state = new ExecutionState();
+        state.LoadFromCheckpoint(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Step,
+                    Status = OperationStatuses.Ready,
+                    StepDetails = new StepDetails { Attempt = 2 }
+                }
+            }
+        });
+        var tm = new TerminationManager();
+        var idGen = new OperationIdGenerator();
+        var lambdaContext = CreateLambdaContext();
+        var context = new DurableContext(state, tm, idGen, "arn:test", lambdaContext);
+
+        var executed = false;
+        var result = await context.StepAsync<string>(
+            async (ctx) =>
+            {
+                executed = true;
+                Assert.Equal(3, ctx.AttemptNumber);
+                await Task.CompletedTask;
+                return "ok";
+            },
+            name: "ready_step",
+            config: new StepConfig { RetryStrategy = RetryStrategy.Default });
+
+        Assert.True(executed);
+        Assert.Equal("ok", result);
+        Assert.False(tm.IsTerminated);
+        Assert.False(state.IsReplaying);
+    }
+
+    [Fact]
+    public async Task StepAsync_AtMostOnce_FlushesStartBeforeExecution()
+    {
+        var state = new ExecutionState();
+        state.LoadFromCheckpoint(null);
+        var tm = new TerminationManager();
+        var idGen = new OperationIdGenerator();
+        var lambdaContext = CreateLambdaContext();
+        var recorder = new RecordingBatcher();
+        var context = new DurableContext(state, tm, idGen, "arn:test", lambdaContext, recorder.Batcher);
+
+        IReadOnlyList<string>? flushedAtFuncEntry = null;
+
+        var result = await context.StepAsync<string>(
+            async (_) =>
+            {
+                flushedAtFuncEntry = recorder.Flushed.Select(o => o.Action.ToString()).ToArray();
+                await Task.CompletedTask;
+                return "done";
+            },
+            name: "amo_step",
+            config: new StepConfig { Semantics = StepSemantics.AtMostOncePerRetry });
+
+        Assert.Equal("done", result);
+
+        // START must be flushed before user func runs (AtMostOnce invariant).
+        Assert.NotNull(flushedAtFuncEntry);
+        Assert.Equal(new[] { "START" }, flushedAtFuncEntry);
+
+        // After step returns, SUCCEED has also been flushed.
+        var actions = recorder.Flushed.Select(o => o.Action.ToString()).ToArray();
+        Assert.Equal(new[] { "START", "SUCCEED" }, actions);
+    }
+
+    [Fact]
+    public async Task StepAsync_AtMostOnce_StartedReplay_TriggersRetryHandler()
+    {
+        var tm = new TerminationManager();
+        var state = new ExecutionState();
+        state.LoadFromCheckpoint(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Step,
+                    Status = OperationStatuses.Started
+                }
+            }
+        });
+        var idGen = new OperationIdGenerator();
+        var lambdaContext = CreateLambdaContext();
+        var recorder = new RecordingBatcher();
+        var context = new DurableContext(state, tm, idGen, "arn:test", lambdaContext, recorder.Batcher);
+
+        var executed = false;
+        var stepTask = context.StepAsync<string>(
+            async (_) => { executed = true; await Task.CompletedTask; return "should not run"; },
+            name: "amo_replay",
+            config: new StepConfig
+            {
+                Semantics = StepSemantics.AtMostOncePerRetry,
+                RetryStrategy = RetryStrategy.Exponential(maxAttempts: 3, jitter: JitterStrategy.None)
+            });
+
+        await Task.Delay(50);
+
+        Assert.False(executed);
+        Assert.True(tm.IsTerminated);
+        Assert.False(stepTask.IsCompleted);
+
+        var checkpoints = recorder.Flushed;
+        Assert.Single(checkpoints);
+        Assert.Equal("RETRY", checkpoints[0].Action);
+    }
+
+    #endregion
 }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/DurableFunctionTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/DurableFunctionTests.cs
@@ -198,30 +198,37 @@ public class DurableFunctionTests
             mockClient);
 
         Assert.Equal(InvocationStatus.Pending, output.Status);
-        Assert.Equal(2, mockClient.CheckpointCalls.Count);
 
-        // First flush: step SUCCEED (the user awaits StepAsync, which awaits
-        // its SUCCEED enqueue, which blocks until the batcher flushes it).
-        var firstCall = mockClient.CheckpointCalls[0];
-        Assert.Equal("arn:aws:lambda:us-east-1:123:durable-execution:checkpoint-test", firstCall.DurableExecutionArn);
-        Assert.Equal("initial-token", firstCall.CheckpointToken);
-        Assert.Single(firstCall.Updates);
-        var stepUpdate = firstCall.Updates[0];
-        Assert.Equal("STEP", stepUpdate.Type);
-        Assert.Equal("SUCCEED", stepUpdate.Action);
-        Assert.Equal("validate", stepUpdate.Name);
-        Assert.NotNull(stepUpdate.Payload);
+        // Each StepAsync emits a fire-and-forget START before user code runs
+        // (telemetry under AtLeastOncePerRetry). With FlushInterval = 0 the
+        // worker may flush the START on its own before SUCCEED arrives, so the
+        // exact batching of START vs SUCCEED is timing-dependent. Assert on
+        // the flat sequence of updates instead.
+        var allUpdates = mockClient.CheckpointCalls
+            .SelectMany(c => c.Updates)
+            .ToList();
 
-        // Second flush: wait START (blocks until the service has the timer
-        // recorded before WaitAsync suspends).
-        var secondCall = mockClient.CheckpointCalls[1];
-        Assert.Single(secondCall.Updates);
-        var waitUpdate = secondCall.Updates[0];
-        Assert.Equal("WAIT", waitUpdate.Type);
-        Assert.Equal("START", waitUpdate.Action);
-        Assert.Equal("delay", waitUpdate.Name);
-        Assert.NotNull(waitUpdate.WaitOptions);
-        Assert.Equal(30, waitUpdate.WaitOptions.WaitSeconds);
+        // Expect: step START, step SUCCEED, wait START (in that order).
+        Assert.Equal(3, allUpdates.Count);
+
+        Assert.Equal("STEP", allUpdates[0].Type);
+        Assert.Equal("START", allUpdates[0].Action);
+        Assert.Equal("validate", allUpdates[0].Name);
+
+        Assert.Equal("STEP", allUpdates[1].Type);
+        Assert.Equal("SUCCEED", allUpdates[1].Action);
+        Assert.Equal("validate", allUpdates[1].Name);
+        Assert.NotNull(allUpdates[1].Payload);
+
+        Assert.Equal("WAIT", allUpdates[2].Type);
+        Assert.Equal("START", allUpdates[2].Action);
+        Assert.Equal("delay", allUpdates[2].Name);
+        Assert.NotNull(allUpdates[2].WaitOptions);
+        Assert.Equal(30, allUpdates[2].WaitOptions.WaitSeconds);
+
+        // The first call sends the initial checkpoint token.
+        Assert.Equal("arn:aws:lambda:us-east-1:123:durable-execution:checkpoint-test", mockClient.CheckpointCalls[0].DurableExecutionArn);
+        Assert.Equal("initial-token", mockClient.CheckpointCalls[0].CheckpointToken);
     }
 
     [Fact]
@@ -502,9 +509,9 @@ public class DurableFunctionTests
     public async Task WrapAsync_HydrationThrows_AlwaysPropagatesToHost()
     {
         // State hydration is OUTSIDE the IsTerminalCheckpointError try/catch — every
-        // GetExecutionStateAsync failure escapes for Lambda retry, matching Python's
-        // GetExecutionStateError (an InvocationError). Use a 4xx that *would* be terminal
-        // if it came from a checkpoint flush to prove the path isn't classified.
+        // GetExecutionStateAsync failure escapes for Lambda retry. Use a 4xx that
+        // *would* be terminal if it came from a checkpoint flush to prove the path
+        // isn't classified.
         var input = new DurableExecutionInvocationInput
         {
             DurableExecutionArn = "arn:aws:lambda:us-east-1:123:durable-execution:hydrate-fail",

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ExecutionStateTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ExecutionStateTests.cs
@@ -49,8 +49,7 @@ public class ExecutionStateTests
     {
         // The service sends one EXECUTION-type op carrying the input payload
         // even on the first invocation. That op is bookkeeping, not user
-        // history — it must not put us into replay mode. (Matches Python
-        // execution.py:258, Java ExecutionManager:81, JS execution-context.ts:62.)
+        // history — it must not put us into replay mode.
         var state = new ExecutionState();
         state.LoadFromCheckpoint(new InitialExecutionState
         {
@@ -105,8 +104,8 @@ public class ExecutionStateTests
     {
         // A PENDING op (e.g. retry timer waiting) is not "completed" in the
         // checkpoint sense — once the workflow has visited every terminally-
-        // completed op the SDK treats subsequent code as fresh. Matches Python's
-        // {SUCCEEDED, FAILED, CANCELLED, STOPPED, TIMED_OUT} terminal set.
+        // completed op the SDK treats subsequent code as fresh. Terminal set
+        // is {SUCCEEDED, FAILED, CANCELLED, STOPPED}.
         var state = new ExecutionState();
         state.LoadFromCheckpoint(new InitialExecutionState
         {
@@ -199,8 +198,8 @@ public class ExecutionStateTests
     public void GetOperation_ReturnsLatestRecord_WhenIdAppearsMultipleTimes()
     {
         // Wire format: when the service replays an envelope it includes the
-        // most recent record per ID. Java/Python/JS reference SDKs all key by
-        // ID alone and rely on the service to provide the authoritative record.
+        // most recent record per ID. We key by ID alone and rely on the service
+        // to provide the authoritative record.
         var state = new ExecutionState();
         state.LoadFromCheckpoint(new InitialExecutionState
         {

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/RetryStrategyTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/RetryStrategyTests.cs
@@ -1,0 +1,202 @@
+using Amazon.Lambda.DurableExecution;
+using Xunit;
+
+namespace Amazon.Lambda.DurableExecution.Tests;
+
+public class RetryStrategyTests
+{
+    [Fact]
+    public void ExponentialDefault_RetriesUpToMaxAttempts()
+    {
+        var strategy = RetryStrategy.Default;
+
+        // Attempts 1-5 should retry (maxAttempts=6 means 6 total attempts)
+        for (int i = 1; i < 6; i++)
+        {
+            var decision = strategy.ShouldRetry(new InvalidOperationException("fail"), i);
+            Assert.True(decision.ShouldRetry);
+            Assert.True(decision.Delay >= TimeSpan.FromSeconds(1));
+        }
+
+        // Attempt 6 should not retry (exhausted)
+        var lastDecision = strategy.ShouldRetry(new InvalidOperationException("fail"), 6);
+        Assert.False(lastDecision.ShouldRetry);
+    }
+
+    [Fact]
+    public void None_NeverRetries()
+    {
+        var strategy = RetryStrategy.None;
+
+        var decision = strategy.ShouldRetry(new Exception("fail"), 1);
+        Assert.False(decision.ShouldRetry);
+    }
+
+    [Fact]
+    public void Transient_RetriesUpTo3Attempts()
+    {
+        var strategy = RetryStrategy.Transient;
+
+        Assert.True(strategy.ShouldRetry(new Exception("fail"), 1).ShouldRetry);
+        Assert.True(strategy.ShouldRetry(new Exception("fail"), 2).ShouldRetry);
+        Assert.False(strategy.ShouldRetry(new Exception("fail"), 3).ShouldRetry);
+    }
+
+    [Fact]
+    public void Exponential_DelayIncreases()
+    {
+        var strategy = RetryStrategy.Exponential(
+            maxAttempts: 5,
+            initialDelay: TimeSpan.FromSeconds(2),
+            maxDelay: TimeSpan.FromSeconds(120),
+            backoffRate: 2.0,
+            jitter: JitterStrategy.None);
+
+        var d1 = strategy.ShouldRetry(new Exception(), 1).Delay;
+        var d2 = strategy.ShouldRetry(new Exception(), 2).Delay;
+        var d3 = strategy.ShouldRetry(new Exception(), 3).Delay;
+
+        // With no jitter: 2s, 4s, 8s (ceiling to whole seconds)
+        Assert.Equal(TimeSpan.FromSeconds(2), d1);
+        Assert.Equal(TimeSpan.FromSeconds(4), d2);
+        Assert.Equal(TimeSpan.FromSeconds(8), d3);
+    }
+
+    [Fact]
+    public void Exponential_DelayCapsAtMax()
+    {
+        var strategy = RetryStrategy.Exponential(
+            maxAttempts: 10,
+            initialDelay: TimeSpan.FromSeconds(10),
+            maxDelay: TimeSpan.FromSeconds(30),
+            backoffRate: 3.0,
+            jitter: JitterStrategy.None);
+
+        // Attempt 3: 10 * 3^2 = 90, capped to 30
+        var decision = strategy.ShouldRetry(new Exception(), 3);
+        Assert.Equal(TimeSpan.FromSeconds(30), decision.Delay);
+    }
+
+    [Fact]
+    public void Exponential_FullJitter_BoundedByDelay()
+    {
+        var strategy = RetryStrategy.Exponential(
+            maxAttempts: 5,
+            initialDelay: TimeSpan.FromSeconds(10),
+            maxDelay: TimeSpan.FromSeconds(100),
+            backoffRate: 2.0,
+            jitter: JitterStrategy.Full);
+
+        // Run multiple times to check bounds
+        for (int i = 0; i < 50; i++)
+        {
+            var decision = strategy.ShouldRetry(new Exception(), 1);
+            Assert.True(decision.Delay >= TimeSpan.FromSeconds(1));
+            Assert.True(decision.Delay <= TimeSpan.FromSeconds(10));
+        }
+    }
+
+    [Fact]
+    public void Exponential_HalfJitter_BoundedBetween50And100Percent()
+    {
+        var strategy = RetryStrategy.Exponential(
+            maxAttempts: 5,
+            initialDelay: TimeSpan.FromSeconds(10),
+            maxDelay: TimeSpan.FromSeconds(100),
+            backoffRate: 2.0,
+            jitter: JitterStrategy.Half);
+
+        for (int i = 0; i < 50; i++)
+        {
+            var decision = strategy.ShouldRetry(new Exception(), 1);
+            Assert.True(decision.Delay >= TimeSpan.FromSeconds(5));
+            Assert.True(decision.Delay <= TimeSpan.FromSeconds(10));
+        }
+    }
+
+    [Fact]
+    public void Exponential_RetryableExceptions_FiltersCorrectly()
+    {
+        var strategy = RetryStrategy.Exponential(
+            maxAttempts: 3,
+            retryableExceptions: new[] { typeof(TimeoutException), typeof(HttpRequestException) });
+
+        Assert.True(strategy.ShouldRetry(new TimeoutException(), 1).ShouldRetry);
+        Assert.True(strategy.ShouldRetry(new HttpRequestException(), 1).ShouldRetry);
+        Assert.False(strategy.ShouldRetry(new InvalidOperationException(), 1).ShouldRetry);
+    }
+
+    [Fact]
+    public void Exponential_RetryableExceptions_MatchesDerivedTypes()
+    {
+        var strategy = RetryStrategy.Exponential(
+            maxAttempts: 3,
+            retryableExceptions: new[] { typeof(IOException) });
+
+        Assert.True(strategy.ShouldRetry(new FileNotFoundException(), 1).ShouldRetry);
+    }
+
+    [Fact]
+    public void Exponential_MessagePatterns_FiltersCorrectly()
+    {
+        var strategy = RetryStrategy.Exponential(
+            maxAttempts: 3,
+            retryableMessagePatterns: new[] { "timeout", "throttl", "5\\d{2}" });
+
+        Assert.True(strategy.ShouldRetry(new Exception("connection timeout"), 1).ShouldRetry);
+        Assert.True(strategy.ShouldRetry(new Exception("request throttled"), 1).ShouldRetry);
+        Assert.True(strategy.ShouldRetry(new Exception("HTTP 503"), 1).ShouldRetry);
+        Assert.False(strategy.ShouldRetry(new Exception("not found"), 1).ShouldRetry);
+    }
+
+    [Fact]
+    public void Exponential_BothFilters_EitherMatches()
+    {
+        var strategy = RetryStrategy.Exponential(
+            maxAttempts: 3,
+            retryableExceptions: new[] { typeof(TimeoutException) },
+            retryableMessagePatterns: new[] { "throttl" });
+
+        // Matches exception type
+        Assert.True(strategy.ShouldRetry(new TimeoutException("any message"), 1).ShouldRetry);
+        // Matches message pattern
+        Assert.True(strategy.ShouldRetry(new Exception("throttled"), 1).ShouldRetry);
+        // Matches neither
+        Assert.False(strategy.ShouldRetry(new InvalidOperationException("bad state"), 1).ShouldRetry);
+    }
+
+    [Fact]
+    public void Exponential_NoFilters_RetriesAllExceptions()
+    {
+        var strategy = RetryStrategy.Exponential(maxAttempts: 3);
+
+        Assert.True(strategy.ShouldRetry(new Exception("anything"), 1).ShouldRetry);
+        Assert.True(strategy.ShouldRetry(new InvalidOperationException(), 1).ShouldRetry);
+        Assert.True(strategy.ShouldRetry(new OutOfMemoryException(), 1).ShouldRetry);
+    }
+
+    [Fact]
+    public void Exponential_MinimumDelayIsOneSecond()
+    {
+        var strategy = RetryStrategy.Exponential(
+            maxAttempts: 3,
+            initialDelay: TimeSpan.FromMilliseconds(100),
+            jitter: JitterStrategy.None);
+
+        var decision = strategy.ShouldRetry(new Exception(), 1);
+        Assert.True(decision.Delay >= TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public void FromDelegate_UsesProvidedFunction()
+    {
+        var strategy = RetryStrategy.FromDelegate((ex, attempt) =>
+            attempt < 2 && ex is TimeoutException
+                ? RetryDecision.RetryAfter(TimeSpan.FromSeconds(5))
+                : RetryDecision.DoNotRetry());
+
+        Assert.True(strategy.ShouldRetry(new TimeoutException(), 1).ShouldRetry);
+        Assert.False(strategy.ShouldRetry(new TimeoutException(), 2).ShouldRetry);
+        Assert.False(strategy.ShouldRetry(new Exception(), 1).ShouldRetry);
+    }
+}


### PR DESCRIPTION
https://github.com/aws/aws-lambda-dotnet/issues/2216

## What

Adds retry support to `Amazon.Lambda.DurableExecution` on top of #2360. A step that throws can now be retried with configurable backoff and jitter. The Lambda suspends between attempts and is re-invoked by the service when the retry timer fires, so compute is not billed during the wait.

Public API:

| Type | Purpose |
|---|---|
| `IRetryStrategy` | Decides whether a failed step should retry, with what delay. |
| `RetryDecision` | Output of `IRetryStrategy.ShouldRetry` — `ShouldRetry` flag plus `Delay`. |
| `RetryStrategy` | Static factory: `Default`, `Transient`, `None`, `Exponential(...)`, `FromDelegate(...)`. |
| `JitterStrategy` | `None` / `Half` / `Full` for exponential backoff. |
| `StepSemantics` | `AtLeastOncePerRetry` (default) / `AtMostOncePerRetry`. |
| `StepConfig.RetryStrategy`, `StepConfig.Semantics` | Per-step retry configuration. |
| `StepInterruptedException` | Surfaced to user retry strategies when a prior attempt crashed mid-execution under `AtMostOncePerRetry`. |

## How

When a step throws, `StepOperation.HandleStepFailureAsync` calls `IRetryStrategy.ShouldRetry(ex, attemptNumber)`. If the strategy says retry, the SDK writes a `RETRY` checkpoint with `NextAttemptDelaySeconds` and suspends — `RunAsync` returns `Pending`. The service holds the execution until the delay elapses, then re-invokes us. On replay, `StepOperation.ReplayAsync` sees the `PENDING` status and either re-suspends (timer not yet up) or re-executes the step with an incremented attempt counter.

```
 Invocation N                 Service                Invocation N+1
 ────────────                 ───────                ──────────────
 step throws
   │
   ▼
 ShouldRetry(ex, n)? ── no ──► FAIL checkpoint ──►  done
   │ yes
   ▼
 RETRY checkpoint   ─────────► schedule timer
 (NextAttemptDelay)            (delay seconds)
   │
   ▼
 SuspendAndAwait
 returns Pending    ─────────► ...wait...
                               timer fires ──────► ReplayAsync
                                                     │
                                                     ▼
                                                   PENDING + elapsed?
                                                     │
                                                     ▼
                                                   re-execute step
                                                   (attempt n+1)
```

### `AtLeastOncePerRetry` (default)

For idempotent steps. The SDK writes the `START` checkpoint as **fire-and-forget** — user code runs immediately, no waiting on the network round-trip. On success the SDK writes `SUCCEED`. The cached result is returned on every subsequent replay; user code never re-executes after success.

If the Lambda crashes mid-attempt (before `SUCCEED` is recorded), replay sees `STARTED` and **re-runs the same attempt** under the same attempt counter. "At least once *per retry*" because the user's logic may run more than once for a single `attemptNumber` if the host dies between START and the terminal record. This is the right default when the step is safe to repeat (a read, an idempotent PUT, a calculation).

### `AtMostOncePerRetry`

For non-idempotent steps (charging a card, sending an email, posting to a non-idempotent API). The SDK writes the `START` checkpoint **synchronously** — user code does not run until the service has acknowledged the START. The flush is correctness-load-bearing: a queued-but-unflushed START would be indistinguishable from "never ran" if the Lambda dies, and replay would re-execute the side effect.

If the Lambda crashes between user code and the `SUCCEED` flush, the service sees a `STARTED` record with no terminal counterpart on the next invocation. Instead of re-running the step, the SDK synthesizes a `StepInterruptedException` and routes it through the retry strategy — the strategy decides whether attempt N+1 should run or whether to give up. The user's code is invoked **at most once per `attemptNumber`**: either it ran to completion (SUCCEED/FAIL recorded), or the host died and that attempt is closed out as failed.

User retry strategies can pattern-match on `StepInterruptedException` to decide whether crash-recovery should retry or surface the failure — useful when the side effect is non-idempotent enough that you'd rather fail than risk replaying.

### Choosing between them

- **Default** is `AtLeastOncePerRetry`. Use it unless your step has a side effect you can't safely repeat.
- **Switch to `AtMostOncePerRetry`** when the step calls a non-idempotent external API. The trade-off: one extra synchronous round-trip per attempt for the START flush.

`ExponentialRetryStrategy` supports max attempts, initial/max delay, backoff rate, jitter, and exception filtering by type or message regex. Built-in factories: `Default` (6 attempts, 5s/60s, 2× backoff, full jitter), `Transient` (3 attempts, 1s/5s, half jitter), `None`. `RetryStrategy.FromDelegate(...)` covers arbitrary policies, including ones that branch on `StepInterruptedException`.

## Testing

21 new unit tests in `Amazon.Lambda.DurableExecution.Tests` (130 total, up from 109 in #2360):

- `RetryStrategyTests` (14) — exponential backoff math, jitter, max-attempt exhaustion, exception-type and message-pattern filtering, delegate strategies.
- `DurableContextTests` retry block (6) — checkpoint-and-suspend on retry, fail-without-strategy, retry exhaustion, future/past `PENDING` replay, `AtMostOnce` start-flush ordering, `STARTED` replay routing through the retry handler.

Integration tests in `Amazon.Lambda.DurableExecution.IntegrationTests` run end-to-end against the durable-execution service:

- `RetryTest` — flaky step recovers on attempt 3.
- `RetryExhaustionTest` — step always throws, exhausts retries, surfaces FAILED with the original exception.
- `AtMostOnceCrashReplayTest` — Lambda is killed mid-attempt under `AtMostOncePerRetry`; service re-invokes, SDK routes through retry strategy, attempt 2 succeeds.
- `LongRetryChainTest` — five failures across multiple invocations, validates the wire-format `Attempt` counter is monotonic and matches `IStepContext.AttemptNumber`.

## Out of scope (follow-up PRs)

- `MapAsync` / `ParallelAsync` / `RunInChildContextAsync` / `WaitForConditionAsync`
- `CallbackAsync`, `InvokeAsync`
- `DefaultJsonCheckpointSerializer`
- `DurableLogger` replay-suppression (currently `NullLogger`)
- Annotations source-generator integration / `[DurableExecution]` attribute
- `DurableTestRunner` / `Amazon.Lambda.DurableExecution.Testing` package
- `dotnet new lambda.DurableFunction` blueprint
