### PR TITLE
Implements NestingType.Flat

### DIFF
--- a/.autover/changes/1086291e-5286-4ea4-b9c1-af4eb1d0314d.json
+++ b/.autover/changes/1086291e-5286-4ea4-b9c1-af4eb1d0314d.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.DurableExecution",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Implement NestingType.Flat for ParallelAsync and MapAsync (previously threw NotSupportedException). Under Flat, each branch/item runs in a virtual context that emits no per-branch CONTEXT checkpoint; per-branch results and errors are recorded inline on the parent operation's payload, reducing checkpoint volume. Operations inside a flat branch (steps, waits) still checkpoint, re-parented to the parallel/map operation. NestingType.Nested remains the default."
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/CLAUDE.md
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/CLAUDE.md
@@ -1,0 +1,151 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`Amazon.Lambda.DurableExecution` is the .NET SDK (preview, 0.x) for resilient, long-running AWS Lambda
+workflows that checkpoint progress after each step and resume after failures or waits. A workflow can run
+for up to ~1 year (the WAIT cap is 31,622,400 seconds) and is only billed for active compute. The SDK is
+client-side glue: the *durable execution service* (part of Lambda) owns the checkpoint store, fires timers,
+and re-invokes the function; this library re-derives in-memory workflow position from the checkpoint history
+the service sends on each invocation. See sibling SDKs (Python/JS/Java) listed in `README.md` for the shared
+model — this SDK deliberately mirrors their semantics.
+
+## Build & test
+
+Targets `net8.0;net10.0` (`DefaultPackageTargets` in `buildtools/common.props`). `TreatWarningsAsErrors` is on
+everywhere, and the main library is `IsTrimmable` with the trim analyzer enabled — keep new code AOT/trim-clean.
+
+```bash
+# Build the library (run from this directory)
+dotnet build
+
+# Unit tests (fast, no AWS). Project: Libraries/test/Amazon.Lambda.DurableExecution.Tests
+dotnet test ../../test/Amazon.Lambda.DurableExecution.Tests/Amazon.Lambda.DurableExecution.Tests.csproj
+
+# A single test
+dotnet test ../../test/Amazon.Lambda.DurableExecution.Tests/Amazon.Lambda.DurableExecution.Tests.csproj \
+  --filter "FullyQualifiedName~StepOperationTests"
+
+# Coverage report (requires reportgenerator tool)
+../../test/Amazon.Lambda.DurableExecution.Tests/coverage.sh
+```
+
+Unit tests reach `internal` types via `InternalsVisibleTo` (declared in the `.csproj`). They use
+`Amazon.Lambda.TestUtilities` (`TestLambdaContext`) and the real `SourceGeneratorLambdaJsonSerializer` —
+set `TestLambdaContext.Serializer` so `LambdaSerializerHelper.GetRequired` finds one.
+
+### Integration tests (expensive, real AWS)
+
+`Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests` deploys real Lambdas. Each test builds a
+`TestFunctions/<X>/` project into a container image via **`dotnet publish` + `docker build`**, pushes to ECR,
+creates an IAM role + Lambda (`DurableFunctionDeployment`), invokes it, and tears everything down on dispose.
+Requires Docker, AWS creds (us-east-1), and is slow. Every behavior in `docs/` should have a paired
+integration test under that project. Prefix AWS commands with `unset AWS_PROFILE` to use `[default]` creds.
+
+**Run integration tests against `net10.0`.** The project multi-targets `net8.0;net10.0`; `dotnet test`
+without a framework spins up one testhost per TFW and runs them concurrently, which races two processes on
+the same `TestFunctions/<X>/` build dir. Pin the framework:
+
+```bash
+dotnet test ../../test/Amazon.Lambda.DurableExecution.IntegrationTests/Amazon.Lambda.DurableExecution.IntegrationTests.csproj \
+  -f net10.0 --filter "FullyQualifiedName~MultipleStepsTest"
+```
+
+## Architecture: the replay model
+
+This is the part you must understand before changing anything. Read these together:
+`DurableFunction.cs`, `DurableExecutionHandler.cs`, `DurableContext.cs`, `Internal/DurableOperation.cs`,
+`Internal/ExecutionState.cs`, `Internal/OperationIdGenerator.cs`, `Internal/TerminationManager.cs`.
+
+**Entry point.** The user's Lambda handler delegates to `DurableFunction.WrapAsync<TInput,TOutput>`, which:
+hydrates `ExecutionState` from `invocationInput.InitialExecutionState` (paging the service via `NextMarker`),
+extracts the user payload from the `EXECUTION`-type op, builds a `CheckpointBatcher` + `DurableContext`, runs
+the workflow through `DurableExecutionHandler.RunAsync`, drains checkpoints, and maps the result to a
+`DurableExecutionInvocationOutput` with status **Succeeded / Failed / Pending**.
+
+**Each operation runs the same workflow code every invocation.** There is no persisted program counter.
+On re-invocation the user function executes from the top again; each durable call (`StepAsync`, `WaitAsync`,
+etc.) looks up its own checkpoint and either replays the cached result or runs fresh. This is why workflow
+code **must be deterministic** — same operations, same order, same names across deployments.
+
+**Deterministic operation IDs** (`OperationIdGenerator`). Each durable call gets an ID = SHA-256 of
+`"<parentPrefix>-<counter>"`, where the counter is per-context and pre-incremented. The same workflow position
+yields the same opaque ID across replays, so a checkpoint correlates to a call by *position*, not by name —
+renaming a step does **not** break replay (the human name rides separately on `OperationUpdate.Name`).
+Reordering or adding/removing calls *does* break it. `ValidateReplayConsistency` enforces this and throws
+`NonDeterministicExecutionException` on type/name drift.
+
+**Suspension is implemented by never completing a Task** (`TerminationManager` + `DurableExecutionHandler`).
+When an op must suspend (wait timer, scheduled retry, pending callback/invoke) it calls
+`Termination.SuspendAndAwait<T>()`, which trips a one-shot signal and returns a Task that *never resolves*.
+`RunAsync` runs the user code via `Task.Run` and races it against `TerminationTask` with `Task.WhenAny`:
+- user task wins → **Succeeded** (or **Failed** if it threw)
+- termination wins → **Pending**; the abandoned user task is GC'd, checkpoints flush, the service fires the
+  timer and re-invokes. On replay the suspended op sees its now-terminal checkpoint and returns normally.
+
+**Operation classes** (`Internal/*Operation.cs`) all extend `DurableOperation<TResult>`. The base's
+`ExecuteAsync` does: `ValidateReplayConsistency` → `TrackReplay` → look up checkpoint → dispatch to
+`StartAsync` (no prior checkpoint) or `ReplayAsync` (checkpoint exists). `StepOperation` is the canonical
+example — read its class doc comment for the full status decision table (Succeeded→cached, Failed→rethrow,
+Pending→re-suspend if retry timer hasn't fired, Started→crash-recovery under `AtMostOncePerRetry`,
+Ready→run next attempt). `DurableContext` is a thin dispatcher: it allocates the op ID, pulls the serializer
+off `ILambdaContext.Serializer`, constructs the right `*Operation`, and calls `ExecuteAsync`.
+
+**Checkpointing** (`CheckpointBatcher`). Outbound `OperationUpdate`s (START/SUCCEED/FAIL/RETRY) are enqueued
+to a background channel worker that batches and flushes them via `LambdaDurableServiceClient` (which wraps
+the `AWSSDK.Lambda` `Checkpoint`/`GetExecutionState` calls). `EnqueueAsync` awaits its batch's flush
+(sync semantics); fire-and-forget callers (e.g. the START checkpoint under the default
+`AtLeastOncePerRetry`) don't await but must observe the Task's exception. Flush errors become a terminal
+error rethrown by the next `EnqueueAsync`/`DrainAsync`. `DurableFunction.IsTerminalCheckpointError`
+classifies SDK errors on the final drain: 4xx (except 429 and stale-token) → **Failed** envelope; 429/5xx/
+network → let it escape so Lambda retries the whole invocation.
+
+**Replay-mode tracking** (`ExecutionState`). `IsReplaying` starts true iff any completed non-`EXECUTION` op
+exists; `TrackReplay` decrements as each is visited and flips to false once the workflow catches up to the
+frontier. `ReplayAwareLogger` uses this to suppress log lines emitted during replay so a 30-step workflow
+re-invoked 30 times logs each line once — **always use `ctx.Logger`**, never `Console.WriteLine`.
+`ExecutionState` is lock-guarded because the batcher worker thread and concurrent parallel/map branches all
+touch it.
+
+### Operations surface (`IDurableContext`)
+
+`StepAsync` (checkpointed code + retries), `WaitAsync` (1s–~1yr timer), `RunInChildContextAsync` (isolated
+sub-workflow checkpointed as one `CONTEXT` op), `CreateCallbackAsync` / `WaitForCallbackAsync` (external
+events; `WaitForCallback` is *composed* from child-context + callback + submitter step — see
+`DurableContext.RunWaitForCallback`), `InvokeAsync` (durable-to-durable chained invoke, qualified ARN
+required), and `ParallelAsync` / `MapAsync` (concurrent branches → `IBatchResult<T>`).
+
+**Nesting (`NestingType`)** matters for parallel/map. `Nested` (default) gives each branch a full `CONTEXT`
+checkpoint. `Flat` runs branches in *virtual* contexts that emit no `CONTEXT` op — inner ops re-parent to the
+parallel/map op via `OperationIdGenerator.CreateVirtualChild(operationId, reportedParentId)`, trading trace
+granularity for fewer checkpoints. The `idPrefix` vs `reportedParentId` split is the subtle part: inner IDs
+always derive from the branch's own op ID (so siblings never collide), but are *reported* under the nearest
+non-virtual ancestor (so they reference a parent that actually exists in the checkpoint store).
+
+### Wire format (`Operation.cs`)
+
+`Operation` and its `*Details` types mirror the service envelope JSON exactly (`[JsonPropertyName]`).
+String constants live in `OperationTypes` (STEP/WAIT/CALLBACK/CHAINED_INVOKE/CONTEXT/EXECUTION),
+`OperationStatuses` (STARTED/SUCCEEDED/FAILED/PENDING/READY/CANCELLED/STOPPED/TIMED_OUT), and
+`OperationSubTypes` (PascalCase finer classifier). Plural type names (`OperationTypes`, not `OperationType`)
+intentionally avoid collision with `AWSSDK.Lambda` model enums.
+
+## Conventions
+
+- **Programming model:** preview supports only the *executable* model — `Main` builds a `LambdaBootstrap`
+  with a handler wrapper and an `ILambdaSerializer`. The serializer is read off `ILambdaContext.Serializer`
+  (a preview API; the project-wide `AWSLAMBDA001` suppression in the `.csproj` is intentional for that
+  reason). All step/result/payload (de)serialization flows through that one registered serializer, so AOT
+  and reflection callers share a single code path — there is no per-call `JsonSerializerContext` argument.
+- **Errors:** durable exceptions carry `ErrorType`/`ErrorData`/`OriginalStackTrace` so a failure can be
+  reconstructed on replay when the live exception object is gone. `StepException`, `ChildContextException`,
+  `CallbackFailedException`/`CallbackTimeoutException`/`CallbackSubmitterException`, `ParallelException`,
+  `MapException`, and `NonDeterministicExecutionException` all derive from `DurableExecutionException`.
+  When adding error-mapping logic, handle *both* the fresh path (`InnerException` is the live exception) and
+  the replay path (`InnerException` is null, `ErrorType` carries the type string) — see
+  `DurableContext.MapWaitForCallbackException` for the pattern.
+- **Public config types** (`StepConfig`, `WaitForCallbackConfig`, `ParallelConfig`, `MapConfig`,
+  `CompletionConfig`, etc.) are nullable optional args; resolve to an effective config inside the dispatcher.
+- Inclusive language is enforced repo-wide (see the user's global rules): no master/slave, whitelist/blacklist.

--- a/Libraries/src/Amazon.Lambda.DurableExecution/DurableContext.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/DurableContext.cs
@@ -240,12 +240,6 @@ internal sealed class DurableContext : IDurableContext
         }
 
         var effectiveConfig = config ?? new ParallelConfig();
-        if (effectiveConfig.NestingType == NestingType.Flat)
-        {
-            throw new NotSupportedException(
-                "NestingType.Flat is not yet supported in the .NET Durable Execution SDK. " +
-                "Use NestingType.Nested (the default) for now.");
-        }
 
         var serializer = LambdaContext.Serializer
             ?? throw new InvalidOperationException(
@@ -279,12 +273,6 @@ internal sealed class DurableContext : IDurableContext
         if (func == null) throw new ArgumentNullException(nameof(func));
 
         var effectiveConfig = config ?? new MapConfig();
-        if (effectiveConfig.NestingType == NestingType.Flat)
-        {
-            throw new NotSupportedException(
-                "NestingType.Flat is not yet supported in the .NET Durable Execution SDK. " +
-                "Use NestingType.Nested (the default) for now.");
-        }
 
         var serializer = LambdaSerializerHelper.GetRequired(LambdaContext);
 
@@ -526,10 +514,31 @@ internal sealed class DurableContext : IDurableContext
     /// but uses a child <see cref="OperationIdGenerator"/> so its operation IDs
     /// are deterministically namespaced under the parent op ID.
     /// </summary>
-    private Func<string, IDurableContext> MakeChildFactory()
+    /// <summary>
+    /// Builds the factory each operation uses to create the inner
+    /// <see cref="DurableContext"/> its user function runs against.
+    /// </summary>
+    /// <remarks>
+    /// The delegate takes <c>(operationId, reportedParentId, isVirtual)</c>:
+    /// <list type="bullet">
+    ///   <item><c>isVirtual == false</c> (the default child-context case): the
+    ///       inner context's ID space and reported parent both root at
+    ///       <c>operationId</c> via <see cref="OperationIdGenerator.CreateChild"/>;
+    ///       <c>reportedParentId</c> is ignored.</item>
+    ///   <item><c>isVirtual == true</c> (a <see cref="NestingType.Flat"/> branch):
+    ///       inner-op IDs still root at <c>operationId</c> (so sibling branches
+    ///       never collide), but inner ops report <c>reportedParentId</c> — the
+    ///       parallel/map operation — as their parent, since the virtual branch
+    ///       emits no CONTEXT checkpoint to reference.</item>
+    /// </list>
+    /// </remarks>
+    private Func<string, string?, bool, IDurableContext> MakeChildFactory()
     {
-        return parentOpId => new DurableContext(
-            _state, _terminationManager, _workflowCancellation, _idGenerator.CreateChild(parentOpId),
+        return (operationId, reportedParentId, isVirtual) => new DurableContext(
+            _state, _terminationManager, _workflowCancellation,
+            isVirtual
+                ? _idGenerator.CreateVirtualChild(operationId, reportedParentId)
+                : _idGenerator.CreateChild(operationId),
             _durableExecutionArn, LambdaContext, _batcher);
     }
 }

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/BatchJsonContext.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/BatchJsonContext.cs
@@ -10,6 +10,7 @@ namespace Amazon.Lambda.DurableExecution.Internal;
 /// </summary>
 [JsonSerializable(typeof(BatchSummary))]
 [JsonSerializable(typeof(BatchUnitSummary))]
+[JsonSerializable(typeof(ErrorObject))]
 internal sealed partial class BatchJsonContext : JsonSerializerContext
 {
 }

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/BatchSummary.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/BatchSummary.cs
@@ -8,9 +8,17 @@ namespace Amazon.Lambda.DurableExecution.Internal;
 /// Shared by both <see cref="ParallelOperation{T}"/> and
 /// <see cref="MapOperation{TItem, TResult}"/>: carries the completion reason and
 /// the per-unit index → status map so the <see cref="IBatchResult{T}"/> can be
-/// rebuilt without depending on user T shape — per-unit results live on the
-/// children's own checkpoints.
+/// rebuilt without depending on user T shape.
 /// </summary>
+/// <remarks>
+/// Under <see cref="NestingType.Nested"/> per-unit results live on the children's
+/// own CONTEXT checkpoints and only <see cref="BatchUnitSummary.Status"/> (plus
+/// index/name) is recorded here. Under <see cref="NestingType.Flat"/> the
+/// children emit no checkpoint, so each unit's serialized result
+/// (<see cref="BatchUnitSummary.Result"/>) or error
+/// (<see cref="BatchUnitSummary.Error"/>) is recorded inline here and read back
+/// on replay.
+/// </remarks>
 internal sealed class BatchSummary
 {
     [JsonPropertyName("CompletionReason")]
@@ -30,4 +38,19 @@ internal sealed class BatchUnitSummary
 
     [JsonPropertyName("Status")]
     public string? Status { get; set; }
+
+    /// <summary>
+    /// Serialized per-unit result, recorded inline only for
+    /// <see cref="NestingType.Flat"/> succeeded units (where no child checkpoint
+    /// exists to read it from). <c>null</c> under <see cref="NestingType.Nested"/>.
+    /// </summary>
+    [JsonPropertyName("Result")]
+    public string? Result { get; set; }
+
+    /// <summary>
+    /// Per-unit error, recorded inline only for <see cref="NestingType.Flat"/>
+    /// failed units. <c>null</c> under <see cref="NestingType.Nested"/>.
+    /// </summary>
+    [JsonPropertyName("Error")]
+    public ErrorObject? Error { get; set; }
 }

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/ChildContextOperation.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/ChildContextOperation.cs
@@ -41,9 +41,10 @@ internal sealed class ChildContextOperation<T> : DurableOperation<T>
     private readonly Func<IDurableContext, CancellationToken, Task<T>> _func;
     private readonly ChildContextConfig? _config;
     private readonly ILambdaSerializer _serializer;
-    private readonly Func<string, IDurableContext> _childContextFactory;
+    private readonly Func<string, string?, bool, IDurableContext> _childContextFactory;
     private readonly WorkflowCancellation _workflowCancellation;
     private readonly CancellationToken _cooperativeBailToken;
+    private readonly bool _isVirtual;
 
     public ChildContextOperation(
         string operationId,
@@ -52,13 +53,14 @@ internal sealed class ChildContextOperation<T> : DurableOperation<T>
         Func<IDurableContext, CancellationToken, Task<T>> func,
         ChildContextConfig? config,
         ILambdaSerializer serializer,
-        Func<string, IDurableContext> childContextFactory,
+        Func<string, string?, bool, IDurableContext> childContextFactory,
         ExecutionState state,
         TerminationManager termination,
         WorkflowCancellation workflowCancellation,
         string durableExecutionArn,
         CheckpointBatcher? batcher = null,
-        CancellationToken cooperativeBailToken = default)
+        CancellationToken cooperativeBailToken = default,
+        bool isVirtual = false)
         : base(operationId, name, parentId, state, termination, durableExecutionArn, batcher)
     {
         _func = func;
@@ -67,24 +69,33 @@ internal sealed class ChildContextOperation<T> : DurableOperation<T>
         _childContextFactory = childContextFactory;
         _workflowCancellation = workflowCancellation;
         _cooperativeBailToken = cooperativeBailToken;
+        _isVirtual = isVirtual;
     }
 
     protected override string OperationType => OperationTypes.Context;
 
     protected override async Task<T> StartAsync(CancellationToken cancellationToken)
     {
-        // Sync-flush CONTEXT START before user code so the service has a record
-        // of the parent context if the inner func suspends (e.g. a Wait inside
-        // the child terminates the workflow before SUCCEED is reached).
-        await EnqueueAsync(new SdkOperationUpdate
+        // Virtual (NestingType.Flat) branches emit no CONTEXT checkpoint of their
+        // own — the parallel/map orchestrator records their outcome inline on the
+        // parent payload. Inner operations still checkpoint (re-parented to the
+        // non-virtual ancestor via the virtual child generator's reported
+        // ParentId), so a suspend inside a virtual branch is still recoverable.
+        if (!_isVirtual)
         {
-            Id = OperationId,
-            ParentId = ParentId,
-            Type = OperationTypes.Context,
-            Action = OperationAction.START,
-            SubType = _config?.SubType,
-            Name = Name
-        }, cancellationToken);
+            // Sync-flush CONTEXT START before user code so the service has a record
+            // of the parent context if the inner func suspends (e.g. a Wait inside
+            // the child terminates the workflow before SUCCEED is reached).
+            await EnqueueAsync(new SdkOperationUpdate
+            {
+                Id = OperationId,
+                ParentId = ParentId,
+                Type = OperationTypes.Context,
+                Action = OperationAction.START,
+                SubType = _config?.SubType,
+                Name = Name
+            }, cancellationToken);
+        }
 
         return await ExecuteFunc(cancellationToken);
     }
@@ -120,7 +131,11 @@ internal sealed class ChildContextOperation<T> : DurableOperation<T>
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var childContext = _childContextFactory(OperationId);
+        // For a virtual (Flat) branch, inner operations report this branch's own
+        // ParentId — the non-virtual parallel/map ancestor — since the branch
+        // itself emits no CONTEXT checkpoint to reference. For a normal child
+        // context the reported parent is ignored (it roots at OperationId).
+        var childContext = _childContextFactory(OperationId, ParentId, _isVirtual);
 
         // Link the caller's token with the workflow-shutdown token, plus the
         // optional cooperative-bail token (a parallel parent signals this when
@@ -163,16 +178,22 @@ internal sealed class ChildContextOperation<T> : DurableOperation<T>
         }
         catch (Exception ex)
         {
-            await EnqueueAsync(new SdkOperationUpdate
+            // Virtual branches suppress the FAIL checkpoint but still propagate
+            // the exception — the orchestrator records the failure inline on the
+            // parent payload.
+            if (!_isVirtual)
             {
-                Id = OperationId,
-                ParentId = ParentId,
-                Type = OperationTypes.Context,
-                Action = OperationAction.FAIL,
-                SubType = _config?.SubType,
-                Name = Name,
-                Error = ToSdkError(ex)
-            }, cancellationToken);
+                await EnqueueAsync(new SdkOperationUpdate
+                {
+                    Id = OperationId,
+                    ParentId = ParentId,
+                    Type = OperationTypes.Context,
+                    Action = OperationAction.FAIL,
+                    SubType = _config?.SubType,
+                    Name = Name,
+                    Error = ToSdkError(ex)
+                }, cancellationToken);
+            }
 
             throw MapFailureException(new ChildContextException(ex.Message, ex)
             {
@@ -182,16 +203,21 @@ internal sealed class ChildContextOperation<T> : DurableOperation<T>
             });
         }
 
-        await EnqueueAsync(new SdkOperationUpdate
+        // Virtual branches suppress the SUCCEED checkpoint; the orchestrator
+        // serializes the result inline on the parent payload instead.
+        if (!_isVirtual)
         {
-            Id = OperationId,
-            ParentId = ParentId,
-            Type = OperationTypes.Context,
-            Action = OperationAction.SUCCEED,
-            SubType = _config?.SubType,
-            Name = Name,
-            Payload = SerializeResult(result)
-        }, cancellationToken);
+            await EnqueueAsync(new SdkOperationUpdate
+            {
+                Id = OperationId,
+                ParentId = ParentId,
+                Type = OperationTypes.Context,
+                Action = OperationAction.SUCCEED,
+                SubType = _config?.SubType,
+                Name = Name,
+                Payload = SerializeResult(result)
+            }, cancellationToken);
+        }
 
         return result;
     }

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/ConcurrentOperation.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/ConcurrentOperation.cs
@@ -48,11 +48,20 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
     private readonly int? _maxConcurrency;
     private readonly WorkflowCancellation _workflowCancellation;
 
+    /// <summary>
+    /// True for <see cref="NestingType.Flat"/>: per-unit child contexts emit no
+    /// CONTEXT checkpoint, so their results/errors are recorded inline on this
+    /// parent operation's <see cref="BatchSummary"/> payload and read back from
+    /// there on replay.
+    /// </summary>
+    private readonly bool _isVirtual;
+
     /// <summary>Serializer used to deserialize per-unit child results on replay.</summary>
     protected readonly ILambdaSerializer Serializer;
 
-    /// <summary>Factory used to build each unit's inner child context.</summary>
-    protected readonly Func<string, IDurableContext> ChildContextFactory;
+    /// <summary>Factory used to build each unit's inner child context. Takes
+    /// <c>(operationId, reportedParentId, isVirtual)</c>.</summary>
+    protected readonly Func<string, string?, bool, IDurableContext> ChildContextFactory;
 
     protected ConcurrentOperation(
         string operationId,
@@ -61,12 +70,13 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
         CompletionConfig completionConfig,
         int? maxConcurrency,
         ILambdaSerializer serializer,
-        Func<string, IDurableContext> childContextFactory,
+        Func<string, string?, bool, IDurableContext> childContextFactory,
         ExecutionState state,
         TerminationManager termination,
         WorkflowCancellation workflowCancellation,
         string durableExecutionArn,
-        CheckpointBatcher? batcher = null)
+        CheckpointBatcher? batcher = null,
+        bool isVirtual = false)
         : base(operationId, name, parentId, state, termination, durableExecutionArn, batcher)
     {
         _policy = new CompletionPolicy(completionConfig);
@@ -74,6 +84,7 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
         _workflowCancellation = workflowCancellation;
         Serializer = serializer;
         ChildContextFactory = childContextFactory;
+        _isVirtual = isVirtual;
     }
 
     protected override string OperationType => OperationTypes.Context;
@@ -396,7 +407,8 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
                 _workflowCancellation,
                 DurableExecutionArn,
                 Batcher,
-                shortCircuitToken);
+                shortCircuitToken,
+                isVirtual: _isVirtual);
 
             try
             {
@@ -522,12 +534,30 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
         for (var i = 0; i < result.All.Count; i++)
         {
             var item = result.All[i];
-            summary.Units.Add(new BatchUnitSummary
+            var unit = new BatchUnitSummary
             {
                 Index = item.Index,
                 Name = item.Name,
                 Status = SerializeStatus(item.Status)
-            });
+            };
+
+            // Flat (virtual) units emit no child checkpoint, so their per-unit
+            // result/error has nowhere to live except inline on this summary.
+            // Nested units leave these null — they're read from each child's own
+            // CONTEXT checkpoint on replay.
+            if (_isVirtual)
+            {
+                if (item.Status == BatchItemStatus.Succeeded)
+                {
+                    unit.Result = SerializeResult(item.Result);
+                }
+                else if (item.Status == BatchItemStatus.Failed && item.Error != null)
+                {
+                    unit.Error = ErrorObject.FromException(item.Error);
+                }
+            }
+
+            summary.Units.Add(unit);
         }
 
         var payload = JsonSerializer.Serialize(summary, BatchJsonContext.Default.BatchSummary);
@@ -581,7 +611,29 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
             T? unitResult = default;
             DurableExecutionException? unitError = null;
 
-            if (status == BatchItemStatus.Succeeded && childOp?.ContextDetails?.Result != null)
+            // Flat (virtual) units have no child checkpoint — their result/error
+            // was recorded inline on this summary. Nested units read from the
+            // child's own CONTEXT checkpoint. A unit is "inline" when the summary
+            // entry carries a Result/Error, which only Flat writes.
+            if (_isVirtual && summaryEntry != null)
+            {
+                if (status == BatchItemStatus.Succeeded && summaryEntry.Result != null)
+                {
+                    unitResult = DeserializeResult(summaryEntry.Result);
+                }
+                else if (status == BatchItemStatus.Failed && summaryEntry.Error != null)
+                {
+                    var err = summaryEntry.Error;
+                    unitError = new ChildContextException(err.ErrorMessage ?? "Unit failed")
+                    {
+                        SubType = ChildSubType,
+                        ErrorType = err.ErrorType,
+                        ErrorData = err.ErrorData,
+                        OriginalStackTrace = err.StackTrace
+                    };
+                }
+            }
+            else if (status == BatchItemStatus.Succeeded && childOp?.ContextDetails?.Result != null)
             {
                 unitResult = DeserializeResult(childOp.ContextDetails.Result);
             }
@@ -677,6 +729,19 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
         var bytes = Encoding.UTF8.GetBytes(serialized);
         using var ms = new MemoryStream(bytes);
         return Serializer.Deserialize<T>(ms);
+    }
+
+    /// <summary>
+    /// Serializes a per-unit result for inline storage in the
+    /// <see cref="BatchSummary"/> (Flat units only). Mirrors the SUCCEED-payload
+    /// serialization a Nested unit's <see cref="ChildContextOperation{T}"/> would
+    /// have written to its own checkpoint.
+    /// </summary>
+    private string SerializeResult(T? value)
+    {
+        using var ms = new MemoryStream();
+        Serializer.Serialize(value!, ms);
+        return Encoding.UTF8.GetString(ms.ToArray());
     }
 
     /// <summary>

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/MapOperation.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/MapOperation.cs
@@ -31,7 +31,7 @@ internal sealed class MapOperation<TItem, TResult> : ConcurrentOperation<TResult
         Func<IDurableContext, TItem, int, IReadOnlyList<TItem>, CancellationToken, Task<TResult>> func,
         MapConfig config,
         ILambdaSerializer serializer,
-        Func<string, IDurableContext> childContextFactory,
+        Func<string, string?, bool, IDurableContext> childContextFactory,
         ExecutionState state,
         TerminationManager termination,
         WorkflowCancellation workflowCancellation,
@@ -39,7 +39,8 @@ internal sealed class MapOperation<TItem, TResult> : ConcurrentOperation<TResult
         CheckpointBatcher? batcher = null)
         : base(operationId, name, parentId, config.CompletionConfig, config.MaxConcurrency,
             serializer, childContextFactory, state, termination, workflowCancellation,
-            durableExecutionArn, batcher)
+            durableExecutionArn, batcher,
+            isVirtual: config.NestingType == NestingType.Flat)
     {
         _items = items;
         _func = func;

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/OperationIdGenerator.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/OperationIdGenerator.cs
@@ -35,10 +35,33 @@ internal sealed class OperationIdGenerator
     /// <c>hash("&lt;parentHash&gt;-1")</c>, <c>hash("&lt;parentHash&gt;-2")</c>, etc.
     /// </summary>
     public OperationIdGenerator(string? parentId)
+        : this(idPrefix: parentId, reportedParentId: parentId)
+    {
+    }
+
+    /// <summary>
+    /// Creates a child generator that decouples the hash prefix used to derive
+    /// inner-operation IDs from the <see cref="ParentId"/> reported on those
+    /// operations' wire <c>OperationUpdate.ParentId</c>.
+    /// </summary>
+    /// <param name="idPrefix">
+    /// Prefix hashed into inner-operation IDs (<c>hash("&lt;idPrefix&gt;-1")</c>, ...).
+    /// Always the owning context's own operation ID, so two sibling branches
+    /// never collide on inner IDs.
+    /// </param>
+    /// <param name="reportedParentId">
+    /// The parent operation ID stamped on inner operations. For a normal
+    /// (non-virtual) context this equals <paramref name="idPrefix"/>. For a
+    /// <see cref="NestingType.Flat"/> branch — a "virtual" context that emits no
+    /// CONTEXT checkpoint of its own — this is the nearest non-virtual ancestor
+    /// (the parallel/map operation), so inner operations re-parent past the
+    /// branch to an operation that actually exists in the checkpoint store.
+    /// </param>
+    private OperationIdGenerator(string? idPrefix, string? reportedParentId)
     {
         _counter = 0;
-        ParentId = parentId;
-        _prefix = parentId != null ? parentId + "-" : string.Empty;
+        ParentId = reportedParentId;
+        _prefix = idPrefix != null ? idPrefix + "-" : string.Empty;
     }
 
     /// <summary>
@@ -83,6 +106,19 @@ internal sealed class OperationIdGenerator
     public OperationIdGenerator CreateChild(string operationId)
     {
         return new OperationIdGenerator(operationId);
+    }
+
+    /// <summary>
+    /// Creates a child generator for a <see cref="NestingType.Flat"/> branch — a
+    /// "virtual" context. Inner-operation IDs are still derived from
+    /// <paramref name="operationId"/> (so sibling branches don't collide), but
+    /// the IDs are reported under <paramref name="reportedParentId"/> (the
+    /// nearest non-virtual ancestor) because the virtual branch emits no CONTEXT
+    /// checkpoint that inner operations could reference as their parent.
+    /// </summary>
+    public OperationIdGenerator CreateVirtualChild(string operationId, string? reportedParentId)
+    {
+        return new OperationIdGenerator(idPrefix: operationId, reportedParentId: reportedParentId);
     }
 
     /// <summary>

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/ParallelOperation.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/ParallelOperation.cs
@@ -25,7 +25,7 @@ internal sealed class ParallelOperation<T> : ConcurrentOperation<T>
         IReadOnlyList<DurableBranch<T>> branches,
         ParallelConfig config,
         ILambdaSerializer serializer,
-        Func<string, IDurableContext> childContextFactory,
+        Func<string, string?, bool, IDurableContext> childContextFactory,
         ExecutionState state,
         TerminationManager termination,
         WorkflowCancellation workflowCancellation,
@@ -33,7 +33,8 @@ internal sealed class ParallelOperation<T> : ConcurrentOperation<T>
         CheckpointBatcher? batcher = null)
         : base(operationId, name, parentId, config.CompletionConfig, config.MaxConcurrency,
             serializer, childContextFactory, state, termination, workflowCancellation,
-            durableExecutionArn, batcher)
+            durableExecutionArn, batcher,
+            isVirtual: config.NestingType == NestingType.Flat)
     {
         _branches = branches;
     }

--- a/Libraries/src/Amazon.Lambda.DurableExecution/MapConfig.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/MapConfig.cs
@@ -57,9 +57,9 @@ public sealed class MapConfig
     /// <see cref="NestingType.Nested"/>.
     /// </summary>
     /// <remarks>
-    /// <see cref="NestingType.Flat"/> is not yet supported in the .NET SDK and
-    /// will throw <see cref="System.NotSupportedException"/> when the map
-    /// operation is invoked.
+    /// Under <see cref="NestingType.Flat"/> each item runs in a virtual context
+    /// that emits no per-item <c>CONTEXT</c> checkpoint; per-item results and
+    /// errors are recorded inline on the map operation's payload instead.
     /// </remarks>
     public NestingType NestingType { get; set; } = NestingType.Nested;
 

--- a/Libraries/src/Amazon.Lambda.DurableExecution/NestingType.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/NestingType.cs
@@ -13,10 +13,9 @@ namespace Amazon.Lambda.DurableExecution;
 /// operation visible in execution traces.
 /// </para>
 /// <para>
-/// <see cref="Flat"/> is reserved for a forthcoming optimisation that uses
-/// virtual contexts to reduce checkpoint volume by ~30%. The .NET SDK currently
-/// throws <see cref="System.NotSupportedException"/> when <see cref="Flat"/> is
-/// supplied; the enum value is kept stable so opting in becomes non-breaking.
+/// <see cref="Flat"/> uses virtual contexts to reduce checkpoint volume (no
+/// per-branch <c>CONTEXT</c> operation): each branch's result or error is
+/// recorded inline on the parent parallel/map operation's payload instead.
 /// </para>
 /// </remarks>
 public enum NestingType
@@ -29,12 +28,12 @@ public enum NestingType
     Nested,
 
     /// <summary>
-    /// Branches use virtual contexts sharing the parent. Reduces checkpoint
-    /// cost at the expense of less granular execution traces.
+    /// Branches run in virtual contexts that emit no <c>CONTEXT</c> checkpoint
+    /// of their own — per-branch results/errors are recorded inline on the
+    /// parent operation's payload. Reduces checkpoint cost at the expense of
+    /// less granular execution traces. Branch operations inside a flat branch
+    /// (steps, waits) still checkpoint, re-parented to the parallel/map
+    /// operation.
     /// </summary>
-    /// <remarks>
-    /// Not yet implemented in the .NET SDK; passing this value throws
-    /// <see cref="System.NotSupportedException"/>.
-    /// </remarks>
     Flat
 }

--- a/Libraries/src/Amazon.Lambda.DurableExecution/ParallelConfig.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/ParallelConfig.cs
@@ -52,9 +52,10 @@ public sealed class ParallelConfig
     /// <see cref="NestingType.Nested"/>.
     /// </summary>
     /// <remarks>
-    /// <see cref="NestingType.Flat"/> is not yet supported in the .NET SDK and
-    /// will throw <see cref="System.NotSupportedException"/> when the parallel
-    /// operation is invoked.
+    /// Under <see cref="NestingType.Flat"/> each branch runs in a virtual
+    /// context that emits no per-branch <c>CONTEXT</c> checkpoint; per-branch
+    /// results and errors are recorded inline on the parallel operation's
+    /// payload instead.
     /// </remarks>
     public NestingType NestingType { get; set; } = NestingType.Nested;
 }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/MapFlatNestingTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/MapFlatNestingTest.cs
@@ -1,0 +1,126 @@
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Amazon.Lambda.Model;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Amazon.Lambda.DurableExecution.IntegrationTests;
+
+public class MapFlatNestingTest
+{
+    private readonly ITestOutputHelper _output;
+    public MapFlatNestingTest(ITestOutputHelper output) => _output = output;
+
+    /// <summary>
+    /// Reproduces the deterministic operation ID the SDK assigns. Item op ids are
+    /// SHA-256(parentOpId + "-" + (index+1)); inner-op ids nest the same way under
+    /// the item op id. Reproduced locally because OperationIdGenerator is internal
+    /// to the SDK.
+    /// </summary>
+    private static string HashOpId(string raw)
+    {
+        var bytes = Encoding.UTF8.GetBytes(raw);
+        var hash = SHA256.HashData(bytes);
+        var sb = new StringBuilder(hash.Length * 2);
+        foreach (var b in hash) sb.Append(b.ToString("x2"));
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// End-to-end <see cref="NestingType.Flat"/> map: three items, each with a
+    /// step + a durable wait (the wait forces a suspend/resume cycle so the map
+    /// actually replays). Verifies the Flat-specific contract against the real
+    /// durable-execution service:
+    ///   1. NO per-item CONTEXT events are emitted — only the parent Map CONTEXT.
+    ///   2. Each item's inner step/wait ops RE-PARENT to the Map op (the nearest
+    ///      non-virtual ancestor), since the virtual item emits no CONTEXT
+    ///      checkpoint to reference as a parent.
+    ///   3. Inner-op ids are still derived from the item op id space.
+    ///   4. The per-item result survives replay (read back from the inline parent
+    ///      payload, not a per-item checkpoint).
+    /// </summary>
+    [Fact]
+    public async Task Map_Flat_SuppressesItemContexts_AndReparentsInnerOps()
+    {
+        await using var deployment = await DurableFunctionDeployment.CreateAsync(
+            DurableFunctionDeployment.FindTestFunctionDir("MapFlatNestingFunction"),
+            "mflat", _output);
+
+        var (invokeResponse, executionName) = await deployment.InvokeAsync("""{"orderId": "mf1"}""");
+        var responsePayload = Encoding.UTF8.GetString(invokeResponse.Payload.ToArray());
+        _output.WriteLine($"Response: {responsePayload}");
+
+        var arn = await deployment.FindDurableExecutionArnByNameAsync(executionName, TimeSpan.FromSeconds(60));
+        Assert.NotNull(arn);
+
+        var status = await deployment.PollForCompletionAsync(arn!, TimeSpan.FromSeconds(120));
+        Assert.Equal("SUCCEEDED", status, ignoreCase: true);
+
+        // The map parent is the first root-level operation -> SHA256("1").
+        var parentOpId = HashOpId("1");
+        var itemOpIds = new[]
+        {
+            HashOpId($"{parentOpId}-1"),
+            HashOpId($"{parentOpId}-2"),
+            HashOpId($"{parentOpId}-3"),
+        };
+        // Each item's "generate" step is the 1st inner op under that item's own
+        // id space: SHA256("<itemOpId>-1").
+        var expectedStepIds = itemOpIds.Select(i => HashOpId($"{i}-1")).ToList();
+
+        // Wait until the parent CONTEXT succeeded and all three items' inner step
+        // + wait events are visible.
+        var history = await deployment.WaitForHistoryAsync(
+            arn!,
+            h =>
+            {
+                var events = h.Events ?? new List<Event>();
+                if (events.Count(e => e.EventType == EventType.ContextSucceeded) < 1) return false;
+                if (events.Count(e => e.EventType == EventType.StepSucceeded) < 3) return false;
+                if (events.Count(e => e.EventType == EventType.WaitSucceeded) < 3) return false;
+                return true;
+            },
+            TimeSpan.FromSeconds(60));
+        var allEvents = history.Events ?? new List<Event>();
+
+        // 1. Exactly ONE CONTEXT operation exists — the parent Map op. No per-item
+        // CONTEXT events under Flat.
+        var contextStartedIds = allEvents
+            .Where(e => e.EventType == EventType.ContextStarted)
+            .Select(e => e.Id)
+            .Distinct()
+            .ToList();
+        Assert.Equal(new[] { parentOpId }, contextStartedIds);
+        Assert.Empty(allEvents.Where(e =>
+            e.EventType == EventType.ContextStarted && itemOpIds.Contains(e.Id)));
+
+        // 2. Each item's "generate" step re-parents to the Map op (NOT to its
+        // virtual item op).
+        var generateSteps = allEvents
+            .Where(e => e.EventType == EventType.StepSucceeded && e.Name == "generate")
+            .ToList();
+        Assert.Equal(3, generateSteps.Count);
+        Assert.All(generateSteps, e => Assert.Equal(parentOpId, e.ParentId));
+
+        // 3. ...but the step ids are still derived from the per-item id space, so
+        // the three items' first steps are distinct and match the expected
+        // SHA256("<itemOpId>-1") values.
+        var observedStepIds = generateSteps.Select(e => e.Id).Distinct().ToList();
+        Assert.Equal(3, observedStepIds.Count);
+        foreach (var expected in expectedStepIds)
+        {
+            Assert.Contains(expected, observedStepIds);
+        }
+
+        // 4. The wait events span at least 2 invocations (suspend + resume),
+        // proving replay actually happened with no per-item checkpoint.
+        var invocations = allEvents.Where(e => e.InvocationCompletedDetails != null).ToList();
+        Assert.True(
+            invocations.Count >= 2,
+            $"Expected >= 2 InvocationCompleted events (suspend + resume), got {invocations.Count}");
+
+        // 5. The user-visible response carries the joined per-item results.
+        Assert.Contains("\"data\"", responsePayload, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/ParallelFlatNestingTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/ParallelFlatNestingTest.cs
@@ -1,0 +1,135 @@
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Amazon.Lambda.Model;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Amazon.Lambda.DurableExecution.IntegrationTests;
+
+public class ParallelFlatNestingTest
+{
+    private readonly ITestOutputHelper _output;
+    public ParallelFlatNestingTest(ITestOutputHelper output) => _output = output;
+
+    /// <summary>
+    /// Reproduces the deterministic operation ID the SDK assigns. Branch op ids
+    /// are SHA-256(parentOpId + "-" + (index+1)); inner-op ids nest the same way
+    /// under the branch op id. Reproduced locally because OperationIdGenerator is
+    /// internal to the SDK.
+    /// </summary>
+    private static string HashOpId(string raw)
+    {
+        var bytes = Encoding.UTF8.GetBytes(raw);
+        var hash = SHA256.HashData(bytes);
+        var sb = new StringBuilder(hash.Length * 2);
+        foreach (var b in hash) sb.Append(b.ToString("x2"));
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// End-to-end <see cref="NestingType.Flat"/> parallel: three branches, each
+    /// with a step + a durable wait (the wait forces a suspend/resume cycle so the
+    /// parallel actually replays). Verifies the Flat-specific contract against the
+    /// real durable-execution service:
+    ///   1. NO per-branch CONTEXT events are emitted — only the parent Parallel
+    ///      CONTEXT. (Under Nested there would be 4 ContextStarted; under Flat,
+    ///      exactly 1.)
+    ///   2. Each branch's inner step/wait ops RE-PARENT to the Parallel op (the
+    ///      nearest non-virtual ancestor), since the virtual branch emits no
+    ///      CONTEXT checkpoint to reference as a parent.
+    ///   3. Inner-op ids are still derived from the branch op id (so the two
+    ///      branches' first steps don't collide), even though they report the
+    ///      Parallel op as parent.
+    ///   4. The per-branch result survives replay (the GUID generated inside
+    ///      <c>generate</c> is preserved across suspend/resume — read back from the
+    ///      inline parent payload, not a per-branch checkpoint).
+    /// </summary>
+    [Fact]
+    public async Task Parallel_Flat_SuppressesBranchContexts_AndReparentsInnerOps()
+    {
+        await using var deployment = await DurableFunctionDeployment.CreateAsync(
+            DurableFunctionDeployment.FindTestFunctionDir("ParallelFlatNestingFunction"),
+            "pflat", _output);
+
+        var (invokeResponse, executionName) = await deployment.InvokeAsync("""{"orderId": "pf1"}""");
+        var responsePayload = Encoding.UTF8.GetString(invokeResponse.Payload.ToArray());
+        _output.WriteLine($"Response: {responsePayload}");
+
+        var arn = await deployment.FindDurableExecutionArnByNameAsync(executionName, TimeSpan.FromSeconds(60));
+        Assert.NotNull(arn);
+
+        var status = await deployment.PollForCompletionAsync(arn!, TimeSpan.FromSeconds(120));
+        Assert.Equal("SUCCEEDED", status, ignoreCase: true);
+
+        // The parallel parent is the first root-level operation -> SHA256("1").
+        var parentOpId = HashOpId("1");
+        var branchOpIds = new[]
+        {
+            HashOpId($"{parentOpId}-1"),
+            HashOpId($"{parentOpId}-2"),
+            HashOpId($"{parentOpId}-3"),
+        };
+        // Each branch's "generate" step is the 1st inner op under that branch's
+        // own id space: SHA256("<branchOpId>-1").
+        var expectedStepIds = branchOpIds.Select(b => HashOpId($"{b}-1")).ToList();
+
+        // Wait until the parent CONTEXT succeeded and all three branches' inner
+        // step + wait events are visible.
+        var history = await deployment.WaitForHistoryAsync(
+            arn!,
+            h =>
+            {
+                var events = h.Events ?? new List<Event>();
+                if (events.Count(e => e.EventType == EventType.ContextSucceeded) < 1) return false;
+                if (events.Count(e => e.EventType == EventType.StepSucceeded) < 3) return false;
+                if (events.Count(e => e.EventType == EventType.WaitSucceeded) < 3) return false;
+                return true;
+            },
+            TimeSpan.FromSeconds(60));
+        var allEvents = history.Events ?? new List<Event>();
+
+        // 1. Exactly ONE CONTEXT operation exists — the parent Parallel op. No
+        // per-branch CONTEXT events under Flat.
+        var contextStartedIds = allEvents
+            .Where(e => e.EventType == EventType.ContextStarted)
+            .Select(e => e.Id)
+            .Distinct()
+            .ToList();
+        Assert.Equal(new[] { parentOpId }, contextStartedIds);
+        Assert.Empty(allEvents.Where(e =>
+            e.EventType == EventType.ContextStarted && branchOpIds.Contains(e.Id)));
+
+        // 2. Each branch's "generate" step re-parents to the Parallel op (NOT to
+        // its virtual branch op).
+        var generateSteps = allEvents
+            .Where(e => e.EventType == EventType.StepSucceeded && e.Name == "generate")
+            .ToList();
+        Assert.Equal(3, generateSteps.Count);
+        Assert.All(generateSteps, e => Assert.Equal(parentOpId, e.ParentId));
+
+        // 3. ...but the step ids are still derived from the per-branch id space,
+        // so the three branches' first steps are distinct and match the expected
+        // SHA256("<branchOpId>-1") values.
+        var observedStepIds = generateSteps.Select(e => e.Id).Distinct().ToList();
+        Assert.Equal(3, observedStepIds.Count);
+        foreach (var expected in expectedStepIds)
+        {
+            Assert.Contains(expected, observedStepIds);
+        }
+
+        // 4. The "generate" step succeeded exactly once per branch — proving
+        // replay returned the cached result rather than re-executing.
+        Assert.Equal(3, generateSteps.Count);
+
+        // 5. The wait events span at least 2 invocations (suspend + resume),
+        // proving replay actually happened with no per-branch checkpoint.
+        var invocations = allEvents.Where(e => e.InvocationCompletedDetails != null).ToList();
+        Assert.True(
+            invocations.Count >= 2,
+            $"Expected >= 2 InvocationCompleted events (suspend + resume), got {invocations.Count}");
+
+        // 6. The user-visible response carries the joined per-branch results.
+        Assert.Contains("\"data\"", responsePayload, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/MapFlatNestingFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/MapFlatNestingFunction/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/provided:al2023
+
+RUN dnf install -y libicu
+
+COPY bin/publish/ ${LAMBDA_TASK_ROOT}
+
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/MapFlatNestingFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/MapFlatNestingFunction/Dockerfile
@@ -1,6 +1,4 @@
-FROM public.ecr.aws/lambda/provided:al2023
-
-RUN dnf install -y libicu
+FROM public.ecr.aws/lambda/dotnet:10
 
 COPY bin/publish/ ${LAMBDA_TASK_ROOT}
 

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/MapFlatNestingFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/MapFlatNestingFunction/Function.cs
@@ -1,0 +1,57 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace DurableExecutionTestFunction;
+
+public class Function
+{
+    public static async Task Main(string[] args)
+    {
+        var handler = new Function();
+        var serializer = new DefaultLambdaJsonSerializer();
+        using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<DurableExecutionInvocationInput, DurableExecutionInvocationOutput>(handler.Handler, serializer);
+        using var bootstrap = new LambdaBootstrap(handlerWrapper);
+        await bootstrap.RunAsync();
+    }
+
+    public Task<DurableExecutionInvocationOutput> Handler(
+        DurableExecutionInvocationInput input, ILambdaContext context)
+        => DurableFunction.WrapAsync<TestEvent, TestResult>(Workflow, input, context);
+
+    private async Task<TestResult> Workflow(TestEvent input, IDurableContext context)
+    {
+        // Three items run under NestingType.Flat. Each item generates a fresh
+        // GUID inside a step, then does a durable wait. The wait forces a
+        // suspend/resume cycle, so the second invocation MUST replay the cached
+        // per-item result — and under Flat that result lives inline on the parent
+        // Map payload, not on a per-item CONTEXT checkpoint (none are emitted).
+        // If Flat replay is broken, the GUID would change between the original
+        // execution and replay, or the inner step/wait ops would reference a
+        // non-existent item parent.
+        var items = new[] { 0, 1, 2 };
+
+        var batch = await context.MapAsync(
+            items,
+            async (ctx, item, index, all) =>
+            {
+                var generatedId = await ctx.StepAsync(
+                    async (_) => { await Task.CompletedTask; return Guid.NewGuid().ToString(); },
+                    name: "generate");
+
+                // Force a suspend/resume cycle to trigger replay of the map.
+                await ctx.WaitAsync(TimeSpan.FromSeconds(2), name: "boundary");
+
+                return generatedId;
+            },
+            name: "fanout",
+            config: new MapConfig { NestingType = NestingType.Flat });
+
+        var joined = string.Join(",", batch.GetResults());
+        return new TestResult { Status = "completed", Data = joined };
+    }
+}
+
+public class TestEvent { public string? OrderId { get; set; } }
+public class TestResult { public string? Status { get; set; } public string? Data { get; set; } }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/MapFlatNestingFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/MapFlatNestingFunction/Function.cs
@@ -34,10 +34,10 @@ public class Function
 
         var batch = await context.MapAsync(
             items,
-            async (ctx, item, index, all) =>
+            async (ctx, item, index, all, ct) =>
             {
                 var generatedId = await ctx.StepAsync(
-                    async (_) => { await Task.CompletedTask; return Guid.NewGuid().ToString(); },
+                    async (_, _) => { await Task.CompletedTask; return Guid.NewGuid().ToString(); },
                     name: "generate");
 
                 // Force a suspend/resume cycle to trigger replay of the map.

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/MapFlatNestingFunction/MapFlatNestingFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/MapFlatNestingFunction/MapFlatNestingFunction.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>bootstrap</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelFlatNestingFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelFlatNestingFunction/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/provided:al2023
+
+RUN dnf install -y libicu
+
+COPY bin/publish/ ${LAMBDA_TASK_ROOT}
+
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelFlatNestingFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelFlatNestingFunction/Dockerfile
@@ -1,6 +1,4 @@
-FROM public.ecr.aws/lambda/provided:al2023
-
-RUN dnf install -y libicu
+FROM public.ecr.aws/lambda/dotnet:10
 
 COPY bin/publish/ ${LAMBDA_TASK_ROOT}
 

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelFlatNestingFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelFlatNestingFunction/Function.cs
@@ -1,0 +1,61 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace DurableExecutionTestFunction;
+
+public class Function
+{
+    public static async Task Main(string[] args)
+    {
+        var handler = new Function();
+        var serializer = new DefaultLambdaJsonSerializer();
+        using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<DurableExecutionInvocationInput, DurableExecutionInvocationOutput>(handler.Handler, serializer);
+        using var bootstrap = new LambdaBootstrap(handlerWrapper);
+        await bootstrap.RunAsync();
+    }
+
+    public Task<DurableExecutionInvocationOutput> Handler(
+        DurableExecutionInvocationInput input, ILambdaContext context)
+        => DurableFunction.WrapAsync<TestEvent, TestResult>(Workflow, input, context);
+
+    private async Task<TestResult> Workflow(TestEvent input, IDurableContext context)
+    {
+        // Three branches run under NestingType.Flat. Each branch generates a
+        // fresh GUID inside a step, then does a durable wait. The wait forces a
+        // suspend/resume cycle, so the second invocation MUST replay the cached
+        // per-branch result — and under Flat that result lives inline on the
+        // parent Parallel payload, not on a per-branch CONTEXT checkpoint (none
+        // are emitted). If Flat replay is broken, the GUID would change between
+        // the original execution and replay, or the inner step/wait ops would
+        // reference a non-existent branch parent.
+        var batch = await context.ParallelAsync(
+            new[]
+            {
+                new DurableBranch<string>("a", BranchAsync),
+                new DurableBranch<string>("b", BranchAsync),
+                new DurableBranch<string>("c", BranchAsync),
+            },
+            name: "fanout",
+            config: new ParallelConfig { NestingType = NestingType.Flat });
+
+        var joined = string.Join(",", batch.GetResults());
+        return new TestResult { Status = "completed", Data = joined };
+    }
+
+    private static async Task<string> BranchAsync(IDurableContext ctx)
+    {
+        var generatedId = await ctx.StepAsync(
+            async (_) => { await Task.CompletedTask; return Guid.NewGuid().ToString(); },
+            name: "generate");
+
+        // Force a suspend/resume cycle to trigger replay of the parallel.
+        await ctx.WaitAsync(TimeSpan.FromSeconds(2), name: "boundary");
+
+        return generatedId;
+    }
+}
+
+public class TestEvent { public string? OrderId { get; set; } }
+public class TestResult { public string? Status { get; set; } public string? Data { get; set; } }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelFlatNestingFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelFlatNestingFunction/Function.cs
@@ -44,10 +44,10 @@ public class Function
         return new TestResult { Status = "completed", Data = joined };
     }
 
-    private static async Task<string> BranchAsync(IDurableContext ctx)
+    private static async Task<string> BranchAsync(IDurableContext ctx, CancellationToken ct)
     {
         var generatedId = await ctx.StepAsync(
-            async (_) => { await Task.CompletedTask; return Guid.NewGuid().ToString(); },
+            async (_, _) => { await Task.CompletedTask; return Guid.NewGuid().ToString(); },
             name: "generate");
 
         // Force a suspend/resume cycle to trigger replay of the parallel.

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelFlatNestingFunction/ParallelFlatNestingFunction.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelFlatNestingFunction/ParallelFlatNestingFunction.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>bootstrap</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.RuntimeSupport\Amazon.Lambda.RuntimeSupport.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/MapOperationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/MapOperationTests.cs
@@ -385,15 +385,104 @@ public class MapOperationTests
     // ──────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task MapAsync_NestingTypeFlat_ThrowsNotSupported()
+    public async Task MapAsync_NestingTypeFlat_SuppressesPerItemContextOps()
     {
-        var (context, _, _, _) = CreateContext();
+        var (context, recorder, _, _) = CreateContext();
 
-        await Assert.ThrowsAsync<NotSupportedException>(() =>
-            context.MapAsync(
-                new[] { 1 },
-                async (ctx, item, index, all, _) => { await Task.Yield(); return item; },
-                config: new MapConfig { NestingType = NestingType.Flat }));
+        var result = await context.MapAsync(
+            new[] { 1, 2, 3 },
+            async (ctx, item, index, all, _) => { await Task.Yield(); return item * 10; },
+            name: "doubler",
+            config: new MapConfig { NestingType = NestingType.Flat });
+
+        Assert.Equal(new[] { 10, 20, 30 }, result.GetResults());
+        Assert.Equal(CompletionReason.AllCompleted, result.CompletionReason);
+
+        await recorder.Batcher.DrainAsync();
+
+        // Parent Map CONTEXT ops still emitted; no per-item CONTEXT ops under Flat.
+        var parentActions = recorder.Flushed
+            .Where(o => o.Type == "CONTEXT" && o.SubType == "Map")
+            .Select(o => $"{o.Action}").ToArray();
+        Assert.Equal(new[] { "START", "SUCCEED" }, parentActions);
+
+        Assert.Empty(recorder.Flushed.Where(o =>
+            o.Type == "CONTEXT" && o.SubType == "MapItem"));
+    }
+
+    [Fact]
+    public async Task MapAsync_NestingTypeFlat_InnerOpsReparentToMapOp()
+    {
+        var (context, recorder, _, _) = CreateContext();
+
+        await context.MapAsync(
+            new[] { 1, 2 },
+            async (ctx, item, index, all, _) =>
+                await ctx.StepAsync(async (_, _) => { await Task.Yield(); return item * 10; }),
+            name: "doubler",
+            config: new MapConfig { NestingType = NestingType.Flat });
+
+        await recorder.Batcher.DrainAsync();
+
+        var parentOpId = IdAt(1);
+        var item0Id = ChildIdAt(parentOpId, 1);
+        var item1Id = ChildIdAt(parentOpId, 2);
+        var step0Id = ChildIdAt(item0Id, 1);
+        var step1Id = ChildIdAt(item1Id, 1);
+
+        // A step emits both START and SUCCEED under the same Id; scope to START
+        // so we assert on exactly one record per step.
+        var steps = recorder.Flushed
+            .Where(o => o.Type == "STEP" && $"{o.Action}" == "START").ToArray();
+        var step0 = Assert.Single(steps, o => o.Id == step0Id);
+        var step1 = Assert.Single(steps, o => o.Id == step1Id);
+
+        // Inner steps re-parent to the MAP op (nearest non-virtual ancestor).
+        Assert.Equal(parentOpId, step0.ParentId);
+        Assert.Equal(parentOpId, step1.ParentId);
+    }
+
+    [Fact]
+    public async Task MapAsync_NestingTypeFlat_ReplaySucceeded_RebuildsFromInlinePayload()
+    {
+        var parentOpId = IdAt(1);
+
+        var summaryJson = """
+            {"CompletionReason":"ALL_COMPLETED","Units":[
+                {"Index":0,"Name":"0","Status":"SUCCEEDED","Result":"10"},
+                {"Index":1,"Name":"1","Status":"SUCCEEDED","Result":"20"}
+            ]}
+            """;
+
+        var (context, recorder, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = parentOpId,
+                    Type = OperationTypes.Context,
+                    Status = OperationStatuses.Succeeded,
+                    SubType = OperationSubTypes.Map,
+                    Name = "doubler",
+                    ContextDetails = new ContextDetails { Result = summaryJson }
+                }
+            }
+        });
+
+        var executed = false;
+        var result = await context.MapAsync(
+            new[] { 1, 2 },
+            async (ctx, item, index, all, _) => { executed = true; await Task.Yield(); return item * 999; },
+            name: "doubler",
+            config: new MapConfig { NestingType = NestingType.Flat });
+
+        Assert.False(executed);
+        Assert.Equal(new[] { 10, 20 }, result.GetResults());
+        Assert.Equal(CompletionReason.AllCompleted, result.CompletionReason);
+
+        await recorder.Batcher.DrainAsync();
+        Assert.Empty(recorder.Flushed);
     }
 
     // ──────────────────────────────────────────────────────────────────────

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ParallelOperationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ParallelOperationTests.cs
@@ -566,14 +566,204 @@ public class ParallelOperationTests
     // ──────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task ParallelAsync_NestingTypeFlat_ThrowsNotSupported()
+    public async Task ParallelAsync_NestingTypeFlat_SuppressesPerBranchContextOps()
     {
-        var (context, _, _, _) = CreateContext();
+        var (context, recorder, _, _) = CreateContext();
 
-        await Assert.ThrowsAsync<NotSupportedException>(() =>
+        var result = await context.ParallelAsync(
+            new Func<IDurableContext, CancellationToken, Task<int>>[]
+            {
+                async (_, _) => { await Task.Yield(); return 10; },
+                async (_, _) => { await Task.Yield(); return 20; },
+                async (_, _) => { await Task.Yield(); return 30; },
+            },
+            name: "fanout",
+            config: new ParallelConfig { NestingType = NestingType.Flat });
+
+        Assert.Equal(new[] { 10, 20, 30 }, result.GetResults());
+        Assert.Equal(CompletionReason.AllCompleted, result.CompletionReason);
+
+        await recorder.Batcher.DrainAsync();
+
+        // Parent Parallel CONTEXT ops are still emitted (the parent is never
+        // virtual)...
+        var parentActions = recorder.Flushed
+            .Where(o => o.Type == "CONTEXT" && o.SubType == "Parallel")
+            .Select(o => $"{o.Action}").ToArray();
+        Assert.Equal(new[] { "START", "SUCCEED" }, parentActions);
+
+        // ...but NO per-branch CONTEXT ops are emitted under Flat.
+        var branchOps = recorder.Flushed
+            .Where(o => o.Type == "CONTEXT" && o.SubType == "ParallelBranch")
+            .ToArray();
+        Assert.Empty(branchOps);
+    }
+
+    [Fact]
+    public async Task ParallelAsync_NestingTypeFlat_InnerOpsReparentToParallelOp()
+    {
+        var (context, recorder, _, _) = CreateContext();
+
+        await context.ParallelAsync(
+            new Func<IDurableContext, CancellationToken, Task<int>>[]
+            {
+                async (ctx, _) => await ctx.StepAsync(async (_, _) => { await Task.Yield(); return 1; }),
+                async (ctx, _) => await ctx.StepAsync(async (_, _) => { await Task.Yield(); return 2; }),
+            },
+            name: "fanout",
+            config: new ParallelConfig { NestingType = NestingType.Flat });
+
+        await recorder.Batcher.DrainAsync();
+
+        var parentOpId = IdAt(1);
+        var branch0Id = ChildIdAt(parentOpId, 1);
+        var branch1Id = ChildIdAt(parentOpId, 2);
+
+        // Each branch's inner STEP is ID-derived from the branch op id (so the
+        // two branches' first steps don't collide)...
+        var step0Id = ChildIdAt(branch0Id, 1);
+        var step1Id = ChildIdAt(branch1Id, 1);
+
+        // A step emits both START and SUCCEED under the same Id; scope to START
+        // so we assert on exactly one record per step.
+        var steps = recorder.Flushed
+            .Where(o => o.Type == "STEP" && $"{o.Action}" == "START").ToArray();
+        var step0 = Assert.Single(steps, o => o.Id == step0Id);
+        var step1 = Assert.Single(steps, o => o.Id == step1Id);
+
+        // ...but each inner step re-parents to the PARALLEL op (the nearest
+        // non-virtual ancestor), NOT to the virtual branch (which emitted no
+        // checkpoint to reference).
+        Assert.Equal(parentOpId, step0.ParentId);
+        Assert.Equal(parentOpId, step1.ParentId);
+    }
+
+    [Fact]
+    public async Task ParallelAsync_NestingTypeFlat_PartialFailure_SurfacesInlineErrors()
+    {
+        var (context, recorder, _, _) = CreateContext();
+
+        var result = await context.ParallelAsync(
+            new Func<IDurableContext, CancellationToken, Task<int>>[]
+            {
+                async (_, _) => { await Task.Yield(); return 1; },
+                async (_, _) => { await Task.Yield(); throw new InvalidOperationException("flat boom"); },
+                async (_, _) => { await Task.Yield(); return 3; },
+            },
+            name: "fanout",
+            config: new ParallelConfig
+            {
+                NestingType = NestingType.Flat,
+                CompletionConfig = CompletionConfig.AllCompleted()
+            });
+
+        Assert.True(result.HasFailure);
+        Assert.Equal(2, result.SuccessCount);
+        Assert.Equal(1, result.FailureCount);
+        Assert.Equal(new[] { 1, 3 }, result.GetResults());
+        Assert.Contains("flat boom", result.GetErrors()[0].Message);
+
+        await recorder.Batcher.DrainAsync();
+
+        // The parent SUCCEED payload carries the inline per-unit results/errors;
+        // no per-branch FAIL op was emitted.
+        Assert.Empty(recorder.Flushed.Where(o =>
+            o.Type == "CONTEXT" && o.SubType == "ParallelBranch"));
+    }
+
+    [Fact]
+    public async Task ParallelAsync_NestingTypeFlat_ReplaySucceeded_RebuildsFromInlinePayload()
+    {
+        var parentOpId = IdAt(1);
+
+        // Flat replay reads per-unit results from the inline summary payload —
+        // there are NO per-branch child CONTEXT ops in state.
+        var summaryJson = """
+            {"CompletionReason":"ALL_COMPLETED","Units":[
+                {"Index":0,"Name":"0","Status":"SUCCEEDED","Result":"100"},
+                {"Index":1,"Name":"1","Status":"SUCCEEDED","Result":"200"}
+            ]}
+            """;
+
+        var (context, recorder, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = parentOpId,
+                    Type = OperationTypes.Context,
+                    Status = OperationStatuses.Succeeded,
+                    SubType = OperationSubTypes.Parallel,
+                    Name = "fanout",
+                    ContextDetails = new ContextDetails { Result = summaryJson }
+                }
+            }
+        });
+
+        var executed = false;
+        var result = await context.ParallelAsync(
+            new Func<IDurableContext, CancellationToken, Task<int>>[]
+            {
+                async (_, _) => { executed = true; await Task.Yield(); return 999; },
+                async (_, _) => { executed = true; await Task.Yield(); return 999; },
+            },
+            name: "fanout",
+            config: new ParallelConfig { NestingType = NestingType.Flat });
+
+        Assert.False(executed);
+        Assert.Equal(new[] { 100, 200 }, result.GetResults());
+        Assert.Equal(CompletionReason.AllCompleted, result.CompletionReason);
+
+        await recorder.Batcher.DrainAsync();
+        Assert.Empty(recorder.Flushed);
+    }
+
+    [Fact]
+    public async Task ParallelAsync_NestingTypeFlat_ReplayFailed_ThrowsWithInlineError()
+    {
+        var parentOpId = IdAt(1);
+
+        var summaryJson = """
+            {"CompletionReason":"FAILURE_TOLERANCE_EXCEEDED","Units":[
+                {"Index":0,"Name":"0","Status":"FAILED","Error":{"ErrorType":"System.InvalidOperationException","ErrorMessage":"flat branch 0 failed"}},
+                {"Index":1,"Name":"1","Status":"SUCCEEDED","Result":"200"}
+            ]}
+            """;
+
+        var (context, _, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = parentOpId,
+                    Type = OperationTypes.Context,
+                    // The parent always checkpoints SUCCEED even on a tolerance
+                    // failure — the FAILURE_TOLERANCE_EXCEEDED reason lives in the
+                    // payload, and replay throws based on that, not the op status.
+                    Status = OperationStatuses.Succeeded,
+                    SubType = OperationSubTypes.Parallel,
+                    Name = "fanout",
+                    ContextDetails = new ContextDetails { Result = summaryJson }
+                }
+            }
+        });
+
+        var ex = await Assert.ThrowsAsync<ParallelException>(() =>
             context.ParallelAsync(
-                new Func<IDurableContext, CancellationToken, Task<int>>[] { async (_, _) => { await Task.Yield(); return 1; } },
+                new Func<IDurableContext, CancellationToken, Task<int>>[]
+                {
+                    async (_, _) => { await Task.Yield(); return 1; },
+                    async (_, _) => { await Task.Yield(); return 2; },
+                },
+                name: "fanout",
                 config: new ParallelConfig { NestingType = NestingType.Flat }));
+
+        Assert.Equal(CompletionReason.FailureToleranceExceeded, ex.CompletionReason);
+        var typed = (IBatchResult<int>)ex.Result!;
+        Assert.Equal(1, typed.FailureCount);
+        Assert.Contains("flat branch 0 failed", typed.GetErrors()[0].Message);
     }
 
     // ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-lambda-dotnet/issues/2216

*Description of changes:*

## Summary

Wires up `NestingType.Flat` for `ParallelAsync` and `MapAsync`. Both previously threw `NotSupportedException` for `Flat`; only `Nested` (the default) worked. The implementation uses an inline-payload strategy matching the Python, JS, and Java durable-execution SDKs.

## What `Flat` does

Each parallel/map branch normally runs in its own child `CONTEXT` operation that emits `START` + `SUCCEED`/`FAIL` checkpoints — roughly one extra op per branch. `NestingType` controls this:

- **`Nested`** (default) — each branch emits a full `CONTEXT` op. Maximum trace observability, more checkpoints.
- **`Flat`** — each branch runs in a **virtual context** that emits no `CONTEXT` checkpoint; per-branch results/errors are recorded inline on the parent operation's payload. Fewer checkpoints, less granular traces.

```csharp
await ctx.ParallelAsync(branches, name: "fanout",
    config: new ParallelConfig { NestingType = NestingType.Flat });

await ctx.MapAsync(items, MapItem, name: "fanout",
    config: new MapConfig { NestingType = NestingType.Flat });
```

`Nested` stays the default, so opting in is non-breaking.

## Execution history: `Nested` vs `Flat`

Take a fan-out of three branches, each running a `generate` step then a `boundary` wait (this is exactly the `ParallelFlatNestingFunction` integration test):

```csharp
await ctx.ParallelAsync(new[]
{
    new DurableBranch<string>("a", BranchAsync),
    new DurableBranch<string>("b", BranchAsync),
    new DurableBranch<string>("c", BranchAsync),
}, name: "fanout", config: new ParallelConfig { NestingType = /* see below */ });

static async Task<string> BranchAsync(IDurableContext ctx, CancellationToken ct)
{
    var id = await ctx.StepAsync(/* generate a GUID */, name: "generate");
    await ctx.WaitAsync(TimeSpan.FromSeconds(2), name: "boundary");
    return id;
}
```

### `Nested` (default) — one `CONTEXT` op per branch

Each branch gets its own `CONTEXT` op, and that branch's inner ops parent to it. **10 operations** (1 parent + 3 branches + 3 steps + 3 waits):

```
CONTEXT  fanout                         id=P        parent=(root)
├─ CONTEXT  a                           id=B1       parent=P
│  ├─ STEP  generate                    id=B1-1     parent=B1
│  └─ WAIT  boundary                    id=B1-2     parent=B1
├─ CONTEXT  b                           id=B2       parent=P
│  ├─ STEP  generate                    id=B2-1     parent=B2
│  └─ WAIT  boundary                    id=B2-2     parent=B2
└─ CONTEXT  c                           id=B3       parent=P
   ├─ STEP  generate                    id=B3-1     parent=B3
   └─ WAIT  boundary                    id=B3-2     parent=B3

Each per-branch result lives on that branch's own CONTEXT checkpoint payload.
```

### `Flat` — no per-branch `CONTEXT` op

The three branch `CONTEXT` ops disappear. Inner ops keep their per-branch ID space (so the three `generate` steps never collide) but **re-parent to `fanout`**, the nearest non-virtual ancestor. **7 operations** (1 parent + 3 steps + 3 waits):

```
CONTEXT  fanout                         id=P        parent=(root)
├─ STEP  generate                       id=B1-1     parent=P    ← re-parented (id still from branch a's space)
├─ WAIT  boundary                       id=B1-2     parent=P
├─ STEP  generate                       id=B2-1     parent=P    ← re-parented (id from branch b's space)
├─ WAIT  boundary                       id=B2-2     parent=P
├─ STEP  generate                       id=B3-1     parent=P    ← re-parented (id from branch c's space)
└─ WAIT  boundary                       id=B3-2     parent=P

fanout's payload carries the per-branch results inline (BatchSummary):
  Units: [
    { Index: 0, Name: "a", Status: "SUCCEEDED", Result: "<guid-a>" },
    { Index: 1, Name: "b", Status: "SUCCEEDED", Result: "<guid-b>" },
    { Index: 2, Name: "c", Status: "SUCCEEDED", Result: "<guid-c>" },
  ]
```

Notes on the IDs (`P`, `B1`… are shorthand for the SHA-256 op IDs the SDK derives by position):

- `P = SHA256("1")` — first root op. `B1 = SHA256("P-1")`, `B2 = SHA256("P-2")`, `B3 = SHA256("P-3")`.
- Inner IDs still derive from the **branch** op ID (`B1-1 = SHA256("B1-1")`, etc.) under both modes — that ID space is load-bearing for replay. Only the **reported parent** changes: `B1` under `Nested`, `P` under `Flat`.
- On a partial failure, a failed unit records `Status: "FAILED"` with an inline `Error` (`ErrorObject`) instead of `Result`, and `fanout` persists the `BatchSummary` even on `FAIL`.

`MapAsync` with `NestingType.Flat` produces the identical shape; units are named by index instead of branch name.

## How it works

A flat branch is a logical scope that owns an ID namespace and logger scope but is invisible in the checkpoint tree:

1. **Decoupled ID generation** (`OperationIdGenerator.CreateVirtualChild`) — inner-op IDs are still prefixed by the branch's own op-id (so siblings never collide and the ID space matches `Nested`, which is load-bearing for replay), but inner ops report the nearest non-virtual ancestor (the parallel/map op) as their wire `ParentId`.
2. **Checkpoint suppression** (`ChildContextOperation`) — an `isVirtual` flag suppresses the branch's `CONTEXT` checkpoints. Exceptions still propagate; inner ops still checkpoint, re-parented per (1).
3. **Inline payload** (`BatchSummary`/`BatchUnitSummary`) — with no child checkpoints to read back on replay, each unit's serialized result/`ErrorObject` is stored inline on the parent's `BatchSummary`. `ConcurrentOperation` persists this even on `FAIL`.
4. **Replay reconstruction** (`ConcurrentOperation.ReconstructFromCheckpoints`) — when virtual, per-unit results/errors are read from the inline summary.

## Tests

- **Unit** (`ParallelOperationTests`, `MapOperationTests`) — replaced the `*_NestingTypeFlat_ThrowsNotSupported` tests with Flat coverage: suppressed per-branch contexts, inner-op re-parenting, inline partial-failure surfacing, and replay-from-inline-payload (success + failure).
- **Integration** (`ParallelFlatNestingTest`, `MapFlatNestingTest`) — end-to-end against the real service with 3 branches each (step + durable wait to force suspend/resume). Assert exactly one `CONTEXT` op, inner ops re-parented to the parallel/map op, inner-op IDs from the per-branch space, and per-branch results surviving replay.

All 331 unit tests pass on net8.0 and net10.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
