### PR TITLE
Add ability to customize structured logging serialization options

### DIFF
--- a/.autover/changes/1d2619b4-c0e7-4fcd-81a6-7ef7dcf4e2e8.json
+++ b/.autover/changes/1d2619b4-c0e7-4fcd-81a6-7ef7dcf4e2e8.json
@@ -1,0 +1,18 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Core",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "[Preview ] Add LambdaLogger.ConfigureStructuredLogging to customize the JsonSerializerOptions used for serializing logging parameters."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.RuntimeSupport",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Add support for handling the structured logging customization from Amazon.Lambda.Core."
+      ]
+    }	
+  ]
+}

--- a/.autover/changes/1d2619b4-c0e7-4fcd-81a6-7ef7dcf4e2e8.json
+++ b/.autover/changes/1d2619b4-c0e7-4fcd-81a6-7ef7dcf4e2e8.json
@@ -4,7 +4,7 @@
       "Name": "Amazon.Lambda.Core",
       "Type": "Minor",
       "ChangelogMessages": [
-        "[Preview ] Add LambdaLogger.ConfigureStructuredLogging to customize the JsonSerializerOptions used for serializing logging parameters."
+        "[Preview] Add LambdaLogger.ConfigureStructuredLogging to customize the JsonSerializerOptions used for serializing logging parameters."
       ]
     },
     {

--- a/Libraries/src/Amazon.Lambda.Core/LambdaLogger.cs
+++ b/Libraries/src/Amazon.Lambda.Core/LambdaLogger.cs
@@ -127,8 +127,8 @@ namespace Amazon.Lambda.Core
         /// <param name="args">Arguments to format the message with.</param>
         public static void Log(LogLevel level, Exception exception, string message, params object[] args) => Log(level.ToString(), exception, message, args);
 
-        // The name of this field must not change or be readonly because Amazon.Lambda.RuntimeSupport will use reflection to replace the
-        // value with an Action that directs the logging into its logging system.
+        // This field must not be readonly because SetConfigureStructuredLoggingAction replaces the value
+        // when Amazon.Lambda.RuntimeSupport registers its structured logging callback.
         private static Action<StructuredLoggingOptions> _configureStructuredLoggingAction = (options) => _placeHolderStructuredLoggingOptions = options;
 
         // Because a user might call ConfigureStructuredLogging before the Lambda runtime has a chance to replace the _configureStructuredLoggingAction with the
@@ -136,10 +136,10 @@ namespace Amazon.Lambda.Core
         private static StructuredLoggingOptions _placeHolderStructuredLoggingOptions;
 
         /// <summary>
-        /// When structured logging is enabled this method will allows overriding the default configuration the Lambda runtime uses for structured logging.
+        /// When structured logging is enabled this method will allow overriding the default configuration the Lambda runtime uses for structured logging.
         /// </summary>
         /// <param name="options">The options to use for configuring structured logging.</param>
-        [RequiresPreviewFeatures("This method is in preview till the latest changes of the .NET Lambda runtime client have been deployed to the Lambda managed runtimes")]
+        [RequiresPreviewFeatures("This method is in preview until the latest changes of the .NET Lambda runtime client have been deployed to the Lambda managed runtimes")]
         public static void ConfigureStructuredLogging(StructuredLoggingOptions options) => _configureStructuredLoggingAction(options);
 
         internal static void SetConfigureStructuredLoggingAction(Action<StructuredLoggingOptions> configureStructuredLoggingAction)

--- a/Libraries/src/Amazon.Lambda.Core/LambdaLogger.cs
+++ b/Libraries/src/Amazon.Lambda.Core/LambdaLogger.cs
@@ -126,6 +126,33 @@ namespace Amazon.Lambda.Core
         /// <param name="message">Message to log. The message may have format arguments.</param>
         /// <param name="args">Arguments to format the message with.</param>
         public static void Log(LogLevel level, Exception exception, string message, params object[] args) => Log(level.ToString(), exception, message, args);
+
+        // The name of this field must not change or be readonly because Amazon.Lambda.RuntimeSupport will use reflection to replace the
+        // value with an Action that directs the logging into its logging system.
+        private static Action<StructuredLoggingOptions> _configureStructuredLoggingAction = (options) => _placeHolderStructuredLoggingOptions = options;
+
+        // Because a user might call ConfigureStructuredLogging before the Lambda runtime has a chance to replace the _configureStructuredLoggingAction with the
+        // real implementation, we need to hold onto the options they provided until the Lambda runtime can use them to configure structured logging.
+        private static StructuredLoggingOptions _placeHolderStructuredLoggingOptions;
+
+        /// <summary>
+        /// When structured logging is enabled this method will allows overriding the default configuration the Lambda runtime uses for structured logging.
+        /// </summary>
+        /// <param name="options">The options to use for configuring structured logging.</param>
+        [RequiresPreviewFeatures("This method is in preview till the latest changes of the .NET Lambda runtime client have been deployed to the Lambda managed runtimes")]
+        public static void ConfigureStructuredLogging(StructuredLoggingOptions options) => _configureStructuredLoggingAction(options);
+
+        internal static void SetConfigureStructuredLoggingAction(Action<StructuredLoggingOptions> configureStructuredLoggingAction)
+        {
+            _configureStructuredLoggingAction = configureStructuredLoggingAction;
+
+            // If a user set the structured logging options before the Lambda runtime set the real _configureStructuredLoggingAction,
+            // we need to call it now to make sure the user's options are applied.
+            if (_placeHolderStructuredLoggingOptions != null)
+            {
+                _configureStructuredLoggingAction(_placeHolderStructuredLoggingOptions);
+            }
+        }
 #endif
     }
 }

--- a/Libraries/src/Amazon.Lambda.Core/StructuredLoggingOptions.cs
+++ b/Libraries/src/Amazon.Lambda.Core/StructuredLoggingOptions.cs
@@ -6,7 +6,7 @@ using System.Text.Json;
 namespace Amazon.Lambda.Core;
 
 /// <summary>
-/// The options that can be overriden for structured logging.
+/// The options that can be overridden for structured logging.
 /// </summary>
 public class StructuredLoggingOptions
 {

--- a/Libraries/src/Amazon.Lambda.Core/StructuredLoggingOptions.cs
+++ b/Libraries/src/Amazon.Lambda.Core/StructuredLoggingOptions.cs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+#if NET8_0_OR_GREATER
+using System.Text.Json;
+
+namespace Amazon.Lambda.Core;
+
+/// <summary>
+/// The options that can be overriden for structured logging.
+/// </summary>
+public class StructuredLoggingOptions
+{
+    /// <summary>
+    /// Override the default JsonSerializerOptions used by the Lambda runtime for structured logging. This allows you to control things like property naming and which properties are included in the structured logs.
+    /// </summary>
+    public JsonSerializerOptions OverrideSerializerOptions { get; set; }
+}
+#endif

--- a/Libraries/src/Amazon.Lambda.Core/StructuredLoggingOptions.cs
+++ b/Libraries/src/Amazon.Lambda.Core/StructuredLoggingOptions.cs
@@ -11,7 +11,7 @@ namespace Amazon.Lambda.Core;
 public class StructuredLoggingOptions
 {
     /// <summary>
-    /// Override the default JsonSerializerOptions used by the Lambda runtime for structured logging. This allows you to control things like property naming and which properties are included in the structured logs.
+    /// Override the default JsonSerializerOptions used by the Lambda runtime for serializing object parameters in structured logs.
     /// </summary>
     public JsonSerializerOptions OverrideSerializerOptions { get; set; }
 }

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/ConfigureJsonLogMessageFormatterIsolated.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/ConfigureJsonLogMessageFormatterIsolated.cs
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Text.Json;
+
+namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
+{
+    internal class ConfigureJsonLogMessageFormatterIsolated
+    {
+        private readonly JsonLogMessageFormatter _formatter;
+        public ConfigureJsonLogMessageFormatterIsolated(JsonLogMessageFormatter formatter)
+        {
+            _formatter = formatter;
+        }
+
+        internal void ConfigureCallbackInCore()
+        {
+            Amazon.Lambda.Core.LambdaLogger.SetConfigureStructuredLoggingAction(ConfigureStructuredLogging);
+        }
+
+        private void ConfigureStructuredLogging(Amazon.Lambda.Core.StructuredLoggingOptions options)
+        {
+            try
+            {
+                var isolatedOptions = new StructuredLoggingOptions
+                {
+                    OverrideSerializerOptions = options.OverrideSerializerOptions
+                };
+            }
+            catch(Exception ex)
+            {
+                InternalLogger.GetDefaultLogger().LogDebug("Failed to configure structured logging. This generally happens when the version of Amazon.Lambda.Core is out of date. Update to latest version of Amazon.Lambda.Core: " + ex.ToString());
+            }
+        }
+
+
+        /// <summary>
+        /// Mirror the version of StructuredLoggingOptions in Amazon.Lambda.Core because we can't guarantee that the version of Amazon.Lambda.Core used by the customer
+        /// will be the same as the version of Amazon.Lambda.RuntimeSupport.
+        /// </summary>
+        internal class StructuredLoggingOptions
+        {
+            public JsonSerializerOptions OverrideSerializerOptions { get; set; }
+        }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/ConfigureJsonLogMessageFormatterIsolated.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/ConfigureJsonLogMessageFormatterIsolated.cs
@@ -12,6 +12,12 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
         {
             Amazon.Lambda.Core.LambdaLogger.SetConfigureStructuredLoggingAction((Amazon.Lambda.Core.StructuredLoggingOptions coreOptions) =>
             {
+                if (coreOptions == null)
+                {
+                    callback(null);
+                    return;
+                }
+
                 var isolatedOptions = new StructuredLoggingOptions();
                 try
                 {

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/ConfigureJsonLogMessageFormatterIsolated.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/ConfigureJsonLogMessageFormatterIsolated.cs
@@ -8,40 +8,22 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
 {
     internal class ConfigureJsonLogMessageFormatterIsolated
     {
-        private readonly JsonLogMessageFormatter _formatter;
-        public ConfigureJsonLogMessageFormatterIsolated(JsonLogMessageFormatter formatter)
+        internal static void ConfigureCallbackInCore(Action<StructuredLoggingOptions> callback)
         {
-            _formatter = formatter;
-        }
-
-        internal void ConfigureCallbackInCore()
-        {
-            Amazon.Lambda.Core.LambdaLogger.SetConfigureStructuredLoggingAction(ConfigureStructuredLogging);
-        }
-
-        private void ConfigureStructuredLogging(Amazon.Lambda.Core.StructuredLoggingOptions options)
-        {
-            try
+            Amazon.Lambda.Core.LambdaLogger.SetConfigureStructuredLoggingAction((Amazon.Lambda.Core.StructuredLoggingOptions coreOptions) =>
             {
-                var isolatedOptions = new StructuredLoggingOptions
+                var isolatedOptions = new StructuredLoggingOptions();
+                try
                 {
-                    OverrideSerializerOptions = options.OverrideSerializerOptions
-                };
-            }
-            catch(Exception ex)
-            {
-                InternalLogger.GetDefaultLogger().LogDebug("Failed to configure structured logging. This generally happens when the version of Amazon.Lambda.Core is out of date. Update to latest version of Amazon.Lambda.Core: " + ex.ToString());
-            }
-        }
+                    isolatedOptions.OverrideSerializerOptions = coreOptions.OverrideSerializerOptions;
+                }
+                catch (Exception ex)
+                {
+                    InternalLogger.GetDefaultLogger().LogDebug("Failed to configure structured logging. This generally happens when the version of Amazon.Lambda.Core is out of date. Update to latest version of Amazon.Lambda.Core: " + ex.ToString());
+                }
 
-
-        /// <summary>
-        /// Mirror the version of StructuredLoggingOptions in Amazon.Lambda.Core because we can't guarantee that the version of Amazon.Lambda.Core used by the customer
-        /// will be the same as the version of Amazon.Lambda.RuntimeSupport.
-        /// </summary>
-        internal class StructuredLoggingOptions
-        {
-            public JsonSerializerOptions OverrideSerializerOptions { get; set; }
+                callback(isolatedOptions);
+            });
         }
     }
 }

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/JsonLogMessageFormatter.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Helpers/Logging/JsonLogMessageFormatter.cs
@@ -18,7 +18,7 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
         private static readonly UTF8Encoding UTF8NoBomNoThrow = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
 
         // Options used when serializing any message property values as a JSON to be added to the structured log message.
-        private readonly JsonSerializerOptions _jsonSerializationOptions;
+        private JsonSerializerOptions _jsonSerializationOptions;
 
         /// <summary>
         /// Constructs an instance of JsonLogMessageFormatter.
@@ -30,9 +30,27 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                 WriteIndented = false
             };
+
+            try
+            {
+                ConfigureJsonLogMessageFormatterIsolated.ConfigureCallbackInCore(ConfigureStructuredLogging);
+            }
+            catch (TypeLoadException)
+            {
+                InternalLogger.GetDefaultLogger().LogDebug("Failed to configure Amazon.Lambda.Core with callback for configuring structured logging. This happens when the version of Amazon.Lambda.Core referenced by the Lambda function is out of date.");
+            }
         }
 
         private static readonly IReadOnlyList<MessageProperty> _emptyMessageProperties = new List<MessageProperty>();
+
+        private void ConfigureStructuredLogging(StructuredLoggingOptions options)
+        {
+            if (options == null)
+                return;
+
+            if (options.OverrideSerializerOptions != null)
+                _jsonSerializationOptions = options.OverrideSerializerOptions;
+        }
 
         /// <summary>
         /// Format the log message as a structured JSON log message.
@@ -312,5 +330,14 @@ namespace Amazon.Lambda.RuntimeSupport.Helpers.Logging
         }
 
         private static string ToInvariantString(object obj) => Convert.ToString(obj, CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Mirror the version of StructuredLoggingOptions in Amazon.Lambda.Core because we can't guarantee that the version of Amazon.Lambda.Core used by the customer
+    /// will be the same as the version of Amazon.Lambda.RuntimeSupport.
+    /// </summary>
+    internal class StructuredLoggingOptions
+    {
+        public JsonSerializerOptions OverrideSerializerOptions { get; set; }
     }
 }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
@@ -2336,6 +2336,7 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
                 DiagnosticResult.CompilerError("CS0117").WithSpan(snapFile, 13, 34, 13, 71).WithArguments("Amazon.Lambda.Core.SnapshotRestore", "CopyBeforeSnapshotCallbacksToRegistry"),
                 DiagnosticResult.CompilerError("CS0117").WithSpan(snapFile, 14, 34, 14, 69).WithArguments("Amazon.Lambda.Core.SnapshotRestore", "CopyAfterRestoreCallbacksToRegistry"),
                 DiagnosticResult.CompilerError("CS0122").WithSpan($"Amazon.Lambda.RuntimeSupport{Path.DirectorySeparatorChar}Bootstrap{Path.DirectorySeparatorChar}ResponseStreaming{Path.DirectorySeparatorChar}ResponseStreamLambdaCoreInitializerIsolated.cs", 37, 51, 37, 72).WithArguments("Amazon.Lambda.Core.ResponseStreaming.ILambdaResponseStream"),
+                DiagnosticResult.CompilerError("CS0117").WithSpan($"Amazon.Lambda.RuntimeSupport{Path.DirectorySeparatorChar}Helpers{Path.DirectorySeparatorChar}Logging{Path.DirectorySeparatorChar}ConfigureJsonLogMessageFormatterIsolated.cs", 13, 45, 13, 80).WithArguments("Amazon.Lambda.Core.LambdaLogger", "SetConfigureStructuredLoggingAction"),
             };
         }
     }

--- a/Libraries/test/Amazon.Lambda.Core.Tests/Amazon.Lambda.Core.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.Core.Tests/Amazon.Lambda.Core.Tests.csproj
@@ -7,6 +7,8 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyOriginatorKeyFile>..\..\..\buildtools\public.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+    <!-- CA2252: Tests call preview features (ConfigureStructuredLogging) which is expected -->
+    <NoWarn>CA2252</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libraries/test/Amazon.Lambda.Core.Tests/StructuredLoggingTests.cs
+++ b/Libraries/test/Amazon.Lambda.Core.Tests/StructuredLoggingTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Text.Json;
+using Xunit;
+
+using Amazon.Lambda.Core;
+
+namespace Amazon.Lambda.Tests
+{
+    public class StructuredLoggingTests
+    {
+        [Fact]
+        public void SetConfigureStructuredLoggingAction_CallbackReceivesOptions()
+        {
+            StructuredLoggingOptions receivedOptions = null;
+
+            LambdaLogger.SetConfigureStructuredLoggingAction(options =>
+            {
+                receivedOptions = options;
+            });
+
+            var expectedOptions = new StructuredLoggingOptions
+            {
+                OverrideSerializerOptions = new JsonSerializerOptions { WriteIndented = true }
+            };
+
+            LambdaLogger.ConfigureStructuredLogging(expectedOptions);
+
+            Assert.NotNull(receivedOptions);
+            Assert.Same(expectedOptions, receivedOptions);
+            Assert.True(receivedOptions.OverrideSerializerOptions.WriteIndented);
+        }
+
+        [Fact]
+        public void ConfigureStructuredLogging_BeforeRuntimeSetsAction_OptionsFlowThroughCurrentAction()
+        {
+            StructuredLoggingOptions capturedOptions = null;
+            LambdaLogger.SetConfigureStructuredLoggingAction(options =>
+            {
+                capturedOptions = options;
+            });
+
+            var userOptions = new StructuredLoggingOptions
+            {
+                OverrideSerializerOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }
+            };
+
+            LambdaLogger.ConfigureStructuredLogging(userOptions);
+            Assert.Same(userOptions, capturedOptions);
+        }
+
+        [Fact]
+        public void SetConfigureStructuredLoggingAction_PendingOptionsForwardedToNewAction()
+        {
+            // Simulate the placeholder behavior: _configureStructuredLoggingAction initially stores options
+            // in _placeHolderStructuredLoggingOptions. When the runtime later calls SetConfigureStructuredLoggingAction,
+            // the pending options are forwarded to the new action.
+
+            // Step 1: Set up a placeholder-like action that stores the options
+            // (This mimics what happens in the real LambdaLogger static initializer)
+            StructuredLoggingOptions placeholderStore = null;
+            LambdaLogger.SetConfigureStructuredLoggingAction(options => placeholderStore = options);
+
+            // Step 2: User calls ConfigureStructuredLogging (simulating early call before runtime is ready)
+            var userOptions = new StructuredLoggingOptions
+            {
+                OverrideSerializerOptions = new JsonSerializerOptions { WriteIndented = true }
+            };
+            LambdaLogger.ConfigureStructuredLogging(userOptions);
+            Assert.Same(userOptions, placeholderStore);
+        }
+
+        [Fact]
+        public void StructuredLoggingOptions_DefaultsToNull()
+        {
+            var options = new StructuredLoggingOptions();
+            Assert.Null(options.OverrideSerializerOptions);
+        }
+    }
+}

--- a/Libraries/test/Amazon.Lambda.Core.Tests/StructuredLoggingTests.cs
+++ b/Libraries/test/Amazon.Lambda.Core.Tests/StructuredLoggingTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using System.Text.Json;
 using Xunit;
 
@@ -51,22 +52,38 @@ namespace Amazon.Lambda.Tests
         [Fact]
         public void SetConfigureStructuredLoggingAction_PendingOptionsForwardedToNewAction()
         {
-            // Simulate the placeholder behavior: _configureStructuredLoggingAction initially stores options
-            // in _placeHolderStructuredLoggingOptions. When the runtime later calls SetConfigureStructuredLoggingAction,
-            // the pending options are forwarded to the new action.
+            // Reset _placeHolderStructuredLoggingOptions and _configureStructuredLoggingAction to initial state
+            // so we can test the forwarding path.
+            var placeholderField = typeof(LambdaLogger).GetField("_placeHolderStructuredLoggingOptions", BindingFlags.NonPublic | BindingFlags.Static);
+            var actionField = typeof(LambdaLogger).GetField("_configureStructuredLoggingAction", BindingFlags.NonPublic | BindingFlags.Static);
 
-            // Step 1: Set up a placeholder-like action that stores the options
-            // (This mimics what happens in the real LambdaLogger static initializer)
-            StructuredLoggingOptions placeholderStore = null;
-            LambdaLogger.SetConfigureStructuredLoggingAction(options => placeholderStore = options);
+            // Reset to initial state: action stores to placeholder, placeholder is null
+            placeholderField.SetValue(null, null);
+            actionField.SetValue(null, new Action<StructuredLoggingOptions>(options =>
+            {
+                placeholderField.SetValue(null, options);
+            }));
 
-            // Step 2: User calls ConfigureStructuredLogging (simulating early call before runtime is ready)
+            // Step 1: User calls ConfigureStructuredLogging before runtime is ready.
+            // This stores the options in _placeHolderStructuredLoggingOptions.
             var userOptions = new StructuredLoggingOptions
             {
                 OverrideSerializerOptions = new JsonSerializerOptions { WriteIndented = true }
             };
             LambdaLogger.ConfigureStructuredLogging(userOptions);
-            Assert.Same(userOptions, placeholderStore);
+
+            Assert.Same(userOptions, placeholderField.GetValue(null));
+
+            // Step 2: Runtime calls SetConfigureStructuredLoggingAction.
+            // The pending options should be forwarded to the new action.
+            StructuredLoggingOptions forwardedOptions = null;
+            LambdaLogger.SetConfigureStructuredLoggingAction(options =>
+            {
+                forwardedOptions = options;
+            });
+
+            Assert.NotNull(forwardedOptions);
+            Assert.Same(userOptions, forwardedOptions);
         }
 
         [Fact]

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/Amazon.Lambda.RuntimeSupport.UnitTests.csproj
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/Amazon.Lambda.RuntimeSupport.UnitTests.csproj
@@ -5,7 +5,8 @@
     <AssemblyOriginatorKeyFile>..\..\..\..\buildtools\public.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <!-- This is turning off the warning for unused parameters in method signatures. There are tests that we need to have parameters in the signature for testing purposes. -->
-    <NoWarn>IDE0060</NoWarn>
+    <!-- CA2252: Tests call preview features (ConfigureStructuredLogging) which is expected -->
+    <NoWarn>IDE0060;CA2252</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LogMessageFormatterTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LogMessageFormatterTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Xunit;
 using static Amazon.Lambda.RuntimeSupport.UnitTests.LogMessageFormatterTests;
 
@@ -578,6 +579,141 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             var properties = formatter.ParseProperties(message);
             var isPositional = formatter.UsingPositionalArguments(properties);
             Assert.Equal(expected, isPositional);
+        }
+
+        [Fact]
+        public void ConfigureStructuredLogging_OverrideSerializerOptions_UsesCustomOptions()
+        {
+            var customOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = false
+            };
+
+            // Constructing the formatter sets it as the callback target in LambdaLogger
+            var formatter = new JsonLogMessageFormatter();
+
+            // Call through the public API on LambdaLogger which flows to the formatter
+            Amazon.Lambda.Core.LambdaLogger.ConfigureStructuredLogging(new Amazon.Lambda.Core.StructuredLoggingOptions
+            {
+                OverrideSerializerOptions = customOptions
+            });
+
+            var timestamp = DateTime.UtcNow;
+            var product = new Product() { Name = "Widget", Inventory = 100 };
+
+            var state = new MessageState()
+            {
+                AwsRequestId = "1234",
+                Level = Helpers.LogLevelLoggerWriter.LogLevel.Information,
+                MessageTemplate = "Product is {@product}",
+                MessageArguments = new object[] { product },
+                TimeStamp = timestamp
+            };
+
+            var json = formatter.FormatMessage(state);
+            var doc = JsonDocument.Parse(json);
+
+            // With camelCase naming policy, the serialized product properties should be camelCase
+            Assert.Equal(JsonValueKind.Object, doc.RootElement.GetProperty("product").ValueKind);
+            Assert.Equal("Widget", doc.RootElement.GetProperty("product").GetProperty("name").GetString());
+            Assert.Equal(100, doc.RootElement.GetProperty("product").GetProperty("inventory").GetInt32());
+        }
+
+        [Fact]
+        public void ConfigureStructuredLogging_NullOptions_DoesNotThrow()
+        {
+            var formatter = new JsonLogMessageFormatter();
+
+            Amazon.Lambda.Core.LambdaLogger.ConfigureStructuredLogging(null);
+
+            var timestamp = DateTime.UtcNow;
+            var product = new Product() { Name = "Widget", Inventory = 100 };
+
+            var state = new MessageState()
+            {
+                AwsRequestId = "1234",
+                Level = Helpers.LogLevelLoggerWriter.LogLevel.Information,
+                MessageTemplate = "Product is {@product}",
+                MessageArguments = new object[] { product },
+                TimeStamp = timestamp
+            };
+
+            // Should still work with default options (PascalCase)
+            var json = formatter.FormatMessage(state);
+            var doc = JsonDocument.Parse(json);
+
+            Assert.Equal(JsonValueKind.Object, doc.RootElement.GetProperty("product").ValueKind);
+            Assert.Equal("Widget", doc.RootElement.GetProperty("product").GetProperty("Name").GetString());
+            Assert.Equal(100, doc.RootElement.GetProperty("product").GetProperty("Inventory").GetInt32());
+        }
+
+        [Fact]
+        public void ConfigureStructuredLogging_NullOverrideSerializerOptions_KeepsDefaults()
+        {
+            var formatter = new JsonLogMessageFormatter();
+
+            Amazon.Lambda.Core.LambdaLogger.ConfigureStructuredLogging(new Amazon.Lambda.Core.StructuredLoggingOptions
+            {
+                OverrideSerializerOptions = null
+            });
+
+            var timestamp = DateTime.UtcNow;
+            var product = new Product() { Name = "Widget", Inventory = 100 };
+
+            var state = new MessageState()
+            {
+                AwsRequestId = "1234",
+                Level = Helpers.LogLevelLoggerWriter.LogLevel.Information,
+                MessageTemplate = "Product is {@product}",
+                MessageArguments = new object[] { product },
+                TimeStamp = timestamp
+            };
+
+            // Default options use PascalCase property names
+            var json = formatter.FormatMessage(state);
+            var doc = JsonDocument.Parse(json);
+
+            Assert.Equal(JsonValueKind.Object, doc.RootElement.GetProperty("product").ValueKind);
+            Assert.Equal("Widget", doc.RootElement.GetProperty("product").GetProperty("Name").GetString());
+            Assert.Equal(100, doc.RootElement.GetProperty("product").GetProperty("Inventory").GetInt32());
+        }
+
+        [Fact]
+        public void ConfigureStructuredLogging_CustomOptionsAffectsNullHandling()
+        {
+            var customOptions = new JsonSerializerOptions
+            {
+                DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+                WriteIndented = false
+            };
+
+            var formatter = new JsonLogMessageFormatter();
+
+            Amazon.Lambda.Core.LambdaLogger.ConfigureStructuredLogging(new Amazon.Lambda.Core.StructuredLoggingOptions
+            {
+                OverrideSerializerOptions = customOptions
+            });
+
+            var timestamp = DateTime.UtcNow;
+            var product = new Product() { Name = "Widget", Inventory = 100, Cat = null };
+
+            var state = new MessageState()
+            {
+                AwsRequestId = "1234",
+                Level = Helpers.LogLevelLoggerWriter.LogLevel.Information,
+                MessageTemplate = "Product is {@product}",
+                MessageArguments = new object[] { product },
+                TimeStamp = timestamp
+            };
+
+            var json = formatter.FormatMessage(state);
+            var doc = JsonDocument.Parse(json);
+
+            // With DefaultIgnoreCondition.Never, null properties should be included
+            Assert.Equal(JsonValueKind.Object, doc.RootElement.GetProperty("product").ValueKind);
+            Assert.True(doc.RootElement.GetProperty("product").TryGetProperty("Cat", out var catProp));
+            Assert.Equal(JsonValueKind.Null, catProp.ValueKind);
         }
 
         public class Product


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/2350

## Description

Adds the ability for users to customize the `JsonSerializerOptions` used by the Lambda runtime when serializing object parameters in structured log messages.

### Changes

- **Amazon.Lambda.Core**: Added `StructuredLoggingOptions` class with an `OverrideSerializerOptions` property allowing users to provide custom `JsonSerializerOptions`. Added `LambdaLogger.ConfigureStructuredLogging(StructuredLoggingOptions)` as the public entry point for configuring structured logging.
- **Amazon.Lambda.RuntimeSupport**: Added `ConfigureJsonLogMessageFormatterIsolated` to bridge the callback from `Amazon.Lambda.Core` into the `JsonLogMessageFormatter`, translating between the Core and RuntimeSupport versions of `StructuredLoggingOptions`. The `JsonLogMessageFormatter` now accepts custom serializer options that override the defaults used when serializing `{@property}` values.

The design handles version mismatches between Amazon.Lambda.Core and Amazon.Lambda.RuntimeSupport:
- A mirror `StructuredLoggingOptions` class in RuntimeSupport avoids a hard coupling to the Core version.
- `ConfigureJsonLogMessageFormatterIsolated` isolates the type load so that an older Core (without `StructuredLoggingOptions`) gracefully falls back via `TypeLoadException` handling.
- A placeholder mechanism in `LambdaLogger` ensures that if a user calls `ConfigureStructuredLogging` before the runtime has initialized, the options are buffered and forwarded once the runtime registers its callback.

## Testing

- Unit tests added in `Amazon.Lambda.RuntimeSupport.UnitTests` (`LogMessageFormatterTests`) verifying the full callback chain from `LambdaLogger.ConfigureStructuredLogging` through to `JsonLogMessageFormatter`, including custom naming policies, null options handling, and custom ignore conditions.
- Unit tests added in `Amazon.Lambda.Core.Tests` (`StructuredLoggingTests`) verifying the `SetConfigureStructuredLoggingAction` callback mechanism, placeholder forwarding, and default state.
- Manually confirmed that the changes in Amazon.Lambda.RuntimeSupport work correctly when deployed with an old version of Amazon.Lambda.Core that does not include the new `StructuredLoggingOptions` type.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.