### PR TITLE
Add AWSSDK.Signin package to support 'aws login' credentials for test tool

### DIFF
--- a/.autover/changes/0eb5580c-be03-4e71-a7b1-c0ae06afea0a.json
+++ b/.autover/changes/0eb5580c-be03-4e71-a7b1-c0ae06afea0a.json
@@ -4,7 +4,7 @@
       "Name": "Amazon.Lambda.TestTool.BlazorTester",
       "Type": "Minor",
       "ChangelogMessages": [
-        "Add AWSSDK.Signer package to support \u0027aws login\u0027 based credentials",
+        "Add AWSSDK.Signin package to support \u0027aws login\u0027 based credentials",
         "Update to V4 of the AWS SDK for .NET"
       ]
     },
@@ -12,7 +12,7 @@
       "Name": "Amazon.Lambda.TestTool",
       "Type": "Minor",
       "ChangelogMessages": [
-        "Add AWSSDK.Signer package to support \u0027aws login\u0027 based credentials",
+        "Add AWSSDK.Signin package to support \u0027aws login\u0027 based credentials",
 		"Update AWS SDK and Amazon Lambda packages to latest versions"
       ]
     }	

--- a/.autover/changes/0eb5580c-be03-4e71-a7b1-c0ae06afea0a.json
+++ b/.autover/changes/0eb5580c-be03-4e71-a7b1-c0ae06afea0a.json
@@ -1,0 +1,20 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.TestTool.BlazorTester",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Add AWSSDK.Signer package to support \u0027aws login\u0027 based credentials",
+        "Update to V4 of the AWS SDK for .NET"
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.TestTool",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Add AWSSDK.Signer package to support \u0027aws login\u0027 based credentials",
+		"Update AWS SDK and Amazon Lambda packages to latest versions"
+      ]
+    }	
+  ]
+}

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -22,19 +22,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.1" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.22" />
-    <PackageReference Include="AWSSDK.Lambda" Version="4.0.13.1" />
-    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.14" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.15.2" />
-    <PackageReference Include="AWSSDK.DynamoDBStreams" Version="4.0.4.17" />
-    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="3.1.2" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.6.3" />
-    <PackageReference Include="AWSSDK.SSO" Version="4.0.2.13" />
-    <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.3.14" />
+    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="3.0.0" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.4.1" />
+    <PackageReference Include="AWSSDK.Lambda" Version="4.0.15.6" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.32" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.18.5" />
+    <PackageReference Include="AWSSDK.DynamoDBStreams" Version="4.0.4.32" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.6.7" />
+    <PackageReference Include="AWSSDK.SSO" Version="4.0.2.31" />
+    <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.4" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.3" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.11" />
     <PackageReference Include="BlazorMonaco" Version="3.2.0" />
   </ItemGroup>

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.6.7" />
     <PackageReference Include="AWSSDK.SSO" Version="4.0.2.31" />
     <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.4" />
+    <PackageReference Include="AWSSDK.Signin" Version="4.0.0.27" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="3.0.0" />

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/Amazon.Lambda.TestTool.IntegrationTests.csproj
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.IntegrationTests/Amazon.Lambda.TestTool.IntegrationTests.csproj
@@ -11,26 +11,26 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.8.1" />
-    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.14.2" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.5" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.3" />
-    <PackageReference Include="AWSSDK.APIGateway" Version="4.0.5.8" />
-    <PackageReference Include="AWSSDK.CloudFormation" Version="4.0.8.8" />
-	  <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.9.7" />
-    <PackageReference Include="AWSSDK.ApiGatewayV2" Version="4.0.4.9" />
-    <PackageReference Include="AWSSDK.Lambda" Version="4.0.13.1" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.6.3" />
-    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.14" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="3.1.0" />
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="3.0.0" />
+    <PackageReference Include="AWSSDK.APIGateway" Version="4.0.7.1" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="4.0.8.26" />
+	  <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.9.26" />
+    <PackageReference Include="AWSSDK.ApiGatewayV2" Version="4.0.6.1" />
+    <PackageReference Include="AWSSDK.Lambda" Version="4.0.15.6" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.6.7" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.32" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.3">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.Tests.Common/Amazon.Lambda.TestTool.Tests.Common.csproj
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.Tests.Common/Amazon.Lambda.TestTool.Tests.Common.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.3" />
+      <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="3.0.0" />
       <PackageReference Include="xunit" Version="2.9.3" />
       <PackageReference Include="xunit.assert" Version="2.9.3" />
     </ItemGroup>

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Amazon.Lambda.TestTool.UnitTests.csproj
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Amazon.Lambda.TestTool.UnitTests.csproj
@@ -12,21 +12,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.14.2" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.5" />
-    <PackageReference Include="AWSSDK.Lambda" Version="4.0.13.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.15.2" />
-    <PackageReference Include="AWSSDK.DynamoDBStreams" Version="4.0.4.17" />
-    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="3.1.2" />
-    <PackageReference Include="coverlet.collector" Version="6.0.3">
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.0" />
+    <PackageReference Include="AWSSDK.Lambda" Version="4.0.15.6" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.18.5" />
+    <PackageReference Include="AWSSDK.DynamoDBStreams" Version="4.0.4.32" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="4.0.0" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Amazon.Lambda.TestTool.csproj
@@ -10,14 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.7.0" />
-    <PackageReference Include="AWSSDK.SSO" Version="3.7.400.85" />
-    <PackageReference Include="AWSSDK.SSOOIDC" Version="3.7.400.86" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="3.1.0" />
+    <PackageReference Include="AWSSDK.Signin" Version="4.0.0.27" />
+    <PackageReference Include="AWSSDK.SSO" Version="4.0.2.31" />
+    <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="YamlDotNet.Signed" Version="5.2.1" />
 
-    <PackageReference Include="AWSSDK.Core" Version="3.7.401.5" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.400.85" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.7.3" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.32" />
   </ItemGroup>
 
 
@@ -34,7 +35,7 @@
   </PropertyGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
@@ -42,7 +43,7 @@
 	</ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/LocalLambdaOptions.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/LocalLambdaOptions.cs
@@ -1,4 +1,4 @@
-﻿using Amazon.Lambda.TestTool.Runtime;
+using Amazon.Lambda.TestTool.Runtime;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -18,7 +18,7 @@ namespace Amazon.Lambda.TestTool
 
         public LambdaFunction LoadLambdaFuntion(string configFile, string functionHandler)
         {
-            var fullConfigFilePath = this.LambdaConfigFiles.FirstOrDefault(x =>
+            var fullConfigFilePath = LambdaConfigFiles.FirstOrDefault(x =>
                 string.Equals(configFile, x, StringComparison.OrdinalIgnoreCase) || string.Equals(configFile, Path.GetFileName(x), StringComparison.OrdinalIgnoreCase));
             if (fullConfigFilePath == null)
             {
@@ -51,7 +51,7 @@ namespace Amazon.Lambda.TestTool
                 throw new Exception($"Failed to find function {functionHandler}");
             }
 
-            var function = this.LambdaRuntime.LoadLambdaFunction(functionInfo);
+            var function = LambdaRuntime.LoadLambdaFunction(functionInfo);
             return function;
         }
 
@@ -60,14 +60,14 @@ namespace Amazon.Lambda.TestTool
         /// </summary>
         public string GetPreferenceDirectory(bool createIfNotExist)
         {
-            var currentDirectory = this.LambdaRuntime.LambdaAssemblyDirectory;
+            var currentDirectory = LambdaRuntime.LambdaAssemblyDirectory;
             while (currentDirectory != null && !Utils.IsProjectDirectory(currentDirectory))
             {
                 currentDirectory = Directory.GetParent(currentDirectory)?.FullName;
             }
 
             if (currentDirectory == null)
-                currentDirectory = this.LambdaRuntime.LambdaAssemblyDirectory;
+                currentDirectory = LambdaRuntime.LambdaAssemblyDirectory;
 
             var preferenceDirectory = Path.Combine(currentDirectory, ".lambda-test-tool");
             if (createIfNotExist && !Directory.Exists(preferenceDirectory))

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/DlqMonitor.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Runtime/DlqMonitor.cs
@@ -1,4 +1,4 @@
-﻿using Amazon.SQS.Model;
+using Amazon.SQS.Model;
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -25,27 +25,27 @@ namespace Amazon.Lambda.TestTool.Runtime
 
         public DlqMonitor(ILocalLambdaRuntime runtime, LambdaFunction function, string profile, string region, string queueUrl)
         {
-            this._runtime = runtime;
-            this._function = function;
-            this._profile = profile;
-            this._region = region;
-            this._queueUrl = queueUrl;
+            _runtime = runtime;
+            _function = function;
+            _profile = profile;
+            _region = region;
+            _queueUrl = queueUrl;
         }
 
         public void Start()
         {
-            this._cancelSource = new CancellationTokenSource();
-            _ = Loop(this._cancelSource.Token);
+            _cancelSource = new CancellationTokenSource();
+            _ = Loop(_cancelSource.Token);
         }
 
         public void Stop()
         {
-            this._cancelSource.Cancel();
+            _cancelSource.Cancel();
         }
 
         private async Task Loop(CancellationToken token)
         {
-            var aws = this._runtime.AWSService;
+            var aws = _runtime.AWSService;
             while (!token.IsCancellationRequested)
             {
                 Message message = null;
@@ -53,7 +53,7 @@ namespace Amazon.Lambda.TestTool.Runtime
                 try
                 {
                     // Read a message from the queue using the ExternalCommands console application.
-                    message = await aws.ReadMessageAsync(this._profile, this._region, this._queueUrl);
+                    message = await aws.ReadMessageAsync(_profile, _region, _queueUrl);
                     if (token.IsCancellationRequested)
                     {
                         return;
@@ -68,9 +68,9 @@ namespace Amazon.Lambda.TestTool.Runtime
                     // If a message was received execute the Lambda function within the test tool.
                     var request = new ExecutionRequest
                     {
-                        AWSProfile = this._profile,
-                        AWSRegion = this._region,
-                        Function = this._function,
+                        AWSProfile = _profile,
+                        AWSRegion = _region,
+                        Function = _function,
                         Payload = JsonSerializer.Serialize(new
                         {
                             Records = new List<Message>
@@ -80,7 +80,7 @@ namespace Amazon.Lambda.TestTool.Runtime
                         })
                     };
 
-                    var response = await this._runtime.ExecuteLambdaFunctionAsync(request);
+                    var response = await _runtime.ExecuteLambdaFunctionAsync(request);
 
                     // Capture the results to send back to the client application.
                     logRecord = new LogRecord
@@ -109,7 +109,7 @@ namespace Amazon.Lambda.TestTool.Runtime
 
                 lock (LOG_LOCK)
                 {
-                    this._records.Add(logRecord);
+                    _records.Add(logRecord);
                 }
             }
         }
@@ -119,8 +119,8 @@ namespace Amazon.Lambda.TestTool.Runtime
         {
             lock (LOG_LOCK)
             {
-                var logsToSend = this._records;
-                this._records = new List<LogRecord>();
+                var logsToSend = _records;
+                _records = new List<LogRecord>();
                 return logsToSend;
             }
         }

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Services/AWSServiceImpl.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/Services/AWSServiceImpl.cs
@@ -1,5 +1,6 @@
-﻿using Amazon.Runtime;
+using Amazon.Runtime;
 using Amazon.Runtime.CredentialManagement;
+using Amazon.Runtime.Credentials;
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using System.Collections.Generic;
@@ -35,7 +36,7 @@ namespace Amazon.Lambda.TestTool.Services
             using (var client = new AmazonSQSClient(creds, RegionEndpoint.GetBySystemName(region)))
             {
                 var response = await client.ListQueuesAsync(new ListQueuesRequest());
-                return response.QueueUrls;
+                return response.QueueUrls ?? new List<string>();
             }
         }
 
@@ -51,11 +52,11 @@ namespace Amazon.Lambda.TestTool.Services
                     WaitTimeSeconds = 20,
                     MaxNumberOfMessages = 1,
                     VisibilityTimeout = 60,
-                    AttributeNames = new List<string>() { "All" },
+                    MessageSystemAttributeNames = new List<string>() { "All" },
                     MessageAttributeNames = new List<string>() { "*" }
                 };
                 var response = await client.ReceiveMessageAsync(request);
-                if (response.Messages.Count == 0)
+                if (response.Messages == null ||response.Messages.Count == 0)
                 {
                     return null;
                 }
@@ -104,7 +105,7 @@ namespace Amazon.Lambda.TestTool.Services
             }
             else
             {
-                credentials = FallbackCredentialsFactory.GetCredentials();
+                credentials = DefaultAWSCredentialsIdentityResolver.GetCredentials();
             }
             return credentials;
         }

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.BlazorTester.Tests/RuntimeApiControllerTests.cs
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.BlazorTester.Tests/RuntimeApiControllerTests.cs
@@ -171,9 +171,9 @@ namespace Amazon.Lambda.TestTool.BlazorTester.Tests
                 {
                     if (disposing)
                     {
-                        this.Client.Dispose();
-                        this.Source.Cancel();
-                        this.WebHost.StopAsync().GetAwaiter().GetResult();
+                        Client.Dispose();
+                        Source.Cancel();
+                        WebHost.StopAsync().GetAwaiter().GetResult();
                     }
 
                     disposedValue = true;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/discussions/2388

*Description of changes:*
The test tools were missing a reference to AWSSDK.Signer so they could not consume profiles that were sourcing their credentials from "aws login". 

While adding the package I updated the other AWS dependencies to the latest including moving the V1 test tool to v4.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
