### PR TITLE
Add WaitForConditionAsync polling primitive (DOTNET-8665)

### DIFF
--- a/.autover/changes/ef22a418-1be3-4359-a442-f086667635ec.json
+++ b/.autover/changes/ef22a418-1be3-4359-a442-f086667635ec.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.DurableExecution",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add WaitForConditionAsync polling primitive: IDurableContext.WaitForConditionAsync<TState>, IConditionCheckContext, WaitForConditionConfig<TState>, IWaitStrategy<TState>, WaitDecision, WaitStrategy factory (Exponential/Linear/Fixed/FromDelegate), and WaitForConditionException with AttemptsExhausted and LastState"
+      ]
+    }
+  ]
+}

--- a/Docs/durable-execution-design.md
+++ b/Docs/durable-execution-design.md
@@ -424,6 +424,29 @@ await context.WaitAsync(TimeSpan.FromDays(7), name: "weekly_reminder");
 
 > **Validation:** The duration must be at least 1 second. Values less than 1 second throw `ArgumentOutOfRangeException`. Sub-second precision is truncated to whole seconds (the underlying service operates at second granularity).
 
+#### Wait For Condition
+
+`WaitForConditionAsync` polls a user-supplied check function until a configured `IWaitStrategy<TState>` decides to stop. Between polls the workflow is suspended (no compute charge); the service re-invokes when the strategy's chosen delay elapses. The check function receives the state from the previous iteration, so users can carry per-poll bookkeeping inside the state itself.
+
+```csharp
+// Poll until an order's status reaches a terminal value.
+var finalStatus = await context.WaitForConditionAsync<OrderStatus>(
+    check: async (state, ctx) =>
+    {
+        ctx.Logger.LogInformation("Polling order on attempt {Attempt}", ctx.AttemptNumber);
+        return await orderService.GetStatusAsync(orderId);
+    },
+    config: new WaitForConditionConfig<OrderStatus>
+    {
+        InitialState = OrderStatus.Unknown,
+        WaitStrategy = WaitStrategy.Exponential<OrderStatus>(
+            isDone: s => s == OrderStatus.Completed || s == OrderStatus.Cancelled)
+    },
+    name: "wait_for_order_settle");
+```
+
+Built-in strategies live on the `WaitStrategy` factory (`Exponential`, `Linear`, `Fixed`, plus `FromDelegate`) and all accept an optional `isDone` predicate so the common case stays declarative. When the strategy hits its `maxAttempts` limit it throws `WaitForConditionException` (carrying `AttemptsExhausted` and `LastState`); when the check function itself throws, the operation surfaces a `StepException` with the original error type. State is checkpointed per-iteration in the operation's payload so polling survives Lambda re-invocations deterministically.
+
 ---
 
 ### Callbacks
@@ -1154,7 +1177,13 @@ public interface IDurableContext
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Poll until a condition is met.
+    /// Poll until a condition is met. The check function returns the next
+    /// state on each invocation; the configured <c>IWaitStrategy&lt;TState&gt;</c>
+    /// decides whether to keep polling and how long to wait between calls.
+    /// State is serialized using the <c>ILambdaSerializer</c> registered on
+    /// <c>ILambdaContext.Serializer</c> (AOT and reflection-based scenarios
+    /// share this single overload — the AOT story is determined by the
+    /// registered serializer).
     /// </summary>
     Task<TState> WaitForConditionAsync<TState>(
         Func<TState, IConditionCheckContext, Task<TState>> check,
@@ -1208,6 +1237,63 @@ public interface IWaitForCallbackContext
 /// traces and can be inspected by name in the test runner.
 /// </summary>
 public record DurableBranch<T>(string Name, Func<IDurableContext, Task<T>> Func);
+
+/// <summary>
+/// Context passed to a WaitForCondition check function on every polling
+/// iteration. Mirrors IStepContext minus OperationId (every iteration of a
+/// wait-for-condition operation shares the same operation ID, so exposing
+/// it here would be misleading).
+/// </summary>
+public interface IConditionCheckContext
+{
+    /// <summary>Logger scoped to this condition-check attempt.</summary>
+    ILogger Logger { get; }
+
+    /// <summary>The current 1-based attempt number.</summary>
+    int AttemptNumber { get; }
+}
+
+/// <summary>
+/// Decides, per polling iteration, whether a WaitForConditionAsync operation
+/// should keep polling and how long to wait. Implementations are typically
+/// obtained via the <c>WaitStrategy</c> factory; users may also implement
+/// directly. Built-in implementations throw <c>WaitForConditionException</c>
+/// when their max-attempts limit is reached so the operation can produce a
+/// failure with the last observed state.
+/// </summary>
+public interface IWaitStrategy<TState>
+{
+    WaitDecision Decide(TState state, int attemptNumber);
+}
+
+/// <summary>
+/// Decision returned by IWaitStrategy on each polling iteration. Stop()
+/// indicates the condition has been met (the operation SUCCEEDs and returns
+/// the latest state); ContinueAfter(delay) schedules the next poll.
+/// </summary>
+public readonly record struct WaitDecision
+{
+    public bool ShouldContinue { get; }
+    public TimeSpan Delay { get; }
+    public static WaitDecision Stop();
+    public static WaitDecision ContinueAfter(TimeSpan delay);
+}
+
+/// <summary>
+/// Factory for built-in IWaitStrategy implementations. Each accepts an
+/// optional isDone predicate so users can terminate polling declaratively
+/// when the latest state satisfies a condition (e.g. state =&gt; state.IsReady)
+/// without implementing IWaitStrategy themselves. Defaults are intentionally
+/// tuned for polling, NOT retry-on-exception: 60 attempts / 5s initial /
+/// 300s max / 1.5x backoff / Full jitter.
+/// </summary>
+public static class WaitStrategy
+{
+    public static IWaitStrategy<TState> Exponential<TState>(...);
+    public static IWaitStrategy<TState> Linear<TState>(...);
+    public static IWaitStrategy<TState> Fixed<TState>(TimeSpan delay, ...);
+    public static IWaitStrategy<TState> FromDelegate<TState>(Func<TState, int, WaitDecision> strategy);
+}
 ```
 
 #### CancellationToken behavior
@@ -1655,11 +1741,18 @@ public class ChildContextException : DurableExecutionException
 
 /// <summary>
 /// Thrown when a wait-for-condition operation exhausts all attempts
-/// without the condition being met.
+/// without the condition being met. Subclassable: future failure modes
+/// (e.g. timeout) should add derived exceptions rather than discriminator
+/// flags so callers can catch by static type.
 /// </summary>
 public class WaitForConditionException : DurableExecutionException
 {
     public int AttemptsExhausted { get; }
+
+    /// <summary>The most recent state observed by the check function before
+    /// the strategy gave up. Boxed because the exception type is not generic;
+    /// callers cast to the workflow's known state type.</summary>
+    public object? LastState { get; }
 }
 
 /// <summary>

--- a/Libraries/src/Amazon.Lambda.DurableExecution/DurableContext.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/DurableContext.cs
@@ -134,6 +134,24 @@ internal sealed class DurableContext : IDurableContext
             name, config, cancellationToken);
     }
 
+    public Task<TState> WaitForConditionAsync<TState>(
+        Func<TState, IConditionCheckContext, Task<TState>> check,
+        WaitForConditionConfig<TState> config,
+        string? name = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(check);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(config.WaitStrategy);
+
+        var serializer = LambdaSerializerHelper.GetRequired(LambdaContext);
+        var operationId = _idGenerator.NextId();
+        var op = new WaitForConditionOperation<TState>(
+            operationId, name, _idGenerator.ParentId, check, config, serializer, Logger,
+            _state, _terminationManager, _durableExecutionArn, _batcher);
+        return op.ExecuteAsync(cancellationToken);
+    }
+
     private Task<T> RunChildContext<T>(
         Func<IDurableContext, Task<T>> func,
         string? name,

--- a/Libraries/src/Amazon.Lambda.DurableExecution/IConditionCheckContext.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/IConditionCheckContext.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Logging;
+
+namespace Amazon.Lambda.DurableExecution;
+
+/// <summary>
+/// Context passed to a <c>WaitForConditionAsync</c> check function on every
+/// polling iteration. Provides a logger scoped to the current attempt and the
+/// 1-based attempt number, mirroring the surface of
+/// <see cref="IStepContext"/> (minus <c>OperationId</c>: every iteration of a
+/// wait-for-condition operation shares the same operation ID, so exposing it
+/// here would be misleading — see <c>DESIGN-QUESTIONS.md#Q6</c>).
+/// </summary>
+public interface IConditionCheckContext
+{
+    /// <summary>
+    /// Logger scoped to this condition-check attempt.
+    /// </summary>
+    ILogger Logger { get; }
+
+    /// <summary>
+    /// The current 1-based attempt number. Increments on every polling
+    /// iteration; on replay, equals the number of attempts already
+    /// checkpointed plus one.
+    /// </summary>
+    int AttemptNumber { get; }
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/IDurableContext.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/IDurableContext.cs
@@ -177,6 +177,34 @@ public interface IDurableContext
         string? name = null,
         InvokeConfig? config = null,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Poll a condition by repeatedly invoking <paramref name="check"/> until
+    /// the configured <see cref="IWaitStrategy{TState}"/> decides to stop.
+    /// Between polls the workflow is suspended (no compute charge); the
+    /// service re-invokes the Lambda when the strategy's chosen delay elapses.
+    /// </summary>
+    /// <remarks>
+    /// On every iteration the <paramref name="check"/> function receives the
+    /// state returned by the previous invocation (seeded by
+    /// <see cref="WaitForConditionConfig{TState}.InitialState"/> on the very
+    /// first call), so users can carry per-poll bookkeeping (e.g. a cursor or
+    /// retry counter) inside the state itself. If the strategy stops because
+    /// of <see cref="IWaitStrategy{TState}"/>'s max-attempts limit (rather
+    /// than because the condition is met), a <see cref="WaitForConditionException"/>
+    /// is thrown carrying the last observed state.
+    /// The check function's return value is serialized to a checkpoint using
+    /// the <see cref="ILambdaSerializer"/> registered on
+    /// <see cref="ILambdaContext.Serializer"/>. AOT and reflection-based
+    /// scenarios share this single overload — the AOT story is determined by
+    /// the registered serializer (e.g.,
+    /// <c>SourceGeneratorLambdaJsonSerializer&lt;TContext&gt;</c>).
+    /// </remarks>
+    Task<TState> WaitForConditionAsync<TState>(
+        Func<TState, IConditionCheckContext, Task<TState>> check,
+        WaitForConditionConfig<TState> config,
+        string? name = null,
+        CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/Libraries/src/Amazon.Lambda.DurableExecution/IDurableContext.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/IDurableContext.cs
@@ -28,6 +28,10 @@ public interface IDurableContext
     /// Swap the underlying logger or toggle replay-aware filtering. Idempotent —
     /// later calls overwrite earlier configuration.
     /// </summary>
+    /// <param name="config">
+    /// The logger configuration specifying the underlying logger and whether
+    /// replay-aware filtering is enabled.
+    /// </param>
     void ConfigureLogger(LoggerConfig config);
 
     /// <summary>
@@ -47,6 +51,20 @@ public interface IDurableContext
     /// share this single overload — the AOT story is determined by the registered
     /// serializer (e.g., <c>SourceGeneratorLambdaJsonSerializer&lt;TContext&gt;</c>).
     /// </summary>
+    /// <typeparam name="T">The type of the step's result.</typeparam>
+    /// <param name="func">
+    /// The step body to execute. Receives an <see cref="IStepContext"/> exposing
+    /// the step's logger, attempt number, and operation ID.
+    /// </param>
+    /// <param name="name">
+    /// An optional name for the step, used for observability and to derive the
+    /// deterministic operation ID. Defaults to a name inferred from the call site.
+    /// </param>
+    /// <param name="config">
+    /// Optional step configuration (e.g. retry policy). Defaults are used when null.
+    /// </param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The deserialized result of the step.</returns>
     Task<T> StepAsync<T>(
         Func<IStepContext, Task<T>> func,
         string? name = null,
@@ -56,6 +74,18 @@ public interface IDurableContext
     /// <summary>
     /// Execute a step that returns no value.
     /// </summary>
+    /// <param name="func">
+    /// The step body to execute. Receives an <see cref="IStepContext"/> exposing
+    /// the step's logger, attempt number, and operation ID.
+    /// </param>
+    /// <param name="name">
+    /// An optional name for the step, used for observability and to derive the
+    /// deterministic operation ID. Defaults to a name inferred from the call site.
+    /// </param>
+    /// <param name="config">
+    /// Optional step configuration (e.g. retry policy). Defaults are used when null.
+    /// </param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
     Task StepAsync(
         Func<IStepContext, Task> func,
         string? name = null,
@@ -67,6 +97,14 @@ public interface IDurableContext
     /// The Lambda is suspended and the service re-invokes it after the wait elapses.
     /// Duration must be at least 1 second (service timer granularity).
     /// </summary>
+    /// <param name="duration">
+    /// How long to suspend execution. Must be at least 1 second.
+    /// </param>
+    /// <param name="name">
+    /// An optional name for the wait, used for observability and to derive the
+    /// deterministic operation ID. Defaults to a name inferred from the call site.
+    /// </param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
     Task WaitAsync(
         TimeSpan duration,
         string? name = null,
@@ -88,6 +126,21 @@ public interface IDurableContext
     /// <see cref="ILambdaSerializer"/> registered on
     /// <see cref="ILambdaContext.Serializer"/>.
     /// </remarks>
+    /// <typeparam name="T">The type of the child context's result.</typeparam>
+    /// <param name="func">
+    /// The user function to run inside the child context. Receives a nested
+    /// <see cref="IDurableContext"/> with its own deterministic operation-ID space.
+    /// </param>
+    /// <param name="name">
+    /// An optional name for the child context, used for observability and to derive
+    /// the deterministic operation ID. Defaults to a name inferred from the call site.
+    /// </param>
+    /// <param name="config">
+    /// Optional child context configuration (e.g.
+    /// <see cref="ChildContextConfig.ErrorMapping"/>). Defaults are used when null.
+    /// </param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The deserialized result of the child context.</returns>
     Task<T> RunInChildContextAsync<T>(
         Func<IDurableContext, Task<T>> func,
         string? name = null,
@@ -107,6 +160,19 @@ public interface IDurableContext
     /// <see cref="ChildContextConfig.ErrorMapping"/> to remap into a
     /// domain-specific exception.
     /// </remarks>
+    /// <param name="func">
+    /// The user function to run inside the child context. Receives a nested
+    /// <see cref="IDurableContext"/> with its own deterministic operation-ID space.
+    /// </param>
+    /// <param name="name">
+    /// An optional name for the child context, used for observability and to derive
+    /// the deterministic operation ID. Defaults to a name inferred from the call site.
+    /// </param>
+    /// <param name="config">
+    /// Optional child context configuration (e.g.
+    /// <see cref="ChildContextConfig.ErrorMapping"/>). Defaults are used when null.
+    /// </param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
     Task RunInChildContextAsync(
         Func<IDurableContext, Task> func,
         string? name = null,
@@ -133,6 +199,19 @@ public interface IDurableContext
     /// across replays.
     /// </para>
     /// </remarks>
+    /// <typeparam name="T">The type of the result the callback will deliver.</typeparam>
+    /// <param name="name">
+    /// An optional name for the callback, used for observability and to derive the
+    /// deterministic operation ID. Defaults to a name inferred from the call site.
+    /// </param>
+    /// <param name="config">
+    /// Optional callback configuration (e.g. timeout). Defaults are used when null.
+    /// </param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>
+    /// An <see cref="ICallback{T}"/> handle exposing the service-allocated callback
+    /// ID and a method to await the result.
+    /// </returns>
     Task<ICallback<T>> CreateCallbackAsync<T>(
         string? name = null,
         CallbackConfig? config = null,
@@ -153,6 +232,21 @@ public interface IDurableContext
     /// surface as <see cref="CallbackFailedException"/> /
     /// <see cref="CallbackTimeoutException"/>.
     /// </remarks>
+    /// <typeparam name="T">The type of the result the callback will deliver.</typeparam>
+    /// <param name="submitter">
+    /// A function that hands the service-allocated <c>callbackId</c> to the external
+    /// system. Receives the callback ID and an <see cref="IWaitForCallbackContext"/>.
+    /// </param>
+    /// <param name="name">
+    /// An optional name for the operation, used for observability and to derive the
+    /// deterministic operation ID. Defaults to a name inferred from the call site.
+    /// </param>
+    /// <param name="config">
+    /// Optional configuration (e.g. submitter retry policy and callback timeout).
+    /// Defaults are used when null.
+    /// </param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The deserialized result delivered by the external system.</returns>
     Task<T> WaitForCallbackAsync<T>(
         Func<string, IWaitForCallbackContext, Task> submitter,
         string? name = null,
@@ -171,6 +265,22 @@ public interface IDurableContext
     /// alias, or <c>$LATEST</c>); unqualified ARNs are rejected by the durable
     /// execution service.
     /// </remarks>
+    /// <typeparam name="TPayload">The type of the payload sent to the target function.</typeparam>
+    /// <typeparam name="TResult">The type of the result returned by the target function.</typeparam>
+    /// <param name="functionName">
+    /// The qualified identifier (version, alias, or <c>$LATEST</c>) of the durable
+    /// Lambda function to invoke. Unqualified ARNs are rejected.
+    /// </param>
+    /// <param name="payload">The payload to pass to the target function.</param>
+    /// <param name="name">
+    /// An optional name for the invocation, used for observability and to derive the
+    /// deterministic operation ID. Defaults to a name inferred from the call site.
+    /// </param>
+    /// <param name="config">
+    /// Optional invocation configuration (e.g. retry policy). Defaults are used when null.
+    /// </param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The deserialized result returned by the target function.</returns>
     Task<TResult> InvokeAsync<TPayload, TResult>(
         string functionName,
         TPayload payload,
@@ -200,6 +310,25 @@ public interface IDurableContext
     /// the registered serializer (e.g.,
     /// <c>SourceGeneratorLambdaJsonSerializer&lt;TContext&gt;</c>).
     /// </remarks>
+    /// <typeparam name="TState">
+    /// The type of the per-poll state carried between condition checks.
+    /// </typeparam>
+    /// <param name="check">
+    /// The condition check invoked on each poll. Receives the state returned by the
+    /// previous invocation (seeded by
+    /// <see cref="WaitForConditionConfig{TState}.InitialState"/> on the first call)
+    /// and an <see cref="IConditionCheckContext"/>, and returns the next state.
+    /// </param>
+    /// <param name="config">
+    /// The configuration controlling polling, including the
+    /// <see cref="IWaitStrategy{TState}"/> and the initial state.
+    /// </param>
+    /// <param name="name">
+    /// An optional name for the operation, used for observability and to derive the
+    /// deterministic operation ID. Defaults to a name inferred from the call site.
+    /// </param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The final state observed when the strategy decides to stop.</returns>
     Task<TState> WaitForConditionAsync<TState>(
         Func<TState, IConditionCheckContext, Task<TState>> check,
         WaitForConditionConfig<TState> config,

--- a/Libraries/src/Amazon.Lambda.DurableExecution/IWaitStrategy.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/IWaitStrategy.cs
@@ -1,0 +1,27 @@
+namespace Amazon.Lambda.DurableExecution;
+
+/// <summary>
+/// Decides, per polling iteration, whether a <c>WaitForConditionAsync</c>
+/// operation should keep polling and how long to wait before the next attempt.
+/// </summary>
+/// <remarks>
+/// Distinct from <see cref="IRetryStrategy"/>: that interface decides
+/// retry-on-exception (input is the thrown <see cref="Exception"/>); this one
+/// decides poll-until-condition (input is the latest <typeparamref name="TState"/>
+/// observed by the check function). Implementations are typically obtained
+/// via the <see cref="WaitStrategy"/> factory; users who need richer logic
+/// (e.g. wall-clock-time budgets, conditional jitter) can implement this
+/// interface directly.
+/// </remarks>
+/// <typeparam name="TState">The state type produced by the check function.</typeparam>
+public interface IWaitStrategy<TState>
+{
+    /// <summary>
+    /// Evaluates the latest <paramref name="state"/> from the check function
+    /// and the 1-based <paramref name="attemptNumber"/> just executed, and
+    /// returns either <see cref="WaitDecision.Stop"/> (terminate) or
+    /// <see cref="WaitDecision.ContinueAfter(TimeSpan)"/> (poll again after
+    /// the given delay).
+    /// </summary>
+    WaitDecision Decide(TState state, int attemptNumber);
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/ExponentialBackoff.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/ExponentialBackoff.cs
@@ -1,0 +1,41 @@
+namespace Amazon.Lambda.DurableExecution.Internal;
+
+/// <summary>
+/// Shared exponential-backoff math for both
+/// <see cref="ExponentialRetryStrategy"/> (retry-on-exception) and
+/// <c>ExponentialWaitStrategy&lt;TState&gt;</c> (wait-for-condition polling).
+/// Computes <c>min(initialDelay * backoff^(attempt-1), maxDelay)</c>, applies
+/// the requested jitter, then ceilings to whole seconds with a 1-second floor
+/// (the service timer's smallest unit).
+/// </summary>
+internal static class ExponentialBackoff
+{
+    [ThreadStatic]
+    private static Random? t_random;
+    private static Random Random => t_random ??= new Random();
+
+    /// <summary>
+    /// Computes the delay for the given <paramref name="attemptNumber"/> (1-based)
+    /// using exponential backoff with the requested jitter strategy. Returned
+    /// delay is always at least 1 second (service timer floor).
+    /// </summary>
+    public static TimeSpan CalculateDelay(
+        int attemptNumber,
+        TimeSpan initialDelay,
+        TimeSpan maxDelay,
+        double backoffRate,
+        JitterStrategy jitter)
+    {
+        var baseDelay = initialDelay.TotalSeconds * Math.Pow(backoffRate, attemptNumber - 1);
+        var cappedDelay = Math.Min(baseDelay, maxDelay.TotalSeconds);
+
+        var finalDelay = jitter switch
+        {
+            JitterStrategy.Full => Random.NextDouble() * cappedDelay,
+            JitterStrategy.Half => cappedDelay * (0.5 + 0.5 * Random.NextDouble()),
+            _ => cappedDelay
+        };
+
+        return TimeSpan.FromSeconds(Math.Max(1, Math.Ceiling(finalDelay)));
+    }
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/WaitForConditionOperation.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/WaitForConditionOperation.cs
@@ -1,0 +1,387 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text;
+using Amazon.Lambda.Core;
+using Microsoft.Extensions.Logging;
+using SdkErrorObject = Amazon.Lambda.Model.ErrorObject;
+using SdkOperationUpdate = Amazon.Lambda.Model.OperationUpdate;
+using SdkStepOptions = Amazon.Lambda.Model.StepOptions;
+
+namespace Amazon.Lambda.DurableExecution.Internal;
+
+/// <summary>
+/// Durable wait-for-condition (polling) operation. Repeatedly invokes a
+/// user-supplied check function until an <see cref="IWaitStrategy{TState}"/>
+/// decides to stop. Between iterations the workflow is suspended so the
+/// Lambda is not billing compute while waiting.
+/// </summary>
+/// <remarks>
+/// Wire format reuses STEP+RETRY exactly:
+/// <list type="bullet">
+///   <item><c>Type=STEP</c>, <c>SubType="WaitForCondition"</c></item>
+///   <item>Each polling iteration emits <c>Action=RETRY</c> with the latest
+///       <typeparamref name="TState"/> in <c>Payload</c> and the strategy's
+///       chosen delay in <c>StepOptions.NextAttemptDelaySeconds</c>.</item>
+///   <item>Termination emits <c>Action=SUCCEED</c> with the final state in
+///       <c>Payload</c>; check-function exceptions emit <c>Action=FAIL</c>.</item>
+/// </list>
+/// Replay branches — example: <c>await ctx.WaitForConditionAsync(check, config, "poll")</c>
+/// <list type="bullet">
+///   <item><b>Fresh</b>: sync-flush START → run check with <see cref="WaitForConditionConfig{TState}.InitialState"/>
+///       → strategy decides Stop/Continue.</item>
+///   <item><b>SUCCEEDED</b>: return the deserialized cached state; check is NOT re-run.</item>
+///   <item><b>FAILED</b>: re-throw a <see cref="WaitForConditionException"/>
+///       (or fall back to <see cref="StepException"/> if the FAIL was caused by
+///       the check function throwing — the latter carries the original
+///       error type/message).</item>
+///   <item><b>PENDING</b> (RETRY scheduled): if the next-attempt timer hasn't
+///       fired yet, re-suspend; otherwise read the prior state from
+///       <c>StepDetails.Result</c>, advance the attempt counter, and run the
+///       check again.</item>
+///   <item><b>READY</b>: timer fired and the service re-invoked us. Read the
+///       prior state, advance the attempt counter, run the check.</item>
+///   <item><b>STARTED</b>: the START checkpoint was written but the very first
+///       check attempt didn't complete (Lambda crash / timeout). Re-execute
+///       with <see cref="WaitForConditionConfig{TState}.InitialState"/> as
+///       the seed.</item>
+/// </list>
+/// State checkpointing in each RETRY's payload is what makes the polling loop
+/// survive Lambda re-invocations deterministically.
+/// </remarks>
+internal sealed class WaitForConditionOperation<TState> : DurableOperation<TState>
+{
+    private readonly Func<TState, IConditionCheckContext, Task<TState>> _check;
+    private readonly WaitForConditionConfig<TState> _config;
+    private readonly ILambdaSerializer _serializer;
+    private readonly ILogger _logger;
+
+    public WaitForConditionOperation(
+        string operationId,
+        string? name,
+        string? parentId,
+        Func<TState, IConditionCheckContext, Task<TState>> check,
+        WaitForConditionConfig<TState> config,
+        ILambdaSerializer serializer,
+        ILogger logger,
+        ExecutionState state,
+        TerminationManager termination,
+        string durableExecutionArn,
+        CheckpointBatcher? batcher = null)
+        : base(operationId, name, parentId, state, termination, durableExecutionArn, batcher)
+    {
+        _check = check;
+        _config = config;
+        _serializer = serializer;
+        _logger = logger;
+    }
+
+    protected override string OperationType => OperationTypes.Step;
+
+    protected override Task<TState> StartAsync(CancellationToken cancellationToken)
+        => ExecuteIteration(_config.InitialState, attemptNumber: 1, cancellationToken);
+
+    protected override Task<TState> ReplayAsync(Operation existing, CancellationToken cancellationToken)
+    {
+        switch (existing.Status)
+        {
+            case OperationStatuses.Succeeded:
+                // Polling concluded on a previous invocation; return the
+                // cached final state without re-running the check.
+                return Task.FromResult(DeserializeState(existing.StepDetails?.Result));
+
+            case OperationStatuses.Failed:
+                throw BuildFailureException(existing);
+
+            case OperationStatuses.Pending:
+                return ReplayPending(existing, cancellationToken);
+
+            case OperationStatuses.Ready:
+                return ReplayReady(existing, cancellationToken);
+
+            case OperationStatuses.Started:
+                // START emitted but no RETRY/SUCCEED yet — the very first
+                // check attempt was lost. Re-execute with InitialState. Do
+                // NOT re-emit START (the original is authoritative).
+                return ExecuteIteration(_config.InitialState, attemptNumber: 1, cancellationToken);
+
+            default:
+                throw new NonDeterministicExecutionException(
+                    $"WaitForCondition operation '{Name ?? OperationId}' has unexpected status '{existing.Status}' on replay.");
+        }
+    }
+
+    /// <summary>
+    /// PENDING means the prior iteration emitted RETRY and the service
+    /// scheduled a timer. If the timer hasn't fired we re-suspend; once it
+    /// fires, the next iteration runs against the previously checkpointed
+    /// state, NOT <see cref="WaitForConditionConfig{TState}.InitialState"/>.
+    /// </summary>
+    private Task<TState> ReplayPending(Operation pending, CancellationToken cancellationToken)
+    {
+        var nextAttemptTs = pending.StepDetails?.NextAttemptTimestamp;
+        if (nextAttemptTs is { } scheduledMs &&
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() < scheduledMs)
+        {
+            // Timer still ticking — re-suspend without re-checkpointing.
+            return Termination.SuspendAndAwait<TState>(
+                TerminationReason.RetryScheduled, $"wait_for_condition:{Name ?? OperationId}");
+        }
+
+        var priorState = DeserializeStateOrInitial(pending.StepDetails?.Result);
+        var attemptNumber = (pending.StepDetails?.Attempt ?? 0) + 1;
+        return ExecuteIteration(priorState, attemptNumber, cancellationToken);
+    }
+
+    /// <summary>
+    /// READY means the service has re-invoked us post-PENDING — the next
+    /// poll is up. Read the latest state from the prior RETRY's payload
+    /// and advance the attempt counter.
+    /// </summary>
+    private Task<TState> ReplayReady(Operation ready, CancellationToken cancellationToken)
+    {
+        var priorState = DeserializeStateOrInitial(ready.StepDetails?.Result);
+        var attemptNumber = (ready.StepDetails?.Attempt ?? 0) + 1;
+        return ExecuteIteration(priorState, attemptNumber, cancellationToken);
+    }
+
+    private async Task<TState> ExecuteIteration(TState currentState, int attemptNumber, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Emit START on the very first attempt only — and sync-flush so the
+        // service has a record of the polling op even if the check function
+        // drives termination via, e.g., a wait inside it. Subsequent
+        // iterations resume from a RETRY/READY/PENDING checkpoint and skip
+        // START.
+        if (State.GetOperation(OperationId) == null)
+        {
+            await EnqueueAsync(new SdkOperationUpdate
+            {
+                Id = OperationId,
+                ParentId = ParentId,
+                Type = OperationTypes.Step,
+                Action = OperationAction.START,
+                SubType = OperationSubTypes.WaitForCondition,
+                Name = Name
+            }, cancellationToken);
+        }
+
+        TState newState;
+        try
+        {
+            var checkContext = new ConditionCheckContext(attemptNumber, _logger);
+            newState = await _check(currentState, checkContext);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // The check threw. WaitForCondition has no per-exception retry
+            // strategy (Python/JS/Java SDKs all treat check failure as terminal),
+            // so checkpoint FAIL and surface the original exception via
+            // StepException — same shape as StepOperation's terminal failure.
+            await EnqueueAsync(new SdkOperationUpdate
+            {
+                Id = OperationId,
+                ParentId = ParentId,
+                Type = OperationTypes.Step,
+                Action = OperationAction.FAIL,
+                SubType = OperationSubTypes.WaitForCondition,
+                Name = Name,
+                Error = ToSdkError(ex)
+            }, cancellationToken);
+
+            throw new StepException(ex.Message, ex)
+            {
+                ErrorType = ex.GetType().FullName
+            };
+        }
+
+        WaitDecision decision;
+        try
+        {
+            decision = _config.WaitStrategy.Decide(newState, attemptNumber);
+        }
+        catch (WaitForConditionException maxEx)
+        {
+            // Strategy is signaling max-attempts reached. The strategy
+            // didn't have access to LastState; we do — populate it now,
+            // checkpoint FAIL, and rethrow.
+            var enriched = new WaitForConditionException(
+                $"WaitForCondition '{Name ?? OperationId}' exhausted {attemptNumber} attempts without the condition being met.",
+                maxEx)
+            {
+                AttemptsExhausted = attemptNumber,
+                LastState = newState
+            };
+
+            // Persist the last observed state in Error.ErrorData so a replay
+            // that hits this cached FAIL can reconstruct LastState identically
+            // to the live throw. The wire protocol forbids a Payload on FAIL
+            // updates, so ErrorData is the only field that survives replay.
+            await EnqueueAsync(new SdkOperationUpdate
+            {
+                Id = OperationId,
+                ParentId = ParentId,
+                Type = OperationTypes.Step,
+                Action = OperationAction.FAIL,
+                SubType = OperationSubTypes.WaitForCondition,
+                Name = Name,
+                Error = new SdkErrorObject
+                {
+                    ErrorType = typeof(WaitForConditionException).FullName,
+                    ErrorMessage = enriched.Message,
+                    ErrorData = SerializeState(newState)
+                }
+            }, cancellationToken);
+
+            throw enriched;
+        }
+
+        if (!decision.ShouldContinue)
+        {
+            // Stop() means the condition has been met. Persist the final
+            // state and return it to the caller.
+            await EnqueueAsync(new SdkOperationUpdate
+            {
+                Id = OperationId,
+                ParentId = ParentId,
+                Type = OperationTypes.Step,
+                Action = OperationAction.SUCCEED,
+                SubType = OperationSubTypes.WaitForCondition,
+                Name = Name,
+                Payload = SerializeState(newState)
+            }, cancellationToken);
+
+            return newState;
+        }
+
+        // Continue polling — emit RETRY with the new state in the payload
+        // and the next-attempt delay in StepOptions. Sync-flush so the
+        // service definitely has the new state and timer scheduled before
+        // we suspend.
+        var delaySeconds = (int)Math.Max(1, Math.Ceiling(decision.Delay.TotalSeconds));
+        await EnqueueAsync(new SdkOperationUpdate
+        {
+            Id = OperationId,
+            ParentId = ParentId,
+            Type = OperationTypes.Step,
+            Action = OperationAction.RETRY,
+            SubType = OperationSubTypes.WaitForCondition,
+            Name = Name,
+            Payload = SerializeState(newState),
+            StepOptions = new SdkStepOptions { NextAttemptDelaySeconds = delaySeconds }
+        }, cancellationToken);
+
+        return await Termination.SuspendAndAwait<TState>(
+            TerminationReason.RetryScheduled, $"wait_for_condition:{Name ?? OperationId}");
+    }
+
+    private TState DeserializeState(string? serialized)
+    {
+        if (serialized == null) return default!;
+        var bytes = Encoding.UTF8.GetBytes(serialized);
+        using var ms = new MemoryStream(bytes);
+        return _serializer.Deserialize<TState>(ms);
+    }
+
+    private TState DeserializeStateOrInitial(string? serialized)
+    {
+        if (serialized == null) return _config.InitialState;
+        try
+        {
+            var bytes = Encoding.UTF8.GetBytes(serialized);
+            using var ms = new MemoryStream(bytes);
+            return _serializer.Deserialize<TState>(ms);
+        }
+        catch (Exception ex)
+        {
+            // If the serializer can't read the prior state, fall back to
+            // InitialState — matches Python's behavior. Log a warning so
+            // corrupted payloads / schema migrations are observable instead
+            // of silently restarting the polling loop.
+            _logger.LogWarning(
+                "WaitForCondition operation '{OperationId}' failed to deserialize prior state ({ExceptionType}: {Message}); falling back to InitialState.",
+                OperationId, ex.GetType().FullName, ex.Message);
+            return _config.InitialState;
+        }
+    }
+
+    private string SerializeState(TState value)
+    {
+        using var ms = new MemoryStream();
+        _serializer.Serialize(value, ms);
+        return Encoding.UTF8.GetString(ms.ToArray());
+    }
+
+    private Exception BuildFailureException(Operation failedOp)
+    {
+        var err = failedOp.StepDetails?.Error;
+        // Distinguish "max attempts exhausted" (we recorded the type as
+        // WaitForConditionException above) from "check function threw"
+        // (recorded as the original exception type via StepException).
+        if (err?.ErrorType == typeof(WaitForConditionException).FullName)
+        {
+            // Recover LastState from the FAIL checkpoint's Error.ErrorData.
+            // Live execution serializes the most recent state alongside the
+            // error so replay surfaces an identically-populated exception.
+            // Falls back to null when ErrorData is absent (legacy data
+            // pre-dating this serialization) or unreadable.
+            object? lastState = null;
+            var lastStatePayload = err?.ErrorData;
+            if (lastStatePayload != null)
+            {
+                try
+                {
+                    var bytes = Encoding.UTF8.GetBytes(lastStatePayload);
+                    using var ms = new MemoryStream(bytes);
+                    lastState = _serializer.Deserialize<TState>(ms);
+                }
+                catch (Exception deserEx)
+                {
+                    _logger.LogWarning(
+                        "WaitForCondition operation '{OperationId}' failed to deserialize LastState from FAIL checkpoint ErrorData ({ExceptionType}: {Message}); LastState will be null on the rethrown exception.",
+                        OperationId, deserEx.GetType().FullName, deserEx.Message);
+                }
+            }
+
+            return new WaitForConditionException(err?.ErrorMessage ?? $"WaitForCondition '{Name ?? OperationId}' exhausted attempts.")
+            {
+                AttemptsExhausted = failedOp.StepDetails?.Attempt ?? 0,
+                LastState = lastState
+            };
+        }
+
+        return new StepException(err?.ErrorMessage ?? "WaitForCondition check function failed")
+        {
+            ErrorType = err?.ErrorType,
+            ErrorData = err?.ErrorData,
+            OriginalStackTrace = err?.StackTrace
+        };
+    }
+
+    private static SdkErrorObject ToSdkError(Exception ex) => new()
+    {
+        ErrorType = ex.GetType().FullName,
+        ErrorMessage = ex.Message,
+        StackTrace = ex.StackTrace?.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).ToList()
+    };
+}
+
+/// <summary>
+/// Internal implementation of <see cref="IConditionCheckContext"/>.
+/// </summary>
+internal sealed class ConditionCheckContext : IConditionCheckContext
+{
+    public ConditionCheckContext(int attemptNumber, ILogger logger)
+    {
+        AttemptNumber = attemptNumber;
+        Logger = logger;
+    }
+
+    public ILogger Logger { get; }
+    public int AttemptNumber { get; }
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Operation.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Operation.cs
@@ -195,6 +195,9 @@ public static class OperationSubTypes
 
     /// <summary>Child-context sub-type.</summary>
     public const string Context = "Context";
+
+    /// <summary>Wait-for-condition (polling) sub-type.</summary>
+    public const string WaitForCondition = "WaitForCondition";
 }
 
 /// <summary>

--- a/Libraries/src/Amazon.Lambda.DurableExecution/README.md
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/README.md
@@ -19,6 +19,7 @@ Your handler delegates to `DurableFunction.WrapAsync`, which gives your workflow
 
 - `ctx.StepAsync` — run code and checkpoint the result. ([docs](docs/core/steps.md))
 - `ctx.WaitAsync` — suspend execution without compute charges. ([docs](docs/core/wait.md))
+- `ctx.WaitForConditionAsync` — poll a check function until a condition is met, suspending between polls. ([docs](docs/core/wait-for-condition.md))
 - `ctx.CreateCallbackAsync` / `ctx.WaitForCallbackAsync` — wait for external events (approvals, webhooks). ([docs](docs/core/callbacks.md))
 - `ctx.RunInChildContextAsync` — run an isolated child context with its own checkpoint log. ([docs](docs/core/child-contexts.md))
 
@@ -92,6 +93,7 @@ For AOT or trim-friendly serialization, swap `DefaultLambdaJsonSerializer` for `
 
 - [Steps](docs/core/steps.md) — execute code with automatic checkpointing, retry strategies, and at-least/at-most-once semantics.
 - [Wait](docs/core/wait.md) — pause execution without compute charges.
+- [Wait For Condition](docs/core/wait-for-condition.md) — poll until a condition is met, suspending between polls with a configurable wait strategy.
 - [Callbacks](docs/core/callbacks.md) — wait for external systems to respond.
 - [Child Contexts](docs/core/child-contexts.md) — group related operations into isolated, checkpointed units.
 

--- a/Libraries/src/Amazon.Lambda.DurableExecution/RetryStrategy.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/RetryStrategy.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Text.RegularExpressions;
+using Amazon.Lambda.DurableExecution.Internal;
 
 namespace Amazon.Lambda.DurableExecution;
 
@@ -175,19 +176,7 @@ internal sealed class ExponentialRetryStrategy : IRetryStrategy
     }
 
     internal TimeSpan CalculateDelay(int attemptNumber)
-    {
-        var baseDelay = _initialDelay.TotalSeconds * Math.Pow(_backoffRate, attemptNumber - 1);
-        var cappedDelay = Math.Min(baseDelay, _maxDelay.TotalSeconds);
-
-        var finalDelay = _jitter switch
-        {
-            JitterStrategy.Full => Random.Shared.NextDouble() * cappedDelay,
-            JitterStrategy.Half => cappedDelay * (0.5 + 0.5 * Random.Shared.NextDouble()),
-            _ => cappedDelay
-        };
-
-        return TimeSpan.FromSeconds(Math.Max(1, Math.Ceiling(finalDelay)));
-    }
+        => ExponentialBackoff.CalculateDelay(attemptNumber, _initialDelay, _maxDelay, _backoffRate, _jitter);
 }
 
 internal sealed class DelegateRetryStrategy : IRetryStrategy

--- a/Libraries/src/Amazon.Lambda.DurableExecution/WaitDecision.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/WaitDecision.cs
@@ -1,0 +1,42 @@
+namespace Amazon.Lambda.DurableExecution;
+
+/// <summary>
+/// Decision returned by an <see cref="IWaitStrategy{TState}"/> on each polling
+/// iteration: either stop polling (the condition has been met or attempts
+/// have been exhausted) or continue after the given delay.
+/// </summary>
+public readonly record struct WaitDecision
+{
+    /// <summary>
+    /// True when the strategy wants the operation to keep polling; false when
+    /// the operation should terminate (condition satisfied or limit reached).
+    /// </summary>
+    public bool ShouldContinue { get; }
+
+    /// <summary>
+    /// Delay before the next poll. Only meaningful when
+    /// <see cref="ShouldContinue"/> is <c>true</c>; otherwise
+    /// <see cref="TimeSpan.Zero"/>. The wire-level timer floors this at 1
+    /// second.
+    /// </summary>
+    public TimeSpan Delay { get; }
+
+    private WaitDecision(bool shouldContinue, TimeSpan delay)
+    {
+        ShouldContinue = shouldContinue;
+        Delay = delay;
+    }
+
+    /// <summary>
+    /// Stop polling. The current state is treated as the final result of the
+    /// wait-for-condition operation and returned to the caller.
+    /// </summary>
+    public static WaitDecision Stop() => new(false, TimeSpan.Zero);
+
+    /// <summary>
+    /// Continue polling after the given delay. The Lambda is suspended until
+    /// the delay elapses, at which point the service re-invokes and the
+    /// condition is re-evaluated.
+    /// </summary>
+    public static WaitDecision ContinueAfter(TimeSpan delay) => new(true, delay);
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/WaitForConditionConfig.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/WaitForConditionConfig.cs
@@ -1,0 +1,29 @@
+namespace Amazon.Lambda.DurableExecution;
+
+/// <summary>
+/// Configuration for a <c>WaitForConditionAsync</c> polling operation.
+/// </summary>
+/// <remarks>
+/// Both properties are required: the strategy decides "continue or stop"
+/// (per-call) and the initial state seeds the very first check invocation.
+/// On replay, the latest checkpointed state is restored from the previous
+/// RETRY checkpoint and used in place of <see cref="InitialState"/>; this
+/// is what makes the polling loop survive Lambda re-invocations
+/// deterministically.
+/// </remarks>
+/// <typeparam name="TState">The state type produced by the check function.</typeparam>
+public sealed class WaitForConditionConfig<TState>
+{
+    /// <summary>
+    /// Initial state passed to the very first invocation of the check
+    /// function. Subsequent invocations receive the state returned by the
+    /// previous call.
+    /// </summary>
+    public required TState InitialState { get; set; }
+
+    /// <summary>
+    /// Strategy that decides, after each check invocation, whether to keep
+    /// polling and how long to wait before the next attempt.
+    /// </summary>
+    public required IWaitStrategy<TState> WaitStrategy { get; set; }
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/WaitForConditionException.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/WaitForConditionException.cs
@@ -1,0 +1,42 @@
+namespace Amazon.Lambda.DurableExecution;
+
+/// <summary>
+/// Thrown when a <c>WaitForConditionAsync</c> operation reaches its
+/// strategy's max-attempts limit without the condition being met.
+/// </summary>
+/// <remarks>
+/// Designed to be subclassable: future failure modes (e.g. timeout once that's
+/// implemented) should be added as derived exceptions rather than discriminator
+/// flags on this type, so users can catch them by static type.
+/// <see cref="LastState"/> exposes the most recently observed state so callers
+/// can incorporate it into the failure path (logging, partial results, etc.).
+/// </remarks>
+public class WaitForConditionException : DurableExecutionException
+{
+    /// <summary>
+    /// Number of attempts the strategy made before giving up. 1-based.
+    /// </summary>
+    public int AttemptsExhausted { get; init; }
+
+    /// <summary>
+    /// The most recent state observed by the check function before the
+    /// strategy decided to stop. Boxed because the exception type is not
+    /// generic; callers cast to the workflow's known state type.
+    /// </summary>
+    /// <remarks>
+    /// Populated identically on live execution and on replay: the operation
+    /// serializes the last observed state into the FAIL checkpoint payload,
+    /// so a re-invocation that hits the cached FAIL reconstructs the same
+    /// <c>LastState</c> the original execution surfaced. Will be <c>null</c>
+    /// only if the FAIL checkpoint predates this serialization (legacy data)
+    /// or if the serializer cannot round-trip the state.
+    /// </remarks>
+    public object? LastState { get; init; }
+
+    /// <summary>Creates an empty <see cref="WaitForConditionException"/>.</summary>
+    public WaitForConditionException() { }
+    /// <summary>Creates a <see cref="WaitForConditionException"/> with the given message.</summary>
+    public WaitForConditionException(string message) : base(message) { }
+    /// <summary>Creates a <see cref="WaitForConditionException"/> wrapping an inner exception.</summary>
+    public WaitForConditionException(string message, Exception innerException) : base(message, innerException) { }
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/WaitStrategy.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/WaitStrategy.cs
@@ -1,0 +1,222 @@
+using Amazon.Lambda.DurableExecution.Internal;
+
+namespace Amazon.Lambda.DurableExecution;
+
+/// <summary>
+/// Factory methods for built-in <see cref="IWaitStrategy{TState}"/>
+/// implementations used with
+/// <c>IDurableContext.WaitForConditionAsync</c>.
+/// </summary>
+/// <remarks>
+/// Each factory accepts an optional <c>isDone</c> predicate so users can
+/// terminate polling declaratively when the latest state satisfies a
+/// condition (e.g. <c>state =&gt; state.IsReady</c>) without implementing
+/// <see cref="IWaitStrategy{TState}"/> themselves. If <c>isDone</c> is
+/// <c>null</c>, the strategy polls until <c>maxAttempts</c> is exhausted —
+/// at which point a <see cref="WaitForConditionException"/> is thrown by
+/// the operation. Defaults are intentionally tuned for polling, not for
+/// retry-on-exception: 60 attempts / 5s initial / 300s max / 1.5x backoff /
+/// Full jitter (matches Python+JS+Java reference SDKs).
+/// </remarks>
+public static class WaitStrategy
+{
+    /// <summary>
+    /// Exponential-backoff wait strategy. Defaults: 60 attempts, 5s initial
+    /// delay, 5min (300s) max delay, 1.5x backoff, Full jitter — matching
+    /// the Python, JS, and Java reference SDKs.
+    /// </summary>
+    /// <param name="maxAttempts">Maximum polling attempts before the operation throws <see cref="WaitForConditionException"/>.</param>
+    /// <param name="initialDelay">Delay before the second attempt; subsequent delays multiply by <paramref name="backoffRate"/> up to <paramref name="maxDelay"/>.</param>
+    /// <param name="maxDelay">Cap on the per-attempt delay.</param>
+    /// <param name="backoffRate">Multiplier applied per attempt.</param>
+    /// <param name="jitter">Jitter strategy applied to each delay.</param>
+    /// <param name="isDone">Optional predicate evaluated against the latest state; when it returns <c>true</c>, polling stops and the state is returned.</param>
+    public static IWaitStrategy<TState> Exponential<TState>(
+        int maxAttempts = 60,
+        TimeSpan? initialDelay = null,
+        TimeSpan? maxDelay = null,
+        double backoffRate = 1.5,
+        JitterStrategy jitter = JitterStrategy.Full,
+        Func<TState, bool>? isDone = null)
+    {
+        return new ExponentialWaitStrategy<TState>(
+            maxAttempts,
+            initialDelay ?? TimeSpan.FromSeconds(5),
+            maxDelay ?? TimeSpan.FromSeconds(300),
+            backoffRate,
+            jitter,
+            isDone);
+    }
+
+    /// <summary>
+    /// Linear-growth wait strategy. The delay starts at
+    /// <paramref name="initialDelay"/> and grows by
+    /// <paramref name="increment"/> each attempt, up to
+    /// <paramref name="maxDelay"/>.
+    /// </summary>
+    /// <param name="maxAttempts">Maximum polling attempts before the operation throws <see cref="WaitForConditionException"/>.</param>
+    /// <param name="initialDelay">Delay before the second attempt.</param>
+    /// <param name="increment">Amount added to the delay on each subsequent attempt.</param>
+    /// <param name="maxDelay">Cap on the per-attempt delay; <c>null</c> means no cap.</param>
+    /// <param name="isDone">Optional predicate evaluated against the latest state; when it returns <c>true</c>, polling stops and the state is returned.</param>
+    public static IWaitStrategy<TState> Linear<TState>(
+        int maxAttempts = 60,
+        TimeSpan? initialDelay = null,
+        TimeSpan? increment = null,
+        TimeSpan? maxDelay = null,
+        Func<TState, bool>? isDone = null)
+    {
+        return new LinearWaitStrategy<TState>(
+            maxAttempts,
+            initialDelay ?? TimeSpan.FromSeconds(5),
+            increment ?? TimeSpan.FromSeconds(5),
+            maxDelay,
+            isDone);
+    }
+
+    /// <summary>
+    /// Fixed-delay wait strategy. Every poll waits the same
+    /// <paramref name="delay"/>.
+    /// </summary>
+    /// <param name="delay">Fixed delay between polls.</param>
+    /// <param name="maxAttempts">Maximum polling attempts before the operation throws <see cref="WaitForConditionException"/>.</param>
+    /// <param name="isDone">Optional predicate evaluated against the latest state; when it returns <c>true</c>, polling stops and the state is returned.</param>
+    public static IWaitStrategy<TState> Fixed<TState>(
+        TimeSpan delay,
+        int maxAttempts = 60,
+        Func<TState, bool>? isDone = null)
+    {
+        return new FixedWaitStrategy<TState>(maxAttempts, delay, isDone);
+    }
+
+    /// <summary>
+    /// Wraps an arbitrary delegate as an <see cref="IWaitStrategy{TState}"/>.
+    /// </summary>
+    public static IWaitStrategy<TState> FromDelegate<TState>(Func<TState, int, WaitDecision> strategy)
+        => new DelegateWaitStrategy<TState>(strategy);
+}
+
+internal sealed class ExponentialWaitStrategy<TState> : IWaitStrategy<TState>
+{
+    private readonly int _maxAttempts;
+    private readonly TimeSpan _initialDelay;
+    private readonly TimeSpan _maxDelay;
+    private readonly double _backoffRate;
+    private readonly JitterStrategy _jitter;
+    private readonly Func<TState, bool>? _isDone;
+
+    public ExponentialWaitStrategy(
+        int maxAttempts,
+        TimeSpan initialDelay,
+        TimeSpan maxDelay,
+        double backoffRate,
+        JitterStrategy jitter,
+        Func<TState, bool>? isDone)
+    {
+        _maxAttempts = maxAttempts;
+        _initialDelay = initialDelay;
+        _maxDelay = maxDelay;
+        _backoffRate = backoffRate;
+        _jitter = jitter;
+        _isDone = isDone;
+    }
+
+    public WaitDecision Decide(TState state, int attemptNumber)
+    {
+        // Predicate satisfied → stop normally (operation SUCCEEDs).
+        if (_isDone != null && _isDone(state)) return WaitDecision.Stop();
+
+        // Attempts saturated → throw WaitForConditionException directly.
+        // Matches the JS reference SDK (wait-strategy-config.ts:54-57); lets
+        // the operation distinguish "condition met" (Stop) from "gave up"
+        // (exception) without a discriminator on WaitDecision. The operation
+        // catches, populates LastState (which the strategy doesn't have
+        // access to), checkpoints FAIL, and rethrows.
+        if (attemptNumber >= _maxAttempts)
+            throw new WaitForConditionException(
+                $"WaitForCondition exceeded maximum attempts ({_maxAttempts}).")
+            {
+                AttemptsExhausted = attemptNumber
+            };
+
+        var delay = ExponentialBackoff.CalculateDelay(
+            attemptNumber, _initialDelay, _maxDelay, _backoffRate, _jitter);
+        return WaitDecision.ContinueAfter(delay);
+    }
+}
+
+internal sealed class LinearWaitStrategy<TState> : IWaitStrategy<TState>
+{
+    private readonly int _maxAttempts;
+    private readonly TimeSpan _initialDelay;
+    private readonly TimeSpan _increment;
+    private readonly TimeSpan? _maxDelay;
+    private readonly Func<TState, bool>? _isDone;
+
+    public LinearWaitStrategy(
+        int maxAttempts,
+        TimeSpan initialDelay,
+        TimeSpan increment,
+        TimeSpan? maxDelay,
+        Func<TState, bool>? isDone)
+    {
+        _maxAttempts = maxAttempts;
+        _initialDelay = initialDelay;
+        _increment = increment;
+        _maxDelay = maxDelay;
+        _isDone = isDone;
+    }
+
+    public WaitDecision Decide(TState state, int attemptNumber)
+    {
+        if (_isDone != null && _isDone(state)) return WaitDecision.Stop();
+        if (attemptNumber >= _maxAttempts)
+            throw new WaitForConditionException(
+                $"WaitForCondition exceeded maximum attempts ({_maxAttempts}).")
+            {
+                AttemptsExhausted = attemptNumber
+            };
+
+        var rawSeconds = _initialDelay.TotalSeconds + _increment.TotalSeconds * (attemptNumber - 1);
+        if (_maxDelay is { } cap) rawSeconds = Math.Min(rawSeconds, cap.TotalSeconds);
+
+        // Floor at 1 second to match the service timer granularity.
+        var seconds = Math.Max(1, Math.Ceiling(rawSeconds));
+        return WaitDecision.ContinueAfter(TimeSpan.FromSeconds(seconds));
+    }
+}
+
+internal sealed class FixedWaitStrategy<TState> : IWaitStrategy<TState>
+{
+    private readonly int _maxAttempts;
+    private readonly TimeSpan _delay;
+    private readonly Func<TState, bool>? _isDone;
+
+    public FixedWaitStrategy(int maxAttempts, TimeSpan delay, Func<TState, bool>? isDone)
+    {
+        _maxAttempts = maxAttempts;
+        _delay = delay;
+        _isDone = isDone;
+    }
+
+    public WaitDecision Decide(TState state, int attemptNumber)
+    {
+        if (_isDone != null && _isDone(state)) return WaitDecision.Stop();
+        if (attemptNumber >= _maxAttempts)
+            throw new WaitForConditionException(
+                $"WaitForCondition exceeded maximum attempts ({_maxAttempts}).")
+            {
+                AttemptsExhausted = attemptNumber
+            };
+
+        var seconds = Math.Max(1, Math.Ceiling(_delay.TotalSeconds));
+        return WaitDecision.ContinueAfter(TimeSpan.FromSeconds(seconds));
+    }
+}
+
+internal sealed class DelegateWaitStrategy<TState> : IWaitStrategy<TState>
+{
+    private readonly Func<TState, int, WaitDecision> _strategy;
+    public DelegateWaitStrategy(Func<TState, int, WaitDecision> strategy) => _strategy = strategy;
+    public WaitDecision Decide(TState state, int attemptNumber) => _strategy(state, attemptNumber);
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/docs/core/wait-for-condition.md
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/docs/core/wait-for-condition.md
@@ -1,0 +1,116 @@
+# Wait For Condition
+
+`WaitForConditionAsync` polls a check function until a wait strategy decides to stop. Between polls the workflow is suspended — the Lambda terminates and is re-invoked when the strategy's chosen delay elapses, so you pay for compute time only while the check actually runs.
+
+Use it when you're waiting on something whose readiness you can only learn by *asking* (an order settling, a file landing in S3, an external job finishing) rather than waiting a fixed duration. For a fixed-duration pause, use [`WaitAsync`](wait.md) instead.
+
+## Signature
+
+```csharp
+Task<TState> WaitForConditionAsync<TState>(
+    Func<TState, IConditionCheckContext, Task<TState>> check,
+    WaitForConditionConfig<TState> config,
+    string? name = null,
+    CancellationToken cancellationToken = default);
+```
+
+On every iteration the `check` function receives the state returned by the previous invocation — seeded by `config.InitialState` on the very first call — and returns the next state. The configured `IWaitStrategy<TState>` then decides whether to keep polling and how long to wait. State is checkpointed each iteration, so the polling loop survives Lambda re-invocations deterministically and you can carry per-poll bookkeeping (a cursor, a counter) inside the state itself.
+
+The `IConditionCheckContext` parameter exposes the current `AttemptNumber` (1-based) and a scoped `Logger`. The returned state is serialized via the `ILambdaSerializer` registered on `ILambdaContext.Serializer`.
+
+When the strategy stops because its `maxAttempts` limit is reached — rather than because the condition was met — the operation throws `WaitForConditionException` carrying `AttemptsExhausted` and the last observed `LastState`.
+
+## Example
+
+Poll an order's status until it reaches a terminal value:
+
+```csharp
+var finalStatus = await ctx.WaitForConditionAsync(
+    check: async (state, checkCtx) =>
+    {
+        checkCtx.Logger.LogInformation("Polling order on attempt {Attempt}", checkCtx.AttemptNumber);
+        return await orderService.GetStatusAsync(orderId);
+    },
+    config: new WaitForConditionConfig<OrderStatus>
+    {
+        InitialState = OrderStatus.Unknown,
+        WaitStrategy = WaitStrategy.Exponential<OrderStatus>(
+            isDone: s => s == OrderStatus.Completed || s == OrderStatus.Cancelled)
+    },
+    name: "wait-for-order-settle");
+```
+
+## Configuration
+
+```csharp
+public sealed class WaitForConditionConfig<TState>
+{
+    public required TState InitialState { get; set; }              // seeds the first check call
+    public required IWaitStrategy<TState> WaitStrategy { get; set; } // decides continue/stop + delay
+}
+```
+
+## Wait strategies
+
+The check function reports state; the `IWaitStrategy<TState>` decides what to do with it. Each built-in strategy on the `WaitStrategy` static class accepts an optional `isDone` predicate, so the common case — stop when the latest state satisfies a condition — stays declarative without implementing the interface yourself.
+
+| Member | Behavior |
+| --- | --- |
+| `WaitStrategy.Exponential<TState>(...)` | Delay grows by `backoffRate` each attempt, up to `maxDelay`. Defaults: 60 attempts, 5s initial, 300s max, 1.5× backoff, Full jitter. |
+| `WaitStrategy.Linear<TState>(...)` | Delay grows by a fixed `increment` each attempt, optionally capped at `maxDelay`. Defaults: 60 attempts, 5s initial, 5s increment. |
+| `WaitStrategy.Fixed<TState>(delay, ...)` | Every poll waits the same `delay`. Default: 60 attempts. |
+| `WaitStrategy.FromDelegate<TState>(Func<TState, int, WaitDecision>)` | Wrap a custom decision function. |
+
+These defaults are tuned for *polling*, not retry-on-exception, and match the Python, JS, and Java reference SDKs.
+
+```csharp
+public static IWaitStrategy<TState> Exponential<TState>(
+    int maxAttempts = 60,
+    TimeSpan? initialDelay = null,         // default 5s
+    TimeSpan? maxDelay = null,             // default 300s
+    double backoffRate = 1.5,
+    JitterStrategy jitter = JitterStrategy.Full,
+    Func<TState, bool>? isDone = null);
+```
+
+### Custom strategies
+
+For richer logic (wall-clock budgets, conditional jitter), use `FromDelegate` or implement `IWaitStrategy<TState>` directly. `Decide` returns a `WaitDecision`:
+
+```csharp
+public interface IWaitStrategy<TState>
+{
+    WaitDecision Decide(TState state, int attemptNumber);
+}
+
+public readonly record struct WaitDecision
+{
+    public bool ShouldContinue { get; }
+    public TimeSpan Delay { get; }   // floored at 1s by the service timer
+
+    public static WaitDecision Stop();                      // condition met → return current state
+    public static WaitDecision ContinueAfter(TimeSpan delay); // suspend, re-evaluate after delay
+}
+```
+
+`Stop()` ends the operation successfully and returns the latest state. `ContinueAfter(delay)` suspends the Lambda until the delay elapses. To signal "gave up," a strategy throws `WaitForConditionException` (the built-in strategies do this when `attemptNumber` reaches `maxAttempts`).
+
+## `WaitForCondition` vs. retries
+
+`IWaitStrategy<TState>` is distinct from [`IRetryStrategy`](steps.md#retry-strategies): a retry strategy decides whether to retry *after an exception* (its input is the thrown `Exception`), while a wait strategy decides whether to keep polling *based on observed state* (its input is the latest `TState`). If the check function itself throws, that error surfaces as a `StepException` — the wait strategy is not consulted.
+
+## Failure handling
+
+```csharp
+try
+{
+    var status = await ctx.WaitForConditionAsync(check, config, name: "poll-job");
+}
+catch (WaitForConditionException ex)
+{
+    // Strategy exhausted its attempts without the condition being met.
+    var attempts = ex.AttemptsExhausted;
+    var last = (JobStatus?)ex.LastState;   // boxed — cast to your state type
+    ctx.Logger.LogWarning("Gave up after {Attempts} polls; last status was {Status}", attempts, last);
+}
+```

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionExponentialFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionExponentialFunction/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/provided:al2023
+
+RUN dnf install -y libicu
+
+COPY bin/publish/ ${LAMBDA_TASK_ROOT}
+
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionExponentialFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionExponentialFunction/Function.cs
@@ -1,0 +1,66 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace DurableExecutionTestFunction;
+
+public class Function
+{
+    public static async Task Main(string[] args)
+    {
+        var handler = new Function();
+        var serializer = new DefaultLambdaJsonSerializer();
+        using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<DurableExecutionInvocationInput, DurableExecutionInvocationOutput>(handler.Handler, serializer);
+        using var bootstrap = new LambdaBootstrap(handlerWrapper);
+        await bootstrap.RunAsync();
+    }
+
+    public Task<DurableExecutionInvocationOutput> Handler(
+        DurableExecutionInvocationInput input, ILambdaContext context)
+        => DurableFunction.WrapAsync<TestEvent, TestResult>(Workflow, input, context);
+
+    private async Task<TestResult> Workflow(TestEvent input, IDurableContext context)
+    {
+        // Exponential strategy with no jitter so the timing is predictable.
+        // Done flips on attempt 3 (1-based). With initialDelay=1s,
+        // backoffRate=1.5, maxDelay=4s, no jitter: delays are 1s, 1.5s
+        // (which the SDK ceilings to 2s due to 1s timer granularity).
+        var finalState = await context.WaitForConditionAsync<State>(
+            check: async (state, ctx) =>
+            {
+                await Task.CompletedTask;
+                var done = ctx.AttemptNumber >= 3;
+                return new State(done, ctx.AttemptNumber);
+            },
+            config: new WaitForConditionConfig<State>
+            {
+                InitialState = new State(false, 0),
+                WaitStrategy = WaitStrategy.Exponential<State>(
+                    maxAttempts: 5,
+                    initialDelay: TimeSpan.FromSeconds(1),
+                    maxDelay: TimeSpan.FromSeconds(4),
+                    backoffRate: 1.5,
+                    jitter: JitterStrategy.None,
+                    isDone: s => s.Done)
+            },
+            name: "exp_poll");
+
+        return new TestResult
+        {
+            Status = "completed",
+            AttemptsTaken = finalState.AttemptNumber,
+            Done = finalState.Done
+        };
+    }
+}
+
+public record State(bool Done, int AttemptNumber);
+
+public class TestEvent { public string? OrderId { get; set; } }
+public class TestResult
+{
+    public string? Status { get; set; }
+    public int AttemptsTaken { get; set; }
+    public bool Done { get; set; }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionExponentialFunction/WaitForConditionExponentialFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionExponentialFunction/WaitForConditionExponentialFunction.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>bootstrap</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionHappyPathFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionHappyPathFunction/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/provided:al2023
+
+RUN dnf install -y libicu
+
+COPY bin/publish/ ${LAMBDA_TASK_ROOT}
+
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionHappyPathFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionHappyPathFunction/Function.cs
@@ -1,0 +1,61 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace DurableExecutionTestFunction;
+
+public class Function
+{
+    public static async Task Main(string[] args)
+    {
+        var handler = new Function();
+        var serializer = new DefaultLambdaJsonSerializer();
+        using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<DurableExecutionInvocationInput, DurableExecutionInvocationOutput>(handler.Handler, serializer);
+        using var bootstrap = new LambdaBootstrap(handlerWrapper);
+        await bootstrap.RunAsync();
+    }
+
+    public Task<DurableExecutionInvocationOutput> Handler(
+        DurableExecutionInvocationInput input, ILambdaContext context)
+        => DurableFunction.WrapAsync<TestEvent, TestResult>(Workflow, input, context);
+
+    private async Task<TestResult> Workflow(TestEvent input, IDurableContext context)
+    {
+        // Counter increments every poll. isDone fires once it hits 3.
+        // Each poll iteration is a separate Lambda invocation; the state is
+        // carried across iterations via the RETRY checkpoint payload.
+        var finalState = await context.WaitForConditionAsync<State>(
+            check: async (state, ctx) =>
+            {
+                await Task.CompletedTask;
+                return new State(state.Counter + 1, ctx.AttemptNumber);
+            },
+            config: new WaitForConditionConfig<State>
+            {
+                InitialState = new State(0, 0),
+                WaitStrategy = WaitStrategy.Fixed<State>(
+                    delay: TimeSpan.FromSeconds(2),
+                    maxAttempts: 10,
+                    isDone: s => s.Counter >= 3)
+            },
+            name: "happy_poll");
+
+        return new TestResult
+        {
+            Status = "completed",
+            Counter = finalState.Counter,
+            AttemptsTaken = finalState.AttemptNumber
+        };
+    }
+}
+
+public record State(int Counter, int AttemptNumber);
+
+public class TestEvent { public string? OrderId { get; set; } }
+public class TestResult
+{
+    public string? Status { get; set; }
+    public int Counter { get; set; }
+    public int AttemptsTaken { get; set; }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionHappyPathFunction/WaitForConditionHappyPathFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionHappyPathFunction/WaitForConditionHappyPathFunction.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>bootstrap</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionMaxAttemptsFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionMaxAttemptsFunction/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/provided:al2023
+
+RUN dnf install -y libicu
+
+COPY bin/publish/ ${LAMBDA_TASK_ROOT}
+
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionMaxAttemptsFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionMaxAttemptsFunction/Function.cs
@@ -1,0 +1,62 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace DurableExecutionTestFunction;
+
+public class Function
+{
+    public static async Task Main(string[] args)
+    {
+        var handler = new Function();
+        var serializer = new DefaultLambdaJsonSerializer();
+        using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<DurableExecutionInvocationInput, DurableExecutionInvocationOutput>(handler.Handler, serializer);
+        using var bootstrap = new LambdaBootstrap(handlerWrapper);
+        await bootstrap.RunAsync();
+    }
+
+    public Task<DurableExecutionInvocationOutput> Handler(
+        DurableExecutionInvocationInput input, ILambdaContext context)
+        => DurableFunction.WrapAsync<TestEvent, TestResult>(Workflow, input, context);
+
+    private async Task<TestResult> Workflow(TestEvent input, IDurableContext context)
+    {
+        // Condition is never satisfied (isDone is always false), so the
+        // strategy will eventually exhaust maxAttempts and the operation will
+        // throw WaitForConditionException. The workflow catches it and
+        // surfaces AttemptsExhausted in the result so the test can assert on
+        // it without inspecting the FAILED status.
+        try
+        {
+            await context.WaitForConditionAsync<int>(
+                check: async (state, _) =>
+                {
+                    await Task.CompletedTask;
+                    return state + 1;
+                },
+                config: new WaitForConditionConfig<int>
+                {
+                    InitialState = 0,
+                    WaitStrategy = WaitStrategy.Fixed<int>(
+                        delay: TimeSpan.FromSeconds(1),
+                        maxAttempts: 3,
+                        isDone: _ => false)
+                },
+                name: "exhausting_poll");
+
+            return new TestResult { Status = "should_not_reach", AttemptsExhausted = -1 };
+        }
+        catch (WaitForConditionException ex)
+        {
+            return new TestResult { Status = "exhausted", AttemptsExhausted = ex.AttemptsExhausted };
+        }
+    }
+}
+
+public class TestEvent { public string? OrderId { get; set; } }
+public class TestResult
+{
+    public string? Status { get; set; }
+    public int AttemptsExhausted { get; set; }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionMaxAttemptsFunction/WaitForConditionMaxAttemptsFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionMaxAttemptsFunction/WaitForConditionMaxAttemptsFunction.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>bootstrap</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionReplayDeterminismFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionReplayDeterminismFunction/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/provided:al2023
+
+RUN dnf install -y libicu
+
+COPY bin/publish/ ${LAMBDA_TASK_ROOT}
+
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionReplayDeterminismFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionReplayDeterminismFunction/Function.cs
@@ -1,0 +1,63 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace DurableExecutionTestFunction;
+
+public class Function
+{
+    public static async Task Main(string[] args)
+    {
+        var handler = new Function();
+        var serializer = new DefaultLambdaJsonSerializer();
+        using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<DurableExecutionInvocationInput, DurableExecutionInvocationOutput>(handler.Handler, serializer);
+        using var bootstrap = new LambdaBootstrap(handlerWrapper);
+        await bootstrap.RunAsync();
+    }
+
+    public Task<DurableExecutionInvocationOutput> Handler(
+        DurableExecutionInvocationInput input, ILambdaContext context)
+        => DurableFunction.WrapAsync<TestEvent, TestResult>(Workflow, input, context);
+
+    private async Task<TestResult> Workflow(TestEvent input, IDurableContext context)
+    {
+        // Step 1: capture a fresh value. On replay this MUST return the
+        // checkpointed value rather than re-executing.
+        var generatedId = await context.StepAsync(
+            async (_) => { await Task.CompletedTask; return Guid.NewGuid().ToString(); },
+            name: "before_poll");
+
+        // Wait-for-condition with 3 polls. Each poll iteration is a separate
+        // invocation, and the operation's deterministic ID + RETRY-payload
+        // state must round-trip across re-invocations.
+        var pollResult = await context.WaitForConditionAsync<Counter>(
+            check: async (state, ctx) =>
+            {
+                await Task.CompletedTask;
+                return new Counter(state.Count + 1);
+            },
+            config: new WaitForConditionConfig<Counter>
+            {
+                InitialState = new Counter(0),
+                WaitStrategy = WaitStrategy.Fixed<Counter>(
+                    delay: TimeSpan.FromSeconds(2),
+                    maxAttempts: 10,
+                    isDone: c => c.Count >= 3)
+            },
+            name: "determinism_poll");
+
+        // Step 2: echo the generated ID. After replay, this should see the
+        // SAME GUID from step 1 — proves replay returned the cached value.
+        var echoed = await context.StepAsync(
+            async (_) => { await Task.CompletedTask; return $"echo:{generatedId}:{pollResult.Count}"; },
+            name: "after_poll");
+
+        return new TestResult { Status = "completed", Data = echoed };
+    }
+}
+
+public record Counter(int Count);
+
+public class TestEvent { public string? OrderId { get; set; } }
+public class TestResult { public string? Status { get; set; } public string? Data { get; set; } }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionReplayDeterminismFunction/WaitForConditionReplayDeterminismFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionReplayDeterminismFunction/WaitForConditionReplayDeterminismFunction.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>bootstrap</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionUserCheckThrowsFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionUserCheckThrowsFunction/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/provided:al2023
+
+RUN dnf install -y libicu
+
+COPY bin/publish/ ${LAMBDA_TASK_ROOT}
+
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionUserCheckThrowsFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionUserCheckThrowsFunction/Function.cs
@@ -1,0 +1,66 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace DurableExecutionTestFunction;
+
+public class Function
+{
+    public static async Task Main(string[] args)
+    {
+        var handler = new Function();
+        var serializer = new DefaultLambdaJsonSerializer();
+        using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<DurableExecutionInvocationInput, DurableExecutionInvocationOutput>(handler.Handler, serializer);
+        using var bootstrap = new LambdaBootstrap(handlerWrapper);
+        await bootstrap.RunAsync();
+    }
+
+    public Task<DurableExecutionInvocationOutput> Handler(
+        DurableExecutionInvocationInput input, ILambdaContext context)
+        => DurableFunction.WrapAsync<TestEvent, TestResult>(Workflow, input, context);
+
+    private async Task<TestResult> Workflow(TestEvent input, IDurableContext context)
+    {
+        // The check function throws on attempt 2. Per the WaitForCondition
+        // contract, the check-thrown exception is checkpointed as FAIL and
+        // surfaced through the SDK as a StepException carrying the original
+        // exception type ("System.InvalidOperationException"). The workflow
+        // catches it and reports the captured ErrorType so the test can assert
+        // without requiring the workflow to FAIL outright.
+        try
+        {
+            await context.WaitForConditionAsync<int>(
+                check: async (state, ctx) =>
+                {
+                    await Task.CompletedTask;
+                    if (ctx.AttemptNumber == 2)
+                        throw new InvalidOperationException("intentional check failure on attempt 2");
+                    return state + 1;
+                },
+                config: new WaitForConditionConfig<int>
+                {
+                    InitialState = 0,
+                    WaitStrategy = WaitStrategy.Fixed<int>(
+                        delay: TimeSpan.FromSeconds(1),
+                        maxAttempts: 10,
+                        isDone: _ => false)
+                },
+                name: "throwing_poll");
+
+            return new TestResult { Status = "should_not_reach", ErrorType = null };
+        }
+        catch (StepException ex)
+        {
+            return new TestResult { Status = "caught_step_exception", ErrorType = ex.ErrorType, ErrorMessage = ex.Message };
+        }
+    }
+}
+
+public class TestEvent { public string? OrderId { get; set; } }
+public class TestResult
+{
+    public string? Status { get; set; }
+    public string? ErrorType { get; set; }
+    public string? ErrorMessage { get; set; }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionUserCheckThrowsFunction/WaitForConditionUserCheckThrowsFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/WaitForConditionUserCheckThrowsFunction/WaitForConditionUserCheckThrowsFunction.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>bootstrap</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/WaitForConditionExponentialTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/WaitForConditionExponentialTest.cs
@@ -1,0 +1,70 @@
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Amazon.Lambda.Model;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Amazon.Lambda.DurableExecution.IntegrationTests;
+
+public class WaitForConditionExponentialTest
+{
+    private readonly ITestOutputHelper _output;
+    public WaitForConditionExponentialTest(ITestOutputHelper output) => _output = output;
+
+    /// <summary>
+    /// End-to-end exponential-backoff polling. The check function flips
+    /// <c>Done</c> on attempt 3, so the strategy stops after exactly 3
+    /// iterations. Validates that the service honors the per-iteration delay
+    /// (which grows with each retry) without any in-process Thread.Sleep.
+    /// Timing is asserted loosely because the service's scheduling latency
+    /// dominates short delays — we only require the gap to be at least the
+    /// configured floor.
+    /// </summary>
+    [Fact]
+    public async Task WaitForCondition_ExponentialBackoff_CompletesOnExpectedAttempt()
+    {
+        await using var deployment = await DurableFunctionDeployment.CreateAsync(
+            DurableFunctionDeployment.FindTestFunctionDir("WaitForConditionExponentialFunction"),
+            "wfcexp", _output);
+
+        var (invokeResponse, executionName) = await deployment.InvokeAsync("""{"orderId": "wfc-exp"}""");
+        var responsePayload = Encoding.UTF8.GetString(invokeResponse.Payload.ToArray());
+        _output.WriteLine($"Response: {responsePayload}");
+
+        var arn = await deployment.FindDurableExecutionArnByNameAsync(executionName, TimeSpan.FromSeconds(60));
+        Assert.NotNull(arn);
+
+        // Total expected wall time: 1s + 2s of timer = ~3s + execution
+        // overhead. Allow generous headroom for service scheduling latency.
+        var status = await deployment.PollForCompletionAsync(arn!, TimeSpan.FromSeconds(120));
+        Assert.Equal("SUCCEEDED", status, ignoreCase: true);
+
+        var history = await deployment.WaitForHistoryAsync(
+            arn!,
+            h => (h.Events?.Any(e => e.StepSucceededDetails != null && e.Name == "exp_poll") ?? false),
+            TimeSpan.FromSeconds(60));
+        var events = history.Events ?? new List<Event>();
+
+        // Each polling iteration surfaces as a StepSucceeded event (one per
+        // RETRY plus one for the terminal SUCCEED). The last one carries the
+        // terminal state.
+        var succeededEvents = events.Where(e => e.StepSucceededDetails != null && e.Name == "exp_poll").ToList();
+        Assert.NotEmpty(succeededEvents);
+        var succeeded = succeededEvents.Last();
+
+        var finalPayload = succeeded.StepSucceededDetails.Result?.Payload;
+        Assert.False(string.IsNullOrEmpty(finalPayload));
+
+        using var doc = JsonDocument.Parse(finalPayload!);
+        Assert.True(doc.RootElement.GetProperty("Done").GetBoolean());
+        Assert.Equal(3, doc.RootElement.GetProperty("AttemptNumber").GetInt32());
+
+        // The polling caused real suspend/resume cycles — at least 3
+        // invocations (one per attempt).
+        var invocations = events.Where(e => e.InvocationCompletedDetails != null).ToList();
+        Assert.True(
+            invocations.Count >= 3,
+            $"Expected at least 3 InvocationCompleted events (one per poll), got {invocations.Count}");
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/WaitForConditionHappyPathTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/WaitForConditionHappyPathTest.cs
@@ -1,0 +1,74 @@
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Amazon.Lambda.Model;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Amazon.Lambda.DurableExecution.IntegrationTests;
+
+public class WaitForConditionHappyPathTest
+{
+    private readonly ITestOutputHelper _output;
+    public WaitForConditionHappyPathTest(ITestOutputHelper output) => _output = output;
+
+    /// <summary>
+    /// End-to-end happy-path polling. The check function increments a counter
+    /// every iteration; the strategy's isDone predicate fires once the counter
+    /// hits 3. Validates that the service honors the RETRY-with-delay pattern,
+    /// re-invokes the Lambda for each poll iteration, and that state survives
+    /// across re-invocations via the RETRY payload — none of which the unit
+    /// tests can prove (they fake state transitions in-memory).
+    /// </summary>
+    [Fact]
+    public async Task WaitForCondition_PollsUntilConditionMet()
+    {
+        await using var deployment = await DurableFunctionDeployment.CreateAsync(
+            DurableFunctionDeployment.FindTestFunctionDir("WaitForConditionHappyPathFunction"),
+            "wfchappy", _output);
+
+        var (invokeResponse, executionName) = await deployment.InvokeAsync("""{"orderId": "wfc-happy"}""");
+        var responsePayload = Encoding.UTF8.GetString(invokeResponse.Payload.ToArray());
+        _output.WriteLine($"Response: {responsePayload}");
+
+        var arn = await deployment.FindDurableExecutionArnByNameAsync(executionName, TimeSpan.FromSeconds(60));
+        Assert.NotNull(arn);
+
+        // Total expected wall time: 3 attempts with ~2s delay between them =
+        // ~4s of timer + execution overhead. Allow generous headroom.
+        var status = await deployment.PollForCompletionAsync(arn!, TimeSpan.FromSeconds(120));
+        Assert.Equal("SUCCEEDED", status, ignoreCase: true);
+
+        var history = await deployment.WaitForHistoryAsync(
+            arn!,
+            h => (h.Events?.Any(e => e.StepSucceededDetails != null) ?? false),
+            TimeSpan.FromSeconds(60));
+        var events = history.Events ?? new List<Event>();
+
+        // Exactly one START emitted on the first iteration (subsequent
+        // iterations resume from a RETRY checkpoint and skip START).
+        Assert.Equal(1, events.Count(e => e.EventType == EventType.StepStarted && e.Name == "happy_poll"));
+
+        // Each polling iteration surfaces as a StepSucceeded event (one per
+        // RETRY plus one for the terminal SUCCEED). The last one carries the
+        // terminal state.
+        var succeededEvents = events.Where(e => e.StepSucceededDetails != null && e.Name == "happy_poll").ToList();
+        Assert.NotEmpty(succeededEvents);
+        var succeeded = succeededEvents.Last();
+
+        var finalPayload = succeeded.StepSucceededDetails.Result?.Payload;
+        Assert.False(string.IsNullOrEmpty(finalPayload),
+            "final SUCCEED payload should carry the terminal state");
+
+        using var doc = JsonDocument.Parse(finalPayload!);
+        Assert.Equal(3, doc.RootElement.GetProperty("Counter").GetInt32());
+        Assert.Equal(3, doc.RootElement.GetProperty("AttemptNumber").GetInt32());
+
+        // The polling actually caused suspend/resume cycles — at least one
+        // invocation per iteration (3 polls = 3+ invocations).
+        var invocations = events.Where(e => e.InvocationCompletedDetails != null).ToList();
+        Assert.True(
+            invocations.Count >= 3,
+            $"Expected at least 3 InvocationCompleted events (one per poll iteration), got {invocations.Count}");
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/WaitForConditionMaxAttemptsTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/WaitForConditionMaxAttemptsTest.cs
@@ -1,0 +1,68 @@
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Amazon.Lambda.Model;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Amazon.Lambda.DurableExecution.IntegrationTests;
+
+public class WaitForConditionMaxAttemptsTest
+{
+    private readonly ITestOutputHelper _output;
+    public WaitForConditionMaxAttemptsTest(ITestOutputHelper output) => _output = output;
+
+    /// <summary>
+    /// Validates that when the strategy's max-attempts limit is reached
+    /// without isDone being satisfied, the operation throws
+    /// <see cref="WaitForConditionException"/> with the correct
+    /// <c>AttemptsExhausted</c> count, and the FAILED checkpoint records the
+    /// exception type. The workflow catches the exception and returns the
+    /// count, so we expect the workflow itself to SUCCEED.
+    /// </summary>
+    [Fact]
+    public async Task WaitForCondition_MaxAttemptsExhausted_ThrowsWithCount()
+    {
+        await using var deployment = await DurableFunctionDeployment.CreateAsync(
+            DurableFunctionDeployment.FindTestFunctionDir("WaitForConditionMaxAttemptsFunction"),
+            "wfcmax", _output);
+
+        var (invokeResponse, executionName) = await deployment.InvokeAsync("""{"orderId": "wfc-max"}""");
+        var responsePayload = Encoding.UTF8.GetString(invokeResponse.Payload.ToArray());
+        _output.WriteLine($"Response: {responsePayload}");
+
+        var arn = await deployment.FindDurableExecutionArnByNameAsync(executionName, TimeSpan.FromSeconds(60));
+        Assert.NotNull(arn);
+
+        // 3 attempts at ~1s delay between them = ~2s of timer + execution
+        // overhead. Allow generous headroom.
+        var status = await deployment.PollForCompletionAsync(arn!, TimeSpan.FromSeconds(120));
+        Assert.Equal("SUCCEEDED", status, ignoreCase: true);
+
+        // The workflow caught the WaitForConditionException and returned a
+        // result containing AttemptsExhausted. Verify the final payload from
+        // the workflow itself (parsed from the GetExecution response).
+        var execution = await deployment.GetExecutionAsync(arn!);
+        var resultPayload = execution.Result;
+        Assert.False(string.IsNullOrEmpty(resultPayload),
+            "workflow result payload should be present");
+
+        using var doc = JsonDocument.Parse(resultPayload!);
+        Assert.Equal("exhausted", doc.RootElement.GetProperty("Status").GetString());
+        // The exact attempts count is 3 — strategy maxAttempts.
+        Assert.Equal(3, doc.RootElement.GetProperty("AttemptsExhausted").GetInt32());
+
+        // Verify the operation itself was checkpointed as FAILED with the
+        // WaitForConditionException type, even though the workflow recovers.
+        var history = await deployment.WaitForHistoryAsync(
+            arn!,
+            h => (h.Events?.Any(e => e.StepFailedDetails != null && e.Name == "exhausting_poll") ?? false),
+            TimeSpan.FromSeconds(60));
+        var events = history.Events ?? new List<Event>();
+
+        var stepFailed = events.FirstOrDefault(e => e.StepFailedDetails != null && e.Name == "exhausting_poll");
+        Assert.NotNull(stepFailed);
+        Assert.Contains("WaitForConditionException",
+            stepFailed!.StepFailedDetails.Error?.Payload?.ErrorType ?? string.Empty);
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/WaitForConditionReplayDeterminismTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/WaitForConditionReplayDeterminismTest.cs
@@ -1,0 +1,90 @@
+using System.Linq;
+using System.Text;
+using Amazon.Lambda.Model;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Amazon.Lambda.DurableExecution.IntegrationTests;
+
+public class WaitForConditionReplayDeterminismTest
+{
+    private readonly ITestOutputHelper _output;
+    public WaitForConditionReplayDeterminismTest(ITestOutputHelper output) => _output = output;
+
+    /// <summary>
+    /// End-to-end replay-determinism check for a step + wait-for-condition +
+    /// step workflow. The wait-for-condition triggers multiple suspend/resume
+    /// cycles (one per polling iteration), so the surrounding steps are
+    /// replayed multiple times. Verifies that:
+    ///   1. The leading step is re-replayed (not re-executed) across all
+    ///      iterations — its checkpointed GUID flows through to the trailing
+    ///      step regardless of how many polling iterations happen.
+    ///   2. The wait-for-condition operation is checkpointed exactly once
+    ///      (one StepStarted), with one terminal SUCCEED carrying the final
+    ///      counter state.
+    ///   3. Multiple invocations were recorded (proves real replay happened).
+    /// </summary>
+    [Fact]
+    public async Task WaitForCondition_ReplayPreservesIdentityAndState()
+    {
+        await using var deployment = await DurableFunctionDeployment.CreateAsync(
+            DurableFunctionDeployment.FindTestFunctionDir("WaitForConditionReplayDeterminismFunction"),
+            "wfcrep", _output);
+
+        var (invokeResponse, executionName) = await deployment.InvokeAsync("""{"orderId": "wfc-replay"}""");
+        var responsePayload = Encoding.UTF8.GetString(invokeResponse.Payload.ToArray());
+        _output.WriteLine($"Response: {responsePayload}");
+
+        var arn = await deployment.FindDurableExecutionArnByNameAsync(executionName, TimeSpan.FromSeconds(60));
+        Assert.NotNull(arn);
+
+        // 3 polls with ~2s delay = ~4s of timer + 2 step invocations.
+        var status = await deployment.PollForCompletionAsync(arn!, TimeSpan.FromSeconds(120));
+        Assert.Equal("SUCCEEDED", status, ignoreCase: true);
+
+        // History is eventually consistent — wait until both step-succeeded
+        // AND the polling op-succeeded events are visible.
+        var history = await deployment.WaitForHistoryAsync(
+            arn!,
+            h => (h.Events?.Count(e => e.StepSucceededDetails != null) ?? 0) >= 3,
+            TimeSpan.FromSeconds(60));
+        var events = history.Events ?? new List<Event>();
+
+        // Each named step / polling op started exactly once. The leading and
+        // trailing steps each have one StepStarted; the polling op also has
+        // one (sub-iterations replay from RETRY/READY/PENDING and skip START).
+        Assert.Single(events.Where(e => e.EventType == EventType.StepStarted && e.Name == "before_poll"));
+        Assert.Single(events.Where(e => e.EventType == EventType.StepStarted && e.Name == "after_poll"));
+        Assert.Single(events.Where(e => e.EventType == EventType.StepStarted && e.Name == "determinism_poll"));
+
+        // Plain steps SUCCEED exactly once (replay returns cached values).
+        // The polling op surfaces one StepSucceeded per iteration (RETRYs +
+        // terminal SUCCEED), so we just require >= 1 there.
+        var stepSucceededEvents = events.Where(e => e.StepSucceededDetails != null).ToList();
+        Assert.Single(stepSucceededEvents.Where(e => e.Name == "before_poll"));
+        Assert.Single(stepSucceededEvents.Where(e => e.Name == "after_poll"));
+        Assert.NotEmpty(stepSucceededEvents.Where(e => e.Name == "determinism_poll"));
+
+        // Verify the trailing step received the GUID from the leading step
+        // verbatim, AND the final counter — proves the cached step value and
+        // the WaitForCondition's terminal payload both round-tripped through
+        // replay.
+        var beforeEvent = stepSucceededEvents.First(e => e.Name == "before_poll");
+        var afterEvent = stepSucceededEvents.First(e => e.Name == "after_poll");
+        var generatedGuid = beforeEvent.StepSucceededDetails.Result?.Payload?.Trim('"');
+        var echoedResult = afterEvent.StepSucceededDetails.Result?.Payload?.Trim('"');
+        Assert.NotNull(generatedGuid);
+        Assert.NotNull(echoedResult);
+        Assert.True(Guid.TryParse(generatedGuid, out _),
+            $"before_poll should produce a valid GUID, got: {generatedGuid}");
+        Assert.Equal($"echo:{generatedGuid}:3", echoedResult);
+
+        // The wait-for-condition truly drove suspend/resume — one invocation
+        // per poll iteration plus one for the final continuation. With 3
+        // polls we expect at least 3 InvocationCompleted events.
+        var invocations = events.Where(e => e.InvocationCompletedDetails != null).ToList();
+        Assert.True(
+            invocations.Count >= 3,
+            $"Expected at least 3 InvocationCompleted events (one per poll iteration), got {invocations.Count}");
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/WaitForConditionUserCheckThrowsTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/WaitForConditionUserCheckThrowsTest.cs
@@ -1,0 +1,71 @@
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Amazon.Lambda.Model;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Amazon.Lambda.DurableExecution.IntegrationTests;
+
+public class WaitForConditionUserCheckThrowsTest
+{
+    private readonly ITestOutputHelper _output;
+    public WaitForConditionUserCheckThrowsTest(ITestOutputHelper output) => _output = output;
+
+    /// <summary>
+    /// Validates the user-check-throws path: when the check function throws
+    /// on a polling iteration, the operation checkpoints FAIL with the
+    /// original exception type and the SDK surfaces a <see cref="StepException"/>
+    /// carrying that <c>ErrorType</c>. Mirrors the unit test
+    /// <c>WaitForConditionOperationTests.CheckThrows_CheckpointsFailAndThrows</c>.
+    /// </summary>
+    [Fact]
+    public async Task WaitForCondition_UserCheckThrows_SurfacesAsStepException()
+    {
+        await using var deployment = await DurableFunctionDeployment.CreateAsync(
+            DurableFunctionDeployment.FindTestFunctionDir("WaitForConditionUserCheckThrowsFunction"),
+            "wfcthrow", _output);
+
+        var (invokeResponse, executionName) = await deployment.InvokeAsync("""{"orderId": "wfc-throw"}""");
+        var responsePayload = Encoding.UTF8.GetString(invokeResponse.Payload.ToArray());
+        _output.WriteLine($"Response: {responsePayload}");
+
+        var arn = await deployment.FindDurableExecutionArnByNameAsync(executionName, TimeSpan.FromSeconds(60));
+        Assert.NotNull(arn);
+
+        // Attempt 1 succeeds (returns state+1=1), strategy schedules ~1s
+        // delay, then attempt 2 throws. ~2s of timer + execution overhead.
+        var status = await deployment.PollForCompletionAsync(arn!, TimeSpan.FromSeconds(120));
+        Assert.Equal("SUCCEEDED", status, ignoreCase: true);
+
+        // The workflow caught the StepException. Verify it captured the
+        // expected error type via the workflow's returned payload.
+        var execution = await deployment.GetExecutionAsync(arn!);
+        var resultPayload = execution.Result;
+        Assert.False(string.IsNullOrEmpty(resultPayload),
+            "workflow result payload should be present");
+
+        using var doc = JsonDocument.Parse(resultPayload!);
+        Assert.Equal("caught_step_exception", doc.RootElement.GetProperty("Status").GetString());
+        Assert.Equal("System.InvalidOperationException",
+            doc.RootElement.GetProperty("ErrorType").GetString());
+        Assert.Contains("intentional check failure",
+            doc.RootElement.GetProperty("ErrorMessage").GetString() ?? string.Empty);
+
+        // Verify the polling op itself was checkpointed as FAILED with the
+        // original exception type (NOT WaitForConditionException — that's
+        // reserved for max-attempts exhaustion).
+        var history = await deployment.WaitForHistoryAsync(
+            arn!,
+            h => (h.Events?.Any(e => e.StepFailedDetails != null && e.Name == "throwing_poll") ?? false),
+            TimeSpan.FromSeconds(60));
+        var events = history.Events ?? new List<Event>();
+
+        var stepFailed = events.FirstOrDefault(e => e.StepFailedDetails != null && e.Name == "throwing_poll");
+        Assert.NotNull(stepFailed);
+        Assert.Equal("System.InvalidOperationException",
+            stepFailed!.StepFailedDetails.Error?.Payload?.ErrorType);
+        Assert.Contains("intentional check failure",
+            stepFailed.StepFailedDetails.Error?.Payload?.ErrorMessage ?? string.Empty);
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/WaitForConditionOperationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/WaitForConditionOperationTests.cs
@@ -1,0 +1,1106 @@
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.DurableExecution.Internal;
+using Amazon.Lambda.Serialization.SystemTextJson;
+using Amazon.Lambda.TestUtilities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using ILambdaSerializer = Amazon.Lambda.Core.ILambdaSerializer;
+
+namespace Amazon.Lambda.DurableExecution.Tests;
+
+public class WaitForConditionOperationTests
+{
+    /// <summary>Reproduces the Id that <see cref="OperationIdGenerator"/> emits for the n-th root-level operation.</summary>
+    private static string IdAt(int position) => OperationIdGenerator.HashOperationId(position.ToString());
+
+    private static TestLambdaContext CreateLambdaContext(ILambdaSerializer? serializer = null) =>
+#pragma warning disable AWSLAMBDA001 // TestLambdaContext.Serializer is experimental.
+        new() { Serializer = serializer ?? new DefaultLambdaJsonSerializer() };
+#pragma warning restore AWSLAMBDA001
+
+    private static (DurableContext context, RecordingBatcher recorder, TerminationManager tm, ExecutionState state)
+        CreateContext(InitialExecutionState? initialState = null, ILambdaSerializer? serializer = null)
+    {
+        var state = new ExecutionState();
+        state.LoadFromCheckpoint(initialState);
+        var tm = new TerminationManager();
+        var idGen = new OperationIdGenerator();
+        var lambdaContext = CreateLambdaContext(serializer);
+        var recorder = new RecordingBatcher();
+        var context = new DurableContext(state, tm, idGen, "arn:test", lambdaContext, recorder.Batcher);
+        return (context, recorder, tm, state);
+    }
+
+    // ── Fresh execution ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FreshExecution_StrategyStopsImmediately_SucceedsWithFinalState()
+    {
+        var (context, recorder, tm, _) = CreateContext();
+
+        // The check function "advances" the state to 42; the strategy's
+        // isDone predicate matches immediately. This exercises the synchronous
+        // success path with no polling iterations.
+        int checkInvocations = 0;
+        var result = await context.WaitForConditionAsync<int>(
+            check: async (state, ctx) =>
+            {
+                checkInvocations++;
+                Assert.Equal(checkInvocations, ctx.AttemptNumber);
+                await Task.CompletedTask;
+                return 42;
+            },
+            config: new WaitForConditionConfig<int>
+            {
+                InitialState = 0,
+                WaitStrategy = WaitStrategy.Exponential<int>(isDone: s => s == 42)
+            },
+            name: "poll");
+
+        Assert.Equal(42, result);
+        Assert.Equal(1, checkInvocations);
+        Assert.False(tm.IsTerminated);
+
+        await recorder.Batcher.DrainAsync();
+
+        var actions = recorder.Flushed.Select(o => $"{o.Type}:{o.Action}").ToArray();
+        Assert.Equal(new[] { "STEP:START", "STEP:SUCCEED" }, actions);
+
+        var succeed = recorder.Flushed.Single(o => o.Action == "SUCCEED");
+        Assert.Equal(IdAt(1), succeed.Id);
+        Assert.Equal("WaitForCondition", succeed.SubType);
+        Assert.Equal("poll", succeed.Name);
+        Assert.Equal("42", succeed.Payload);
+    }
+
+    [Fact]
+    public async Task FreshExecution_StrategyContinues_EmitsRetryAndSuspends()
+    {
+        var (context, recorder, tm, _) = CreateContext();
+
+        // Strategy says continue → operation must emit RETRY and suspend.
+        var task = context.WaitForConditionAsync<int>(
+            check: async (state, _) => { await Task.CompletedTask; return state + 1; },
+            config: new WaitForConditionConfig<int>
+            {
+                InitialState = 0,
+                WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(3), maxAttempts: 10)
+            },
+            name: "poll");
+
+        await Task.Delay(50);
+
+        Assert.True(tm.IsTerminated);
+        Assert.False(task.IsCompleted);
+
+        await recorder.Batcher.DrainAsync();
+
+        var actions = recorder.Flushed.Select(o => $"{o.Type}:{o.Action}").ToArray();
+        Assert.Equal(new[] { "STEP:START", "STEP:RETRY" }, actions);
+
+        var retry = recorder.Flushed.Single(o => o.Action == "RETRY");
+        Assert.Equal("WaitForCondition", retry.SubType);
+        Assert.Equal("1", retry.Payload);  // state advanced to 1
+        Assert.NotNull(retry.StepOptions);
+        Assert.Equal(3, retry.StepOptions.NextAttemptDelaySeconds);
+    }
+
+    [Fact]
+    public async Task FreshExecution_UsesInitialStateOnFirstCall()
+    {
+        var (context, _, _, _) = CreateContext();
+
+        int? observedInitial = null;
+        await context.WaitForConditionAsync<int>(
+            check: async (state, _) =>
+            {
+                observedInitial ??= state;
+                await Task.CompletedTask;
+                return state;
+            },
+            config: new WaitForConditionConfig<int>
+            {
+                InitialState = 99,
+                WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(1), maxAttempts: 10, isDone: _ => true)
+            },
+            name: "poll");
+
+        Assert.Equal(99, observedInitial);
+    }
+
+    [Fact]
+    public async Task FreshExecution_AttemptNumberIs1OnFirstCall()
+    {
+        var (context, _, _, _) = CreateContext();
+
+        int observed = -1;
+        await context.WaitForConditionAsync<int>(
+            check: async (state, ctx) =>
+            {
+                observed = ctx.AttemptNumber;
+                await Task.CompletedTask;
+                return state;
+            },
+            config: new WaitForConditionConfig<int>
+            {
+                InitialState = 0,
+                WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(1), maxAttempts: 5, isDone: _ => true)
+            });
+
+        Assert.Equal(1, observed);
+    }
+
+    [Fact]
+    public async Task CheckContext_ExposesLogger()
+    {
+        // The check function receives an IConditionCheckContext whose Logger
+        // is a real ILogger forwarded from the durable runtime — user code
+        // can use it to emit observability without threading a logger in.
+        var (context, _, _, _) = CreateContext();
+
+        ILogger? observedLogger = null;
+        await context.WaitForConditionAsync<int>(
+            check: async (state, ctx) =>
+            {
+                observedLogger = ctx.Logger;
+                await Task.CompletedTask;
+                return state;
+            },
+            config: new WaitForConditionConfig<int>
+            {
+                InitialState = 0,
+                WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(1), maxAttempts: 5, isDone: _ => true)
+            });
+
+        Assert.NotNull(observedLogger);
+    }
+
+    // ── Replay paths ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Replay_Succeeded_ReturnsCachedAndSkipsCheck()
+    {
+        var (context, recorder, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Step,
+                    SubType = OperationSubTypes.WaitForCondition,
+                    Status = OperationStatuses.Succeeded,
+                    Name = "poll",
+                    StepDetails = new StepDetails { Result = "7" }
+                }
+            }
+        });
+
+        var checkInvoked = false;
+        var result = await context.WaitForConditionAsync<int>(
+            check: async (_, _) => { checkInvoked = true; await Task.CompletedTask; return 0; },
+            config: new WaitForConditionConfig<int>
+            {
+                InitialState = 0,
+                WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(1))
+            },
+            name: "poll");
+
+        Assert.False(checkInvoked);
+        Assert.Equal(7, result);
+
+        await recorder.Batcher.DrainAsync();
+        Assert.Empty(recorder.Flushed);
+    }
+
+    [Fact]
+    public async Task Replay_PendingTimerNotFired_ReSuspends()
+    {
+        // NextAttemptTimestamp 1 hour in the future → timer hasn't fired,
+        // operation must re-suspend without re-checkpointing or re-running.
+        var futureMs = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeMilliseconds();
+
+        var (context, recorder, tm, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Step,
+                    SubType = OperationSubTypes.WaitForCondition,
+                    Status = OperationStatuses.Pending,
+                    Name = "poll",
+                    StepDetails = new StepDetails
+                    {
+                        Result = "5",
+                        Attempt = 2,
+                        NextAttemptTimestamp = futureMs
+                    }
+                }
+            }
+        });
+
+        var checkInvoked = false;
+        var task = context.WaitForConditionAsync<int>(
+            check: async (_, _) => { checkInvoked = true; await Task.CompletedTask; return 0; },
+            config: new WaitForConditionConfig<int>
+            {
+                InitialState = 0,
+                WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(1))
+            },
+            name: "poll");
+
+        await Task.Delay(50);
+
+        Assert.False(checkInvoked);
+        Assert.True(tm.IsTerminated);
+        Assert.False(task.IsCompleted);
+
+        await recorder.Batcher.DrainAsync();
+        Assert.Empty(recorder.Flushed);
+    }
+
+    [Fact]
+    public async Task Replay_PendingTimerFired_ResumesWithCheckpointedState()
+    {
+        // NextAttemptTimestamp 1 hour in the past → timer fired (service
+        // hasn't yet stamped READY but the deadline is met). Continue.
+        var pastMs = DateTimeOffset.UtcNow.AddHours(-1).ToUnixTimeMilliseconds();
+
+        var (context, recorder, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Step,
+                    SubType = OperationSubTypes.WaitForCondition,
+                    Status = OperationStatuses.Pending,
+                    Name = "poll",
+                    StepDetails = new StepDetails
+                    {
+                        Result = "5",
+                        Attempt = 2,
+                        NextAttemptTimestamp = pastMs
+                    }
+                }
+            }
+        });
+
+        int? observedState = null;
+        int? observedAttempt = null;
+        var result = await context.WaitForConditionAsync<int>(
+            check: async (state, ctx) =>
+            {
+                observedState = state;
+                observedAttempt = ctx.AttemptNumber;
+                await Task.CompletedTask;
+                return state;  // condition met (isDone returns true)
+            },
+            config: new WaitForConditionConfig<int>
+            {
+                InitialState = 0,
+                WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(1), isDone: _ => true)
+            },
+            name: "poll");
+
+        // Critical: state survives across iterations. Check receives the
+        // PRIOR state (5, from the prior RETRY's payload), not InitialState (0).
+        Assert.Equal(5, observedState);
+        Assert.Equal(3, observedAttempt);  // prior attempt was 2, this is attempt 3
+        Assert.Equal(5, result);
+
+        await recorder.Batcher.DrainAsync();
+
+        // No new START — original is authoritative.
+        Assert.DoesNotContain(recorder.Flushed, o => o.Action == "START");
+        Assert.Contains(recorder.Flushed, o => o.Action == "SUCCEED");
+    }
+
+    [Fact]
+    public async Task Replay_Ready_ResumesWithCheckpointedState()
+    {
+        var (context, recorder, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Step,
+                    SubType = OperationSubTypes.WaitForCondition,
+                    Status = OperationStatuses.Ready,
+                    Name = "poll",
+                    StepDetails = new StepDetails
+                    {
+                        Result = "11",
+                        Attempt = 3
+                    }
+                }
+            }
+        });
+
+        int? observedState = null;
+        int? observedAttempt = null;
+        var result = await context.WaitForConditionAsync<int>(
+            check: async (state, ctx) =>
+            {
+                observedState = state;
+                observedAttempt = ctx.AttemptNumber;
+                await Task.CompletedTask;
+                return state * 2;
+            },
+            config: new WaitForConditionConfig<int>
+            {
+                InitialState = 0,
+                WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(1), isDone: _ => true)
+            },
+            name: "poll");
+
+        Assert.Equal(11, observedState);
+        Assert.Equal(4, observedAttempt);  // prior=3 → next=4
+        Assert.Equal(22, result);
+
+        await recorder.Batcher.DrainAsync();
+        Assert.DoesNotContain(recorder.Flushed, o => o.Action == "START");
+    }
+
+    [Fact]
+    public async Task Replay_Started_ResumesWithInitialState()
+    {
+        // STARTED with no payload means the very first check attempt was
+        // lost (Lambda crash before RETRY/SUCCEED). Re-execute with
+        // InitialState since no prior state is available.
+        var (context, recorder, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Step,
+                    SubType = OperationSubTypes.WaitForCondition,
+                    Status = OperationStatuses.Started,
+                    Name = "poll"
+                }
+            }
+        });
+
+        int? observedState = null;
+        int? observedAttempt = null;
+        var result = await context.WaitForConditionAsync<int>(
+            check: async (state, ctx) =>
+            {
+                observedState = state;
+                observedAttempt = ctx.AttemptNumber;
+                await Task.CompletedTask;
+                return state + 100;
+            },
+            config: new WaitForConditionConfig<int>
+            {
+                InitialState = 50,
+                WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(1), isDone: _ => true)
+            },
+            name: "poll");
+
+        Assert.Equal(50, observedState);  // InitialState is the seed
+        Assert.Equal(1, observedAttempt);
+        Assert.Equal(150, result);
+
+        await recorder.Batcher.DrainAsync();
+        // Do NOT re-emit START on STARTED replay.
+        Assert.DoesNotContain(recorder.Flushed, o => o.Action == "START");
+    }
+
+    [Fact]
+    public async Task Replay_Failed_FromCheckException_ThrowsStepException()
+    {
+        var (context, _, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Step,
+                    SubType = OperationSubTypes.WaitForCondition,
+                    Status = OperationStatuses.Failed,
+                    Name = "poll",
+                    StepDetails = new StepDetails
+                    {
+                        Error = new ErrorObject
+                        {
+                            ErrorType = "System.InvalidOperationException",
+                            ErrorMessage = "check went wrong",
+                            StackTrace = new[] { "at A.B()" }
+                        }
+                    }
+                }
+            }
+        });
+
+        var ex = await Assert.ThrowsAsync<StepException>(() =>
+            context.WaitForConditionAsync<int>(
+                check: async (_, _) => { await Task.CompletedTask; return 0; },
+                config: new WaitForConditionConfig<int>
+                {
+                    InitialState = 0,
+                    WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(1))
+                },
+                name: "poll"));
+
+        Assert.Equal("check went wrong", ex.Message);
+        Assert.Equal("System.InvalidOperationException", ex.ErrorType);
+    }
+
+    [Fact]
+    public async Task Replay_Failed_FromMaxAttempts_ThrowsWaitForConditionException()
+    {
+        // The FAIL checkpoint records LastState in Error.ErrorData (the wire
+        // protocol disallows a Payload on FAIL updates) so replay can
+        // reconstruct an identically-populated exception. Live execution sets
+        // the same field in MaxAttemptsExhausted_FreshExecution.
+        var (context, _, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Step,
+                    SubType = OperationSubTypes.WaitForCondition,
+                    Status = OperationStatuses.Failed,
+                    Name = "poll",
+                    StepDetails = new StepDetails
+                    {
+                        Attempt = 3,
+                        Error = new ErrorObject
+                        {
+                            ErrorType = typeof(WaitForConditionException).FullName,
+                            ErrorMessage = "exhausted",
+                            ErrorData = "42"
+                        }
+                    }
+                }
+            }
+        });
+
+        var ex = await Assert.ThrowsAsync<WaitForConditionException>(() =>
+            context.WaitForConditionAsync<int>(
+                check: async (_, _) => { await Task.CompletedTask; return 0; },
+                config: new WaitForConditionConfig<int>
+                {
+                    InitialState = 0,
+                    WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(1))
+                },
+                name: "poll"));
+
+        Assert.Equal(3, ex.AttemptsExhausted);
+        Assert.Equal("exhausted", ex.Message);
+        Assert.Equal(42, ex.LastState);  // round-tripped from FAIL Error.ErrorData
+    }
+
+    [Fact]
+    public async Task Replay_Failed_FromMaxAttempts_LastState_MatchesLiveExecution()
+    {
+        // Live execution path: exhaust max-attempts and capture the
+        // exception's LastState. Then construct a FAIL checkpoint mirroring
+        // what was written, replay, and assert LastState round-trips.
+        var (liveCtx, liveRecorder, _, _) = CreateContext();
+
+        var liveEx = await Assert.ThrowsAsync<WaitForConditionException>(() =>
+            liveCtx.WaitForConditionAsync<int>(
+                check: async (state, _) => { await Task.CompletedTask; return state + 1; },
+                config: new WaitForConditionConfig<int>
+                {
+                    InitialState = 5,
+                    WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(1), maxAttempts: 1)
+                },
+                name: "poll"));
+
+        await liveRecorder.Batcher.DrainAsync();
+        var failUpdate = liveRecorder.Flushed.Single(o => o.Action == "FAIL");
+        Assert.Null(failUpdate.Payload);  // wire protocol forbids Payload on FAIL
+        Assert.Equal("6", failUpdate.Error?.ErrorData);  // last state was 5+1=6, stored in ErrorData
+
+        // Reconstruct the operation as the service would echo it back on
+        // replay (Error → StepDetails.Error; LastState lives in Error.ErrorData).
+        var (replayCtx, _, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Step,
+                    SubType = OperationSubTypes.WaitForCondition,
+                    Status = OperationStatuses.Failed,
+                    Name = "poll",
+                    StepDetails = new StepDetails
+                    {
+                        Attempt = liveEx.AttemptsExhausted,
+                        Error = new ErrorObject
+                        {
+                            ErrorType = failUpdate.Error?.ErrorType,
+                            ErrorMessage = failUpdate.Error?.ErrorMessage,
+                            ErrorData = failUpdate.Error?.ErrorData
+                        }
+                    }
+                }
+            }
+        });
+
+        var replayEx = await Assert.ThrowsAsync<WaitForConditionException>(() =>
+            replayCtx.WaitForConditionAsync<int>(
+                check: async (_, _) => { await Task.CompletedTask; return 0; },
+                config: new WaitForConditionConfig<int>
+                {
+                    InitialState = 0,
+                    WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(1), maxAttempts: 1)
+                },
+                name: "poll"));
+
+        Assert.Equal(liveEx.AttemptsExhausted, replayEx.AttemptsExhausted);
+        Assert.NotNull(replayEx.LastState);
+        Assert.Equal(liveEx.LastState, replayEx.LastState);
+    }
+
+    [Fact]
+    public async Task Replay_Failed_FromMaxAttempts_NullPayload_LeavesLastStateNull()
+    {
+        // Backwards-compat: a FAIL checkpoint produced before LastState
+        // was stored in ErrorData (or one that lost its ErrorData) should
+        // not blow up — LastState falls back to null.
+        var (context, _, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Step,
+                    SubType = OperationSubTypes.WaitForCondition,
+                    Status = OperationStatuses.Failed,
+                    Name = "poll",
+                    StepDetails = new StepDetails
+                    {
+                        Attempt = 2,
+                        Error = new ErrorObject
+                        {
+                            ErrorType = typeof(WaitForConditionException).FullName,
+                            ErrorMessage = "exhausted"
+                            // ErrorData intentionally null (legacy FAIL).
+                        }
+                    }
+                }
+            }
+        });
+
+        var ex = await Assert.ThrowsAsync<WaitForConditionException>(() =>
+            context.WaitForConditionAsync<int>(
+                check: async (_, _) => { await Task.CompletedTask; return 0; },
+                config: new WaitForConditionConfig<int>
+                {
+                    InitialState = 0,
+                    WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(1))
+                },
+                name: "poll"));
+
+        Assert.Equal(2, ex.AttemptsExhausted);
+        Assert.Null(ex.LastState);
+    }
+
+    // ── Max attempts exhaustion ─────────────────────────────────────────
+
+    [Fact]
+    public async Task MaxAttemptsExhausted_FreshExecution_ThrowsWaitForConditionException()
+    {
+        var (context, recorder, _, _) = CreateContext();
+
+        // maxAttempts=1 + isDone always false → strategy stops on attempt 1
+        // but it's because the counter is saturated, NOT because the
+        // condition was met. Operation must throw, not SUCCEED.
+        var ex = await Assert.ThrowsAsync<WaitForConditionException>(() =>
+            context.WaitForConditionAsync<int>(
+                check: async (state, _) => { await Task.CompletedTask; return state + 1; },
+                config: new WaitForConditionConfig<int>
+                {
+                    InitialState = 5,
+                    WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(1), maxAttempts: 1)
+                },
+                name: "poll"));
+
+        Assert.Equal(1, ex.AttemptsExhausted);
+        Assert.Equal(6, ex.LastState);  // last state observed was 5+1
+
+        await recorder.Batcher.DrainAsync();
+        var actions = recorder.Flushed.Select(o => $"{o.Type}:{o.Action}").ToArray();
+        Assert.Equal(new[] { "STEP:START", "STEP:FAIL" }, actions);
+
+        var fail = recorder.Flushed.Single(o => o.Action == "FAIL");
+        Assert.Equal("WaitForCondition", fail.SubType);
+        Assert.NotNull(fail.Error);
+        Assert.Equal(typeof(WaitForConditionException).FullName, fail.Error.ErrorType);
+        // LastState round-trips through Error.ErrorData (wire protocol forbids
+        // a Payload on FAIL). See Replay_Failed_FromMaxAttempts_LastState_MatchesLiveExecution.
+        Assert.Null(fail.Payload);
+        Assert.Equal("6", fail.Error.ErrorData);
+    }
+
+    [Fact]
+    public async Task MaxAttemptsExhausted_DistinguishesFromConditionMet()
+    {
+        var (context, _, _, _) = CreateContext();
+
+        // The same maxAttempts=1 strategy WITH an isDone that's satisfied
+        // should SUCCEED, not throw.
+        var result = await context.WaitForConditionAsync<int>(
+            check: async (_, _) => { await Task.CompletedTask; return 99; },
+            config: new WaitForConditionConfig<int>
+            {
+                InitialState = 0,
+                WaitStrategy = WaitStrategy.Fixed<int>(
+                    TimeSpan.FromSeconds(1),
+                    maxAttempts: 1,
+                    isDone: state => state == 99)
+            },
+            name: "poll");
+
+        Assert.Equal(99, result);
+    }
+
+    // ── Check function exception ────────────────────────────────────────
+
+    [Fact]
+    public async Task CheckThrows_CheckpointsFailAndThrows()
+    {
+        var (context, recorder, _, _) = CreateContext();
+
+        var ex = await Assert.ThrowsAsync<StepException>(() =>
+            context.WaitForConditionAsync<int>(
+                check: async (_, _) => { await Task.CompletedTask; throw new InvalidOperationException("boom"); },
+                config: new WaitForConditionConfig<int>
+                {
+                    InitialState = 0,
+                    WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(1))
+                },
+                name: "poll"));
+
+        Assert.Equal("boom", ex.Message);
+        Assert.Equal("System.InvalidOperationException", ex.ErrorType);
+
+        await recorder.Batcher.DrainAsync();
+        var actions = recorder.Flushed.Select(o => $"{o.Type}:{o.Action}").ToArray();
+        Assert.Equal(new[] { "STEP:START", "STEP:FAIL" }, actions);
+
+        var fail = recorder.Flushed.Single(o => o.Action == "FAIL");
+        Assert.Equal("WaitForCondition", fail.SubType);
+        Assert.Equal("System.InvalidOperationException", fail.Error?.ErrorType);
+    }
+
+    // ── Replay determinism: state survives iterations ───────────────────
+
+    [Fact]
+    public async Task ReplayDeterminism_StateIsCarriedAcrossIterations()
+    {
+        // Simulate a multi-iteration history: invocation N had advanced the
+        // state to {Count=3}; invocation N+1 should pick that up and
+        // continue from there.
+        var pastMs = DateTimeOffset.UtcNow.AddSeconds(-1).ToUnixTimeMilliseconds();
+
+        var (context, recorder, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Step,
+                    SubType = OperationSubTypes.WaitForCondition,
+                    Status = OperationStatuses.Ready,
+                    Name = "counter",
+                    StepDetails = new StepDetails
+                    {
+                        Result = """{"Count":3}""",
+                        Attempt = 3,
+                        NextAttemptTimestamp = pastMs
+                    }
+                }
+            }
+        });
+
+        CounterState? observed = null;
+        int? observedAttempt = null;
+        var result = await context.WaitForConditionAsync<CounterState>(
+            check: async (state, ctx) =>
+            {
+                observed = state;
+                observedAttempt = ctx.AttemptNumber;
+                await Task.CompletedTask;
+                return new CounterState { Count = state.Count + 1 };
+            },
+            config: new WaitForConditionConfig<CounterState>
+            {
+                InitialState = new CounterState { Count = 0 },  // ignored on replay
+                WaitStrategy = WaitStrategy.Fixed<CounterState>(
+                    TimeSpan.FromSeconds(1),
+                    maxAttempts: 100,
+                    isDone: c => c.Count >= 4)  // stop when we hit 4
+            },
+            name: "counter");
+
+        // Started from the checkpointed counter=3 (NOT InitialState=0),
+        // incremented to 4, isDone returned true, returned 4.
+        Assert.Equal(3, observed?.Count);
+        Assert.Equal(4, observedAttempt);
+        Assert.Equal(4, result.Count);
+
+        await recorder.Batcher.DrainAsync();
+        var succeed = recorder.Flushed.Single(o => o.Action == "SUCCEED");
+        Assert.Equal("""{"Count":4}""", succeed.Payload);
+    }
+
+    [Fact]
+    public async Task ReplayDeterminism_RoundTripsThroughLambdaSerializer()
+    {
+        var serializer = new RecordingPersonSerializer();
+        var (context, _, _, _) = CreateContext(
+            new InitialExecutionState
+            {
+                Operations = new List<Operation>
+                {
+                    new()
+                    {
+                        Id = IdAt(1),
+                        Type = OperationTypes.Step,
+                        SubType = OperationSubTypes.WaitForCondition,
+                        Status = OperationStatuses.Succeeded,
+                        Name = "poll",
+                        StepDetails = new StepDetails { Result = "<custom>Marie,30</custom>" }
+                    }
+                }
+            },
+            serializer: serializer);
+
+        var result = await context.WaitForConditionAsync<TestPerson>(
+            check: async (_, _) => { await Task.CompletedTask; return new TestPerson { Name = "ignored", Age = 0 }; },
+            config: new WaitForConditionConfig<TestPerson>
+            {
+                InitialState = new TestPerson { Name = "init", Age = 0 },
+                WaitStrategy = WaitStrategy.Fixed<TestPerson>(TimeSpan.FromSeconds(1))
+            },
+            name: "poll");
+
+        Assert.True(serializer.DeserializeCalled);
+        Assert.Equal("Marie", result.Name);
+        Assert.Equal(30, result.Age);
+    }
+
+    // ── Sync-flush of START before suspending ───────────────────────────
+
+    [Fact]
+    public async Task FreshExecution_FlushesStartBeforeSuspending()
+    {
+        // The START checkpoint MUST be persisted before the workflow
+        // suspends — otherwise the service has no record of the polling op
+        // and replay can't find it.
+        var (context, recorder, tm, _) = CreateContext();
+
+        var task = context.WaitForConditionAsync<int>(
+            check: async (state, _) => { await Task.CompletedTask; return state + 1; },
+            config: new WaitForConditionConfig<int>
+            {
+                InitialState = 0,
+                WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(5), maxAttempts: 10)
+            },
+            name: "poll");
+
+        await Task.Delay(50);
+
+        Assert.True(tm.IsTerminated);
+        Assert.False(task.IsCompleted);
+
+        // At the moment of suspension, both START and RETRY must already be
+        // flushed (sync-enqueued ahead of SuspendAndAwait). No drain needed.
+        var actions = recorder.Flushed.Select(o => $"{o.Type}:{o.Action}").ToArray();
+        Assert.Contains("STEP:START", actions);
+        Assert.Contains("STEP:RETRY", actions);
+    }
+
+    // ── Replay non-determinism guards ───────────────────────────────────
+
+    [Fact]
+    public async Task ReplayUnknownStatus_ThrowsNonDeterministicException()
+    {
+        var (context, _, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Step,
+                    SubType = OperationSubTypes.WaitForCondition,
+                    Status = "BOGUS",
+                    Name = "poll"
+                }
+            }
+        });
+
+        await Assert.ThrowsAsync<NonDeterministicExecutionException>(() =>
+            context.WaitForConditionAsync<int>(
+                check: async (_, _) => { await Task.CompletedTask; return 0; },
+                config: new WaitForConditionConfig<int>
+                {
+                    InitialState = 0,
+                    WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(1))
+                },
+                name: "poll"));
+    }
+
+    [Fact]
+    public async Task ReplayTypeMismatch_ThrowsNonDeterministicException()
+    {
+        // Same Id but a different Type — operation order changed between
+        // deployments. The base class's ValidateReplayConsistency catches it.
+        var (context, _, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Wait,
+                    Status = OperationStatuses.Succeeded,
+                    Name = "poll"
+                }
+            }
+        });
+
+        var ex = await Assert.ThrowsAsync<NonDeterministicExecutionException>(() =>
+            context.WaitForConditionAsync<int>(
+                check: async (_, _) => { await Task.CompletedTask; return 0; },
+                config: new WaitForConditionConfig<int>
+                {
+                    InitialState = 0,
+                    WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(1))
+                },
+                name: "poll"));
+
+        Assert.Contains("expected type 'STEP'", ex.Message);
+    }
+
+    // ── Argument validation ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task NullCheck_ThrowsArgumentNullException()
+    {
+        var (context, _, _, _) = CreateContext();
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            context.WaitForConditionAsync<int>(
+                check: null!,
+                config: new WaitForConditionConfig<int>
+                {
+                    InitialState = 0,
+                    WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(1))
+                }));
+    }
+
+    [Fact]
+    public async Task NullConfig_ThrowsArgumentNullException()
+    {
+        var (context, _, _, _) = CreateContext();
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            context.WaitForConditionAsync<int>(
+                check: async (_, _) => { await Task.CompletedTask; return 0; },
+                config: null!));
+    }
+
+    // ── Observability: warning on payload deserialization failure ──────
+
+    [Fact]
+    public async Task DeserializeStateOrInitial_CorruptPayload_LogsWarningAndFallsBack()
+    {
+        // A READY checkpoint with a payload the serializer cannot read should
+        // NOT fail the workflow (Python parity); it should fall back to
+        // InitialState. The recovery should be logged at Warning level so
+        // corruption / schema-migrations are observable.
+        var state = new ExecutionState();
+        state.LoadFromCheckpoint(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Step,
+                    SubType = OperationSubTypes.WaitForCondition,
+                    Status = OperationStatuses.Ready,
+                    Name = "poll",
+                    StepDetails = new StepDetails { Result = "this-is-not-valid", Attempt = 2 }
+                }
+            }
+        });
+
+        var recorder = new RecordingBatcher();
+        var logger = new RecordingLogger();
+
+        var op = new WaitForConditionOperation<int>(
+            operationId: IdAt(1),
+            name: "poll",
+            parentId: null,
+            check: async (s, _) => { await Task.CompletedTask; return s; },
+            config: new WaitForConditionConfig<int>
+            {
+                InitialState = 999,
+                WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(1), isDone: _ => true)
+            },
+            serializer: new ThrowingLambdaSerializer(),
+            logger: logger,
+            state: state,
+            termination: new TerminationManager(),
+            durableExecutionArn: "arn:test",
+            batcher: recorder.Batcher);
+
+        var result = await op.ExecuteAsync(CancellationToken.None);
+
+        Assert.Equal(999, result);  // fell back to InitialState
+        var warning = Assert.Single(logger.Entries.Where(e => e.Level == LogLevel.Warning));
+        Assert.Contains("failed to deserialize prior state", warning.Message);
+        Assert.Contains(IdAt(1), warning.Message);
+    }
+
+    [Fact]
+    public async Task ReplayFailed_CorruptLastStatePayload_LogsWarningAndLastStateNull()
+    {
+        // FAIL replay's LastState recovery: same observability story — if the
+        // FAIL Error.ErrorData can't be deserialized, log a warning and
+        // surface LastState=null instead of throwing.
+        var state = new ExecutionState();
+        state.LoadFromCheckpoint(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Step,
+                    SubType = OperationSubTypes.WaitForCondition,
+                    Status = OperationStatuses.Failed,
+                    Name = "poll",
+                    StepDetails = new StepDetails
+                    {
+                        Attempt = 4,
+                        Error = new ErrorObject
+                        {
+                            ErrorType = typeof(WaitForConditionException).FullName,
+                            ErrorMessage = "exhausted",
+                            ErrorData = "bogus-payload"
+                        }
+                    }
+                }
+            }
+        });
+
+        var recorder = new RecordingBatcher();
+        var logger = new RecordingLogger();
+
+        var op = new WaitForConditionOperation<int>(
+            operationId: IdAt(1),
+            name: "poll",
+            parentId: null,
+            check: async (s, _) => { await Task.CompletedTask; return s; },
+            config: new WaitForConditionConfig<int>
+            {
+                InitialState = 0,
+                WaitStrategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(1))
+            },
+            serializer: new ThrowingLambdaSerializer(),
+            logger: logger,
+            state: state,
+            termination: new TerminationManager(),
+            durableExecutionArn: "arn:test",
+            batcher: recorder.Batcher);
+
+        var ex = await Assert.ThrowsAsync<WaitForConditionException>(() => op.ExecuteAsync(CancellationToken.None));
+
+        Assert.Equal(4, ex.AttemptsExhausted);
+        Assert.Null(ex.LastState);
+        var warning = Assert.Single(logger.Entries.Where(e => e.Level == LogLevel.Warning));
+        Assert.Contains("failed to deserialize LastState", warning.Message);
+    }
+
+    // ── Test helpers ────────────────────────────────────────────────────
+
+    private class CounterState
+    {
+        public int Count { get; set; }
+    }
+
+    private class TestPerson
+    {
+        public string? Name { get; set; }
+        public int Age { get; set; }
+    }
+
+    /// <summary>
+    /// ILambdaSerializer that round-trips <see cref="TestPerson"/> through a
+    /// custom non-JSON wire format so tests can verify the serializer on
+    /// ILambdaContext.Serializer is the one used during checkpointing.
+    /// </summary>
+    private class RecordingPersonSerializer : ILambdaSerializer
+    {
+        public bool SerializeCalled { get; private set; }
+        public bool DeserializeCalled { get; private set; }
+
+        public void Serialize<T>(T response, Stream responseStream)
+        {
+            SerializeCalled = true;
+            var person = (TestPerson)(object)response!;
+            using var writer = new StreamWriter(responseStream, leaveOpen: true);
+            writer.Write($"<custom>{person.Name},{person.Age}</custom>");
+        }
+
+        public T Deserialize<T>(Stream requestStream)
+        {
+            DeserializeCalled = true;
+            using var reader = new StreamReader(requestStream);
+            var data = reader.ReadToEnd();
+            var inner = data.Replace("<custom>", "").Replace("</custom>", "");
+            var parts = inner.Split(',');
+            var person = new TestPerson { Name = parts[0], Age = int.Parse(parts[1]) };
+            return (T)(object)person;
+        }
+    }
+
+    /// <summary>Serializer whose Deserialize always throws — exercises the fallback paths.</summary>
+    private sealed class ThrowingLambdaSerializer : ILambdaSerializer
+    {
+        public void Serialize<T>(T response, Stream responseStream)
+        {
+            using var writer = new StreamWriter(responseStream, leaveOpen: true);
+            writer.Write(response?.ToString() ?? string.Empty);
+        }
+
+        public T Deserialize<T>(Stream requestStream)
+        {
+            using var reader = new StreamReader(requestStream);
+            var data = reader.ReadToEnd();
+            throw new InvalidOperationException($"cannot deserialize '{data}'");
+        }
+    }
+
+    /// <summary>Captures log calls so tests can assert on level and rendered message.</summary>
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => Entries.Add((logLevel, formatter(state, exception)));
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/WaitStrategyTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/WaitStrategyTests.cs
@@ -1,0 +1,226 @@
+using Amazon.Lambda.DurableExecution;
+using Xunit;
+
+namespace Amazon.Lambda.DurableExecution.Tests;
+
+public class WaitStrategyTests
+{
+    [Fact]
+    public void Exponential_Defaults_MatchReferenceSDKs()
+    {
+        // Reference SDKs (Python, JS, Java) all default to:
+        //   maxAttempts=60, initialDelay=5s, maxDelay=300s, backoff=1.5x, FullJitter.
+        // Verify by exercising the boundary: an attempt one short of 60
+        // continues; the 60th throws (matches the JS SDK pattern of
+        // signaling max-attempts via exception so the operation can produce
+        // a WaitForConditionException carrying the last state).
+        var strategy = WaitStrategy.Exponential<string>();
+
+        Assert.True(strategy.Decide("any", 1).ShouldContinue);
+        Assert.True(strategy.Decide("any", 59).ShouldContinue);
+
+        var ex = Assert.Throws<WaitForConditionException>(() => strategy.Decide("any", 60));
+        Assert.Equal(60, ex.AttemptsExhausted);
+    }
+
+    [Fact]
+    public void Exponential_NoIsDone_ThrowsAtMaxAttempts()
+    {
+        var strategy = WaitStrategy.Exponential<int>(maxAttempts: 5);
+
+        Assert.True(strategy.Decide(0, 1).ShouldContinue);
+        Assert.True(strategy.Decide(0, 4).ShouldContinue);
+
+        var ex = Assert.Throws<WaitForConditionException>(() => strategy.Decide(0, 5));
+        Assert.Equal(5, ex.AttemptsExhausted);
+    }
+
+    [Fact]
+    public void Exponential_IsDoneTrue_StopsRegardlessOfAttempt()
+    {
+        var strategy = WaitStrategy.Exponential<int>(
+            maxAttempts: 100,
+            isDone: state => state >= 10);
+
+        // Predicate is the gate, not the attempt counter.
+        Assert.True(strategy.Decide(5, 1).ShouldContinue);
+        Assert.False(strategy.Decide(10, 1).ShouldContinue);
+        Assert.False(strategy.Decide(15, 1).ShouldContinue);
+    }
+
+    [Fact]
+    public void Exponential_DelayGrowsAndCapsAtMax()
+    {
+        var strategy = WaitStrategy.Exponential<int>(
+            maxAttempts: 20,
+            initialDelay: TimeSpan.FromSeconds(2),
+            maxDelay: TimeSpan.FromSeconds(20),
+            backoffRate: 2.0,
+            jitter: JitterStrategy.None);
+
+        Assert.Equal(TimeSpan.FromSeconds(2), strategy.Decide(0, 1).Delay);
+        Assert.Equal(TimeSpan.FromSeconds(4), strategy.Decide(0, 2).Delay);
+        Assert.Equal(TimeSpan.FromSeconds(8), strategy.Decide(0, 3).Delay);
+        Assert.Equal(TimeSpan.FromSeconds(16), strategy.Decide(0, 4).Delay);
+        // 2 * 2^4 = 32, capped at 20.
+        Assert.Equal(TimeSpan.FromSeconds(20), strategy.Decide(0, 5).Delay);
+    }
+
+    [Fact]
+    public void Exponential_FullJitter_StaysWithinBounds()
+    {
+        var strategy = WaitStrategy.Exponential<int>(
+            maxAttempts: 20,
+            initialDelay: TimeSpan.FromSeconds(10),
+            maxDelay: TimeSpan.FromSeconds(100),
+            backoffRate: 2.0,
+            jitter: JitterStrategy.Full);
+
+        for (int i = 0; i < 50; i++)
+        {
+            var d = strategy.Decide(0, 1).Delay;
+            // With Full jitter at attempt 1: between 1 (floor) and 10 inclusive.
+            Assert.True(d >= TimeSpan.FromSeconds(1));
+            Assert.True(d <= TimeSpan.FromSeconds(10));
+        }
+    }
+
+    [Fact]
+    public void Exponential_HalfJitter_StaysWithinBounds()
+    {
+        // Half-jitter formula: cappedDelay * (0.5 + 0.5 * rand) ⇒ output is in
+        // [cappedDelay/2, cappedDelay], then ceilinged to whole seconds with a
+        // 1-second floor. At attempt 3 with initialDelay=10s, backoff=2.0:
+        // cappedDelay = min(10 * 2^2, 100) = 40s ⇒ output ∈ [20, 40] seconds.
+        var strategy = WaitStrategy.Exponential<int>(
+            maxAttempts: 20,
+            initialDelay: TimeSpan.FromSeconds(10),
+            maxDelay: TimeSpan.FromSeconds(100),
+            backoffRate: 2.0,
+            jitter: JitterStrategy.Half);
+
+        for (int i = 0; i < 50; i++)
+        {
+            var d = strategy.Decide(0, 3).Delay;
+            Assert.True(d >= TimeSpan.FromSeconds(20), $"expected >= 20s, got {d}");
+            Assert.True(d <= TimeSpan.FromSeconds(40), $"expected <= 40s, got {d}");
+        }
+    }
+
+    [Fact]
+    public void Linear_DefaultsAreSensible()
+    {
+        // Default: 5s initial, +5s per attempt, no cap, 60 attempts.
+        var strategy = WaitStrategy.Linear<int>();
+
+        Assert.Equal(TimeSpan.FromSeconds(5), strategy.Decide(0, 1).Delay);
+        Assert.Equal(TimeSpan.FromSeconds(10), strategy.Decide(0, 2).Delay);
+        Assert.Equal(TimeSpan.FromSeconds(15), strategy.Decide(0, 3).Delay);
+    }
+
+    [Fact]
+    public void Linear_RespectsMaxDelay()
+    {
+        var strategy = WaitStrategy.Linear<int>(
+            maxAttempts: 10,
+            initialDelay: TimeSpan.FromSeconds(2),
+            increment: TimeSpan.FromSeconds(3),
+            maxDelay: TimeSpan.FromSeconds(8));
+
+        Assert.Equal(TimeSpan.FromSeconds(2), strategy.Decide(0, 1).Delay);
+        Assert.Equal(TimeSpan.FromSeconds(5), strategy.Decide(0, 2).Delay);
+        Assert.Equal(TimeSpan.FromSeconds(8), strategy.Decide(0, 3).Delay);
+        // 2+3*3=11, capped to 8.
+        Assert.Equal(TimeSpan.FromSeconds(8), strategy.Decide(0, 4).Delay);
+    }
+
+    [Fact]
+    public void Linear_ThrowsAtMaxAttempts()
+    {
+        var strategy = WaitStrategy.Linear<int>(maxAttempts: 3);
+
+        Assert.True(strategy.Decide(0, 1).ShouldContinue);
+        Assert.True(strategy.Decide(0, 2).ShouldContinue);
+        Assert.Throws<WaitForConditionException>(() => strategy.Decide(0, 3));
+    }
+
+    [Fact]
+    public void Linear_IsDonePredicate_ShortCircuits()
+    {
+        var strategy = WaitStrategy.Linear<int>(
+            maxAttempts: 100,
+            isDone: state => state == 42);
+
+        Assert.True(strategy.Decide(1, 1).ShouldContinue);
+        Assert.False(strategy.Decide(42, 1).ShouldContinue);
+    }
+
+    [Fact]
+    public void Fixed_AlwaysReturnsSameDelay()
+    {
+        var strategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(7), maxAttempts: 5);
+
+        Assert.Equal(TimeSpan.FromSeconds(7), strategy.Decide(0, 1).Delay);
+        Assert.Equal(TimeSpan.FromSeconds(7), strategy.Decide(0, 2).Delay);
+        Assert.Equal(TimeSpan.FromSeconds(7), strategy.Decide(0, 4).Delay);
+    }
+
+    [Fact]
+    public void Fixed_ThrowsAtMaxAttempts()
+    {
+        var strategy = WaitStrategy.Fixed<int>(TimeSpan.FromSeconds(2), maxAttempts: 3);
+
+        Assert.True(strategy.Decide(0, 1).ShouldContinue);
+        Assert.True(strategy.Decide(0, 2).ShouldContinue);
+        Assert.Throws<WaitForConditionException>(() => strategy.Decide(0, 3));
+    }
+
+    [Fact]
+    public void Fixed_FloorsDelayAtOneSecond()
+    {
+        // Service timer granularity is 1 second; sub-second delays would
+        // round to 0 if we didn't floor.
+        var strategy = WaitStrategy.Fixed<int>(TimeSpan.FromMilliseconds(100), maxAttempts: 3);
+        var decision = strategy.Decide(0, 1);
+        Assert.True(decision.ShouldContinue);
+        Assert.Equal(TimeSpan.FromSeconds(1), decision.Delay);
+    }
+
+    [Fact]
+    public void Fixed_IsDonePredicate_ShortCircuits()
+    {
+        var strategy = WaitStrategy.Fixed<bool>(
+            TimeSpan.FromSeconds(1),
+            maxAttempts: 50,
+            isDone: state => state);
+
+        Assert.True(strategy.Decide(false, 1).ShouldContinue);
+        Assert.False(strategy.Decide(true, 1).ShouldContinue);
+    }
+
+    [Fact]
+    public void FromDelegate_UsesProvidedFunction()
+    {
+        var strategy = WaitStrategy.FromDelegate<int>((state, attempt) =>
+            state >= 3 || attempt >= 5
+                ? WaitDecision.Stop()
+                : WaitDecision.ContinueAfter(TimeSpan.FromSeconds(state + 1)));
+
+        Assert.True(strategy.Decide(0, 1).ShouldContinue);
+        Assert.Equal(TimeSpan.FromSeconds(1), strategy.Decide(0, 1).Delay);
+        Assert.False(strategy.Decide(3, 1).ShouldContinue);
+        Assert.False(strategy.Decide(0, 5).ShouldContinue);
+    }
+
+    [Fact]
+    public void WaitDecision_StopAndContinueAfter_ProduceExpectedShape()
+    {
+        var stop = WaitDecision.Stop();
+        Assert.False(stop.ShouldContinue);
+        Assert.Equal(TimeSpan.Zero, stop.Delay);
+
+        var cont = WaitDecision.ContinueAfter(TimeSpan.FromSeconds(3));
+        Assert.True(cont.ShouldContinue);
+        Assert.Equal(TimeSpan.FromSeconds(3), cont.Delay);
+    }
+}


### PR DESCRIPTION
https://github.com/aws/aws-lambda-dotnet/issues/2216

## What

Adds service-mediated polling to `Amazon.Lambda.DurableExecution`. `WaitForConditionAsync` repeatedly evaluates a check function with a configurable wait strategy between attempts; each iteration runs in its own Lambda invocation (suspended via `STEP` + `RETRY` checkpoints carrying `NextAttemptDelaySeconds`), so polling does not consume compute time while waiting between checks.

Public API:

| Type | Purpose |
|---|---|
| `IDurableContext.WaitForConditionAsync<TState>(...)` | Poll until the user-supplied predicate signals done or `maxAttempts` is exhausted. Per-iteration state is serialized via the `ILambdaSerializer` registered on `ILambdaContext.Serializer` (same pattern as `StepAsync` / `RunInChildContextAsync`). |
| `IConditionCheckContext` | Passed to the check func: `Logger`, `AttemptNumber`. |
| `WaitForConditionConfig<TState>` | Required `InitialState` + `WaitStrategy`. |
| `IWaitStrategy<TState>` | `Decide(state, attempt)` returning `WaitDecision`. |
| `WaitDecision` | Readonly record struct: `ShouldContinue`, `Delay`, factories `Stop()` / `ContinueAfter(TimeSpan)`. |
| `WaitStrategy` factories | `Exponential`, `Linear`, `Fixed`, `FromDelegate` — each accepting an optional `Func<TState, bool> isDone` predicate. |
| `WaitForConditionException` | Thrown when `maxAttempts` is exhausted; carries `AttemptsExhausted` and `LastState` (preserved across both live execution and replay). |

## How

`Internal/WaitForConditionOperation<TState>` runs as a `STEP` with `SubType = "WaitForCondition"`:

- **Each iteration** calls the user check function with the current state. The strategy's `Decide(state, attempt)` returns either `Stop()` (success — return state) or `ContinueAfter(delay)` (suspend until next attempt). Continuing emits `Action=RETRY` with the new state in the payload and `NextAttemptDelaySeconds` set so the durable execution service schedules the next invocation without consuming compute time.
- **Strategies** signal max-attempts exhausted by throwing `WaitForConditionException` directly from `Decide()`; the operation enriches with `LastState` before checkpointing FAIL. `LastState` survives FAIL replay: serialized into the FAIL payload at write time and deserialized in `BuildFailureException` with a warning-logged fallback for legacy / corrupt data.
- **Serialization** is delegated to the registered `ILambdaSerializer` via stream-based `Serialize<T>` / `Deserialize<T>` calls — no AOT trim attributes on the public API. Mirrors `StepOperation` / `ChildContextOperation`.
- **`ExponentialBackoff` helper** is extracted for sharing between this operation and `ExponentialRetryStrategy`. Math is byte-for-byte identical to the existing implementation.

**Defaults:** 60 attempts, 5s initial delay, 300s max delay, 1.5x rate, Full jitter — distinct from `RetryStrategy.Default` and matching Python/JS/Java reference SDKs.

> **Cross-SDK note:** Python returns success on max-attempts exhausted; .NET / Java / JS throw. Workflows ported from Python should review for new failure modes. Documented in the design doc.



