### PR TITLE
Mark Amazon.Lambda.DurableExecution as preview (0.0.1-preview)

### DIFF
--- a/.autover/autover.json
+++ b/.autover/autover.json
@@ -49,7 +49,8 @@
     },
     {
       "Name": "Amazon.Lambda.DurableExecution",
-      "Path": "Libraries/src/Amazon.Lambda.DurableExecution/Amazon.Lambda.DurableExecution.csproj"
+      "Path": "Libraries/src/Amazon.Lambda.DurableExecution/Amazon.Lambda.DurableExecution.csproj",
+      "PrereleaseLabel": "preview"
     },
     {
       "Name": "Amazon.Lambda.DynamoDBEvents",

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Amazon.Lambda.DurableExecution.csproj
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Amazon.Lambda.DurableExecution.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>$(DefaultPackageTargets)</TargetFrameworks>
     <Description>Amazon Lambda .NET SDK for Durable Execution - write multi-step workflows that persist state automatically.</Description>
     <AssemblyTitle>Amazon.Lambda.DurableExecution</AssemblyTitle>
-    <Version>0.0.1-preview</Version>
+    <Version>0.0.1</Version>
     <AssemblyName>Amazon.Lambda.DurableExecution</AssemblyName>
     <PackageId>Amazon.Lambda.DurableExecution</PackageId>
     <PackageTags>AWS;Amazon;Lambda;Durable;Workflow</PackageTags>

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Amazon.Lambda.DurableExecution.csproj
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Amazon.Lambda.DurableExecution.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>$(DefaultPackageTargets)</TargetFrameworks>
     <Description>Amazon Lambda .NET SDK for Durable Execution - write multi-step workflows that persist state automatically.</Description>
     <AssemblyTitle>Amazon.Lambda.DurableExecution</AssemblyTitle>
-    <Version>0.1.0</Version>
+    <Version>0.0.1-preview</Version>
     <AssemblyName>Amazon.Lambda.DurableExecution</AssemblyName>
     <PackageId>Amazon.Lambda.DurableExecution</PackageId>
     <PackageTags>AWS;Amazon;Lambda;Durable;Workflow</PackageTags>


### PR DESCRIPTION
## Summary
- Set `Amazon.Lambda.DurableExecution` package version to `0.0.1-preview` so NuGet treats it as a pre-release package and hides it from default gallery searches while the project is still in early development.
