### PR TITLE
Fix IOutputCache empty-body bug (#1702): bump feature revision in InvokeFeatures.Set

### DIFF
--- a/.autover/changes/a0faddb0-c508-415c-b436-d99d68eafc56.json
+++ b/.autover/changes/a0faddb0-c508-415c-b436-d99d68eafc56.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.AspNetCoreServer",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fix InvokeFeatures.Set<TFeature> to bump the feature collection revision so middleware that wraps the response body (e.g. OutputCache, ResponseCompression) is properly visible to ASP.NET Core's FeatureReferences cache. Resolves https://github.com/aws/aws-lambda-dotnet/issues/1702 where IOutputCache stored empty response bodies."
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/InvokeFeatures.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/InvokeFeatures.cs
@@ -117,10 +117,11 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
 
         public void Set<TFeature>(TFeature instance)
         {
-            if (instance == null)
-                return;
-
-            _features[typeof(TFeature)] = instance;
+            // Delegate to the indexer so _containerRevision is bumped, otherwise
+            // ASP.NET Core's FeatureReferences cache will return stale feature
+            // references after middleware (e.g. OutputCache, ResponseCompression)
+            // wraps the response body via HttpContext.Response.Body = wrapper.
+            this[typeof(TFeature)] = instance;
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/UtilitiesTest.cs
+++ b/Libraries/test/Amazon.Lambda.AspNetCoreServer.Test/UtilitiesTest.cs
@@ -29,5 +29,57 @@ namespace Amazon.Lambda.AspNetCoreServer.Test
             var feature = new InvokeFeatures() as IHttpResponseFeature;
             Assert.Equal(200, feature.StatusCode);
         }
+
+        // Regression test for https://github.com/aws/aws-lambda-dotnet/issues/1702.
+        // ASP.NET Core's FeatureReferences cache uses Revision to detect when a
+        // feature has been swapped (e.g. OutputCache/ResponseCompression replacing
+        // IHttpResponseBodyFeature to wrap the response body). If Set<TFeature>
+        // does not bump the revision, cached references stay stale and writes
+        // bypass the wrapper.
+        [Fact]
+        public void SetFeatureBumpsRevision()
+        {
+            IFeatureCollection features = new InvokeFeatures();
+            var initialRevision = features.Revision;
+
+            features.Set<IHttpResponseBodyFeature>(new TestResponseBodyFeature());
+
+            Assert.NotEqual(initialRevision, features.Revision);
+        }
+
+        [Fact]
+        public void SetFeatureStoresAndRetrievesInstance()
+        {
+            IFeatureCollection features = new InvokeFeatures();
+            var replacement = new TestResponseBodyFeature();
+
+            features.Set<IHttpResponseBodyFeature>(replacement);
+
+            Assert.Same(replacement, features.Get<IHttpResponseBodyFeature>());
+        }
+
+        [Fact]
+        public void SetFeatureNullRemovesEntryAndBumpsRevision()
+        {
+            IFeatureCollection features = new InvokeFeatures();
+            // InvokeFeatures seeds itself as the IHttpResponseBodyFeature in its constructor.
+            Assert.NotNull(features.Get<IHttpResponseBodyFeature>());
+            var revisionBeforeRemove = features.Revision;
+
+            features.Set<IHttpResponseBodyFeature>(null);
+
+            Assert.Null(features.Get<IHttpResponseBodyFeature>());
+            Assert.NotEqual(revisionBeforeRemove, features.Revision);
+        }
+
+        private sealed class TestResponseBodyFeature : IHttpResponseBodyFeature
+        {
+            public System.IO.Stream Stream => System.IO.Stream.Null;
+            public System.IO.Pipelines.PipeWriter Writer => System.IO.Pipelines.PipeWriter.Create(System.IO.Stream.Null);
+            public System.Threading.Tasks.Task CompleteAsync() => System.Threading.Tasks.Task.CompletedTask;
+            public void DisableBuffering() { }
+            public System.Threading.Tasks.Task SendFileAsync(string path, long offset, long? count, System.Threading.CancellationToken cancellationToken) => System.Threading.Tasks.Task.CompletedTask;
+            public System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken) => System.Threading.Tasks.Task.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Fixes [#1702](https://github.com/aws/aws-lambda-dotnet/issues/1702): `IOutputCache` (and any other middleware that wraps the response body) caches/sees zero bytes when an ASP.NET Core app is hosted in Lambda.
- One-line behavioral change in `Internal/InvokeFeatures.cs`: `Set<TFeature>` now delegates to the indexer so `_containerRevision` is bumped on every mutation.

## The bug

When middleware does `HttpContext.Response.Body = wrapperStream`, ASP.NET Core's `DefaultHttpResponse.Body.set` replaces the active `IHttpResponseBodyFeature` via `Features.Set<IHttpResponseBodyFeature>(new StreamResponseBodyFeature(value, oldFeature))` ([source](https://github.com/dotnet/aspnetcore/blob/main/src/Http/Http/src/Internal/DefaultHttpResponse.cs)).

ASP.NET Core caches feature lookups via `FeatureReferences<T>.Fetch`, which only re-reads the dictionary when `Collection.Revision` changes ([source](https://github.com/dotnet/aspnetcore/blob/main/src/Extensions/Features/src/FeatureReferences.cs)).

Our `InvokeFeatures.Set<TFeature>` was bypassing the indexer:

```csharp
public void Set<TFeature>(TFeature instance)
{
    if (instance == null)
        return;

    _features[typeof(TFeature)] = instance;   // <-- never bumps _containerRevision
}
```

So after `Response.Body = OutputCacheStream`:
1. The dictionary entry for `IHttpResponseBodyFeature` is updated to the new `StreamResponseBodyFeature` wrapping `OutputCacheStream`.
2. `_containerRevision` is **not** bumped.
3. ASP.NET Core's cached `IHttpResponseBodyFeature` reference (and the `PipeWriter` it produced) still point at the original feature, which writes directly to the underlying `MemoryStream`.
4. `WriteAsJsonAsync` (and friends) → `response.BodyWriter` → cached writer → bytes flow into the `MemoryStream` and never visit `OutputCacheStream`.
5. `OutputCacheMiddleware.FinalizeCacheBodyAsync` reads `context.OutputCacheStream.GetCachedResponseBody()` → empty → caches an empty entry.
6. Every subsequent request is served from the cache as an empty body.

## The fix

```csharp
public void Set<TFeature>(TFeature instance)
{
    this[typeof(TFeature)] = instance;   // indexer already does _containerRevision++
}
```

The indexer setter (just above in the same file) was already correct — it increments `_containerRevision` on every change and supports null-removal per the `IFeatureCollection` contract. Delegating to it makes both code paths behave identically. No other change is needed; the bug is invisible until middleware swaps a feature mid-request.

This change also helps any other middleware that wraps the body via `Response.Body =` / `Response.BodyWriter =` (e.g. `ResponseCompression`).

## How we tested

End-to-end on real AWS Lambda + API Gateway HTTP API v2:

1. **Reproduced the bug on `dev` (unfixed):** deployed a minimal app — `services.AddOutputCache()` + `app.UseOutputCache()` + `MapGet(\"/api/values\", () => new[]{\"value1\",\"value2\"})`. First request returned `Content-Length: 19`, body `[\"value1\",\"value2\"]`. Every subsequent request returned `Content-Length: 0`, empty body, with `age` header confirming it was served from the cache.

2. **Verified PR [#2150](https://github.com/aws/aws-lambda-dotnet/pull/2150) does not fix it.** That PR adds `responseFeatures.Body.Position = 0L` after marshalling. Deployed it; bug still repros. A diag endpoint confirmed the underlying `MemoryStream` had `len=19, pos=0` after the request — the position reset worked, but it was on the wrong stream. The OutputCache buffer was always empty because writes never reached `OutputCacheStream`.

3. **Verified the real fix works.** Built a NuGet from this branch, redeployed the same sample. Result:

```
Request 1 (cold):  200, Content-Length: 19, body: [\"value1\",\"value2\"]
Request 2:         200, Content-Length: 19, body: [\"value1\",\"value2\"], age: 0
Request 3:         200, Content-Length: 19, body: [\"value1\",\"value2\"], age: 0
Request 4:         200, Content-Length: 19, body: [\"value1\",\"value2\"], age: 1
```

All four requests return the full body. Requests 2-4 carry the `age` header, proving they're served from the OutputCache (and that the cache contains real bytes, not zero-length).

## Test plan

- [x] Reproduce the bug end-to-end against current `dev`
- [x] Verify PR #2150's proposed fix does not solve the bug
- [x] Verify this PR's fix solves the bug end-to-end against the same repro
- [x] CI: existing `Amazon.Lambda.AspNetCoreServer.Test` suite passes

## Notes

- PR #2150 should be closed in favor of this; its `Position = 0L` line addresses a symptom on the wrong stream and has no effect on the OutputCache scenario.
- Single-line behavioral change; same fix applies to all three hosting modes (`APIGatewayProxyFunction`, `APIGatewayHttpApiV2ProxyFunction`, `ApplicationLoadBalancerFunction`) because they all share `InvokeFeatures`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)