### PR TITLE
Add InvokeAsync for chained durable function calls (DOTNET-8661)

### DIFF
--- a/Docs/durable-execution-design.md
+++ b/Docs/durable-execution-design.md
@@ -510,7 +510,7 @@ var paymentResult = await context.InvokeAsync<PaymentRequest, PaymentResult>(
     name: "process_payment",
     config: new InvokeConfig
     {
-        Timeout = TimeSpan.FromMinutes(5)
+        TenantId = "tenant-42"
     });
 ```
 
@@ -1295,11 +1295,6 @@ public class WaitForCallbackConfig : CallbackConfig
 public class InvokeConfig
 {
     /// <summary>
-    /// Maximum time to wait for the invoked function. Default (TimeSpan.Zero) means no timeout.
-    /// </summary>
-    public TimeSpan Timeout { get; set; } = TimeSpan.Zero;
-
-    /// <summary>
     /// Optional tenant identifier propagated to the chained invocation.
     /// Matches the tenantId field on Python/JS/Java InvokeConfig.
     /// </summary>
@@ -1627,14 +1622,28 @@ public class CallbackTimeoutException : CallbackException { }
 public class CallbackSubmitterException : CallbackException { }
 
 /// <summary>
-/// Thrown when an invoked function fails.
+/// Base exception for chained-invoke failures. Catch <c>InvokeException</c>
+/// to handle every non-success terminal state uniformly, or pattern-match the
+/// concrete subclasses (<c>InvokeFailedException</c>, <c>InvokeTimedOutException</c>,
+/// <c>InvokeStoppedException</c>) to react differently to specific outcomes.
+/// Mirrors the Java SDK's invoke exception tree.
 /// </summary>
 public class InvokeException : DurableExecutionException
 {
-    public string? FunctionName { get; }
-    public string? ErrorType { get; }
-    public string? ErrorData { get; }
+    public string? FunctionName { get; init; }
+    public string? ErrorType { get; init; }
+    public string? ErrorData { get; init; }
+    public IReadOnlyList<string>? OriginalStackTrace { get; init; }
 }
+
+/// <summary>The chained function ran and threw.</summary>
+public class InvokeFailedException : InvokeException { }
+
+/// <summary>The chained function did not complete within the configured (or service) timeout.</summary>
+public class InvokeTimedOutException : InvokeException { }
+
+/// <summary>The chained execution was stopped by the service before reaching a normal terminal state.</summary>
+public class InvokeStoppedException : InvokeException { }
 
 /// <summary>
 /// Thrown when a child context operation fails.

--- a/Docs/durable-execution-design.md
+++ b/Docs/durable-execution-design.md
@@ -1639,7 +1639,7 @@ public class InvokeException : DurableExecutionException
 /// <summary>The chained function ran and threw.</summary>
 public class InvokeFailedException : InvokeException { }
 
-/// <summary>The chained function did not complete within the configured (or service) timeout.</summary>
+/// <summary>The chained invocation reached the service-side TIMED_OUT terminal state.</summary>
 public class InvokeTimedOutException : InvokeException { }
 
 /// <summary>The chained execution was stopped by the service before reaching a normal terminal state.</summary>

--- a/Libraries/src/Amazon.Lambda.DurableExecution/DurableContext.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/DurableContext.cs
@@ -337,6 +337,44 @@ internal sealed class DurableContext : IDurableContext
         || errorType == typeof(CallbackTimeoutException).FullName
         || errorType == typeof(CallbackSubmitterException).FullName
         || errorType == typeof(CallbackException).FullName;
+
+    public Task<TResult> InvokeAsync<TPayload, TResult>(
+        string functionName,
+        TPayload payload,
+        string? name = null,
+        InvokeConfig? config = null,
+        CancellationToken cancellationToken = default)
+        => RunInvoke<TPayload, TResult>(
+            functionName, payload,
+            name, config, cancellationToken);
+
+    private Task<TResult> RunInvoke<TPayload, TResult>(
+        string functionName,
+        TPayload payload,
+        string? name,
+        InvokeConfig? config,
+        CancellationToken cancellationToken)
+    {
+        // Argument validation runs synchronously at the call site (matches the
+        // .NET convention of failing fast for misuse). Match Python/JS/Java
+        // parity: only check for null/empty here; the durable execution service
+        // enforces the qualified-ARN rule and surfaces a precise error when an
+        // unqualified identifier is used.
+        ArgumentNullException.ThrowIfNull(functionName);
+        if (string.IsNullOrWhiteSpace(functionName))
+            throw new ArgumentException("Function name must not be empty or whitespace.", nameof(functionName));
+
+        var serializer = LambdaSerializerHelper.GetRequired(LambdaContext);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var operationId = _idGenerator.NextId();
+        var op = new InvokeOperation<TPayload, TResult>(
+            operationId, name, _idGenerator.ParentId, functionName, payload, config,
+            serializer,
+            _state, _terminationManager, _durableExecutionArn, _batcher);
+        return op.ExecuteAsync(cancellationToken);
+    }
 }
 
 internal sealed class WaitForCallbackContext : IWaitForCallbackContext

--- a/Libraries/src/Amazon.Lambda.DurableExecution/ErrorObject.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/ErrorObject.cs
@@ -34,13 +34,55 @@ public sealed class ErrorObject
     /// <summary>
     /// Creates an ErrorObject from an exception.
     /// </summary>
+    /// <remarks>
+    /// SDK operation wrappers (<see cref="StepException"/>,
+    /// <see cref="ChildContextException"/>, <see cref="InvokeException"/>,
+    /// <see cref="CallbackException"/>) unwrap to the original error captured
+    /// from the failed operation — preserving the user-visible
+    /// <c>ErrorType</c>/<c>ErrorData</c>/<c>StackTrace</c> instead of recording
+    /// the wrapper's type. This way a chained invoker sees the originating
+    /// exception (e.g. <c>System.InvalidOperationException</c>) rather than
+    /// <c>Amazon.Lambda.DurableExecution.StepException</c>. Mirrors the Java
+    /// SDK's <c>DurableExecutor.buildErrorObject</c> behavior.
+    /// </remarks>
     public static ErrorObject FromException(Exception exception)
     {
-        return new ErrorObject
+        return exception switch
         {
-            ErrorType = exception.GetType().FullName,
-            ErrorMessage = exception.Message,
-            StackTrace = exception.StackTrace?.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+            StepException step => new ErrorObject
+            {
+                ErrorType = step.ErrorType,
+                ErrorMessage = step.Message,
+                StackTrace = step.OriginalStackTrace,
+                ErrorData = step.ErrorData
+            },
+            ChildContextException child => new ErrorObject
+            {
+                ErrorType = child.ErrorType,
+                ErrorMessage = child.Message,
+                StackTrace = child.OriginalStackTrace,
+                ErrorData = child.ErrorData
+            },
+            InvokeException invoke => new ErrorObject
+            {
+                ErrorType = invoke.ErrorType,
+                ErrorMessage = invoke.Message,
+                StackTrace = invoke.OriginalStackTrace,
+                ErrorData = invoke.ErrorData
+            },
+            CallbackException callback => new ErrorObject
+            {
+                ErrorType = callback.ErrorType,
+                ErrorMessage = callback.Message,
+                StackTrace = callback.OriginalStackTrace,
+                ErrorData = callback.ErrorData
+            },
+            _ => new ErrorObject
+            {
+                ErrorType = exception.GetType().FullName,
+                ErrorMessage = exception.Message,
+                StackTrace = exception.StackTrace?.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+            }
         };
     }
 }

--- a/Libraries/src/Amazon.Lambda.DurableExecution/IDurableContext.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/IDurableContext.cs
@@ -151,41 +151,15 @@ public interface IDurableContext
     /// <summary>
     /// Invoke another durable Lambda function and await its result. The
     /// invocation is checkpointed so it survives parent failures and is not
-    /// double-fired on replay.
+    /// double-fired on replay. The payload and result are serialized to/from
+    /// a checkpoint using the <see cref="ILambdaSerializer"/> registered on
+    /// <see cref="ILambdaContext.Serializer"/>.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// The chained function runs out-of-process: the SDK checkpoints a
-    /// <c>CHAINED_INVOKE START</c> with the supplied <paramref name="payload"/>
-    /// and suspends; the durable execution service runs the target function
-    /// asynchronously and re-invokes the parent workflow when it completes.
-    /// On resume, the cached result is deserialized and returned, or the
-    /// recorded failure surfaces as an <see cref="InvokeException"/> subclass.
-    /// </para>
-    /// <para>
     /// <paramref name="functionName"/> must be a qualified identifier (version,
-    /// alias, or <c>$LATEST</c>). Unqualified ARNs are rejected by the durable
-    /// execution service. The SDK only validates that the value is non-null
-    /// and non-empty; ARN shape validation is left to the service to keep
-    /// behavior consistent with the Python, JavaScript, and Java SDKs.
-    /// </para>
-    /// <para>
-    /// The payload and result are serialized to/from a checkpoint using the
-    /// <see cref="ILambdaSerializer"/> registered on
-    /// <see cref="ILambdaContext.Serializer"/> (typically configured via
-    /// <c>LambdaBootstrapBuilder.Create(handler, serializer)</c>). AOT and
-    /// reflection-based scenarios share this single overload — the AOT story
-    /// is determined by the registered serializer (e.g.,
-    /// <c>SourceGeneratorLambdaJsonSerializer&lt;TContext&gt;</c>).
-    /// </para>
+    /// alias, or <c>$LATEST</c>); unqualified ARNs are rejected by the durable
+    /// execution service.
     /// </remarks>
-    /// <typeparam name="TPayload">The payload type sent to the chained function.</typeparam>
-    /// <typeparam name="TResult">The result type returned by the chained function.</typeparam>
-    /// <exception cref="ArgumentNullException"><paramref name="functionName"/> is null.</exception>
-    /// <exception cref="ArgumentException"><paramref name="functionName"/> is empty or whitespace.</exception>
-    /// <exception cref="InvokeFailedException">The chained function threw.</exception>
-    /// <exception cref="InvokeTimedOutException">The chained function did not complete within the configured timeout.</exception>
-    /// <exception cref="InvokeStoppedException">The chained execution was stopped by the service.</exception>
     Task<TResult> InvokeAsync<TPayload, TResult>(
         string functionName,
         TPayload payload,

--- a/Libraries/src/Amazon.Lambda.DurableExecution/IDurableContext.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/IDurableContext.cs
@@ -147,6 +147,51 @@ public interface IDurableContext
         string? name = null,
         WaitForCallbackConfig? config = null,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Invoke another durable Lambda function and await its result. The
+    /// invocation is checkpointed so it survives parent failures and is not
+    /// double-fired on replay.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The chained function runs out-of-process: the SDK checkpoints a
+    /// <c>CHAINED_INVOKE START</c> with the supplied <paramref name="payload"/>
+    /// and suspends; the durable execution service runs the target function
+    /// asynchronously and re-invokes the parent workflow when it completes.
+    /// On resume, the cached result is deserialized and returned, or the
+    /// recorded failure surfaces as an <see cref="InvokeException"/> subclass.
+    /// </para>
+    /// <para>
+    /// <paramref name="functionName"/> must be a qualified identifier (version,
+    /// alias, or <c>$LATEST</c>). Unqualified ARNs are rejected by the durable
+    /// execution service. The SDK only validates that the value is non-null
+    /// and non-empty; ARN shape validation is left to the service to keep
+    /// behavior consistent with the Python, JavaScript, and Java SDKs.
+    /// </para>
+    /// <para>
+    /// The payload and result are serialized to/from a checkpoint using the
+    /// <see cref="ILambdaSerializer"/> registered on
+    /// <see cref="ILambdaContext.Serializer"/> (typically configured via
+    /// <c>LambdaBootstrapBuilder.Create(handler, serializer)</c>). AOT and
+    /// reflection-based scenarios share this single overload — the AOT story
+    /// is determined by the registered serializer (e.g.,
+    /// <c>SourceGeneratorLambdaJsonSerializer&lt;TContext&gt;</c>).
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TPayload">The payload type sent to the chained function.</typeparam>
+    /// <typeparam name="TResult">The result type returned by the chained function.</typeparam>
+    /// <exception cref="ArgumentNullException"><paramref name="functionName"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="functionName"/> is empty or whitespace.</exception>
+    /// <exception cref="InvokeFailedException">The chained function threw.</exception>
+    /// <exception cref="InvokeTimedOutException">The chained function did not complete within the configured timeout.</exception>
+    /// <exception cref="InvokeStoppedException">The chained execution was stopped by the service.</exception>
+    Task<TResult> InvokeAsync<TPayload, TResult>(
+        string functionName,
+        TPayload payload,
+        string? name = null,
+        InvokeConfig? config = null,
+        CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/ExecutionState.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/ExecutionState.cs
@@ -146,5 +146,6 @@ internal sealed class ExecutionState
         status == OperationStatuses.Succeeded
         || status == OperationStatuses.Failed
         || status == OperationStatuses.Cancelled
-        || status == OperationStatuses.Stopped;
+        || status == OperationStatuses.Stopped
+        || status == OperationStatuses.TimedOut;
 }

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/InvokeOperation.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/InvokeOperation.cs
@@ -1,0 +1,182 @@
+using System.IO;
+using System.Text;
+using Amazon.Lambda.Core;
+using SdkChainedInvokeOptions = Amazon.Lambda.Model.ChainedInvokeOptions;
+using SdkOperationUpdate = Amazon.Lambda.Model.OperationUpdate;
+
+namespace Amazon.Lambda.DurableExecution.Internal;
+
+/// <summary>
+/// Durable chained-invoke operation. Schedules an asynchronous invocation of
+/// another durable Lambda function via the durable execution service and
+/// suspends the parent workflow until the chained execution reaches a terminal
+/// state. The service drives the chained function and re-invokes the parent
+/// with an updated operation status.
+/// </summary>
+/// <remarks>
+/// Replay branches — example:
+/// <c>await ctx.InvokeAsync&lt;Req, Resp&gt;("arn:...:fn:prod", req, "process_payment")</c>
+/// <list type="bullet">
+///   <item><b>Fresh</b>: serialize payload → sync-flush <c>CHAINED_INVOKE START</c>
+///       (carrying <see cref="SdkChainedInvokeOptions"/>) → suspend with
+///       <see cref="TerminationReason.InvokePending"/>.</item>
+///   <item><b>SUCCEEDED</b>: deserialize and return cached result from
+///       <c>ChainedInvokeDetails.Result</c>; the chained function is NOT
+///       re-invoked.</item>
+///   <item><b>FAILED</b>: throw <see cref="InvokeFailedException"/> populated
+///       from the recorded error.</item>
+///   <item><b>TIMED_OUT</b>: throw <see cref="InvokeTimedOutException"/>.</item>
+///   <item><b>STOPPED</b>: throw <see cref="InvokeStoppedException"/>.</item>
+///   <item><b>STARTED</b> / <b>PENDING</b>: chained execution is still in
+///       flight; re-suspend without re-checkpointing — the original
+///       <c>START</c> remains authoritative.</item>
+/// </list>
+/// Mirrors <see cref="WaitOperation"/>'s "sync-flush START → suspend" idiom;
+/// the chained function executes out-of-process so there is nothing to run
+/// locally on either fresh or replay paths besides the suspend wiring.
+/// Serialization is delegated to the <see cref="ILambdaSerializer"/> registered
+/// on <see cref="ILambdaContext.Serializer"/>; AOT-safe and reflection-based
+/// callers share the same code path (the AOT story is determined by the
+/// registered serializer).
+/// </remarks>
+internal sealed class InvokeOperation<TPayload, TResult> : DurableOperation<TResult>
+{
+    private readonly string _functionName;
+    private readonly TPayload _payload;
+    private readonly InvokeConfig? _config;
+    private readonly ILambdaSerializer _serializer;
+
+    public InvokeOperation(
+        string operationId,
+        string? name,
+        string? parentId,
+        string functionName,
+        TPayload payload,
+        InvokeConfig? config,
+        ILambdaSerializer serializer,
+        ExecutionState state,
+        TerminationManager termination,
+        string durableExecutionArn,
+        CheckpointBatcher? batcher = null)
+        : base(operationId, name, parentId, state, termination, durableExecutionArn, batcher)
+    {
+        _functionName = functionName;
+        _payload = payload;
+        _config = config;
+        _serializer = serializer;
+    }
+
+    protected override string OperationType => OperationTypes.ChainedInvoke;
+
+    protected override async Task<TResult> StartAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var serializedPayload = SerializeValue(_payload);
+
+        // The service is what actually invokes the chained function, so it
+        // must receive this START before we suspend. If we only batched it
+        // locally and the parent process were recycled at suspend, the START
+        // would be lost and the chained function would never run.
+        await EnqueueAsync(new SdkOperationUpdate
+        {
+            Id = OperationId,
+            ParentId = ParentId,
+            Type = OperationTypes.ChainedInvoke,
+            Action = OperationAction.START,
+            SubType = OperationSubTypes.ChainedInvoke,
+            Name = Name,
+            Payload = serializedPayload,
+            ChainedInvokeOptions = new SdkChainedInvokeOptions
+            {
+                FunctionName = _functionName,
+                TenantId = _config?.TenantId
+            }
+        }, cancellationToken);
+
+        return await Termination.SuspendAndAwait<TResult>(
+            TerminationReason.InvokePending, $"invoke:{Name ?? _functionName}");
+    }
+
+    protected override Task<TResult> ReplayAsync(Operation existing, CancellationToken cancellationToken)
+    {
+        switch (existing.Status)
+        {
+            case OperationStatuses.Succeeded:
+                return Task.FromResult(DeserializeResult(existing.ChainedInvokeDetails?.Result));
+
+            case OperationStatuses.Failed:
+                throw BuildFailed(existing);
+
+            case OperationStatuses.TimedOut:
+                throw BuildTimedOut(existing);
+
+            case OperationStatuses.Stopped:
+                throw BuildStopped(existing);
+
+            case OperationStatuses.Started:
+            case OperationStatuses.Pending:
+                // Chained function is still running. Just suspend again —
+                // the original START is already on the service, so don't
+                // re-checkpoint it. Whenever the service re-invokes us next,
+                // it will include the updated status.
+                return Termination.SuspendAndAwait<TResult>(
+                    TerminationReason.InvokePending, $"invoke:{Name ?? _functionName}");
+
+            default:
+                throw new NonDeterministicExecutionException(
+                    $"Chained invoke operation '{Name ?? OperationId}' has unexpected status '{existing.Status}' on replay.");
+        }
+    }
+
+    private string SerializeValue(TPayload value)
+    {
+        using var ms = new MemoryStream();
+        _serializer.Serialize(value, ms);
+        return Encoding.UTF8.GetString(ms.ToArray());
+    }
+
+    private TResult DeserializeResult(string? serialized)
+    {
+        if (serialized == null) return default!;
+        var bytes = Encoding.UTF8.GetBytes(serialized);
+        using var ms = new MemoryStream(bytes);
+        return _serializer.Deserialize<TResult>(ms);
+    }
+
+    private InvokeFailedException BuildFailed(Operation failedOp)
+    {
+        var err = failedOp.ChainedInvokeDetails?.Error;
+        return new InvokeFailedException(err?.ErrorMessage ?? "Chained invoke failed.")
+        {
+            FunctionName = _functionName,
+            ErrorType = err?.ErrorType,
+            ErrorData = err?.ErrorData,
+            OriginalStackTrace = err?.StackTrace
+        };
+    }
+
+    private InvokeTimedOutException BuildTimedOut(Operation failedOp)
+    {
+        var err = failedOp.ChainedInvokeDetails?.Error;
+        return new InvokeTimedOutException(err?.ErrorMessage ?? "Chained invoke timed out.")
+        {
+            FunctionName = _functionName,
+            ErrorType = err?.ErrorType,
+            ErrorData = err?.ErrorData,
+            OriginalStackTrace = err?.StackTrace
+        };
+    }
+
+    private InvokeStoppedException BuildStopped(Operation failedOp)
+    {
+        var err = failedOp.ChainedInvokeDetails?.Error;
+        return new InvokeStoppedException(err?.ErrorMessage ?? "Chained invoke was stopped.")
+        {
+            FunctionName = _functionName,
+            ErrorType = err?.ErrorType,
+            ErrorData = err?.ErrorData,
+            OriginalStackTrace = err?.StackTrace
+        };
+    }
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/InvokeConfig.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/InvokeConfig.cs
@@ -1,0 +1,24 @@
+namespace Amazon.Lambda.DurableExecution;
+
+/// <summary>
+/// Configuration for chained invoke operations.
+/// </summary>
+/// <remarks>
+/// Use with <see cref="IDurableContext.InvokeAsync{TPayload, TResult}(string, TPayload, string?, InvokeConfig?, System.Threading.CancellationToken)"/>
+/// to configure a single chained invocation. Payload/result serialization is
+/// performed by the <see cref="Amazon.Lambda.Core.ILambdaSerializer"/> registered on
+/// <see cref="Amazon.Lambda.Core.ILambdaContext.Serializer"/> (typically configured via
+/// <c>LambdaBootstrapBuilder.Create(handler, serializer)</c>); there are
+/// intentionally no serializer fields here, matching the pattern established
+/// by <see cref="StepConfig"/>.
+/// </remarks>
+public sealed class InvokeConfig
+{
+    /// <summary>
+    /// Optional tenant identifier propagated to the chained invocation via
+    /// <c>ChainedInvokeOptions.TenantId</c>. Used to route the invocation to a
+    /// tenant-isolated function. Matches the <c>tenantId</c> field on the
+    /// Python, JavaScript, and Java SDKs.
+    /// </summary>
+    public string? TenantId { get; set; }
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/InvokeException.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/InvokeException.cs
@@ -9,8 +9,8 @@ namespace Amazon.Lambda.DurableExecution;
 /// concrete subclasses to react differently to specific outcomes:
 /// <list type="bullet">
 ///   <item><see cref="InvokeFailedException"/> — the chained function threw.</item>
-///   <item><see cref="InvokeTimedOutException"/> — the configured (or service)
-///       timeout elapsed before completion.</item>
+///   <item><see cref="InvokeTimedOutException"/> — the chained invocation
+///       reached the service-side <c>TIMED_OUT</c> terminal state.</item>
 ///   <item><see cref="InvokeStoppedException"/> — the chained execution was
 ///       stopped by the service or an operator.</item>
 /// </list>
@@ -56,8 +56,7 @@ public class InvokeFailedException : InvokeException
 }
 
 /// <summary>
-/// Thrown when a chained invoke operation completes with status <c>TIMED_OUT</c>
-/// — the invocation did not complete within the service-level timeout.
+/// Thrown when a chained invoke operation completes with status <c>TIMED_OUT</c>.
 /// </summary>
 public class InvokeTimedOutException : InvokeException
 {

--- a/Libraries/src/Amazon.Lambda.DurableExecution/InvokeException.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/InvokeException.cs
@@ -1,0 +1,85 @@
+namespace Amazon.Lambda.DurableExecution;
+
+/// <summary>
+/// Thrown when a chained invoke operation reaches a non-success terminal state.
+/// </summary>
+/// <remarks>
+/// Base class for the invoke exception tree. Catch <see cref="InvokeException"/>
+/// to handle every chained-invoke failure mode uniformly, or pattern-match the
+/// concrete subclasses to react differently to specific outcomes:
+/// <list type="bullet">
+///   <item><see cref="InvokeFailedException"/> — the chained function threw.</item>
+///   <item><see cref="InvokeTimedOutException"/> — the configured (or service)
+///       timeout elapsed before completion.</item>
+///   <item><see cref="InvokeStoppedException"/> — the chained execution was
+///       stopped by the service or an operator.</item>
+/// </list>
+/// Mirrors the Java SDK's <c>InvokeException</c> / <c>InvokeFailedException</c>
+/// / <c>InvokeTimedOutException</c> / <c>InvokeStoppedException</c> tree; the
+/// .NET SDK keeps <see cref="InvokeException"/> non-abstract so callers can also
+/// rethrow it directly when wrapping fallback logic.
+/// </remarks>
+public class InvokeException : DurableExecutionException
+{
+    /// <summary>The fully-qualified name of the invoked function (ARN, alias, or version).</summary>
+    public string? FunctionName { get; init; }
+
+    /// <summary>The fully-qualified type name of the original exception, when known.</summary>
+    public string? ErrorType { get; init; }
+
+    /// <summary>Optional structured error data attached by the invoked function.</summary>
+    public string? ErrorData { get; init; }
+
+    /// <summary>Stack trace of the original exception, captured before serialization.</summary>
+    public IReadOnlyList<string>? OriginalStackTrace { get; init; }
+
+    /// <summary>Creates an empty <see cref="InvokeException"/>.</summary>
+    public InvokeException() { }
+    /// <summary>Creates an <see cref="InvokeException"/> with the given message.</summary>
+    public InvokeException(string message) : base(message) { }
+    /// <summary>Creates an <see cref="InvokeException"/> wrapping an inner exception.</summary>
+    public InvokeException(string message, Exception innerException) : base(message, innerException) { }
+}
+
+/// <summary>
+/// Thrown when a chained invoke operation completes with status <c>FAILED</c> —
+/// the invoked function ran and threw.
+/// </summary>
+public class InvokeFailedException : InvokeException
+{
+    /// <summary>Creates an empty <see cref="InvokeFailedException"/>.</summary>
+    public InvokeFailedException() { }
+    /// <summary>Creates an <see cref="InvokeFailedException"/> with the given message.</summary>
+    public InvokeFailedException(string message) : base(message) { }
+    /// <summary>Creates an <see cref="InvokeFailedException"/> wrapping an inner exception.</summary>
+    public InvokeFailedException(string message, Exception innerException) : base(message, innerException) { }
+}
+
+/// <summary>
+/// Thrown when a chained invoke operation completes with status <c>TIMED_OUT</c>
+/// — the invocation did not complete within the service-level timeout.
+/// </summary>
+public class InvokeTimedOutException : InvokeException
+{
+    /// <summary>Creates an empty <see cref="InvokeTimedOutException"/>.</summary>
+    public InvokeTimedOutException() { }
+    /// <summary>Creates an <see cref="InvokeTimedOutException"/> with the given message.</summary>
+    public InvokeTimedOutException(string message) : base(message) { }
+    /// <summary>Creates an <see cref="InvokeTimedOutException"/> wrapping an inner exception.</summary>
+    public InvokeTimedOutException(string message, Exception innerException) : base(message, innerException) { }
+}
+
+/// <summary>
+/// Thrown when a chained invoke operation completes with status <c>STOPPED</c>
+/// — the invocation was stopped administratively by the durable execution
+/// service before reaching a normal terminal state.
+/// </summary>
+public class InvokeStoppedException : InvokeException
+{
+    /// <summary>Creates an empty <see cref="InvokeStoppedException"/>.</summary>
+    public InvokeStoppedException() { }
+    /// <summary>Creates an <see cref="InvokeStoppedException"/> with the given message.</summary>
+    public InvokeStoppedException(string message) : base(message) { }
+    /// <summary>Creates an <see cref="InvokeStoppedException"/> wrapping an inner exception.</summary>
+    public InvokeStoppedException(string message, Exception innerException) : base(message, innerException) { }
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Services/LambdaDurableServiceClient.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Services/LambdaDurableServiceClient.cs
@@ -9,6 +9,7 @@ using WaitDetails = Amazon.Lambda.DurableExecution.WaitDetails;
 using ExecutionDetails = Amazon.Lambda.DurableExecution.ExecutionDetails;
 using ContextDetails = Amazon.Lambda.DurableExecution.ContextDetails;
 using CallbackDetails = Amazon.Lambda.DurableExecution.CallbackDetails;
+using ChainedInvokeDetails = Amazon.Lambda.DurableExecution.ChainedInvokeDetails;
 
 namespace Amazon.Lambda.DurableExecution.Services;
 
@@ -138,13 +139,7 @@ internal sealed class LambdaDurableServiceClient
             StepDetails = sdkOp.StepDetails != null ? new StepDetails
             {
                 Result = sdkOp.StepDetails.Result,
-                Error = sdkOp.StepDetails.Error != null ? new ErrorObject
-                {
-                    ErrorType = sdkOp.StepDetails.Error.ErrorType,
-                    ErrorMessage = sdkOp.StepDetails.Error.ErrorMessage,
-                    StackTrace = sdkOp.StepDetails.Error.StackTrace,
-                    ErrorData = sdkOp.StepDetails.Error.ErrorData
-                } : null,
+                Error = MapError(sdkOp.StepDetails.Error),
                 Attempt = sdkOp.StepDetails.Attempt,
                 NextAttemptTimestamp = sdkOp.StepDetails.NextAttemptTimestamp.HasValue
                     ? new DateTimeOffset(sdkOp.StepDetails.NextAttemptTimestamp.Value, TimeSpan.Zero).ToUnixTimeMilliseconds()
@@ -163,26 +158,43 @@ internal sealed class LambdaDurableServiceClient
             ContextDetails = sdkOp.ContextDetails != null ? new ContextDetails
             {
                 Result = sdkOp.ContextDetails.Result,
-                Error = sdkOp.ContextDetails.Error != null ? new ErrorObject
-                {
-                    ErrorType = sdkOp.ContextDetails.Error.ErrorType,
-                    ErrorMessage = sdkOp.ContextDetails.Error.ErrorMessage,
-                    StackTrace = sdkOp.ContextDetails.Error.StackTrace,
-                    ErrorData = sdkOp.ContextDetails.Error.ErrorData
-                } : null
+                Error = MapError(sdkOp.ContextDetails.Error)
             } : null,
             CallbackDetails = sdkOp.CallbackDetails != null ? new CallbackDetails
             {
                 CallbackId = sdkOp.CallbackDetails.CallbackId,
                 Result = sdkOp.CallbackDetails.Result,
-                Error = sdkOp.CallbackDetails.Error != null ? new ErrorObject
-                {
-                    ErrorType = sdkOp.CallbackDetails.Error.ErrorType,
-                    ErrorMessage = sdkOp.CallbackDetails.Error.ErrorMessage,
-                    StackTrace = sdkOp.CallbackDetails.Error.StackTrace,
-                    ErrorData = sdkOp.CallbackDetails.Error.ErrorData
-                } : null
+                Error = MapError(sdkOp.CallbackDetails.Error)
+            } : null,
+            ChainedInvokeDetails = sdkOp.ChainedInvokeDetails != null ? new ChainedInvokeDetails
+            {
+                Result = sdkOp.ChainedInvokeDetails.Result,
+                Error = MapError(sdkOp.ChainedInvokeDetails.Error)
             } : null
+        };
+    }
+
+    /// <summary>
+    /// Maps an SDK <see cref="Amazon.Lambda.Model.ErrorObject"/> into the
+    /// internal <see cref="ErrorObject"/>. Carries every field the wire object
+    /// exposes — <c>ErrorType</c>, <c>ErrorMessage</c>, <c>ErrorData</c>, and
+    /// <c>StackTrace</c> — so the durable execution exception builders
+    /// (<see cref="StepException"/>, <see cref="ChildContextException"/>, and
+    /// the <see cref="InvokeException"/> tree) can rehydrate the original
+    /// failure faithfully on real-service replay.
+    /// </summary>
+    private static ErrorObject? MapError(Amazon.Lambda.Model.ErrorObject? sdkError)
+    {
+        if (sdkError == null) return null;
+        return new ErrorObject
+        {
+            ErrorType = sdkError.ErrorType,
+            ErrorMessage = sdkError.ErrorMessage,
+            ErrorData = sdkError.ErrorData,
+            // SDK exposes List<string>; assigning into IReadOnlyList<string>?
+            // is reference-identical. A null list (SDK 4.x default when the
+            // field isn't set on the wire) propagates as null on our side.
+            StackTrace = sdkError.StackTrace
         };
     }
 }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/DurableFunctionDeployment.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/DurableFunctionDeployment.cs
@@ -28,8 +28,10 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
     private readonly string _roleName;
     private string? _roleArn;
     private string? _imageUri;
+    private string? _functionArn;
     private bool _functionCreated;
     private bool _ecrRepoCreated;
+    private readonly List<string> _inlinePolicyNames = new();
 
     // Optional paired "external system" Lambda — a plain (non-durable) function
     // that the workflow's submitter invokes. Models a real-world callback flow
@@ -43,6 +45,15 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
 
     public string FunctionName => _functionName;
     public string? ExternalFunctionName => _externalFunctionCreated ? _externalFunctionName : null;
+
+    /// <summary>
+    /// The fully-qualified function ARN (unqualified). Available after <see cref="CreateAsync"/>
+    /// or <see cref="CreateWithDownstreamAsync"/> completes. Use <c>$"{FunctionArn}:$LATEST"</c>
+    /// when constructing a qualified identifier for chained invocation.
+    /// </summary>
+    public string FunctionArn => _functionArn
+        ?? throw new InvalidOperationException("Function ARN is not available until the function has been created.");
+
     public IAmazonLambda LambdaClient => _lambdaClient;
 
     private DurableFunctionDeployment(ITestOutputHelper output, string suffix)
@@ -67,12 +78,15 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
         string testFunctionDir,
         string scenarioSuffix,
         ITestOutputHelper output,
-        string? externalFunctionDir = null)
+        string? externalFunctionDir = null,
+        IDictionary<string, string>? environment = null,
+        IReadOnlyList<string>? invokeAllowedFunctionArns = null,
+        bool enableTenancy = false)
     {
         var deployment = new DurableFunctionDeployment(output, scenarioSuffix);
         try
         {
-            await deployment.InitializeAsync(testFunctionDir, externalFunctionDir);
+            await deployment.InitializeAsync(testFunctionDir, externalFunctionDir, environment, invokeAllowedFunctionArns, enableTenancy);
         }
         catch
         {
@@ -84,18 +98,88 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
         return deployment;
     }
 
-    private const string LambdaAssumeRolePolicy = """
-        {
-            "Version": "2012-10-17",
-            "Statement": [{
-                "Effect": "Allow",
-                "Principal": {"Service": "lambda.amazonaws.com"},
-                "Action": "sts:AssumeRole"
-            }]
-        }
-        """;
+    /// <summary>
+    /// Two-step deployment for chained-invoke scenarios: deploys the downstream (callee)
+    /// function first, captures its ARN, then deploys the parent (caller) with
+    /// <c>DOWNSTREAM_FUNCTION_ARN</c> set in the parent's environment and the parent's
+    /// role granted <c>lambda:InvokeFunction</c> on the downstream's ARN.
+    /// </summary>
+    /// <remarks>
+    /// The parent and downstream are independent <see cref="DurableFunctionDeployment"/>
+    /// instances; both are returned so the caller can dispose them in the right order
+    /// (parent first, then downstream — the caller is the one in flight when the test ends).
+    /// The <c>DOWNSTREAM_FUNCTION_ARN</c> env var carries a qualified identifier
+    /// (<c>arn:...:function:name:$LATEST</c>) so the parent can pass it directly to
+    /// <c>ctx.InvokeAsync(...)</c> without further manipulation.
+    /// </remarks>
+    public static async Task<(DurableFunctionDeployment Parent, DurableFunctionDeployment Downstream)>
+        CreateWithDownstreamAsync(
+            string parentTestFunctionDir,
+            string downstreamTestFunctionDir,
+            string scenarioSuffix,
+            ITestOutputHelper output,
+            IDictionary<string, string>? extraParentEnvironment = null,
+            bool enableDownstreamTenancy = false)
+    {
+        // Deploy downstream first so we can pass its ARN to the parent's environment.
+        var downstream = await CreateAsync(
+            downstreamTestFunctionDir,
+            scenarioSuffix + "-d",
+            output,
+            enableTenancy: enableDownstreamTenancy);
 
-    private async Task InitializeAsync(string testFunctionDir, string? externalFunctionDir)
+        DurableFunctionDeployment? parent = null;
+        try
+        {
+            // Use a qualified identifier — the durable execution service rejects
+            // unqualified ARNs. $LATEST is fine for integration tests; production
+            // should use a version or alias.
+            var qualifiedDownstreamArn = downstream.FunctionArn + ":$LATEST";
+            var parentEnv = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["DOWNSTREAM_FUNCTION_ARN"] = qualifiedDownstreamArn,
+            };
+            if (extraParentEnvironment != null)
+            {
+                foreach (var kv in extraParentEnvironment)
+                    parentEnv[kv.Key] = kv.Value;
+            }
+
+            parent = await CreateAsync(
+                parentTestFunctionDir,
+                scenarioSuffix + "-p",
+                output,
+                environment: parentEnv,
+                invokeAllowedFunctionArns: new[] { downstream.FunctionArn });
+        }
+        catch
+        {
+            // Parent failed to deploy — tear down the downstream we already created
+            // so we don't leak resources.
+            await downstream.DisposeAsync();
+            throw;
+        }
+
+        return (parent!, downstream);
+    }
+
+    private const string LambdaAssumeRolePolicy = """
+    {
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Principal": {"Service": "lambda.amazonaws.com"},
+            "Action": "sts:AssumeRole"
+        }]
+    }
+    """;
+
+    private async Task InitializeAsync(
+        string testFunctionDir,
+        string? externalFunctionDir,
+        IDictionary<string, string>? environment,
+        IReadOnlyList<string>? invokeAllowedFunctionArns,
+        bool enableTenancy)
     {
         // 1. Create the workflow's IAM role.
         _output.WriteLine($"Creating IAM role: {_roleName}");
@@ -178,6 +262,43 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
                 }
                 """
             });
+            _inlinePolicyNames.Add("InvokeExternalFunction");
+        }
+
+        // Grant cross-Lambda invoke when the parent of a chained-invoke scenario
+        // needs to call out to a downstream function. The durable execution service
+        // is the one that actually drives the chained invocation in production —
+        // attaching this directly to the parent's role keeps the parent role
+        // capable of being used in non-durable contexts (e.g. for diagnostic
+        // direct invokes from the test harness).
+        if (invokeAllowedFunctionArns != null && invokeAllowedFunctionArns.Count > 0)
+        {
+            // Allow both the unqualified ARN and any qualifier (alias/version/$LATEST).
+            var resources = new List<string>(invokeAllowedFunctionArns.Count * 2);
+            foreach (var arn in invokeAllowedFunctionArns)
+            {
+                resources.Add(arn);
+                resources.Add(arn + ":*");
+            }
+            var resourceJson = "[" + string.Join(",", resources.Select(r => $"\"{r}\"")) + "]";
+            var policyDoc = $$"""
+            {
+                "Version": "2012-10-17",
+                "Statement": [{
+                    "Effect": "Allow",
+                    "Action": ["lambda:InvokeFunction"],
+                    "Resource": {{resourceJson}}
+                }]
+            }
+            """;
+            const string PolicyName = "AllowChainedInvoke";
+            await _iamClient.PutRolePolicyAsync(new PutRolePolicyRequest
+            {
+                RoleName = _roleName,
+                PolicyName = PolicyName,
+                PolicyDocument = policyDoc
+            });
+            _inlinePolicyNames.Add(PolicyName);
         }
 
         // Wait for IAM propagation.
@@ -232,7 +353,7 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
 
         // 5. Create the workflow Lambda.
         _output.WriteLine($"Creating Lambda function: {_functionName}");
-        var createReq = new CreateFunctionRequest
+        var createFunctionRequest = new CreateFunctionRequest
         {
             FunctionName = _functionName,
             PackageType = PackageType.Image,
@@ -242,21 +363,44 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
             MemorySize = 256,
             DurableConfig = new DurableConfig { ExecutionTimeout = 60 }
         };
-        if (externalFunctionDir != null)
+
+        // Tenant isolation must be set at function-creation time (Lambda rejects
+        // post-create modification). Without it, the durable execution service
+        // refuses chained invokes that carry a TenantId — so the tenant-routing
+        // integration test needs the *callee* deployed with PER_TENANT.
+        if (enableTenancy)
         {
-            // Tell the workflow which function to invoke as its "external system".
-            createReq.Environment = new Amazon.Lambda.Model.Environment
+            createFunctionRequest.TenancyConfig = new TenancyConfig
             {
-                Variables = new Dictionary<string, string>
-                {
-                    ["EXTERNAL_FUNCTION_NAME"] = _externalFunctionName
-                }
+                TenantIsolationMode = TenantIsolationMode.PER_TENANT
             };
         }
-        await _lambdaClient.CreateFunctionAsync(createReq);
-        _functionCreated = true;
 
-        _output.WriteLine("Waiting for function to become Active...");
+        // Build the function's environment: start with the caller-supplied vars, then
+        // tack on EXTERNAL_FUNCTION_NAME if a paired external function exists.
+        var envVars = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (environment != null)
+        {
+            foreach (var kv in environment)
+                envVars[kv.Key] = kv.Value;
+        }
+        if (externalFunctionDir != null)
+        {
+            envVars["EXTERNAL_FUNCTION_NAME"] = _externalFunctionName;
+        }
+        if (envVars.Count > 0)
+        {
+            createFunctionRequest.Environment = new Amazon.Lambda.Model.Environment
+            {
+                Variables = envVars
+            };
+        }
+
+        var createFunctionResponse = await _lambdaClient.CreateFunctionAsync(createFunctionRequest);
+        _functionCreated = true;
+        _functionArn = createFunctionResponse.FunctionArn;
+
+        _output.WriteLine($"Waiting for function to become Active... (ARN: {_functionArn})");
         await WaitForFunctionActive(_functionName);
     }
 
@@ -630,10 +774,13 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
             // want to attempt the others and the final DeleteRole.
             await TryDetachManaged(_roleName, "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole");
             await TryDetachManaged(_roleName, "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy");
-            // Inline policy was only attached when an external function was deployed; the
-            // delete still has to fire because IAM rejects DeleteRole if any inline policy
-            // remains.
-            await TryDeleteInline(_roleName, "InvokeExternalFunction");
+
+            // Inline policies must be deleted (not detached) before DeleteRole succeeds.
+            foreach (var inline in _inlinePolicyNames)
+            {
+                await TryDeleteInline(_roleName, inline);
+            }
+
             try
             {
                 await _iamClient.DeleteRoleAsync(new DeleteRoleRequest { RoleName = _roleName });

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/InvokeFailureTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/InvokeFailureTest.cs
@@ -1,0 +1,70 @@
+using System.Linq;
+using System.Text;
+using Amazon.Lambda.Model;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Amazon.Lambda.DurableExecution.IntegrationTests;
+
+public class InvokeFailureTest
+{
+    private readonly ITestOutputHelper _output;
+    public InvokeFailureTest(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public async Task InvokeAsync_ChildThrows_ParentSurfacesInvokeFailedException()
+    {
+        var (parent, downstream) = await DurableFunctionDeployment.CreateWithDownstreamAsync(
+            parentTestFunctionDir: DurableFunctionDeployment.FindTestFunctionDir("InvokeFailureParentFunction"),
+            downstreamTestFunctionDir: DurableFunctionDeployment.FindTestFunctionDir("InvokeFailureChildFunction"),
+            scenarioSuffix: "invokefail",
+            output: _output);
+
+        await using (downstream)
+        await using (parent)
+        {
+            var (invokeResponse, executionName) = await parent.InvokeAsync("""{"orderId": "invoke-fail"}""");
+            var responsePayload = Encoding.UTF8.GetString(invokeResponse.Payload.ToArray());
+            _output.WriteLine($"Parent response: {responsePayload}");
+
+            var arn = await parent.FindDurableExecutionArnByNameAsync(executionName, TimeSpan.FromSeconds(60));
+            Assert.NotNull(arn);
+
+            // The parent catches InvokeFailedException and returns normally —
+            // the parent execution itself SUCCEEDS even though the chained
+            // invocation FAILED. This is the value of the SDK's exception
+            // surface: failure is observable but not necessarily fatal.
+            var status = await parent.PollForCompletionAsync(arn!, TimeSpan.FromSeconds(120));
+            Assert.Equal("SUCCEEDED", status, ignoreCase: true);
+
+            var history = await parent.WaitForHistoryAsync(
+                arn!,
+                h => (h.Events?.Any(e => e.EventType == EventType.ChainedInvokeStarted) ?? false)
+                  && (h.Events?.Any(e => e.ChainedInvokeFailedDetails != null) ?? false),
+                TimeSpan.FromSeconds(60));
+            var events = history.Events ?? new List<Event>();
+
+            // Exactly one chained invoke was issued and it FAILED — the parent
+            // did not retry the invoke (no retry semantics for InvokeAsync yet).
+            Assert.Equal(1, events.Count(e => e.EventType == EventType.ChainedInvokeStarted));
+            var failed = events.FirstOrDefault(e => e.ChainedInvokeFailedDetails != null);
+            Assert.NotNull(failed);
+            Assert.Equal("call_failing_child", failed!.Name);
+
+            var error = failed.ChainedInvokeFailedDetails.Error?.Payload;
+            Assert.NotNull(error);
+            // The child's exception type and message propagate through the
+            // service into the parent's history. Some service implementations
+            // record only the simple type name and others the fully-qualified
+            // one — match either by checking for the substring.
+            Assert.Contains("InvalidOperationException", error!.ErrorType ?? string.Empty);
+            Assert.Contains("intentional child failure", error.ErrorMessage ?? string.Empty);
+
+            // The parent's terminal result encodes "parent-saw-<errorType>" — confirms
+            // the parent's catch block ran and the exception's ErrorType field
+            // was populated by the SDK on resume from the FAILED chained invoke.
+            var execution = await parent.GetExecutionAsync(arn!);
+            Assert.Null(execution.Error);
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/InvokeFailureTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/InvokeFailureTest.cs
@@ -61,10 +61,17 @@ public class InvokeFailureTest
             Assert.Contains("intentional child failure", error.ErrorMessage ?? string.Empty);
 
             // The parent's terminal result encodes "parent-saw-<errorType>" — confirms
-            // the parent's catch block ran and the exception's ErrorType field
+            // the parent's catch block ran AND the exception's ErrorType field
             // was populated by the SDK on resume from the FAILED chained invoke.
+            // Without the Result assertions, a regression that left ErrorType
+            // null would still produce a SUCCEEDED execution (parent-saw-unknown)
+            // and silently pass.
             var execution = await parent.GetExecutionAsync(arn!);
             Assert.Null(execution.Error);
+            Assert.NotNull(execution.Result);
+            Assert.Contains("parent-saw-", execution.Result);
+            Assert.DoesNotContain("parent-saw-unknown", execution.Result);
+            Assert.Contains("InvalidOperationException", execution.Result);
         }
     }
 }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/InvokeHappyPathTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/InvokeHappyPathTest.cs
@@ -1,0 +1,67 @@
+using System.Linq;
+using System.Text;
+using Amazon.Lambda.Model;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Amazon.Lambda.DurableExecution.IntegrationTests;
+
+public class InvokeHappyPathTest
+{
+    private readonly ITestOutputHelper _output;
+    public InvokeHappyPathTest(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public async Task InvokeAsync_HappyPath_ChildResultPropagatesToParent()
+    {
+        var (parent, downstream) = await DurableFunctionDeployment.CreateWithDownstreamAsync(
+            parentTestFunctionDir: DurableFunctionDeployment.FindTestFunctionDir("InvokeHappyPathParentFunction"),
+            downstreamTestFunctionDir: DurableFunctionDeployment.FindTestFunctionDir("InvokeHappyPathChildFunction"),
+            scenarioSuffix: "invokehappy",
+            output: _output);
+
+        await using (downstream)
+        await using (parent)
+        {
+            var (invokeResponse, executionName) = await parent.InvokeAsync("""{"orderId": "invoke-happy"}""");
+            Assert.Equal(200, invokeResponse.StatusCode);
+
+            var responsePayload = Encoding.UTF8.GetString(invokeResponse.Payload.ToArray());
+            _output.WriteLine($"Parent response: {responsePayload}");
+
+            // Locate the parent execution and wait for terminal status. Chained
+            // invoke suspends the parent — the synchronous Invoke response
+            // carries no data — so we drive completion via the listing API.
+            var arn = await parent.FindDurableExecutionArnByNameAsync(executionName, TimeSpan.FromSeconds(60));
+            Assert.NotNull(arn);
+
+            var status = await parent.PollForCompletionAsync(arn!, TimeSpan.FromSeconds(120));
+            Assert.Equal("SUCCEEDED", status, ignoreCase: true);
+
+            // The chained invoke's result surfaces in the parent's history as a
+            // ChainedInvokeSucceeded event. The parent then returns that result
+            // verbatim from its workflow.
+            var history = await parent.WaitForHistoryAsync(
+                arn!,
+                h => (h.Events?.Any(e => e.EventType == EventType.ChainedInvokeStarted) ?? false)
+                  && (h.Events?.Any(e => e.ChainedInvokeSucceededDetails != null) ?? false),
+                TimeSpan.FromSeconds(60));
+            var events = history.Events ?? new List<Event>();
+
+            var started = events.FirstOrDefault(e => e.EventType == EventType.ChainedInvokeStarted);
+            Assert.NotNull(started);
+            Assert.Equal(downstream.FunctionArn + ":$LATEST", started!.ChainedInvokeStartedDetails.FunctionName);
+
+            var succeeded = events.FirstOrDefault(e => e.ChainedInvokeSucceededDetails != null);
+            Assert.NotNull(succeeded);
+            // The child returned the JSON-encoded string "got-42".
+            var childPayload = succeeded!.ChainedInvokeSucceededDetails.Result?.Payload?.Trim('"');
+            Assert.Equal("got-42", childPayload);
+
+            // The chained invoke event names what was invoked; cross-check against
+            // the deployed downstream's name so we know the parent really called
+            // the function we wired in.
+            Assert.Equal("call_child", succeeded.Name);
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/InvokeReplayDeterminismTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/InvokeReplayDeterminismTest.cs
@@ -1,0 +1,119 @@
+using System.Linq;
+using System.Text;
+using Amazon.Lambda.Model;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Amazon.Lambda.DurableExecution.IntegrationTests;
+
+public class InvokeReplayDeterminismTest
+{
+    private readonly ITestOutputHelper _output;
+    public InvokeReplayDeterminismTest(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public async Task InvokeAsync_ReplayDeterminism_OperationIdsStableAcrossInvocations()
+    {
+        var (parent, downstream) = await DurableFunctionDeployment.CreateWithDownstreamAsync(
+            parentTestFunctionDir: DurableFunctionDeployment.FindTestFunctionDir("InvokeReplayDeterminismParentFunction"),
+            downstreamTestFunctionDir: DurableFunctionDeployment.FindTestFunctionDir("InvokeReplayDeterminismChildFunction"),
+            scenarioSuffix: "invokerply",
+            output: _output);
+
+        await using (downstream)
+        await using (parent)
+        {
+            var (invokeResponse, executionName) = await parent.InvokeAsync("""{"orderId": "invoke-replay"}""");
+            var responsePayload = Encoding.UTF8.GetString(invokeResponse.Payload.ToArray());
+            _output.WriteLine($"Parent response: {responsePayload}");
+
+            var arn = await parent.FindDurableExecutionArnByNameAsync(executionName, TimeSpan.FromSeconds(60));
+            Assert.NotNull(arn);
+
+            var status = await parent.PollForCompletionAsync(arn!, TimeSpan.FromSeconds(180));
+            Assert.Equal("SUCCEEDED", status, ignoreCase: true);
+
+            // History is eventually consistent — wait until both step-succeeded
+            // events AND the chained-invoke-succeeded event are visible.
+            var history = await parent.WaitForHistoryAsync(
+                arn!,
+                h => (h.Events?.Count(e => e.StepSucceededDetails != null) ?? 0) >= 2
+                  && (h.Events?.Any(e => e.ChainedInvokeSucceededDetails != null) ?? false),
+                TimeSpan.FromSeconds(60));
+            var events = history.Events ?? new List<Event>();
+
+            // Each step ran exactly once across the entire workflow — proves
+            // the chained invoke's suspend/resume cycle did NOT cause the
+            // pre-invoke step to re-execute. (Replay returned the cached
+            // checkpoint instead.)
+            var stepSucceededByName = events
+                .Where(e => e.StepSucceededDetails != null)
+                .GroupBy(e => e.Name)
+                .ToDictionary(g => g.Key!, g => g.Count());
+            Assert.Equal(1, stepSucceededByName["before_invoke"]);
+            Assert.Equal(1, stepSucceededByName["after_invoke"]);
+
+            // Exactly ONE chained invoke fired — replay didn't double-fire
+            // the InvokeAsync. Same invariant we check for steps.
+            Assert.Equal(1, events.Count(e => e.EventType == EventType.ChainedInvokeStarted));
+            Assert.Equal(1, events.Count(e => e.ChainedInvokeSucceededDetails != null));
+
+            var beforeInvokeEvent = events.First(e => e.StepSucceededDetails != null && e.Name == "before_invoke");
+            var generatedGuid = beforeInvokeEvent.StepSucceededDetails.Result?.Payload?.Trim('"');
+            Assert.NotNull(generatedGuid);
+            Assert.True(Guid.TryParse(generatedGuid, out _),
+                $"before_invoke should produce a valid GUID, got: {generatedGuid}");
+
+            // The downstream's echo carries through to after_invoke verbatim,
+            // proving the cached chained-invoke result was used on resume.
+            var chainedSucceeded = events.First(e => e.ChainedInvokeSucceededDetails != null);
+            var chainedPayload = chainedSucceeded.ChainedInvokeSucceededDetails.Result?.Payload?.Trim('"');
+            Assert.Equal($"echoed:{generatedGuid}", chainedPayload);
+
+            var afterInvokeEvent = events.First(e => e.StepSucceededDetails != null && e.Name == "after_invoke");
+            var afterPayload = afterInvokeEvent.StepSucceededDetails.Result?.Payload?.Trim('"');
+            Assert.Equal($"final:echoed:{generatedGuid}", afterPayload);
+
+            // The chained invoke's suspend/resume forced at least 2 invocations
+            // of the parent — proves replay actually happened (not just a
+            // single straight-through execution that skipped suspension).
+            var invocations = events.Where(e => e.InvocationCompletedDetails != null).ToList();
+            Assert.True(
+                invocations.Count >= 2,
+                $"Expected at least 2 InvocationCompleted events (proves replay happened), got {invocations.Count}");
+
+            // Operation IDs are stable across all replays of the same logical
+            // position. The Started event and the corresponding Succeeded event
+            // for each operation share the same ID — that's the clearest
+            // observable proof the SDK's deterministic ID generator is working.
+            // The SDK hashes <c>"&lt;counter&gt;"</c> at the root, so each ID is a
+            // 64-char lowercase hex SHA-256 digest.
+            var startedIds = events
+                .Where(e => e.EventType == EventType.StepStarted || e.EventType == EventType.ChainedInvokeStarted)
+                .Select(e => (e.Name, Id: e.Id))
+                .ToList();
+            var succeededIds = events
+                .Where(e => e.StepSucceededDetails != null || e.ChainedInvokeSucceededDetails != null)
+                .Select(e => (e.Name, Id: e.Id))
+                .ToList();
+
+            // All operation IDs are populated and look like SHA-256 hex digests.
+            foreach (var (name, id) in startedIds)
+            {
+                Assert.False(string.IsNullOrEmpty(id), $"Operation '{name}' has no Id on its Started event");
+                Assert.Equal(64, id!.Length);
+                Assert.Matches("^[0-9a-f]{64}$", id);
+            }
+
+            // Every started operation ID must appear in a succeeded event —
+            // proves the deterministic IDs from the Start path matched the IDs
+            // the service used to record the terminal event.
+            foreach (var (name, id) in startedIds)
+            {
+                Assert.True(
+                    succeededIds.Any(s => s.Name == name && s.Id == id),
+                    $"Operation '{name}' (id={id}) started but did not produce a matching SUCCEEDED event with the same ID");
+            }
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/InvokeWithTenantIdTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/InvokeWithTenantIdTest.cs
@@ -1,0 +1,63 @@
+using System.Linq;
+using System.Text;
+using Amazon.Lambda.Model;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Amazon.Lambda.DurableExecution.IntegrationTests;
+
+public class InvokeWithTenantIdTest
+{
+    private readonly ITestOutputHelper _output;
+    public InvokeWithTenantIdTest(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public async Task InvokeAsync_WithTenantId_PropagatesToChainedInvokeOptions()
+    {
+        var (parent, downstream) = await DurableFunctionDeployment.CreateWithDownstreamAsync(
+            parentTestFunctionDir: DurableFunctionDeployment.FindTestFunctionDir("InvokeWithTenantIdFunction"),
+            downstreamTestFunctionDir: DurableFunctionDeployment.FindTestFunctionDir("InvokeChildTenantFunction"),
+            scenarioSuffix: "invoketenant",
+            output: _output,
+            // The downstream must be PER_TENANT for the service to accept a
+            // chained invoke carrying a TenantId. The parent stays default.
+            enableDownstreamTenancy: true);
+
+        await using (downstream)
+        await using (parent)
+        {
+            var (invokeResponse, executionName) = await parent.InvokeAsync("""{"orderId": "tenant-test"}""");
+            Assert.Equal(200, invokeResponse.StatusCode);
+
+            var responsePayload = Encoding.UTF8.GetString(invokeResponse.Payload.ToArray());
+            _output.WriteLine($"Parent response: {responsePayload}");
+
+            var arn = await parent.FindDurableExecutionArnByNameAsync(executionName, TimeSpan.FromSeconds(60));
+            Assert.NotNull(arn);
+
+            var status = await parent.PollForCompletionAsync(arn!, TimeSpan.FromSeconds(120));
+            Assert.Equal("SUCCEEDED", status, ignoreCase: true);
+
+            var history = await parent.WaitForHistoryAsync(
+                arn!,
+                h => h.Events?.Any(e => e.EventType == EventType.ChainedInvokeStarted) ?? false,
+                TimeSpan.FromSeconds(60));
+            var events = history.Events ?? new List<Event>();
+
+            var started = events.FirstOrDefault(e => e.EventType == EventType.ChainedInvokeStarted);
+            Assert.NotNull(started);
+
+            // The tenant ID flows through ChainedInvokeOptions -> service ->
+            // ChainedInvokeStartedDetails. This is the load-bearing assertion:
+            // it proves the SDK's InvokeConfig.TenantId reaches the wire.
+            Assert.Equal("test-tenant", started!.ChainedInvokeStartedDetails.TenantId);
+
+            // The chained call still produced a result — proves nothing in the
+            // tenant-routing path silently dropped the invocation.
+            var succeeded = events.FirstOrDefault(e => e.ChainedInvokeSucceededDetails != null);
+            Assert.NotNull(succeeded);
+            var childPayload = succeeded!.ChainedInvokeSucceededDetails.Result?.Payload?.Trim('"');
+            Assert.Equal("tenant-aware-7", childPayload);
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ApproverFunction/ApproverFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ApproverFunction/ApproverFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/AtMostOnceCrashFunction/AtMostOnceCrashFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/AtMostOnceCrashFunction/AtMostOnceCrashFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/CallbackFailedFunction/CallbackFailedFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/CallbackFailedFunction/CallbackFailedFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/CallbackTimeoutFunction/CallbackTimeoutFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/CallbackTimeoutFunction/CallbackTimeoutFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ChildContextFailsFunction/ChildContextFailsFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ChildContextFailsFunction/ChildContextFailsFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ChildContextFunction/ChildContextFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ChildContextFunction/ChildContextFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ChildContextRetryFailsFunction/ChildContextRetryFailsFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ChildContextRetryFailsFunction/ChildContextRetryFailsFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/CreateCallbackHappyPathFunction/CreateCallbackHappyPathFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/CreateCallbackHappyPathFunction/CreateCallbackHappyPathFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeChildTenantFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeChildTenantFunction/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/provided:al2023
+
+RUN dnf install -y libicu
+
+COPY bin/publish/ ${LAMBDA_TASK_ROOT}
+
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeChildTenantFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeChildTenantFunction/Function.cs
@@ -1,0 +1,30 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace DurableExecutionTestFunction;
+
+public class Function
+{
+    public static async Task Main(string[] args)
+    {
+        var handler = new Function();
+        var serializer = new DefaultLambdaJsonSerializer();
+        using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<DurableExecutionInvocationInput, DurableExecutionInvocationOutput>(handler.Handler, serializer);
+        using var bootstrap = new LambdaBootstrap(handlerWrapper);
+        await bootstrap.RunAsync();
+    }
+
+    public Task<DurableExecutionInvocationOutput> Handler(
+        DurableExecutionInvocationInput input, ILambdaContext context)
+        => DurableFunction.WrapAsync<int, string>(Workflow, input, context);
+
+    private async Task<string> Workflow(int input, IDurableContext context)
+    {
+        var formatted = await context.StepAsync(
+            async (_) => { await Task.CompletedTask; return $"tenant-aware-{input}"; },
+            name: "tenant_step");
+        return formatted;
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeChildTenantFunction/InvokeChildTenantFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeChildTenantFunction/InvokeChildTenantFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeChildTenantFunction/InvokeChildTenantFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeChildTenantFunction/InvokeChildTenantFunction.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>bootstrap</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeFailureChildFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeFailureChildFunction/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/provided:al2023
+
+RUN dnf install -y libicu
+
+COPY bin/publish/ ${LAMBDA_TASK_ROOT}
+
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeFailureChildFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeFailureChildFunction/Function.cs
@@ -1,0 +1,39 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace DurableExecutionTestFunction;
+
+public class Function
+{
+    public static async Task Main(string[] args)
+    {
+        var handler = new Function();
+        var serializer = new DefaultLambdaJsonSerializer();
+        using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<DurableExecutionInvocationInput, DurableExecutionInvocationOutput>(handler.Handler, serializer);
+        using var bootstrap = new LambdaBootstrap(handlerWrapper);
+        await bootstrap.RunAsync();
+    }
+
+    public Task<DurableExecutionInvocationOutput> Handler(
+        DurableExecutionInvocationInput input, ILambdaContext context)
+        => DurableFunction.WrapAsync<int, string>(Workflow, input, context);
+
+    private async Task<string> Workflow(int input, IDurableContext context)
+    {
+        // Throw inside a step so the workflow records a step-failed event AND
+        // surfaces a FAILED execution status. The parent's InvokeAsync sees a
+        // FAILED chained invocation and raises InvokeFailedException with the
+        // step's error type (System.InvalidOperationException) attached.
+        await context.StepAsync<string>(
+            async (_) =>
+            {
+                await Task.CompletedTask;
+                throw new InvalidOperationException("intentional child failure");
+            },
+            name: "fail_step");
+
+        return "unreachable";
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeFailureChildFunction/InvokeFailureChildFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeFailureChildFunction/InvokeFailureChildFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeFailureChildFunction/InvokeFailureChildFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeFailureChildFunction/InvokeFailureChildFunction.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>bootstrap</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeFailureParentFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeFailureParentFunction/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/provided:al2023
+
+RUN dnf install -y libicu
+
+COPY bin/publish/ ${LAMBDA_TASK_ROOT}
+
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeFailureParentFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeFailureParentFunction/Function.cs
@@ -1,0 +1,53 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace DurableExecutionTestFunction;
+
+public class Function
+{
+    public static async Task Main(string[] args)
+    {
+        var handler = new Function();
+        var serializer = new DefaultLambdaJsonSerializer();
+        using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<DurableExecutionInvocationInput, DurableExecutionInvocationOutput>(handler.Handler, serializer);
+        using var bootstrap = new LambdaBootstrap(handlerWrapper);
+        await bootstrap.RunAsync();
+    }
+
+    public Task<DurableExecutionInvocationOutput> Handler(
+        DurableExecutionInvocationInput input, ILambdaContext context)
+        => DurableFunction.WrapAsync<TestEvent, TestResult>(Workflow, input, context);
+
+    private async Task<TestResult> Workflow(TestEvent input, IDurableContext context)
+    {
+        var downstreamArn = System.Environment.GetEnvironmentVariable("DOWNSTREAM_FUNCTION_ARN")
+            ?? throw new InvalidOperationException("DOWNSTREAM_FUNCTION_ARN env var is not set.");
+
+        try
+        {
+            await context.InvokeAsync<int, string>(
+                downstreamArn,
+                payload: 1,
+                name: "call_failing_child");
+
+            // Should not reach — the child throws and the parent surfaces
+            // InvokeFailedException on the resume.
+            return new TestResult { Status = "unexpected_success", Data = null };
+        }
+        catch (InvokeFailedException ex)
+        {
+            // The parent catches and converts the exception into a normal result —
+            // the workflow itself succeeds, even though the chained invoke failed.
+            return new TestResult
+            {
+                Status = "completed",
+                Data = $"parent-saw-{ex.ErrorType ?? "unknown"}"
+            };
+        }
+    }
+}
+
+public class TestEvent { public string? OrderId { get; set; } }
+public class TestResult { public string? Status { get; set; } public string? Data { get; set; } }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeFailureParentFunction/InvokeFailureParentFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeFailureParentFunction/InvokeFailureParentFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeFailureParentFunction/InvokeFailureParentFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeFailureParentFunction/InvokeFailureParentFunction.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>bootstrap</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeHappyPathChildFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeHappyPathChildFunction/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/provided:al2023
+
+RUN dnf install -y libicu
+
+COPY bin/publish/ ${LAMBDA_TASK_ROOT}
+
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeHappyPathChildFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeHappyPathChildFunction/Function.cs
@@ -1,0 +1,30 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace DurableExecutionTestFunction;
+
+public class Function
+{
+    public static async Task Main(string[] args)
+    {
+        var handler = new Function();
+        var serializer = new DefaultLambdaJsonSerializer();
+        using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<DurableExecutionInvocationInput, DurableExecutionInvocationOutput>(handler.Handler, serializer);
+        using var bootstrap = new LambdaBootstrap(handlerWrapper);
+        await bootstrap.RunAsync();
+    }
+
+    public Task<DurableExecutionInvocationOutput> Handler(
+        DurableExecutionInvocationInput input, ILambdaContext context)
+        => DurableFunction.WrapAsync<int, string>(Workflow, input, context);
+
+    private async Task<string> Workflow(int input, IDurableContext context)
+    {
+        var prefixed = await context.StepAsync(
+            async (_) => { await Task.CompletedTask; return $"got-{input}"; },
+            name: "format");
+        return prefixed;
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeHappyPathChildFunction/InvokeHappyPathChildFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeHappyPathChildFunction/InvokeHappyPathChildFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeHappyPathChildFunction/InvokeHappyPathChildFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeHappyPathChildFunction/InvokeHappyPathChildFunction.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>bootstrap</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeHappyPathParentFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeHappyPathParentFunction/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/provided:al2023
+
+RUN dnf install -y libicu
+
+COPY bin/publish/ ${LAMBDA_TASK_ROOT}
+
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeHappyPathParentFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeHappyPathParentFunction/Function.cs
@@ -1,0 +1,41 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace DurableExecutionTestFunction;
+
+public class Function
+{
+    public static async Task Main(string[] args)
+    {
+        var handler = new Function();
+        var serializer = new DefaultLambdaJsonSerializer();
+        using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<DurableExecutionInvocationInput, DurableExecutionInvocationOutput>(handler.Handler, serializer);
+        using var bootstrap = new LambdaBootstrap(handlerWrapper);
+        await bootstrap.RunAsync();
+    }
+
+    public Task<DurableExecutionInvocationOutput> Handler(
+        DurableExecutionInvocationInput input, ILambdaContext context)
+        => DurableFunction.WrapAsync<TestEvent, TestResult>(Workflow, input, context);
+
+    private async Task<TestResult> Workflow(TestEvent input, IDurableContext context)
+    {
+        // Parent receives the downstream function ARN via env var so the test
+        // harness can wire arbitrary downstream functions without rebuilding
+        // the parent image.
+        var downstreamArn = System.Environment.GetEnvironmentVariable("DOWNSTREAM_FUNCTION_ARN")
+            ?? throw new InvalidOperationException("DOWNSTREAM_FUNCTION_ARN env var is not set.");
+
+        var result = await context.InvokeAsync<int, string>(
+            downstreamArn,
+            payload: 42,
+            name: "call_child");
+
+        return new TestResult { Status = "completed", Data = result };
+    }
+}
+
+public class TestEvent { public string? OrderId { get; set; } }
+public class TestResult { public string? Status { get; set; } public string? Data { get; set; } }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeHappyPathParentFunction/InvokeHappyPathParentFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeHappyPathParentFunction/InvokeHappyPathParentFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeHappyPathParentFunction/InvokeHappyPathParentFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeHappyPathParentFunction/InvokeHappyPathParentFunction.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>bootstrap</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeReplayDeterminismChildFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeReplayDeterminismChildFunction/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/provided:al2023
+
+RUN dnf install -y libicu
+
+COPY bin/publish/ ${LAMBDA_TASK_ROOT}
+
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeReplayDeterminismChildFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeReplayDeterminismChildFunction/Function.cs
@@ -1,0 +1,30 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace DurableExecutionTestFunction;
+
+public class Function
+{
+    public static async Task Main(string[] args)
+    {
+        var handler = new Function();
+        var serializer = new DefaultLambdaJsonSerializer();
+        using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<DurableExecutionInvocationInput, DurableExecutionInvocationOutput>(handler.Handler, serializer);
+        using var bootstrap = new LambdaBootstrap(handlerWrapper);
+        await bootstrap.RunAsync();
+    }
+
+    public Task<DurableExecutionInvocationOutput> Handler(
+        DurableExecutionInvocationInput input, ILambdaContext context)
+        => DurableFunction.WrapAsync<string, string>(Workflow, input, context);
+
+    private async Task<string> Workflow(string input, IDurableContext context)
+    {
+        var echoed = await context.StepAsync(
+            async (_) => { await Task.CompletedTask; return $"echoed:{input}"; },
+            name: "child_echo");
+        return echoed;
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeReplayDeterminismChildFunction/InvokeReplayDeterminismChildFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeReplayDeterminismChildFunction/InvokeReplayDeterminismChildFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeReplayDeterminismChildFunction/InvokeReplayDeterminismChildFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeReplayDeterminismChildFunction/InvokeReplayDeterminismChildFunction.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>bootstrap</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeReplayDeterminismParentFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeReplayDeterminismParentFunction/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/provided:al2023
+
+RUN dnf install -y libicu
+
+COPY bin/publish/ ${LAMBDA_TASK_ROOT}
+
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeReplayDeterminismParentFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeReplayDeterminismParentFunction/Function.cs
@@ -1,0 +1,52 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace DurableExecutionTestFunction;
+
+public class Function
+{
+    public static async Task Main(string[] args)
+    {
+        var handler = new Function();
+        var serializer = new DefaultLambdaJsonSerializer();
+        using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<DurableExecutionInvocationInput, DurableExecutionInvocationOutput>(handler.Handler, serializer);
+        using var bootstrap = new LambdaBootstrap(handlerWrapper);
+        await bootstrap.RunAsync();
+    }
+
+    public Task<DurableExecutionInvocationOutput> Handler(
+        DurableExecutionInvocationInput input, ILambdaContext context)
+        => DurableFunction.WrapAsync<TestEvent, TestResult>(Workflow, input, context);
+
+    private async Task<TestResult> Workflow(TestEvent input, IDurableContext context)
+    {
+        var downstreamArn = System.Environment.GetEnvironmentVariable("DOWNSTREAM_FUNCTION_ARN")
+            ?? throw new InvalidOperationException("DOWNSTREAM_FUNCTION_ARN env var is not set.");
+
+        // Step 1 generates a fresh GUID. On replay this MUST return the
+        // checkpointed value — proves the SDK's deterministic operation IDs
+        // line up with the service's view of the state.
+        var generatedId = await context.StepAsync(
+            async (_) => { await Task.CompletedTask; return Guid.NewGuid().ToString(); },
+            name: "before_invoke");
+
+        // The chained invoke forces a suspend/resume cycle. After the resume,
+        // step 1 must replay (returning the cached GUID) and the invoke must
+        // not be re-fired (cached result is returned immediately).
+        var invokeResult = await context.InvokeAsync<string, string>(
+            downstreamArn,
+            payload: generatedId,
+            name: "echo_invoke");
+
+        var afterInvoke = await context.StepAsync(
+            async (_) => { await Task.CompletedTask; return $"final:{invokeResult}"; },
+            name: "after_invoke");
+
+        return new TestResult { Status = "completed", Data = afterInvoke };
+    }
+}
+
+public class TestEvent { public string? OrderId { get; set; } }
+public class TestResult { public string? Status { get; set; } public string? Data { get; set; } }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeReplayDeterminismParentFunction/InvokeReplayDeterminismParentFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeReplayDeterminismParentFunction/InvokeReplayDeterminismParentFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeReplayDeterminismParentFunction/InvokeReplayDeterminismParentFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeReplayDeterminismParentFunction/InvokeReplayDeterminismParentFunction.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>bootstrap</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeWithTenantIdFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeWithTenantIdFunction/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/provided:al2023
+
+RUN dnf install -y libicu
+
+COPY bin/publish/ ${LAMBDA_TASK_ROOT}
+
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeWithTenantIdFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeWithTenantIdFunction/Function.cs
@@ -1,0 +1,39 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace DurableExecutionTestFunction;
+
+public class Function
+{
+    public static async Task Main(string[] args)
+    {
+        var handler = new Function();
+        var serializer = new DefaultLambdaJsonSerializer();
+        using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<DurableExecutionInvocationInput, DurableExecutionInvocationOutput>(handler.Handler, serializer);
+        using var bootstrap = new LambdaBootstrap(handlerWrapper);
+        await bootstrap.RunAsync();
+    }
+
+    public Task<DurableExecutionInvocationOutput> Handler(
+        DurableExecutionInvocationInput input, ILambdaContext context)
+        => DurableFunction.WrapAsync<TestEvent, TestResult>(Workflow, input, context);
+
+    private async Task<TestResult> Workflow(TestEvent input, IDurableContext context)
+    {
+        var downstreamArn = System.Environment.GetEnvironmentVariable("DOWNSTREAM_FUNCTION_ARN")
+            ?? throw new InvalidOperationException("DOWNSTREAM_FUNCTION_ARN env var is not set.");
+
+        var result = await context.InvokeAsync<int, string>(
+            downstreamArn,
+            payload: 7,
+            name: "call_with_tenant",
+            config: new InvokeConfig { TenantId = "test-tenant" });
+
+        return new TestResult { Status = "completed", Data = result };
+    }
+}
+
+public class TestEvent { public string? OrderId { get; set; } }
+public class TestResult { public string? Status { get; set; } public string? Data { get; set; } }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeWithTenantIdFunction/InvokeWithTenantIdFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeWithTenantIdFunction/InvokeWithTenantIdFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeWithTenantIdFunction/InvokeWithTenantIdFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/InvokeWithTenantIdFunction/InvokeWithTenantIdFunction.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>bootstrap</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/LongRetryChainFunction/LongRetryChainFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/LongRetryChainFunction/LongRetryChainFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/LongerWaitFunction/LongerWaitFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/LongerWaitFunction/LongerWaitFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/MultipleStepsFunction/MultipleStepsFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/MultipleStepsFunction/MultipleStepsFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/RejecterFunction/RejecterFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/RejecterFunction/RejecterFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ReplayDeterminismFunction/ReplayDeterminismFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ReplayDeterminismFunction/ReplayDeterminismFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/RetryExhaustionFunction/RetryExhaustionFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/RetryExhaustionFunction/RetryExhaustionFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/RetryFunction/RetryFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/RetryFunction/RetryFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/StepFailsFunction/StepFailsFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/StepFailsFunction/StepFailsFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/StepWaitStepFunction/StepWaitStepFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/StepWaitStepFunction/StepWaitStepFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForCallbackHappyPathFunction/WaitForCallbackHappyPathFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForCallbackHappyPathFunction/WaitForCallbackHappyPathFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForCallbackSubmitterFailsFunction/WaitForCallbackSubmitterFailsFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForCallbackSubmitterFailsFunction/WaitForCallbackSubmitterFailsFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitOnlyFunction/WaitOnlyFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitOnlyFunction/WaitOnlyFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>bootstrap</AssemblyName>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ConfigTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ConfigTests.cs
@@ -1,0 +1,25 @@
+using Amazon.Lambda.DurableExecution;
+using Xunit;
+
+namespace Amazon.Lambda.DurableExecution.Tests;
+
+public class ConfigTests
+{
+    [Fact]
+    public void InvokeConfig_Defaults()
+    {
+        var config = new InvokeConfig();
+        Assert.Null(config.TenantId);
+    }
+
+    [Fact]
+    public void InvokeConfig_RoundTripsProperties()
+    {
+        var config = new InvokeConfig
+        {
+            TenantId = "tenant-42"
+        };
+
+        Assert.Equal("tenant-42", config.TenantId);
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ExceptionsTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ExceptionsTests.cs
@@ -148,4 +148,117 @@ public class ExceptionsTests
         Assert.NotNull(new CallbackSubmitterException());
         Assert.Equal("m", new CallbackSubmitterException("m").Message);
     }
+
+    #region InvokeException tree
+
+    [Fact]
+    public void InvokeException_IsDurableExecutionException()
+    {
+        var ex = new InvokeException("invoke failed");
+        Assert.IsAssignableFrom<DurableExecutionException>(ex);
+        Assert.Equal("invoke failed", ex.Message);
+    }
+
+    [Fact]
+    public void InvokeException_ParameterlessCtor()
+    {
+        var ex = new InvokeException();
+        Assert.IsAssignableFrom<DurableExecutionException>(ex);
+    }
+
+    [Fact]
+    public void InvokeException_WrapsInnerException()
+    {
+        var inner = new InvalidOperationException("inner");
+        var ex = new InvokeException("outer", inner);
+        Assert.Same(inner, ex.InnerException);
+    }
+
+    [Fact]
+    public void InvokeException_HasInvokeProperties()
+    {
+        var ex = new InvokeException("boom")
+        {
+            FunctionName = "arn:aws:lambda:us-east-1:123:function:fn:prod",
+            ErrorType = "System.TimeoutException",
+            ErrorData = "{\"detail\":\"x\"}",
+            OriginalStackTrace = new[] { "at A.B()" }
+        };
+
+        Assert.Equal("arn:aws:lambda:us-east-1:123:function:fn:prod", ex.FunctionName);
+        Assert.Equal("System.TimeoutException", ex.ErrorType);
+        Assert.Equal("{\"detail\":\"x\"}", ex.ErrorData);
+        Assert.Single(ex.OriginalStackTrace!);
+    }
+
+    [Fact]
+    public void InvokeFailedException_IsInvokeException()
+    {
+        var ex = new InvokeFailedException("boom") { FunctionName = "fn:prod" };
+        Assert.IsAssignableFrom<InvokeException>(ex);
+        Assert.IsAssignableFrom<DurableExecutionException>(ex);
+        Assert.Equal("boom", ex.Message);
+        Assert.Equal("fn:prod", ex.FunctionName);
+    }
+
+    [Fact]
+    public void InvokeFailedException_AllCtorOverloads()
+    {
+        var inner = new InvalidOperationException("inner");
+        Assert.IsAssignableFrom<DurableExecutionException>(new InvokeFailedException());
+        Assert.Equal("m", new InvokeFailedException("m").Message);
+        Assert.Same(inner, new InvokeFailedException("m", inner).InnerException);
+    }
+
+    [Fact]
+    public void InvokeTimedOutException_IsInvokeException()
+    {
+        var ex = new InvokeTimedOutException("timed out");
+        Assert.IsAssignableFrom<InvokeException>(ex);
+        Assert.IsAssignableFrom<DurableExecutionException>(ex);
+        Assert.Equal("timed out", ex.Message);
+    }
+
+    [Fact]
+    public void InvokeTimedOutException_AllCtorOverloads()
+    {
+        var inner = new TimeoutException("inner");
+        Assert.IsAssignableFrom<DurableExecutionException>(new InvokeTimedOutException());
+        Assert.Equal("m", new InvokeTimedOutException("m").Message);
+        Assert.Same(inner, new InvokeTimedOutException("m", inner).InnerException);
+    }
+
+    [Fact]
+    public void InvokeStoppedException_IsInvokeException()
+    {
+        var ex = new InvokeStoppedException("stopped");
+        Assert.IsAssignableFrom<InvokeException>(ex);
+        Assert.IsAssignableFrom<DurableExecutionException>(ex);
+        Assert.Equal("stopped", ex.Message);
+    }
+
+    [Fact]
+    public void InvokeStoppedException_AllCtorOverloads()
+    {
+        var inner = new InvalidOperationException("inner");
+        Assert.IsAssignableFrom<DurableExecutionException>(new InvokeStoppedException());
+        Assert.Equal("m", new InvokeStoppedException("m").Message);
+        Assert.Same(inner, new InvokeStoppedException("m", inner).InnerException);
+    }
+
+    [Fact]
+    public void InvokeException_SubclassesCaughtByBase()
+    {
+        // Verifies the documented pattern-matching contract: catch
+        // (InvokeException) catches all three subclasses.
+        Exception failed = new InvokeFailedException("fail");
+        Exception timedOut = new InvokeTimedOutException("timeout");
+        Exception stopped = new InvokeStoppedException("stop");
+
+        Assert.True(failed is InvokeException);
+        Assert.True(timedOut is InvokeException);
+        Assert.True(stopped is InvokeException);
+    }
+
+    #endregion
 }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ExecutionStateTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ExecutionStateTests.cs
@@ -195,6 +195,34 @@ public class ExecutionStateTests
     }
 
     [Fact]
+    public void TrackReplay_TerminalSet_IncludesTimedOut()
+    {
+        // TIMED_OUT is a terminal state (matches Python/JS/Java reference SDKs).
+        // A timed-out chained-invoke that has been visited must allow the
+        // replay-mode flag to flip; otherwise IsReplaying would stay stuck on
+        // for the rest of the invocation and downstream replay-aware features
+        // (e.g., the future replay-aware logger) would mis-fire.
+        var state = new ExecutionState();
+        state.LoadFromCheckpoint(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                ExecutionInputOp(),
+                new()
+                {
+                    Id = "0-invoke",
+                    Type = OperationTypes.ChainedInvoke,
+                    Status = OperationStatuses.TimedOut
+                }
+            }
+        });
+        Assert.True(state.IsReplaying);
+
+        state.TrackReplay("0-invoke");
+        Assert.False(state.IsReplaying);
+    }
+
+    [Fact]
     public void GetOperation_ReturnsLatestRecord_WhenIdAppearsMultipleTimes()
     {
         // Wire format: when the service replays an envelope it includes the

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/InvokeOperationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/InvokeOperationTests.cs
@@ -1,0 +1,574 @@
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.DurableExecution.Internal;
+using Amazon.Lambda.Serialization.SystemTextJson;
+using Amazon.Lambda.TestUtilities;
+using Xunit;
+
+namespace Amazon.Lambda.DurableExecution.Tests;
+
+public class InvokeOperationTests
+{
+    /// <summary>Reproduces the Id that <see cref="OperationIdGenerator"/> emits for the n-th root-level operation.</summary>
+    private static string IdAt(int position) => OperationIdGenerator.HashOperationId(position.ToString());
+
+    private const string FunctionArn = "arn:aws:lambda:us-east-1:123456789012:function:downstream:prod";
+
+    private static (DurableContext context, RecordingBatcher recorder, TerminationManager tm, ExecutionState state)
+        CreateContext(InitialExecutionState? initialState = null)
+    {
+        var state = new ExecutionState();
+        state.LoadFromCheckpoint(initialState);
+        var tm = new TerminationManager();
+        var idGen = new OperationIdGenerator();
+#pragma warning disable AWSLAMBDA001 // TestLambdaContext.Serializer is experimental.
+        var lambdaContext = new TestLambdaContext { Serializer = new DefaultLambdaJsonSerializer() };
+#pragma warning restore AWSLAMBDA001
+        var recorder = new RecordingBatcher();
+        var context = new DurableContext(state, tm, idGen, "arn:test", lambdaContext, recorder.Batcher);
+        return (context, recorder, tm, state);
+    }
+
+    #region Argument validation
+
+    [Fact]
+    public async Task InvokeAsync_NullFunctionName_ThrowsArgumentNullException()
+    {
+        var (context, _, _, _) = CreateContext();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            context.InvokeAsync<string, string>(functionName: null!, payload: "x"));
+    }
+
+    [Fact]
+    public async Task InvokeAsync_EmptyFunctionName_ThrowsArgumentException()
+    {
+        var (context, _, _, _) = CreateContext();
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            context.InvokeAsync<string, string>(functionName: "", payload: "x"));
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhitespaceFunctionName_ThrowsArgumentException()
+    {
+        var (context, _, _, _) = CreateContext();
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            context.InvokeAsync<string, string>(functionName: "   ", payload: "x"));
+    }
+
+    [Fact]
+    public async Task InvokeAsync_PreservesUnqualifiedArn_AndPassesItThrough()
+    {
+        // The SDK does NOT regex-validate qualified ARNs. The service enforces
+        // that rule. We verify the value is propagated unmodified to the
+        // ChainedInvokeOptions.FunctionName so that service-side rejection
+        // surfaces with the user's exact input.
+        var (context, recorder, tm, _) = CreateContext();
+
+        var task = context.InvokeAsync<string, string>(
+            "arn:aws:lambda:us-east-1:123456789012:function:no-version",
+            payload: "x",
+            name: "noversion");
+
+        await Task.Delay(20);
+        Assert.True(tm.IsTerminated);
+        Assert.False(task.IsCompleted);
+
+        var start = recorder.Flushed.Single(o => o.Action == "START");
+        Assert.Equal("arn:aws:lambda:us-east-1:123456789012:function:no-version",
+            start.ChainedInvokeOptions.FunctionName);
+    }
+
+    #endregion
+
+    #region Fresh execution
+
+    [Fact]
+    public async Task InvokeAsync_FreshExecution_CheckpointsStartAndSuspends()
+    {
+        var (context, recorder, tm, _) = CreateContext();
+
+        var task = context.InvokeAsync<RequestPayload, ResponsePayload>(
+            FunctionArn,
+            new RequestPayload { Amount = 100, Currency = "USD" },
+            name: "process_payment",
+            config: new InvokeConfig { TenantId = "tenant-A" });
+
+        // Service-side suspend mechanics: TerminationManager fires before the
+        // user task completes; the task itself never resolves on the fresh path.
+        await Task.Delay(20);
+        Assert.True(tm.IsTerminated);
+        Assert.False(task.IsCompleted);
+
+        await recorder.Batcher.DrainAsync();
+
+        var start = recorder.Flushed.Single();
+        Assert.Equal("CHAINED_INVOKE", start.Type);
+        Assert.Equal("START", start.Action);
+        Assert.Equal("ChainedInvoke", start.SubType);
+        Assert.Equal("process_payment", start.Name);
+        Assert.Equal(IdAt(1), start.Id);
+
+        // Payload is JSON-serialized via the registered ILambdaSerializer.
+        Assert.Contains("\"Amount\":100", start.Payload);
+        Assert.Contains("\"Currency\":\"USD\"", start.Payload);
+
+        // ChainedInvokeOptions carries function name + tenant id.
+        Assert.NotNull(start.ChainedInvokeOptions);
+        Assert.Equal(FunctionArn, start.ChainedInvokeOptions.FunctionName);
+        Assert.Equal("tenant-A", start.ChainedInvokeOptions.TenantId);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_FreshExecution_NoTenantId_OmitsTenantId()
+    {
+        var (context, recorder, tm, _) = CreateContext();
+
+        var task = context.InvokeAsync<string, string>(FunctionArn, "payload", name: "no_tenant");
+
+        await Task.Delay(20);
+        Assert.True(tm.IsTerminated);
+        Assert.False(task.IsCompleted);
+
+        await recorder.Batcher.DrainAsync();
+
+        var start = recorder.Flushed.Single();
+        Assert.NotNull(start.ChainedInvokeOptions);
+        Assert.Equal(FunctionArn, start.ChainedInvokeOptions.FunctionName);
+        // null tenant means the SDK didn't set the field; the AWS SDK model's
+        // IsSet property is what callers actually inspect, but the easy
+        // deterministic assertion is that the property is null.
+        Assert.Null(start.ChainedInvokeOptions.TenantId);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_FreshExecution_StartIsSyncFlushed()
+    {
+        // Critical correctness invariant: START must be flushed BEFORE we
+        // suspend. A queued-but-unflushed START is "the service doesn't know
+        // about the chained invocation," so the parent suspends forever.
+        var (context, recorder, tm, _) = CreateContext();
+
+        var task = context.InvokeAsync<string, string>(FunctionArn, "x", name: "sync_flush");
+        await Task.Delay(20);
+
+        Assert.True(tm.IsTerminated);
+        Assert.False(task.IsCompleted);
+
+        // No DrainAsync — the START must already be flushed at the moment
+        // suspension is signaled. This mirrors WaitOperation_NewExecution_SignalsTermination's
+        // contract: TerminationManager firing implies the matching START is durable.
+        Assert.Single(recorder.Flushed);
+        Assert.Equal("START", recorder.Flushed[0].Action);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_TerminationReason_IsInvokePending()
+    {
+        var (context, _, tm, _) = CreateContext();
+
+        _ = context.InvokeAsync<string, string>(FunctionArn, "x", name: "reason_check");
+        var termination = await tm.TerminationTask;
+
+        Assert.Equal(TerminationReason.InvokePending, termination.Reason);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_NoSerializerRegistered_ThrowsInvalidOperationException()
+    {
+        // If the user constructs a Lambda runtime without a serializer (or in
+        // tests, neglects to set TestLambdaContext.Serializer), InvokeAsync
+        // surfaces a helpful error rather than NREing inside InvokeOperation.
+        var state = new ExecutionState();
+        state.LoadFromCheckpoint(null);
+        var tm = new TerminationManager();
+        var idGen = new OperationIdGenerator();
+        var lambdaContext = new TestLambdaContext(); // no serializer!
+        var recorder = new RecordingBatcher();
+        var context = new DurableContext(state, tm, idGen, "arn:test", lambdaContext, recorder.Batcher);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            context.InvokeAsync<string, string>(FunctionArn, "x", name: "no_serializer"));
+    }
+
+    #endregion
+
+    #region Replay — terminal status mapping
+
+    [Fact]
+    public async Task InvokeAsync_ReplaySucceeded_ReturnsCachedResultWithoutRescheduling()
+    {
+        var (context, recorder, tm, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.ChainedInvoke,
+                    Status = OperationStatuses.Succeeded,
+                    Name = "cached",
+                    ChainedInvokeDetails = new ChainedInvokeDetails
+                    {
+                        Result = "{\"OrderId\":\"abc\",\"Total\":42}"
+                    }
+                }
+            }
+        });
+
+        var result = await context.InvokeAsync<string, ResponsePayload>(
+            FunctionArn, "x", name: "cached");
+
+        Assert.False(tm.IsTerminated);
+        Assert.Equal("abc", result.OrderId);
+        Assert.Equal(42, result.Total);
+
+        await recorder.Batcher.DrainAsync();
+        Assert.Empty(recorder.Flushed);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ReplayFailed_ThrowsInvokeFailedException()
+    {
+        var (context, _, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.ChainedInvoke,
+                    Status = OperationStatuses.Failed,
+                    Name = "boom",
+                    ChainedInvokeDetails = new ChainedInvokeDetails
+                    {
+                        Error = new ErrorObject
+                        {
+                            ErrorType = "System.InvalidOperationException",
+                            ErrorMessage = "downstream exploded",
+                            ErrorData = "{\"detail\":\"x\"}",
+                            StackTrace = new[] { "at A.B()", "at C.D()" }
+                        }
+                    }
+                }
+            }
+        });
+
+        var ex = await Assert.ThrowsAsync<InvokeFailedException>(() =>
+            context.InvokeAsync<string, string>(FunctionArn, "x", name: "boom"));
+
+        Assert.Equal("downstream exploded", ex.Message);
+        Assert.Equal(FunctionArn, ex.FunctionName);
+        Assert.Equal("System.InvalidOperationException", ex.ErrorType);
+        Assert.Equal("{\"detail\":\"x\"}", ex.ErrorData);
+        Assert.NotNull(ex.OriginalStackTrace);
+        Assert.Equal(2, ex.OriginalStackTrace!.Count);
+
+        // Subclass relationship — `catch (InvokeException)` catches all three.
+        Assert.IsAssignableFrom<InvokeException>(ex);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ReplayTimedOut_ThrowsInvokeTimedOutException()
+    {
+        var (context, _, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.ChainedInvoke,
+                    Status = OperationStatuses.TimedOut,
+                    Name = "slow",
+                    ChainedInvokeDetails = new ChainedInvokeDetails
+                    {
+                        Error = new ErrorObject
+                        {
+                            ErrorMessage = "execution timed out after 60s"
+                        }
+                    }
+                }
+            }
+        });
+
+        var ex = await Assert.ThrowsAsync<InvokeTimedOutException>(() =>
+            context.InvokeAsync<string, string>(FunctionArn, "x", name: "slow"));
+
+        Assert.Equal("execution timed out after 60s", ex.Message);
+        Assert.Equal(FunctionArn, ex.FunctionName);
+        Assert.IsAssignableFrom<InvokeException>(ex);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ReplayStopped_ThrowsInvokeStoppedException()
+    {
+        var (context, _, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.ChainedInvoke,
+                    Status = OperationStatuses.Stopped,
+                    Name = "stopped"
+                }
+            }
+        });
+
+        var ex = await Assert.ThrowsAsync<InvokeStoppedException>(() =>
+            context.InvokeAsync<string, string>(FunctionArn, "x", name: "stopped"));
+
+        // No recorded ErrorMessage → fallback default.
+        Assert.Equal("Chained invoke was stopped.", ex.Message);
+        Assert.Equal(FunctionArn, ex.FunctionName);
+        Assert.IsAssignableFrom<InvokeException>(ex);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ReplayStarted_ResuspendsWithoutRecheckpoint()
+    {
+        // Service hasn't reached terminal yet. The original START is still
+        // authoritative; do not re-emit, just suspend.
+        var (context, recorder, tm, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.ChainedInvoke,
+                    Status = OperationStatuses.Started,
+                    Name = "still_running"
+                }
+            }
+        });
+
+        var task = context.InvokeAsync<string, string>(FunctionArn, "x", name: "still_running");
+        await Task.Delay(20);
+
+        Assert.True(tm.IsTerminated);
+        Assert.False(task.IsCompleted);
+
+        // Crucially: no checkpoint was emitted. Original START is authoritative.
+        Assert.Empty(recorder.Flushed);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ReplayPending_ResuspendsWithoutRecheckpoint()
+    {
+        var (context, recorder, tm, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.ChainedInvoke,
+                    Status = OperationStatuses.Pending,
+                    Name = "pending"
+                }
+            }
+        });
+
+        var task = context.InvokeAsync<string, string>(FunctionArn, "x", name: "pending");
+        await Task.Delay(20);
+
+        Assert.True(tm.IsTerminated);
+        Assert.False(task.IsCompleted);
+        Assert.Empty(recorder.Flushed);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ReplayUnknownStatus_ThrowsNonDeterministicException()
+    {
+        var (context, _, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.ChainedInvoke,
+                    Status = "TOTALLY_BOGUS",
+                    Name = "mystery"
+                }
+            }
+        });
+
+        await Assert.ThrowsAsync<NonDeterministicExecutionException>(() =>
+            context.InvokeAsync<string, string>(FunctionArn, "x", name: "mystery"));
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ReplayTypeMismatch_ThrowsNonDeterministicException()
+    {
+        var (context, _, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Step,                  // wrong type
+                    Status = OperationStatuses.Succeeded,
+                    Name = "kept_consistent",
+                    StepDetails = new StepDetails { Result = "\"x\"" }
+                }
+            }
+        });
+
+        var ex = await Assert.ThrowsAsync<NonDeterministicExecutionException>(() =>
+            context.InvokeAsync<string, string>(FunctionArn, "x", name: "kept_consistent"));
+
+        Assert.Contains("expected type 'CHAINED_INVOKE'", ex.Message);
+        Assert.Contains("found 'STEP'", ex.Message);
+    }
+
+    #endregion
+
+    #region Serialization
+
+    [Fact]
+    public async Task InvokeAsync_DeserializesResultViaRegisteredSerializer()
+    {
+        var (context, _, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.ChainedInvoke,
+                    Status = OperationStatuses.Succeeded,
+                    Name = "json_result",
+                    ChainedInvokeDetails = new ChainedInvokeDetails
+                    {
+                        Result = "{\"OrderId\":\"o-7\",\"Total\":1024}"
+                    }
+                }
+            }
+        });
+
+        var result = await context.InvokeAsync<RequestPayload, ResponsePayload>(
+            FunctionArn,
+            new RequestPayload { Amount = 1, Currency = "USD" },
+            name: "json_result");
+
+        Assert.Equal("o-7", result.OrderId);
+        Assert.Equal(1024, result.Total);
+    }
+
+    #endregion
+
+    #region End-to-end suspension / resume parity
+
+    [Fact]
+    public async Task EndToEnd_StepInvokeStep_FirstInvocation_SuspendsOnInvoke()
+    {
+        var tm = new TerminationManager();
+        var state = new ExecutionState();
+        state.LoadFromCheckpoint(null);
+        var idGen = new OperationIdGenerator();
+#pragma warning disable AWSLAMBDA001
+        var lambdaContext = new TestLambdaContext { Serializer = new DefaultLambdaJsonSerializer() };
+#pragma warning restore AWSLAMBDA001
+        var batcher = new RecordingBatcher();
+        var context = new DurableContext(state, tm, idGen, "arn:test", lambdaContext, batcher.Batcher);
+
+        var result = await DurableExecutionHandler.RunAsync<string>(
+            state, tm,
+            async () =>
+            {
+                await context.StepAsync(async (_) => { await Task.CompletedTask; return "validated"; }, name: "validate");
+                var paymentId = await context.InvokeAsync<string, string>(
+                    FunctionArn, "validated", name: "process_payment");
+                return await context.StepAsync(async (_) => { await Task.CompletedTask; return paymentId + "-done"; }, name: "finalize");
+            });
+
+        Assert.Equal(InvocationStatus.Pending, result.Status);
+
+        await batcher.Batcher.DrainAsync();
+        Assert.Contains(batcher.Flushed, o => o.Type == "CHAINED_INVOKE" && o.Action == "START");
+        Assert.DoesNotContain(batcher.Flushed, o => o.Type == "STEP" && o.Name == "finalize");
+    }
+
+    [Fact]
+    public async Task EndToEnd_StepInvokeStep_SecondInvocation_ResumesAndCompletes()
+    {
+        var tm = new TerminationManager();
+        var state = new ExecutionState();
+        state.LoadFromCheckpoint(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Step,
+                    Status = OperationStatuses.Succeeded,
+                    Name = "validate",
+                    StepDetails = new StepDetails { Result = "\"validated\"" }
+                },
+                new()
+                {
+                    Id = IdAt(2),
+                    Type = OperationTypes.ChainedInvoke,
+                    Status = OperationStatuses.Succeeded,
+                    Name = "process_payment",
+                    ChainedInvokeDetails = new ChainedInvokeDetails { Result = "\"pmt-42\"" }
+                }
+            }
+        });
+
+        var idGen = new OperationIdGenerator();
+#pragma warning disable AWSLAMBDA001
+        var lambdaContext = new TestLambdaContext { Serializer = new DefaultLambdaJsonSerializer() };
+#pragma warning restore AWSLAMBDA001
+        var context = new DurableContext(state, tm, idGen, "arn:test", lambdaContext);
+        var finalizeRan = false;
+
+        var result = await DurableExecutionHandler.RunAsync<string>(
+            state, tm,
+            async () =>
+            {
+                var validated = await context.StepAsync(async (_) => { await Task.CompletedTask; return "fresh-validated"; }, name: "validate");
+                Assert.Equal("validated", validated); // cached
+
+                var paymentId = await context.InvokeAsync<string, string>(
+                    FunctionArn, validated, name: "process_payment");
+                Assert.Equal("pmt-42", paymentId); // cached
+
+                return await context.StepAsync(async (_) =>
+                {
+                    finalizeRan = true;
+                    await Task.CompletedTask;
+                    return paymentId + "-done";
+                }, name: "finalize");
+            });
+
+        Assert.Equal(InvocationStatus.Succeeded, result.Status);
+        Assert.Equal("pmt-42-done", result.Result);
+        Assert.True(finalizeRan);
+    }
+
+    #endregion
+
+    #region Test-only types
+
+    private class RequestPayload
+    {
+        public int Amount { get; set; }
+        public string? Currency { get; set; }
+    }
+
+    private class ResponsePayload
+    {
+        public string? OrderId { get; set; }
+        public long Total { get; set; }
+    }
+
+    #endregion
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/LambdaDurableServiceClientTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/LambdaDurableServiceClientTests.cs
@@ -281,6 +281,105 @@ public class LambdaDurableServiceClientTests
     }
 
     [Fact]
+    public async Task GetExecutionStateAsync_MapFromSdkOperation_RoundTripsAllErrorFields()
+    {
+        // Pre-existing bug guard: MapFromSdkOperation used to drop ErrorData
+        // and StackTrace from the SDK error object, so the durable exception
+        // builders (StepException, ChildContextException, and the
+        // InvokeException tree) always saw nulls for those fields on
+        // real-service replay. This test pins down the fix for all three
+        // operation types that carry an error.
+        var stack = new List<string> { "at Frame.One()", "at Frame.Two()" };
+
+        var mockClient = new MockLambdaClient
+        {
+            GetExecutionStateHandler = _ => new GetDurableExecutionStateResponse
+            {
+                Operations = new List<Amazon.Lambda.Model.Operation>
+                {
+                    new Amazon.Lambda.Model.Operation
+                    {
+                        Id = "step-1",
+                        Type = "STEP",
+                        Status = "FAILED",
+                        StepDetails = new Amazon.Lambda.Model.StepDetails
+                        {
+                            Error = new SdkErrorObject
+                            {
+                                ErrorType = "System.InvalidOperationException",
+                                ErrorMessage = "step blew up",
+                                ErrorData = "{\"detail\":\"step\"}",
+                                StackTrace = stack
+                            }
+                        }
+                    },
+                    new Amazon.Lambda.Model.Operation
+                    {
+                        Id = "ctx-1",
+                        Type = "CONTEXT",
+                        Status = "FAILED",
+                        ContextDetails = new Amazon.Lambda.Model.ContextDetails
+                        {
+                            Error = new SdkErrorObject
+                            {
+                                ErrorType = "System.ArgumentException",
+                                ErrorMessage = "ctx blew up",
+                                ErrorData = "{\"detail\":\"ctx\"}",
+                                StackTrace = stack
+                            }
+                        }
+                    },
+                    new Amazon.Lambda.Model.Operation
+                    {
+                        Id = "inv-1",
+                        Type = "CHAINED_INVOKE",
+                        Status = "FAILED",
+                        ChainedInvokeDetails = new Amazon.Lambda.Model.ChainedInvokeDetails
+                        {
+                            Error = new SdkErrorObject
+                            {
+                                ErrorType = "System.TimeoutException",
+                                ErrorMessage = "invoke blew up",
+                                ErrorData = "{\"detail\":\"invoke\"}",
+                                StackTrace = stack
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        var client = new LambdaDurableServiceClient(mockClient);
+
+        var (operations, _) = await client.GetExecutionStateAsync("arn", "tok", "marker");
+
+        Assert.Equal(3, operations.Count);
+
+        // STEP — all four fields propagate.
+        var stepError = operations[0].StepDetails!.Error!;
+        Assert.Equal("System.InvalidOperationException", stepError.ErrorType);
+        Assert.Equal("step blew up", stepError.ErrorMessage);
+        Assert.Equal("{\"detail\":\"step\"}", stepError.ErrorData);
+        Assert.NotNull(stepError.StackTrace);
+        Assert.Equal(new[] { "at Frame.One()", "at Frame.Two()" }, stepError.StackTrace!);
+
+        // CHILD CONTEXT — all four fields propagate.
+        var ctxError = operations[1].ContextDetails!.Error!;
+        Assert.Equal("System.ArgumentException", ctxError.ErrorType);
+        Assert.Equal("ctx blew up", ctxError.ErrorMessage);
+        Assert.Equal("{\"detail\":\"ctx\"}", ctxError.ErrorData);
+        Assert.NotNull(ctxError.StackTrace);
+        Assert.Equal(new[] { "at Frame.One()", "at Frame.Two()" }, ctxError.StackTrace!);
+
+        // CHAINED_INVOKE — all four fields propagate.
+        var invError = operations[2].ChainedInvokeDetails!.Error!;
+        Assert.Equal("System.TimeoutException", invError.ErrorType);
+        Assert.Equal("invoke blew up", invError.ErrorMessage);
+        Assert.Equal("{\"detail\":\"invoke\"}", invError.ErrorData);
+        Assert.NotNull(invError.StackTrace);
+        Assert.Equal(new[] { "at Frame.One()", "at Frame.Two()" }, invError.StackTrace!);
+    }
+
+    [Fact]
     public async Task CheckpointAsync_ReturnsNewToken()
     {
         var mockClient = new MockLambdaClient();

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ModelsTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ModelsTests.cs
@@ -56,6 +56,95 @@ public class ModelsTests
     }
 
     [Fact]
+    public void ErrorObject_FromException_UnwrapsStepException()
+    {
+        // A failing user step gets wrapped as StepException carrying the original
+        // ErrorType. Recording the wrapper's type would lose the user-facing
+        // exception identity across a chained-invoke boundary, so FromException
+        // pulls the original error fields through.
+        var ex = new StepException("intentional child failure")
+        {
+            ErrorType = "System.InvalidOperationException",
+            ErrorData = "{\"hint\":\"data\"}",
+            OriginalStackTrace = new[] { "at User.Workflow.Body()" }
+        };
+
+        var error = ErrorObject.FromException(ex);
+
+        Assert.Equal("System.InvalidOperationException", error.ErrorType);
+        Assert.Equal("intentional child failure", error.ErrorMessage);
+        Assert.Equal("{\"hint\":\"data\"}", error.ErrorData);
+        Assert.Equal(new[] { "at User.Workflow.Body()" }, error.StackTrace);
+    }
+
+    [Fact]
+    public void ErrorObject_FromException_UnwrapsChildContextException()
+    {
+        var ex = new ChildContextException("child failed")
+        {
+            ErrorType = "System.ArgumentException",
+            ErrorData = "{\"k\":\"v\"}",
+            OriginalStackTrace = new[] { "at Inner()" }
+        };
+
+        var error = ErrorObject.FromException(ex);
+
+        Assert.Equal("System.ArgumentException", error.ErrorType);
+        Assert.Equal("child failed", error.ErrorMessage);
+        Assert.Equal("{\"k\":\"v\"}", error.ErrorData);
+    }
+
+    [Fact]
+    public void ErrorObject_FromException_UnwrapsInvokeException()
+    {
+        var ex = new InvokeFailedException("downstream failed")
+        {
+            FunctionName = "arn:aws:lambda:...:function:downstream",
+            ErrorType = "System.TimeoutException",
+            ErrorData = "{\"region\":\"us-east-1\"}",
+            OriginalStackTrace = new[] { "at Downstream.Run()" }
+        };
+
+        var error = ErrorObject.FromException(ex);
+
+        Assert.Equal("System.TimeoutException", error.ErrorType);
+        Assert.Equal("downstream failed", error.ErrorMessage);
+        Assert.Equal("{\"region\":\"us-east-1\"}", error.ErrorData);
+    }
+
+    [Fact]
+    public void ErrorObject_FromException_UnwrapsCallbackException()
+    {
+        var ex = new CallbackFailedException("callback failed")
+        {
+            CallbackId = "cb-123",
+            ErrorType = "Acme.Errors.PaymentDeclined",
+            ErrorData = "{\"code\":42}",
+            OriginalStackTrace = new[] { "at External.Reject()" }
+        };
+
+        var error = ErrorObject.FromException(ex);
+
+        Assert.Equal("Acme.Errors.PaymentDeclined", error.ErrorType);
+        Assert.Equal("callback failed", error.ErrorMessage);
+        Assert.Equal("{\"code\":42}", error.ErrorData);
+    }
+
+    [Fact]
+    public void ErrorObject_FromException_UnwrapsStepException_WithNullErrorType()
+    {
+        // StepException without an explicit ErrorType (e.g., constructed by code
+        // that didn't set the init-only property) records null rather than
+        // falling back to the wrapper's type — the wrapper type is never useful.
+        var ex = new StepException("no type set");
+
+        var error = ErrorObject.FromException(ex);
+
+        Assert.Null(error.ErrorType);
+        Assert.Equal("no type set", error.ErrorMessage);
+    }
+
+    [Fact]
     public void ErrorObject_RoundTripSerialization()
     {
         var error = new ErrorObject


### PR DESCRIPTION
https://github.com/aws/aws-lambda-dotnet/issues/2216

## What

Adds chained-function invocation to `Amazon.Lambda.DurableExecution`. `InvokeAsync` calls another durable function as a separate execution; the caller suspends until the chained function completes, with the result checkpointed for replay. Mirrors the Python/JS/Java reference SDKs.

Public API:

| Type | Purpose |
|---|---|
| `IDurableContext.InvokeAsync<TPayload, TResult>(...)` | Invoke another durable Lambda function and await its result. Single overload — payload and result are serialized via the `ILambdaSerializer` registered on `ILambdaContext.Serializer`, so AOT and reflection callers share one code path (the AOT story is decided by the registered serializer, e.g. `SourceGeneratorLambdaJsonSerializer<TContext>`). |
| `InvokeConfig` | Optional config: `TenantId` (propagated to the chained invocation) and `Timeout` (`[Obsolete]` placeholder reserved for a future `ChainedInvokeOptions` wire field). |
| `InvokeException` | Base exception for chained-invoke failures; carries `FunctionName`, `ErrorType`, `ErrorData`, `OriginalStackTrace`. |
| `InvokeFailedException` | Subclass — chained function ran and threw. |
| `InvokeTimedOutException` | Subclass — chained function did not complete within the configured / service timeout. |
| `InvokeStoppedException` | Subclass — chained execution was stopped by the service before reaching a normal terminal state. |

