### PR TITLE
Include AWSSDK.SecurityToken to resolve AWS credential profiles

### DIFF
--- a/.autover/changes/5fa2fe86-10ce-47ac-89d7-cf2bb383078d.json
+++ b/.autover/changes/5fa2fe86-10ce-47ac-89d7-cf2bb383078d.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.TestTool",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Include AWSSDK.SecurityToken to resolve AWS credential profiles"
+      ]
+    }
+  ]
+}

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.15.2" />
     <PackageReference Include="AWSSDK.DynamoDBStreams" Version="4.0.4.17" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="3.1.2" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.6.3" />
     <PackageReference Include="AWSSDK.SSO" Version="4.0.2.13" />
     <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.3.14" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/Amazon.Lambda.TestTool.IntegrationTests.csproj
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/Amazon.Lambda.TestTool.IntegrationTests.csproj
@@ -20,7 +20,7 @@
 	  <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.9.7" />
     <PackageReference Include="AWSSDK.ApiGatewayV2" Version="4.0.4.9" />
     <PackageReference Include="AWSSDK.Lambda" Version="4.0.13.1" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.9" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.6.3" />
     <PackageReference Include="AWSSDK.SQS" Version="4.0.2.14" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
*Description of changes:*
Include `AWSSDK.SecurityToken` to resolve AWS credential profiles

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
