### PR TITLE
Harden GitHub Actions workflows based on zizmor audit

### DIFF
--- a/.github/workflows/auto-update-Dockerfiles.yml
+++ b/.github/workflows/auto-update-Dockerfiles.yml
@@ -1,8 +1,6 @@
 name: Auto-Update Lambda Dockerfiles Daily
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 on:
   # Run daily at midnight UTC
@@ -11,9 +9,17 @@ on:
   # Allows to run this workflow manually from the Actions tab for testing
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   auto-update:
+    name: Auto-update Dockerfiles and open PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to push the daily Dockerfile update branch
+      pull-requests: write # to open the update PR and label it
     env:
       NET_8_AMD64_Dockerfile: "LambdaRuntimeDockerfiles/Images/net8/amd64/Dockerfile"
       NET_8_ARM64_Dockerfile: "LambdaRuntimeDockerfiles/Images/net8/arm64/Dockerfile"
@@ -39,7 +45,7 @@ jobs:
         run: |
           $version = & "./LambdaRuntimeDockerfiles/get-latest-aspnet-versions.ps1" -MajorVersion "8"
           if (-not [string]::IsNullOrEmpty($version)) {
-            & "./LambdaRuntimeDockerfiles/update-dockerfile.ps1" -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion $version
+            & "./LambdaRuntimeDockerfiles/update-dockerfile.ps1" -DockerfilePath "$env:DOCKERFILE_PATH" -NextVersion $version
           } else {
             Write-Host "Skipping .NET 8 AMD64 update - No version detected"
           }
@@ -53,7 +59,7 @@ jobs:
         run: |
           $version = & "./LambdaRuntimeDockerfiles/get-latest-aspnet-versions.ps1" -MajorVersion "8"
           if (-not [string]::IsNullOrEmpty($version)) {
-            & "./LambdaRuntimeDockerfiles/update-dockerfile.ps1" -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion $version
+            & "./LambdaRuntimeDockerfiles/update-dockerfile.ps1" -DockerfilePath "$env:DOCKERFILE_PATH" -NextVersion $version
           } else {
             Write-Host "Skipping .NET 8 ARM64 update - No version detected"
           }
@@ -67,7 +73,7 @@ jobs:
         run: |
           $version = & "./LambdaRuntimeDockerfiles/get-latest-aspnet-versions.ps1" -MajorVersion "9"
           if (-not [string]::IsNullOrEmpty($version)) {
-            & "./LambdaRuntimeDockerfiles/update-dockerfile.ps1" -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion $version
+            & "./LambdaRuntimeDockerfiles/update-dockerfile.ps1" -DockerfilePath "$env:DOCKERFILE_PATH" -NextVersion $version
           } else {
             Write-Host "Skipping .NET 9 AMD64 update - No version detected"
           }
@@ -81,7 +87,7 @@ jobs:
         run: |
           $version = & "./LambdaRuntimeDockerfiles/get-latest-aspnet-versions.ps1" -MajorVersion "9"
           if (-not [string]::IsNullOrEmpty($version)) {
-            & "./LambdaRuntimeDockerfiles/update-dockerfile.ps1" -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion $version
+            & "./LambdaRuntimeDockerfiles/update-dockerfile.ps1" -DockerfilePath "$env:DOCKERFILE_PATH" -NextVersion $version
           } else {
             Write-Host "Skipping .NET 9 ARM64 update - No version detected"
           }
@@ -95,7 +101,7 @@ jobs:
         run: |
           $version = & "./LambdaRuntimeDockerfiles/get-latest-aspnet-versions.ps1" -MajorVersion "10"
           if (-not [string]::IsNullOrEmpty($version)) {
-            & "./LambdaRuntimeDockerfiles/update-dockerfile.ps1" -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion $version
+            & "./LambdaRuntimeDockerfiles/update-dockerfile.ps1" -DockerfilePath "$env:DOCKERFILE_PATH" -NextVersion $version
           } else {
             Write-Host "Skipping .NET 10 AMD64 update - No version detected"
           }
@@ -109,7 +115,7 @@ jobs:
         run: |
           $version = & "./LambdaRuntimeDockerfiles/get-latest-aspnet-versions.ps1" -MajorVersion "10"
           if (-not [string]::IsNullOrEmpty($version)) {
-            & "./LambdaRuntimeDockerfiles/update-dockerfile.ps1" -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion $version
+            & "./LambdaRuntimeDockerfiles/update-dockerfile.ps1" -DockerfilePath "$env:DOCKERFILE_PATH" -NextVersion $version
           } else {
             Write-Host "Skipping .NET 10 ARM64 update - No version detected"
           }
@@ -123,7 +129,7 @@ jobs:
         run: |
           $version = & "./LambdaRuntimeDockerfiles/get-latest-aspnet-versions.ps1" -MajorVersion "11"
           if (-not [string]::IsNullOrEmpty($version)) {
-            & "./LambdaRuntimeDockerfiles/update-dockerfile.ps1" -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion $version
+            & "./LambdaRuntimeDockerfiles/update-dockerfile.ps1" -DockerfilePath "$env:DOCKERFILE_PATH" -NextVersion $version
           } else {
             Write-Host "Skipping .NET 11 AMD64 update - No version detected"
           }
@@ -137,7 +143,7 @@ jobs:
         run: |
           $version = & "./LambdaRuntimeDockerfiles/get-latest-aspnet-versions.ps1" -MajorVersion "11"
           if (-not [string]::IsNullOrEmpty($version)) {
-            & "./LambdaRuntimeDockerfiles/update-dockerfile.ps1" -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion $version
+            & "./LambdaRuntimeDockerfiles/update-dockerfile.ps1" -DockerfilePath "$env:DOCKERFILE_PATH" -NextVersion $version
           } else {
             Write-Host "Skipping .NET 11 ARM64 update - No version detected"
           }
@@ -196,7 +202,7 @@ jobs:
       - name: Create Pull Request
         id: pull-request
         if: ${{ steps.commit-push.outputs.CHANGES_MADE == 'true' }}
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2
         with:
           source_branch: ${{ steps.commit-push.outputs.BRANCH }}
           destination_branch: "dev"
@@ -226,13 +232,15 @@ jobs:
       # Add "Release Not Needed" label to the PR
       - name: Add Release Not Needed label
         if: ${{ steps.pull-request.outputs.pr_number }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          PR_NUMBER: ${{ steps.pull-request.outputs.pr_number }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: ${{ steps.pull-request.outputs.pr_number }},
+              issue_number: Number(process.env.PR_NUMBER),
               labels: ['Release Not Needed']
             })

--- a/.github/workflows/aws-ci.yml
+++ b/.github/workflows/aws-ci.yml
@@ -8,12 +8,18 @@ on:
       - dev
       - "feature/**"
 
-permissions:
-  id-token: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-ci:
+    name: Run CI
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # to assume AWS roles via OIDC
     steps:
       - name: Configure Load Balancer Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6.0.0
@@ -24,8 +30,13 @@ jobs:
       - name: Invoke Load Balancer Lambda
         id: lambda
         shell: pwsh
+        env:
+          LOAD_BALANCER_LAMBDA_NAME: ${{ secrets.CI_TESTING_LOAD_BALANCER_LAMBDA_NAME }}
+          TEST_RUNNER_ACCOUNT_ROLES: ${{ secrets.CI_TEST_RUNNER_ACCOUNT_ROLES }}
+          CODE_BUILD_PROJECT_NAME: ${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}
+          BRANCH: ${{ github.sha }}
         run: |
-          aws lambda invoke response.json --function-name "${{ secrets.CI_TESTING_LOAD_BALANCER_LAMBDA_NAME }}" --cli-binary-format raw-in-base64-out --payload '{"Roles": "${{ secrets.CI_TEST_RUNNER_ACCOUNT_ROLES }}", "ProjectName": "${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}", "Branch": "${{ github.sha }}"}'
+          aws lambda invoke response.json --function-name "$env:LOAD_BALANCER_LAMBDA_NAME" --cli-binary-format raw-in-base64-out --payload "{`"Roles`": `"$env:TEST_RUNNER_ACCOUNT_ROLES`", `"ProjectName`": `"$env:CODE_BUILD_PROJECT_NAME`", `"Branch`": `"$env:BRANCH`"}"
           $roleArn=$(cat ./response.json)
           "roleArn=$($roleArn -replace '"', '')" >> $env:GITHUB_OUTPUT
       - name: Configure Test Runner Credentials
@@ -36,7 +47,7 @@ jobs:
           aws-region: us-west-2
       - name: Run Tests on AWS
         id: codebuild
-        uses: aws-actions/aws-codebuild-run-build@v1
+        uses: aws-actions/aws-codebuild-run-build@4d15a47425739ac2296ba5e7eee3bdd4bfbdd767 # v1.0.18
         with:
           project-name: ${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}
       - name: Configure Test Sweeper Lambda Credentials
@@ -49,10 +60,15 @@ jobs:
       - name: Invoke Test Sweeper Lambda
         if: always()
         shell: pwsh
+        env:
+          TEST_SWEEPER_LAMBDA_NAME: ${{ secrets.CI_TESTING_TEST_SWEEPER_LAMBDA_NAME }}
+          CODE_BUILD_PROJECT_NAME: ${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}
         run: |
-          aws lambda invoke response.json --function-name "${{ secrets.CI_TESTING_TEST_SWEEPER_LAMBDA_NAME }}" --cli-binary-format raw-in-base64-out --payload '{"Tags": "aws-repo=${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}"}'
+          aws lambda invoke response.json --function-name "$env:TEST_SWEEPER_LAMBDA_NAME" --cli-binary-format raw-in-base64-out --payload "{`"Tags`": `"aws-repo=$env:CODE_BUILD_PROJECT_NAME`"}"
       - name: CodeBuild Link
         shell: pwsh
+        env:
+          BUILD_ID: ${{ steps.codebuild.outputs.aws-build-id }}
         run: |
-          $buildId = "${{ steps.codebuild.outputs.aws-build-id }}"
+          $buildId = "$env:BUILD_ID"
           echo $buildId

--- a/.github/workflows/build-lambda-runtime-dockerfiles.yml
+++ b/.github/workflows/build-lambda-runtime-dockerfiles.yml
@@ -8,13 +8,18 @@ on:
     paths:
       - "LambdaRuntimeDockerfiles/**"
 
-permissions:
-  contents: read
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-runtime-images:
     name: Build runtime image (${{ matrix.name }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # to check out the repository and build the Dockerfiles
     strategy:
       fail-fast: false
       matrix:
@@ -45,16 +50,18 @@ jobs:
             platform: linux/arm64
 
     steps:
-      - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2 #v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Build ${{ matrix.name }}
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/change-file-in-pr.yml
+++ b/.github/workflows/change-file-in-pr.yml
@@ -4,24 +4,36 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   check-files-in-directory:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'Release Not Needed') && !contains(github.event.pull_request.labels.*.name, 'Release PR') }}
     name: Change File Included in PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # to check out the repository and list changed files
 
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get List of Changed Files
         id: changed-files
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323  # v47.0.5
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
 
       - name: Check for Change File(s) in .autover/changes/
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           DIRECTORY=".autover/changes/"
-          if echo "${{ steps.changed-files.outputs.all_changed_files }}" | grep -q "$DIRECTORY"; then
+          if echo "$ALL_CHANGED_FILES" | grep -q "$DIRECTORY"; then
             echo "✅ One or more change files in '$DIRECTORY' are included in this PR."
           else
             echo "❌ No change files in '$DIRECTORY' are included in this PR."

--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -3,18 +3,24 @@ on:
     issues:
        types: [closed]
 
-permissions:
-  issues: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
     auto_comment:
+        name: Comment on closed issue
         runs-on: ubuntu-latest
+        permissions:
+          issues: write # to comment on the closed issue
         steps:
-        - uses: aws-actions/closed-issue-message@v2
+        - uses: aws-actions/closed-issue-message@10aaf6366131b673a7c8b7742f8b3849f1d44f18 # v2
           with:
             # These inputs are both required
             repo-token: "${{ secrets.GITHUB_TOKEN }}"
             message: |
-                     Comments on closed issues are hard for our team to see. 
-                     If you need more assistance, please either tag a team member or open a new issue that references this one. 
+                     Comments on closed issues are hard for our team to see.
+                     If you need more assistance, please either tag a team member or open a new issue that references this one.
                      If you wish to keep having a conversation with other community members under this issue feel free to do so.

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -11,14 +11,19 @@ on:
         type: string
         required: false
 
-permissions:
-  id-token: write
-  repository-projects: read
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   release-pr:
     name: Release PR
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # to assume AWS roles via OIDC
+      repository-projects: read # to read project metadata when creating the release PR
 
     env:
       INPUT_OVERRIDE_VERSION: ${{ github.event.inputs.OVERRIDE_VERSION }}
@@ -97,10 +102,11 @@ jobs:
         run: autover changelog
       # Push the release branch up as well as the created tag
       - name: Push Changes
+        env:
+          BRANCH: ${{ steps.create-release-branch.outputs.BRANCH }}
         run: |
-          branch=${{ steps.create-release-branch.outputs.BRANCH }}
-          git push origin $branch
-          git push origin $branch --tags
+          git push origin "$BRANCH"
+          git push origin "$BRANCH" --tags
       # Get the release name that will be used to create a PR
       - name: Read Release Name
         id: read-release-name
@@ -117,7 +123,10 @@ jobs:
       - name: Create Pull Request
         env:
           GITHUB_TOKEN: ${{ env.FG_PAT }}
+          VERSION: ${{ steps.read-release-name.outputs.VERSION }}
+          CHANGELOG: ${{ steps.read-changelog.outputs.CHANGELOG }}
+          BRANCH: ${{ steps.create-release-branch.outputs.BRANCH }}
         run: |
           gh label create "Release PR" --description "A Release PR that includes versioning and changelog changes" -c "#FF0000" -f
-          pr_url="$(gh pr create --title "${{ steps.read-release-name.outputs.VERSION }}" --label "Release PR" --body "${{ steps.read-changelog.outputs.CHANGELOG }}" --base dev --head ${{ steps.create-release-branch.outputs.BRANCH }})"
+          pr_url="$(gh pr create --title "$VERSION" --label "Release PR" --body "$CHANGELOG" --base dev --head "$BRANCH")"
 

--- a/.github/workflows/handle-stale-discussions.yml
+++ b/.github/workflows/handle-stale-discussions.yml
@@ -5,14 +5,20 @@ on:
   discussion_comment:
     types: [created]
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   handle-stale-discussions:
     name: Handle stale discussions
     runs-on: ubuntu-latest
     permissions:
-      discussions: write
+      discussions: write # to mark and close stale discussions
     steps:
       - name: Stale discussions action
-        uses: aws-github-ops/handle-stale-discussions@v1.6.0
+        uses: aws-github-ops/handle-stale-discussions@c0beee451a5d33d9c8f048a6d4e7c856b5422544 # v1.6.0
         env:
           GITHUB_TOKEN:  ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/issue-regression-labeler.yml
+++ b/.github/workflows/issue-regression-labeler.yml
@@ -3,16 +3,21 @@ name: issue-regression-label
 on:
   issues:
     types: [opened, edited]
+permissions: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
 jobs:
   add-regression-label:
+    name: Add potential-regression label
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      issues: write # to add or remove the potential-regression label
     steps:
     - name: Fetch template body
       id: check_regression
-      uses: actions/github-script@v8
-      env: 
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TEMPLATE_BODY: ${{ github.event.issue.body }}
       with:
@@ -24,9 +29,11 @@ jobs:
     - name: Manage regression label
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        IS_REGRESSION: ${{ steps.check_regression.outputs.is_regression }}
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
       run: |
-        if [ "${{ steps.check_regression.outputs.is_regression }}" == "true" ]; then
-          gh issue edit ${{ github.event.issue.number }} --add-label "potential-regression" -R ${{ github.repository }}
+        if [ "$IS_REGRESSION" == "true" ]; then
+          gh issue edit "$ISSUE_NUMBER" --add-label "potential-regression" -R "$GITHUB_REPOSITORY"
         else
-          gh issue edit ${{ github.event.issue.number }} --remove-label "potential-regression" -R ${{ github.repository }}
+          gh issue edit "$ISSUE_NUMBER" --remove-label "potential-regression" -R "$GITHUB_REPOSITORY"
         fi

--- a/.github/workflows/semgrep-analysis.yml
+++ b/.github/workflows/semgrep-analysis.yml
@@ -13,19 +13,28 @@ on:
   # Manually trigger the workflow
   workflow_dispatch:
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   semgrep:
     name: Scan
     permissions:
-      security-events: write
+      contents: read # to check out the repository
+      security-events: write # to upload SARIF results to the code scanning dashboard
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep
+      image: returntocorp/semgrep@sha256:06938c1f365d3f67b8cedd8bc117607ae64253f88a0e768e9da9408548927dd6 # latest
     # Skip any PR created by dependabot to avoid permission issues
     if: (github.actor != 'dependabot[bot]')
     steps:
       # Fetch project source
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - run: semgrep ci --sarif > semgrep.sarif
         env:

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -5,16 +5,21 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write # to mark and close stale issues
+      pull-requests: write # to mark and close stale pull requests
     steps:
-    - uses: aws-actions/stale-issue-cleanup@v7
+    - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440 # v7.1.1
       with:
         # Setting messages to an empty string will cause the automation to skip
         # that category

--- a/.github/workflows/sync-master-dev.yml
+++ b/.github/workflows/sync-master-dev.yml
@@ -8,9 +8,11 @@ on:
   pull_request:
     types: [closed]
 
-permissions:
-  contents: write
-  id-token: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   # This job will check if the PR was successfully merged, it's source branch is `releases/next-release` and target branch is `dev`.
@@ -23,6 +25,9 @@ jobs:
       github.event.pull_request.head.ref == 'releases/next-release' &&
       github.event.pull_request.base.ref == 'dev'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to merge dev into master and push the release tag
+      id-token: write # to assume AWS roles via OIDC
     steps:
       # Assume an AWS Role that provides access to the Access Token
       - name: Configure AWS Credentials
@@ -96,8 +101,11 @@ jobs:
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ env.FG_PAT }}
+          TAG: ${{ steps.read-tag-name.outputs.TAG }}
+          VERSION: ${{ steps.read-release-name.outputs.VERSION }}
+          CHANGELOG: ${{ steps.read-changelog.outputs.CHANGELOG }}
         run: |
-          gh release create "${{ steps.read-tag-name.outputs.TAG }}" --title "${{ steps.read-release-name.outputs.VERSION }}" --notes "${{ steps.read-changelog.outputs.CHANGELOG }}"
+          gh release create "$TAG" --title "$VERSION" --notes "$CHANGELOG"
       # Delete the `releases/next-release` branch
       - name: Clean up
         run: |
@@ -118,6 +126,8 @@ jobs:
       github.event.pull_request.head.ref == 'releases/next-release' &&
       github.event.pull_request.base.ref == 'dev'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to delete the release tag and branch
     steps:
       # Checkout a full clone of the repo using the deploy key (push runs over SSH)
       - name: Checkout code
@@ -156,9 +166,11 @@ jobs:
           echo "TAG=$tag" >> $GITHUB_OUTPUT
       # Delete the tag created by AutoVer and the release branch
       - name: Clean up
+        env:
+          TAG: ${{ steps.read-tag-name.outputs.TAG }}
         run: |
           git fetch origin
-          git push --delete origin ${{ steps.read-tag-name.outputs.TAG }}
+          git push --delete origin "$TAG"
           if git ls-remote --exit-code --heads origin releases/next-release > /dev/null; then
             echo "Branch 'releases/next-release' exists on origin. Deleting..."
             git push origin --delete releases/next-release

--- a/.github/workflows/update-Dockerfiles.yml
+++ b/.github/workflows/update-Dockerfiles.yml
@@ -1,8 +1,6 @@
 name: Update Lambda Dockerfiles
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 on:
   # Allows to run this workflow manually from the Actions tab
@@ -65,9 +63,17 @@ on:
         type: string
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   build:
+    name: Update Dockerfiles and open PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to push the Dockerfile update branch
+      pull-requests: write # to open the update PR and label it
     env:
       NET_8_AMD64_Dockerfile: "LambdaRuntimeDockerfiles/Images/net8/amd64/Dockerfile"
       NET_8_ARM64_Dockerfile: "LambdaRuntimeDockerfiles/Images/net8/arm64/Dockerfile"
@@ -92,7 +98,7 @@ jobs:
           DOCKERFILE_PATH: ${{ env.NET_8_AMD64_Dockerfile }}
           NEXT_VERSION: ${{ github.event.inputs.NET_8_NEXT_VERSION }}
         run: |
-          .\LambdaRuntimeDockerfiles\update-dockerfile.ps1 -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion "${{ env.NEXT_VERSION }}"
+          .\LambdaRuntimeDockerfiles\update-dockerfile.ps1 -DockerfilePath "$env:DOCKERFILE_PATH" -NextVersion "$env:NEXT_VERSION"
         if: ${{ github.event.inputs.NET_8_AMD64 == 'true' }}
 
       - name: Update .NET 8 ARM64
@@ -102,7 +108,7 @@ jobs:
           DOCKERFILE_PATH: ${{ env.NET_8_ARM64_Dockerfile }}
           NEXT_VERSION: ${{ github.event.inputs.NET_8_NEXT_VERSION }}
         run: |
-          .\LambdaRuntimeDockerfiles\update-dockerfile.ps1 -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion "${{ env.NEXT_VERSION }}"
+          .\LambdaRuntimeDockerfiles\update-dockerfile.ps1 -DockerfilePath "$env:DOCKERFILE_PATH" -NextVersion "$env:NEXT_VERSION"
         if: ${{ github.event.inputs.NET_8_ARM64 == 'true' }}
 
       - name: Update .NET 9 AMD64
@@ -112,7 +118,7 @@ jobs:
           DOCKERFILE_PATH: ${{ env.NET_9_AMD64_Dockerfile }}
           NEXT_VERSION: ${{ github.event.inputs.NET_9_NEXT_VERSION }}
         run: |
-          .\LambdaRuntimeDockerfiles\update-dockerfile.ps1 -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion "${{ env.NEXT_VERSION }}"
+          .\LambdaRuntimeDockerfiles\update-dockerfile.ps1 -DockerfilePath "$env:DOCKERFILE_PATH" -NextVersion "$env:NEXT_VERSION"
         if: ${{ github.event.inputs.NET_9_AMD64 == 'true' }}
 
       - name: Update .NET 9 ARM64
@@ -122,7 +128,7 @@ jobs:
           DOCKERFILE_PATH: ${{ env.NET_9_ARM64_Dockerfile }}
           NEXT_VERSION: ${{ github.event.inputs.NET_9_NEXT_VERSION }}
         run: |
-          .\LambdaRuntimeDockerfiles\update-dockerfile.ps1 -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion "${{ env.NEXT_VERSION }}"
+          .\LambdaRuntimeDockerfiles\update-dockerfile.ps1 -DockerfilePath "$env:DOCKERFILE_PATH" -NextVersion "$env:NEXT_VERSION"
         if: ${{ github.event.inputs.NET_9_ARM64 == 'true' }}
 
       - name: Update .NET 10 AMD64
@@ -132,7 +138,7 @@ jobs:
           DOCKERFILE_PATH: ${{ env.NET_10_AMD64_Dockerfile }}
           NEXT_VERSION: ${{ github.event.inputs.NET_10_NEXT_VERSION }}
         run: |
-          .\LambdaRuntimeDockerfiles\update-dockerfile.ps1 -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion "${{ env.NEXT_VERSION }}"
+          .\LambdaRuntimeDockerfiles\update-dockerfile.ps1 -DockerfilePath "$env:DOCKERFILE_PATH" -NextVersion "$env:NEXT_VERSION"
         if: ${{ github.event.inputs.NET_10_AMD64 == 'true' }}
 
       - name: Update .NET 10 ARM64
@@ -142,7 +148,7 @@ jobs:
           DOCKERFILE_PATH: ${{ env.NET_10_ARM64_Dockerfile }}
           NEXT_VERSION: ${{ github.event.inputs.NET_10_NEXT_VERSION }}
         run: |
-          .\LambdaRuntimeDockerfiles\update-dockerfile.ps1 -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion "${{ env.NEXT_VERSION }}"
+          .\LambdaRuntimeDockerfiles\update-dockerfile.ps1 -DockerfilePath "$env:DOCKERFILE_PATH" -NextVersion "$env:NEXT_VERSION"
         if: ${{ github.event.inputs.NET_10_ARM64 == 'true' }}
 
       - name: Update .NET 11 AMD64
@@ -152,7 +158,7 @@ jobs:
           DOCKERFILE_PATH: ${{ env.NET_11_AMD64_Dockerfile }}
           NEXT_VERSION: ${{ github.event.inputs.NET_11_NEXT_VERSION }}
         run: |
-          .\LambdaRuntimeDockerfiles\update-dockerfile.ps1 -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion "${{ env.NEXT_VERSION }}"
+          .\LambdaRuntimeDockerfiles\update-dockerfile.ps1 -DockerfilePath "$env:DOCKERFILE_PATH" -NextVersion "$env:NEXT_VERSION"
         if: ${{ github.event.inputs.NET_11_AMD64 == 'true' }}
 
       - name: Update .NET 11 ARM64
@@ -162,7 +168,7 @@ jobs:
           DOCKERFILE_PATH: ${{ env.NET_11_ARM64_Dockerfile }}
           NEXT_VERSION: ${{ github.event.inputs.NET_11_NEXT_VERSION }}
         run: |
-          .\LambdaRuntimeDockerfiles\update-dockerfile.ps1 -DockerfilePath "${{ env.DOCKERFILE_PATH }}" -NextVersion "${{ env.NEXT_VERSION }}"
+          .\LambdaRuntimeDockerfiles\update-dockerfile.ps1 -DockerfilePath "$env:DOCKERFILE_PATH" -NextVersion "$env:NEXT_VERSION"
         if: ${{ github.event.inputs.NET_11_ARM64 == 'true' }}
 
       # Update Dockerfiles if newer version of ASP.NET Core is available
@@ -184,7 +190,7 @@ jobs:
       - name: Pull Request
         id: pull-request
         if: ${{ steps.commit-push.outputs.BRANCH }}
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2
         with:
           source_branch: ${{ steps.commit-push.outputs.BRANCH }}
           destination_branch: "dev"
@@ -211,13 +217,15 @@ jobs:
       # Add "Release Not Needed" label to the PR
       - name: Add Release Not Needed label
         if: ${{ steps.pull-request.outputs.pr_number }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          PR_NUMBER: ${{ steps.pull-request.outputs.pr_number }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: ${{ steps.pull-request.outputs.pr_number }},
+              issue_number: Number(process.env.PR_NUMBER),
               labels: ['Release Not Needed']
             })


### PR DESCRIPTION
AppSec ticket V2263249804 flagged script injection in `issue-regression-labeler.yml`. Fixed it and ran zizmor over all the workflows to address the same class of issues. This repo had the most to clean up.

Same approach as aws-sdk-net-staging#1375. No action versions bumped, pinned to the SHA each tag already resolved to.

## Changes

- Move untrusted `${{ }}` values into `env:` vars (fixes the AppSec finding)
- Fix PowerShell and github-script injection in the Dockerfile-update workflows
- Pin all actions to commit SHAs
- Set top-level `permissions: {}` with minimal per-job grants
- Add concurrency groups and job names
- Pin the semgrep container image by digest



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
