### PR TITLE
ci: add contents: read to change-file-in-pr workflow

### DIFF
--- a/.github/workflows/change-file-in-pr.yml
+++ b/.github/workflows/change-file-in-pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
+permissions:
+  contents: read
+
 jobs:
   check-files-in-directory:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'Release Not Needed') && !contains(github.event.pull_request.labels.*.name, 'Release PR') }}


### PR DESCRIPTION
Single-workflow PR. `change-file-in-pr.yml` checks every PR for a release-note change file under `.autover/changes/` using `tj-actions/changed-files`. Pure read; no comments, pushes, or release writes. `contents: read` is the minimum.