### PR TITLE
Rename durable execution log scope key to executionArn

### DIFF
--- a/.autover/changes/durable-execution-arn-log-key.json
+++ b/.autover/changes/durable-execution-arn-log-key.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.DurableExecution",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Rename the durable execution logging scope key from `durableExecutionArn` to `executionArn` so the AWS Lambda console correctly surfaces an execution's logs."
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/DurableFunction.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/DurableFunction.cs
@@ -118,10 +118,13 @@ public static class DurableFunction
             // Push execution-level metadata into a logging scope so structured
             // providers (the runtime's JSON formatter, Serilog, Powertools,
             // etc.) tag every log line emitted by user code with the
-            // execution ARN and request id.
+            // execution ARN and request id. The key is "executionArn" because
+            // that is the field the Lambda console filters on when rendering an
+            // execution's logs; "durableExecutionArn" caused logs to be dropped
+            // from the console view (issue #2423).
             using (context.Logger.BeginScope(new Dictionary<string, object>
             {
-                ["durableExecutionArn"] = invocationInput.DurableExecutionArn,
+                ["executionArn"] = invocationInput.DurableExecutionArn,
                 ["awsRequestId"] = lambdaContext.AwsRequestId ?? string.Empty,
             }))
             {

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/LambdaCoreLogger.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/LambdaCoreLogger.cs
@@ -27,7 +27,7 @@ namespace Amazon.Lambda.DurableExecution.Internal;
 /// <see cref="BeginScope"/> maintains an <see cref="AsyncLocal{T}"/> chain of
 /// scope state. Scopes whose state is a key/value collection have each entry
 /// appended to the outgoing template/args, so structured scope metadata
-/// (<c>durableExecutionArn</c>, <c>operationId</c>, etc.) shows up as
+/// (<c>executionArn</c>, <c>operationId</c>, etc.) shows up as
 /// top-level JSON fields without callers having to swap in a third-party
 /// logger. Inner scopes win on key collision; explicit message arguments
 /// always win over scope keys.

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/ReplayAwareLoggerTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/ReplayAwareLoggerTest.cs
@@ -120,8 +120,8 @@ public class ReplayAwareLoggerTest
 
         if (requireExecutionScope)
         {
-            Assert.True(root.TryGetProperty("durableExecutionArn", out _),
-                $"durableExecutionArn missing on record: {record}");
+            Assert.True(root.TryGetProperty("executionArn", out _),
+                $"executionArn missing on record: {record}");
             Assert.True(root.TryGetProperty("awsRequestId", out _),
                 $"awsRequestId missing on record: {record}");
         }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ReplayAwareLoggerFunction/Dockerfile
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ReplayAwareLoggerFunction/Dockerfile
@@ -3,7 +3,7 @@ FROM public.ecr.aws/lambda/dotnet:10
 COPY bin/publish/ ${LAMBDA_TASK_ROOT}
 
 # Emit structured JSON logs so the integration test can parse log records and
-# assert the durable-execution scope keys (durableExecutionArn, operationId,
+# assert the durable-execution scope keys (executionArn, operationId,
 # etc.) appear as top-level fields.
 ENV AWS_LAMBDA_LOG_FORMAT=JSON
 

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ReplayAwareLoggerFunction/Function.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/TestFunctions/ReplayAwareLoggerFunction/Function.cs
@@ -39,7 +39,7 @@ public class Function
             async (_, _) =>
             {
                 // Emitted inside the step's BeginScope, so the line carries
-                // both execution-level scope (durableExecutionArn, awsRequestId)
+                // both execution-level scope (executionArn, awsRequestId)
                 // AND step-level scope (operationId, operationName, attempt).
                 context.Logger.LogInformation("LOG_REPLAY_TEST inside_step1 order={OrderId}", input.OrderId);
                 await Task.CompletedTask;

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/Internal/LambdaCoreLoggerTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/Internal/LambdaCoreLoggerTests.cs
@@ -136,7 +136,7 @@ public class LambdaCoreLoggerTests : IDisposable
 
         using (logger.BeginScope(new Dictionary<string, object>
         {
-            ["durableExecutionArn"] = "arn-outer",
+            ["executionArn"] = "arn-outer",
             ["awsRequestId"] = "req-1",
         }))
         using (logger.BeginScope(new Dictionary<string, object>
@@ -151,7 +151,7 @@ public class LambdaCoreLoggerTests : IDisposable
         var entry = Assert.Single(_captured);
         // Inner scope keys appear before outer; the inner awsRequestId wins.
         Assert.Equal(
-            "hello {Name} {operationId} {awsRequestId} {durableExecutionArn}",
+            "hello {Name} {operationId} {awsRequestId} {executionArn}",
             entry.Template);
         Assert.Equal(
             new object[] { "world", "op-1", "req-INNER-WINS", "arn-outer" },


### PR DESCRIPTION
## Issue

Fixes #2423

The .NET durable execution library emitted the execution ARN into the logging scope under the key `durableExecutionArn`, but the AWS Lambda console filters an execution's logs on the field `executionArn`. The mismatch caused user log lines to be dropped from the console's "Logger output" view.

## Change

Rename the logged scope key in `DurableFunction.cs` from `durableExecutionArn` to `executionArn`, along with the corresponding test assertions and documentation.

The SDK request/response field `DurableExecutionArn` is intentionally **left unchanged**, since that is the name used by the API (per the issue discussion, it is "more widely used e.g. in API requests/responses").

### Files touched
- `DurableFunction.cs` — the logged scope key (the fix) + explanatory comment
- `LambdaCoreLogger.cs` — doc comment
- `LambdaCoreLoggerTests.cs` — unit test scope-key example + expected template
- `ReplayAwareLoggerTest.cs` — integration test assertion now checks `executionArn`
- `ReplayAwareLoggerFunction/Function.cs` + `Dockerfile` — comments

## Testing

All 358 `Amazon.Lambda.DurableExecution.Tests` pass on net8.0 and net10.0. The integration test assertion was updated but not executed (requires deployed Lambda infrastructure).