### PR TITLE
Fix ARM integ tests

### DIFF
--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/BaseCustomRuntimeTest.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/BaseCustomRuntimeTest.cs
@@ -1,15 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Amazon.IdentityManagement;
 using Amazon.IdentityManagement.Model;
 using Amazon.Lambda.Model;
 using Amazon.S3;
 using Amazon.S3.Model;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
 {
@@ -291,7 +292,8 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
                 MemorySize = FUNCTION_MEMORY_MB,
                 Timeout = 30,
                 Runtime = runtime,
-                Role = ExecutionRoleArn
+                Role = ExecutionRoleArn,
+                Architectures = new List<string> { RuntimeInformation.OSArchitecture == System.Runtime.InteropServices.Architecture.Arm64 ? Architecture.Arm64 : Architecture.X86_64 }
             };
 
             var startTime = DateTime.Now;


### PR DESCRIPTION
*Description of changes:*
We recently added back in the ARM integ tests to the full CI system. This uncovered the fact that Lambda deployment bundles were being packages using the [architecture of the host environment](https://github.com/aws/aws-lambda-dotnet/blob/master/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/Helpers/LambdaToolsHelper.cs#L42) but not using that architecture when creating the Lambda function. 

To fix that I updated the call to create the function to also use the host architecture. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
