### PR TITLE
Fix Parallel integration test Dockerfiles to use .NET 10 base image

### DIFF
--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelFailureToleranceFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelFailureToleranceFunction/Dockerfile
@@ -1,6 +1,4 @@
-FROM public.ecr.aws/lambda/provided:al2023
-
-RUN dnf install -y libicu
+FROM public.ecr.aws/lambda/dotnet:10
 
 COPY bin/publish/ ${LAMBDA_TASK_ROOT}
 

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelFirstSuccessfulFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelFirstSuccessfulFunction/Dockerfile
@@ -1,6 +1,4 @@
-FROM public.ecr.aws/lambda/provided:al2023
-
-RUN dnf install -y libicu
+FROM public.ecr.aws/lambda/dotnet:10
 
 COPY bin/publish/ ${LAMBDA_TASK_ROOT}
 

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelHappyPathFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelHappyPathFunction/Dockerfile
@@ -1,6 +1,4 @@
-FROM public.ecr.aws/lambda/provided:al2023
-
-RUN dnf install -y libicu
+FROM public.ecr.aws/lambda/dotnet:10
 
 COPY bin/publish/ ${LAMBDA_TASK_ROOT}
 

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelMaxConcurrencyFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelMaxConcurrencyFunction/Dockerfile
@@ -1,6 +1,4 @@
-FROM public.ecr.aws/lambda/provided:al2023
-
-RUN dnf install -y libicu
+FROM public.ecr.aws/lambda/dotnet:10
 
 COPY bin/publish/ ${LAMBDA_TASK_ROOT}
 

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelPartialFailureFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelPartialFailureFunction/Dockerfile
@@ -1,6 +1,4 @@
-FROM public.ecr.aws/lambda/provided:al2023
-
-RUN dnf install -y libicu
+FROM public.ecr.aws/lambda/dotnet:10
 
 COPY bin/publish/ ${LAMBDA_TASK_ROOT}
 

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelReplayDeterminismFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ParallelReplayDeterminismFunction/Dockerfile
@@ -1,6 +1,4 @@
-FROM public.ecr.aws/lambda/provided:al2023
-
-RUN dnf install -y libicu
+FROM public.ecr.aws/lambda/dotnet:10
 
 COPY bin/publish/ ${LAMBDA_TASK_ROOT}
 


### PR DESCRIPTION
update tests to use .net10 docker image. think this change was lost in the rebase so adding it now


```
 dotnet test Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/Amazon.Lambda.DurableExecution.IntegrationTests.csproj -f net8.0  --filter "FullyQualifiedName~Parallel"
    info NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  Amazon.Lambda.Core net8.0 succeeded (2.3s) → Libraries\src\Amazon.Lambda.Core\bin\Debug\net8.0\Amazon.Lambda.Core.dll
  Amazon.Lambda.DurableExecution net8.0 succeeded (1.9s) → Libraries\src\Amazon.Lambda.DurableExecution\bin\Debug\net8.0\Amazon.Lambda.DurableExecution.dll
  Amazon.Lambda.DurableExecution.IntegrationTests net8.0 succeeded (1.3s) → Libraries\test\Amazon.Lambda.DurableExecution.IntegrationTests\bin\Debug\net8.0\Amazon.Lambda.DurableExecution.IntegrationTests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.4.3+1b45f5407b (64-bit .NET 8.0.27)
[xUnit.net 00:00:00.89]   Discovering: Amazon.Lambda.DurableExecution.IntegrationTests
[xUnit.net 00:00:00.94]   Discovered:  Amazon.Lambda.DurableExecution.IntegrationTests
[xUnit.net 00:00:00.95]   Starting:    Amazon.Lambda.DurableExecution.IntegrationTests
[xUnit.net 00:09:26.42]   Finished:    Amazon.Lambda.DurableExecution.IntegrationTests
  Amazon.Lambda.DurableExecution.IntegrationTests test net8.0 succeeded (568.1s)

Test summary: total: 6, failed: 0, succeeded: 6, skipped: 0, duration: 568.0s
Build succeeded in 574.1s
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
