### PR TITLE
Reapply Lambda Architecture when deploy test app

### DIFF
--- a/Libraries/test/TestServerlessApp/serverless.template
+++ b/Libraries/test/TestServerlessApp/serverless.template
@@ -2,6 +2,30 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
   "Description": "This template is partially managed by Amazon.Lambda.Annotations (v2.0.1.0).",
+  "Parameters": {
+    "ArchitectureTypeParameter": {
+      "Type": "String",
+      "Default": "x86_64",
+      "AllowedValues": [
+        "x86_64",
+        "arm64"
+      ],
+      "Description": "The architecture of the Lambda function."
+    }
+  },
+  "Globals": {
+    "Function": {
+      "Architectures": [
+        {
+          "Ref": "ArchitectureTypeParameter"
+        }
+      ],
+      "Tags": {
+        "aws-tests": "TestServerlessApp",
+        "aws-repo": "aws-lambda-dotnet"
+      }
+    }
+  },
   "Resources": {
     "AnnotationsHttpApi": {
       "Type": "AWS::Serverless::HttpApi",


### PR DESCRIPTION
*Description of changes:*
Now that the ARM tests are back in the pipeline the integ tests for the Annotations TestServerlessApp project fail because the containers are being built using ARM architecture but the functions are being deployed defaulting to X64. This commit https://github.com/aws/aws-lambda-dotnet/commit/fcb5208ec20b44522afdab3c1b10d9ce1ccebdd7#diff-9990804bd7941f64d259a5da783877ca3153cbb32aac36e0fa7b54dbc787c3ed merged a few months ago accidently removed the CloudFormation template parameter for the deployment to set the architecture. 

The PR adds back the CloudFormation template parameter that the `DeploymentScript.ps1` script used to deploy was already setting.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
