### PR TITLE
Fix AWSLambdaPSCore 5.0.0 dotnet10 runtime failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Release 2026-05-15
+
+### AWSLambdaPSCore PowerShell Module (5.0.1)
+* Fix dotnet10 runtime failures by updating template package references to versions with net10.0 assets. Bumped Amazon.Lambda.PowerShellHost from 3.0.3 to 4.0.0, Amazon.Lambda.Core from 2.8.1 to 3.0.0 (required transitively by PowerShellHost 4.0.0), and the default Microsoft.PowerShell.SDK from 7.5.4 to 7.6.0.
+
 ## Release 2026-05-13
 
 ### Amazon.Lambda.TestTool (0.14.1)

--- a/PowerShell/Module/AWSLambdaPSCore.psd1
+++ b/PowerShell/Module/AWSLambdaPSCore.psd1
@@ -12,7 +12,7 @@
 RootModule = 'AWSLambdaPSCore.psm1'
 
 # Version number of this module.
-ModuleVersion = '5.0.0.0'
+ModuleVersion = '5.0.1.0'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core'

--- a/PowerShell/Module/Private/_Constants.ps1
+++ b/PowerShell/Module/Private/_Constants.ps1
@@ -20,7 +20,7 @@ if (!($AwsPowerShellFunctionEnvName))
 
 if (!($AwsPowerShellDefaultSdkVersion))
 {
-    New-Variable -Name AwsPowerShellDefaultSdkVersion -Value '7.5.4' -Option Constant
+    New-Variable -Name AwsPowerShellDefaultSdkVersion -Value '7.6.0' -Option Constant
 }
 
 if (!($AwsPowerShellTargetFramework))

--- a/PowerShell/Module/Templates/Blueprints/aws-lambda-tools-defaults.txt
+++ b/PowerShell/Module/Templates/Blueprints/aws-lambda-tools-defaults.txt
@@ -2,7 +2,7 @@
     "profile"     : "CONFIGURED_PROFILE",
     "region"      : "CONFIGURED_REGION",
     "configuration" : "Release",
-    "function-runtime" : "dotnet6",
+    "function-runtime" : "",
     "function-memory-size" : DEFAULT_MEMORY,
     "function-timeout"     : DEFAULT_TIMEOUT,
     "function-handler"     : "PROJECT_NAME::PROJECT_NAME.Bootstrap::ExecuteFunction",

--- a/PowerShell/Module/Templates/Blueprints/projectfile.csproj.txt
+++ b/PowerShell/Module/Templates/Blueprints/projectfile.csproj.txt
@@ -16,7 +16,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.PowerShell.SDK" Version="POWERSHELL_SDK_VERSION" />
 
-        <PackageReference Include="Amazon.Lambda.Core" Version="2.8.1" />
-        <PackageReference Include="Amazon.Lambda.PowerShellHost" Version="3.0.3" />
+        <PackageReference Include="Amazon.Lambda.Core" Version="3.0.0" />
+        <PackageReference Include="Amazon.Lambda.PowerShellHost" Version="4.0.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

AWSLambdaPSCore `5.0.0` (released 2026-02-18 in #2286) retargeted the generated Lambda project to `net10.0`/`dotnet10` but left two pinned dependencies on versions that ship no `net10.0` assets:

- `Amazon.Lambda.PowerShellHost 3.0.3` ships only `lib/net8.0/`
- `Microsoft.PowerShell.SDK 7.5.4` ships only `runtimes/unix/lib/net9.0/`

NuGet's nearest-TFM fallback resolves these at restore time, so builds and `Publish-AWSPowerShellLambda` succeed, but at runtime the .NET 10 host can't load the PowerShell module DLLs. Customers see empty `$PSScriptRoot`, `Microsoft.PowerShell.Management` and `Microsoft.PowerShell.Utility` failing to load, and any cmdlet from those modules (`Write-Host`, `Write-Warning`, `Import-Module`, etc.) returning a fatal `errorType: "Write-Host"` style failure.

The upstream `Amazon.Lambda.PowerShellHost 4.0.0` (shipped in the 2026-05-06 release, #2357) and `Microsoft.PowerShell.SDK 7.6.0` both add net10.0 assets, but the AWSLambdaPSCore template was never updated to consume them.

Reported via internal trouble ticket D453237646.

## Changes

| File | Change |
|---|---|
| `PowerShell/Module/Templates/Blueprints/projectfile.csproj.txt` | `Amazon.Lambda.PowerShellHost` 3.0.3 → 4.0.0 |
| `PowerShell/Module/Templates/Blueprints/projectfile.csproj.txt` | `Amazon.Lambda.Core` 2.8.1 → 3.0.0 (required transitively by PowerShellHost 4.0.0; without the bump, NUI restore fails NU1605) |
| `PowerShell/Module/Private/_Constants.ps1` | `AwsPowerShellDefaultSdkVersion` 7.5.4 → 7.6.0 |
| `PowerShell/Module/AWSLambdaPSCore.psd1` | `ModuleVersion` 5.0.0.0 → 5.0.1.0 |
| `CHANGELOG.md` | new `## Release 2026-05-15` section with `### AWSLambdaPSCore PowerShell Module (5.0.1)` entry |

## Reproduction (verified locally)

1. Mimic what `New-AWSPowerShellLambdaPackage` produces from the current 5.0.0 template by writing a project file with the exact dependency set:
   ```xml
   <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
       <TargetFramework>net10.0</TargetFramework>
       <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     </PropertyGroup>
     <ItemGroup>
       <PackageReference Include="Microsoft.PowerShell.SDK"     Version="7.5.4" />
       <PackageReference Include="Amazon.Lambda.Core"           Version="2.8.1" />
       <PackageReference Include="Amazon.Lambda.PowerShellHost" Version="3.0.3" />
     </ItemGroup>
   </Project>
   ```
2. `dotnet publish -c Release -f net10.0 --runtime linux-x64 --self-contained false`
3. Inspect the generated `*.deps.json` — it shows the broken TFM resolution that matches the customer evidence in the ticket verbatim:
   ```
   Amazon.Lambda.PowerShellHost/3.0.3              -> lib/net8.0/Amazon.Lambda.PowerShellHost.dll
   Microsoft.PowerShell.Commands.Management/7.5.4  -> runtimes/unix/lib/net9.0/...
   Microsoft.PowerShell.Commands.Utility/7.5.4     -> runtimes/unix/lib/net9.0/...
   Microsoft.PowerShell.SDK/7.5.4                  -> runtimes/unix/lib/net9.0/...
   System.Management.Automation/7.5.4              -> runtimes/unix/lib/net9.0/...
   ```
4. Apply the dependency bumps from this PR (`PowerShellHost` → 4.0.0, `Core` → 3.0.0, `Microsoft.PowerShell.SDK` → 7.6.0), `dotnet publish` again, and inspect `deps.json`:
   ```
   Amazon.Lambda.PowerShellHost/4.0.0              -> lib/net10.0/Amazon.Lambda.PowerShellHost.dll
   Microsoft.PowerShell.Commands.Management/7.6.0  -> runtimes/unix/lib/net10.0/...
   Microsoft.PowerShell.Commands.Utility/7.6.0     -> runtimes/unix/lib/net10.0/...
   Microsoft.PowerShell.SDK/7.6.0                  -> runtimes/unix/lib/net10.0/...
   System.Management.Automation/7.6.0              -> runtimes/unix/lib/net10.0/...
   ```

The `Amazon.Lambda.Core` 2.8.1 → 3.0.0 bump is not optional — the first `dotnet publish` after only updating PowerShellHost fails with `NU1605: Detected package downgrade: Amazon.Lambda.Core from 3.0.0 to 2.8.1`, because PowerShellHost 4.0.0 declares `Amazon.Lambda.Core (>= 3.0.0)` as a transitive dependency.

`runtimeconfig.json` is unchanged at `tfm: net10.0` for both before and after — only the `deps.json` resolution changes.

## Test plan

- [x] Local build-time repro (above): bad deps.json shows net8.0/net9.0 paths; fixed deps.json shows net10.0 paths.
- [ ] End-to-end runtime test: deploy a `New-AWSPowerShellLambda`-generated function on `dotnet10` with the patched module, invoke a script that uses `Write-Host`, `Write-Warning`, `$PSScriptRoot`, and `Import-Module Microsoft.PowerShell.Management` to confirm none of the customer-reported symptoms reappear. (Not run locally; recommend running before publishing 5.0.1 to PSGallery.)

## Notes

- AWSLambdaPSCore is not managed by autover, matching the precedent of the 5.0.0 update in #2286 (commit 70a47b09): the `.psd1` ModuleVersion bump and CHANGELOG entry are included directly in this PR rather than handled by a follow-up "Release YYYY-MM-DD" PR.
- The CHANGELOG date heading (`2026-05-15`) is independent of the autover release cadence; if a new autover release PR lands first, the AWSLambdaPSCore section can be merged into its date heading instead.