### PR TITLE
feat(durable): put SDK identifier in UserAgent

### DIFF
--- a/.autover/changes/durable-sdk-user-agent.json
+++ b/.autover/changes/durable-sdk-user-agent.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.DurableExecution",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Identify durable-execution requests with an `aws-durable-execution-sdk-dotnet/<version>` user-agent component so the service can track .NET SDK usage at runtime, matching the sibling Python/Java/JS SDKs."
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Amazon.Lambda.DurableExecution.csproj
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Amazon.Lambda.DurableExecution.csproj
@@ -37,4 +37,19 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
+  <!-- Emits the package version as a compile-time constant so DurableUserAgent can
+       build the "aws-durable-execution-sdk-dotnet/<version>" user-agent component
+       without a runtime assembly-version reflection lookup (trim/AOT-safe). -->
+  <Target Name="_GenerateDurableUserAgentVersion" BeforeTargets="CoreCompile">
+    <PropertyGroup>
+      <_DurableUserAgentVersionFile>$(IntermediateOutputPath)DurableUserAgentVersion.g.cs</_DurableUserAgentVersionFile>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(_DurableUserAgentVersionFile)"
+      Lines="namespace Amazon.Lambda.DurableExecution.Internal { internal static partial class DurableUserAgent { internal const string AssemblyVersion = &quot;$(Version)&quot;%3B } }"
+      Overwrite="true" />
+    <ItemGroup>
+      <Compile Include="$(_DurableUserAgentVersionFile)" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/DurableUserAgent.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/DurableUserAgent.cs
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Runtime;
+using Amazon.Runtime.Internal;
+
+namespace Amazon.Lambda.DurableExecution.Internal;
+
+/// <summary>
+/// Tags the durable-execution requests this SDK issues with a SDK-identifying
+/// user-agent component so the service can track usage of the .NET durable
+/// execution SDK at runtime. Mirrors the sibling SDKs (e.g. the Java SDK emits
+/// <c>aws-durable-execution-sdk-java/&lt;version&gt;</c>).
+///
+/// Applied per request — on the two <see cref="Services.LambdaDurableServiceClient"/>
+/// calls — rather than via a process-wide pipeline customizer, so it works for both
+/// the default client and a caller-supplied <see cref="IAmazonLambda"/> and never
+/// tags unrelated requests on a shared client. The <see cref="AssemblyVersion"/>
+/// member is generated at build time from the package <c>$(Version)</c> by the
+/// <c>_GenerateDurableUserAgentVersion</c> MSBuild target.
+/// </summary>
+internal static partial class DurableUserAgent
+{
+    /// <summary>
+    /// The user-agent component appended to every durable-execution request, e.g.
+    /// <c>aws-durable-execution-sdk-dotnet/0.1.0-preview</c>.
+    /// </summary>
+    internal static readonly string UserAgentString =
+        $"aws-durable-execution-sdk-dotnet/{AssemblyVersion}";
+
+    /// <summary>
+    /// Appends the SDK-identifying component to the request's user agent. The
+    /// underlying <c>UserAgentDetails</c> dedupes components internally, so repeated
+    /// calls are harmless.
+    /// </summary>
+    internal static void Apply(AmazonWebServiceRequest request)
+    {
+        ((IAmazonWebServiceRequest)request).UserAgentDetails.AddUserAgentComponent(UserAgentString);
+    }
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Services/LambdaDurableServiceClient.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Services/LambdaDurableServiceClient.cs
@@ -56,6 +56,7 @@ internal sealed class LambdaDurableServiceClient
             CheckpointToken = checkpointToken ?? "",
             Updates = pendingOperations is List<SdkOperationUpdate> list ? list : pendingOperations.ToList()
         };
+        DurableUserAgent.Apply(request);
 
         CheckpointDurableExecutionResponse response;
         try
@@ -104,6 +105,7 @@ internal sealed class LambdaDurableServiceClient
             CheckpointToken = checkpointToken ?? "",
             Marker = marker
         };
+        DurableUserAgent.Apply(request);
 
         GetDurableExecutionStateResponse response;
         try

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/LambdaDurableServiceClientTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/LambdaDurableServiceClientTests.cs
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using Amazon.Lambda.DurableExecution.Internal;
 using Amazon.Lambda.DurableExecution.Services;
 using Amazon.Lambda.Model;
+using Amazon.Runtime.Internal;
 using SdkErrorObject = Amazon.Lambda.Model.ErrorObject;
 using Xunit;
 
@@ -400,6 +402,49 @@ public class LambdaDurableServiceClientTests
         var mapped = LambdaDurableServiceClient.MapFromSdkOperationForTest(sdkOp);
 
         Assert.True(mapped.ContextDetails!.ReplayChildren);
+    }
+
+    [Fact]
+    public void UserAgentString_IdentifiesTheDotnetDurableSdk()
+    {
+        // The service tracks SDK usage off this prefix; the version suffix is the
+        // package $(Version) injected by the _GenerateDurableUserAgentVersion target.
+        Assert.StartsWith("aws-durable-execution-sdk-dotnet/", DurableUserAgent.UserAgentString);
+        Assert.NotEqual("aws-durable-execution-sdk-dotnet/", DurableUserAgent.UserAgentString);
+    }
+
+    [Fact]
+    public async Task CheckpointAsync_TagsRequestWithSdkUserAgent()
+    {
+        var mockClient = new MockLambdaClient();
+        var client = new LambdaDurableServiceClient(mockClient);
+
+        await client.CheckpointAsync(
+            "arn",
+            "tok",
+            new[]
+            {
+                new OperationUpdate { Id = "0-x", Type = "STEP", Action = "SUCCEED" }
+            });
+
+        var request = (IAmazonWebServiceRequest)Assert.Single(mockClient.CheckpointCalls);
+        Assert.Contains(
+            DurableUserAgent.UserAgentString,
+            request.UserAgentDetails.GetCustomUserAgentComponents());
+    }
+
+    [Fact]
+    public async Task GetExecutionStateAsync_TagsRequestWithSdkUserAgent()
+    {
+        var mockClient = new MockLambdaClient();
+        var client = new LambdaDurableServiceClient(mockClient);
+
+        await client.GetExecutionStateAsync("arn", "tok", "marker");
+
+        var request = (IAmazonWebServiceRequest)Assert.Single(mockClient.GetExecutionStateCalls);
+        Assert.Contains(
+            DurableUserAgent.UserAgentString,
+            request.UserAgentDetails.GetCustomUserAgentComponents());
     }
 
     [Fact]


### PR DESCRIPTION
## Issue
Closes #2437

## Description
Adds an SDK-identifying user-agent component to the durable-execution requests this SDK issues so the durable execution service can track .NET SDK usage at runtime. Mirrors the sibling SDKs (the Java SDK emits `aws-durable-execution-sdk-java/<version>`; this emits `aws-durable-execution-sdk-dotnet/<version>`).

Referenced the [aws-dotnet-ai user-agent implementation](https://github.com/aws/aws-dotnet-ai/pull/18) for the version-constant generation pattern.

## Implementation
- **`Internal/DurableUserAgent.cs`** — builds the `aws-durable-execution-sdk-dotnet/<version>` component and appends it to a request's `UserAgentDetails` (which dedupes internally).
- **`Amazon.Lambda.DurableExecution.csproj`** — new `_GenerateDurableUserAgentVersion` MSBuild target writes the package `$(Version)` as a compile-time `const` (trim/AOT-safe; no runtime reflection), matching the reference PR's approach.
- **`Services/LambdaDurableServiceClient.cs`** — applies the component to the two outbound requests (`CheckpointDurableExecution`, `GetDurableExecutionState`).

Applied per request in `LambdaDurableServiceClient` rather than via a process-wide `RuntimePipelineCustomizerRegistry` (as the reference PR does) so it works for both the default cached client and a caller-supplied `IAmazonLambda`, and never tags unrelated requests on a shared client.

## Testing
- Added 3 unit tests in `LambdaDurableServiceClientTests`: user-agent string format, and that both `CheckpointAsync` and `GetExecutionStateAsync` tag the request.
- Full `LambdaDurableServiceClientTests` suite passes on net8.0 and net10.0 (14/14).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.