### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/change-file-in-pr.yml
+++ b/.github/workflows/change-file-in-pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
+permissions:
+  contents: read
+
 jobs:
   check-files-in-directory:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'Release Not Needed') && !contains(github.event.pull_request.labels.*.name, 'Release PR') }}


### PR DESCRIPTION
Potential fix for [https://github.com/aws/aws-lambda-dotnet/security/code-scanning/36](https://github.com/aws/aws-lambda-dotnet/security/code-scanning/36)

Add an explicit top-level `permissions` block in `.github/workflows/change-file-in-pr.yml` so the workflow does not inherit potentially broad defaults.  
Best fix without changing functionality: set:

- `contents: read`

This is sufficient for the displayed steps (`actions/checkout`, reading changed files, and shell checks) and aligns with CodeQL’s minimal recommendation.  
Change location: near the top of the workflow, after the `on:` trigger block and before `jobs:`.

No imports, methods, or external dependencies are needed.

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
