### PR TITLE
Add lambda.DurableFunction blueprint (vs2026)

### DIFF
--- a/.autover/changes/durable-execution-blueprints.json
+++ b/.autover/changes/durable-execution-blueprints.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Templates",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Add lambda.DurableFunction and serverless.DurableFunction blueprints (vs2026) for Lambda durable execution workflows. lambda.DurableFunction uses the class-library static-wrapper model (DurableFunction.WrapAsync) and deploys via dotnet lambda deploy-function; serverless.DurableFunction uses the annotations model ([LambdaFunction] + [DurableExecution]) and deploys via CloudFormation (serverless.template). Both target the managed dotnet10 runtime and ship a sample ProcessOrder workflow plus a local test project driven by Amazon.Lambda.DurableExecution.Testing. Preview."
+      ]
+    }
+  ]
+}

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/blueprint-manifest.json
@@ -1,0 +1,13 @@
+{
+  "display-name": "Durable Function",
+  "system-name": "DurableFunction",
+  "description": "A durable execution workflow that checkpoints every step, so it can be suspended during waits and resumed after a crash without re-running completed work.",
+  "sort-order": 130,
+  "hidden-tags": [
+    "C#",
+    "ServerlessProject"
+  ],
+  "tags": [
+    "Durable"
+  ]
+}

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/blueprint-manifest.json
@@ -1,11 +1,11 @@
 {
   "display-name": "Durable Function",
   "system-name": "DurableFunction",
-  "description": "A durable execution workflow that checkpoints every step, so it can be suspended during waits and resumed after a crash without re-running completed work.",
+  "description": "A durable execution workflow that checkpoints every step, so it can be suspended during waits and resumed after a crash without re-running completed work. Deploys straight to Lambda with the 'dotnet lambda deploy-function' command.",
   "sort-order": 130,
   "hidden-tags": [
     "C#",
-    "ServerlessProject"
+    "LambdaProject"
   ],
   "tags": [
     "Durable"

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/blueprint-manifest.json
@@ -2,7 +2,7 @@
   "display-name": "Durable Function",
   "system-name": "DurableFunction",
   "description": "A durable execution workflow that checkpoints every step, so it can be suspended during waits and resumed after a crash without re-running completed work. Deploys straight to Lambda with the 'dotnet lambda deploy-function' command.",
-  "sort-order": 130,
+  "sort-order": 124,
   "hidden-tags": [
     "C#",
     "LambdaProject"

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/.template.config/template.json
@@ -1,0 +1,39 @@
+{
+  "author": "AWS",
+  "classifications": [
+    "AWS",
+    "Lambda",
+    "Serverless"
+  ],
+  "name": "Lambda Durable Function",
+  "identity": "AWS.Lambda.Function.Durable.CSharp",
+  "groupIdentity": "AWS.Lambda.Function.Durable",
+  "shortName": "lambda.DurableFunction",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "BlueprintBaseName.1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "profile": {
+      "type": "parameter",
+      "description": "The AWS credentials profile set in aws-lambda-tools-defaults.json and used as the default profile when interacting with AWS.",
+      "datatype": "string",
+      "replaces": "DefaultProfile",
+      "defaultValue": ""
+    },
+    "region": {
+      "type": "parameter",
+      "description": "The AWS region set in aws-lambda-tools-defaults.json and used as the default region when interacting with AWS.",
+      "datatype": "string",
+      "replaces": "DefaultRegion",
+      "defaultValue": ""
+    }
+  },
+  "primaryOutputs": [
+    {
+      "path": "./BlueprintBaseName.1.csproj"
+    }
+  ]
+}

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!--
+      Class-library programming model: there is NO OutputType=Exe and NO hand-written Main.
+      The Amazon.Lambda.Annotations source generator emits the durable handler wrapper, and the
+      managed dotnet10 runtime hosts its own bootstrap and invokes that wrapper via an
+      Assembly::Type::Method handler string. Durable execution requires the managed dotnet10 runtime.
+    -->
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AWSProjectType>Lambda</AWSProjectType>
+    <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!-- Generate ready to run images during publishing to improvement cold starts. -->
+    <PublishReadyToRun>true</PublishReadyToRun>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="3.1.1" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.0" />
+    <PackageReference Include="Amazon.Lambda.Annotations" Version="2.0.1" />
+    <PackageReference Include="Amazon.Lambda.DurableExecution" Version="0.1.1-preview" />
+  </ItemGroup>
+</Project>

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/Function.cs
@@ -9,17 +9,6 @@ using Microsoft.Extensions.Logging;
 
 namespace BlueprintBaseName._1;
 
-/// <summary>
-/// A durable order-processing workflow. A single invocation reads like one straight-line method,
-/// but durable execution checkpoints every operation, so the function can be suspended (during the
-/// settlement wait) and re-invoked without re-running completed work. If the process crashes
-/// mid-flight it resumes from the last checkpoint — no lost orders, no double charges.
-///
-/// This template uses the <b>static wrapper</b> programming model and the class-library hosting
-/// model on the managed <c>dotnet10</c> runtime: there is no <c>[DurableExecution]</c> annotation and
-/// no <c>serverless.template</c>. The handler delegates to <see cref="DurableFunction.WrapAsync"/>,
-/// and the function deploys straight to Lambda with <c>dotnet lambda deploy-function</c>.
-/// </summary>
 public class Function
 {
     /// <summary>
@@ -32,10 +21,6 @@ public class Function
         DurableExecutionInvocationInput input, ILambdaContext context)
         => DurableFunction.WrapAsync<OrderRequest, OrderResult>(ProcessOrder, input, context);
 
-    /// <summary>
-    /// The durable workflow. The signature is <c>(TInput, IDurableContext) -&gt; Task&lt;TOutput&gt;</c>.
-    /// It is public so the test project can drive it directly with the durable test runner.
-    /// </summary>
     public async Task<OrderResult> ProcessOrder(OrderRequest order, IDurableContext context)
     {
         // The durable logger is replay-aware: this line is emitted once, not once per replay.

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/Function.cs
@@ -1,0 +1,116 @@
+using Amazon.Lambda.Annotations;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution;
+using Microsoft.Extensions.Logging;
+
+// Durable execution uses the Lambda Annotations programming model in the CLASS-LIBRARY variant:
+// there is no hand-written Main. The Amazon.Lambda.Annotations source generator turns the
+// [LambdaFunction] + [DurableExecution] method below into a handler wrapper that delegates to
+// Amazon.Lambda.DurableExecution.DurableFunction.WrapAsync. The managed dotnet10 runtime hosts its
+// own bootstrap, resolves the serializer from the assembly attribute here, and invokes the
+// generated wrapper directly.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace BlueprintBaseName._1;
+
+/// <summary>
+/// A durable order-processing workflow. A single invocation reads like one straight-line method,
+/// but durable execution checkpoints every operation, so the function can be suspended (during the
+/// settlement wait) and re-invoked without re-running completed work. If the process crashes
+/// mid-flight it resumes from the last checkpoint — no lost orders, no double charges.
+/// </summary>
+public class Function
+{
+    /// <summary>
+    /// The durable workflow entry point. The method signature is
+    /// <c>(TInput, IDurableContext) -&gt; Task&lt;TOutput&gt;</c>; the source generator wires it to the
+    /// durable runtime and emits the matching CloudFormation resource (with DurableConfig and the
+    /// durable IAM policy) in serverless.template.
+    /// </summary>
+    [LambdaFunction]
+    [DurableExecution]
+    public async Task<OrderResult> ProcessOrder(OrderRequest order, IDurableContext context)
+    {
+        // The durable logger is replay-aware: this line is emitted once, not once per replay.
+        context.Logger.LogInformation("Processing order {OrderId}", order.OrderId);
+
+        // 1) VALIDATE — a plain step. The result is checkpointed; on replay the cached value is
+        //    returned instead of re-running the body.
+        var itemCount = await context.StepAsync(
+            async (_, _) =>
+            {
+                await Task.CompletedTask;
+                if (order.Items is null || order.Items.Length == 0)
+                    throw new InvalidOperationException("Order has no items.");
+                return order.Items.Length;
+            },
+            name: "validate_order");
+
+        // 2) CHARGE PAYMENT — a step with a retry policy. Payment gateways are flaky, so the SDK
+        //    transparently retries with exponential backoff and checkpoints only the successful
+        //    attempt. AtMostOncePerRetry avoids double-charging if Lambda is re-invoked mid-attempt.
+        var transactionId = await context.StepAsync(
+            async (_, _) =>
+            {
+                await Task.CompletedTask;
+                return $"txn-{order.OrderId}";
+            },
+            name: "charge_payment",
+            config: new StepConfig
+            {
+                RetryStrategy = RetryStrategy.Exponential(
+                    maxAttempts: 5,
+                    initialDelay: TimeSpan.FromSeconds(2),
+                    maxDelay: TimeSpan.FromSeconds(30),
+                    backoffRate: 2.0),
+                Semantics = StepSemantics.AtMostOncePerRetry,
+            });
+
+        // 3) SETTLEMENT WAIT — suspend the workflow for a fixed delay. While suspended there is no
+        //    compute charge; the runtime re-invokes the function when the timer fires.
+        await context.WaitAsync(TimeSpan.FromSeconds(5), name: "settlement_delay");
+
+        // 4) SHIP — group related steps into a single child context. The packing and labeling steps
+        //    are checkpointed together as one logical operation.
+        var trackingId = await context.RunInChildContextAsync(
+            async (childContext, _) =>
+            {
+                await childContext.StepAsync(
+                    async (_, _) => { await Task.CompletedTask; return "packed"; },
+                    name: "pack");
+
+                return await childContext.StepAsync(
+                    async (_, _) => { await Task.CompletedTask; return $"trk-{order.OrderId}"; },
+                    name: "label");
+            },
+            name: "ship_order");
+
+        context.Logger.LogInformation("Order {OrderId} shipped: {TrackingId}", order.OrderId, trackingId);
+
+        return new OrderResult
+        {
+            OrderId = order.OrderId,
+            Status = "shipped",
+            ItemCount = itemCount,
+            TransactionId = transactionId,
+            TrackingId = trackingId,
+        };
+    }
+}
+
+/// <summary>Input payload for the workflow.</summary>
+public class OrderRequest
+{
+    public string? OrderId { get; set; }
+    public string[]? Items { get; set; }
+}
+
+/// <summary>Output payload returned when the workflow completes.</summary>
+public class OrderResult
+{
+    public string? OrderId { get; set; }
+    public string? Status { get; set; }
+    public int ItemCount { get; set; }
+    public string? TransactionId { get; set; }
+    public string? TrackingId { get; set; }
+}

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/Function.cs
@@ -3,12 +3,6 @@ using Amazon.Lambda.Core;
 using Amazon.Lambda.DurableExecution;
 using Microsoft.Extensions.Logging;
 
-// Durable execution uses the Lambda Annotations programming model in the CLASS-LIBRARY variant:
-// there is no hand-written Main. The Amazon.Lambda.Annotations source generator turns the
-// [LambdaFunction] + [DurableExecution] method below into a handler wrapper that delegates to
-// Amazon.Lambda.DurableExecution.DurableFunction.WrapAsync. The managed dotnet10 runtime hosts its
-// own bootstrap, resolves the serializer from the assembly attribute here, and invokes the
-// generated wrapper directly.
 [assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 
 namespace BlueprintBaseName._1;

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/Readme.md
@@ -1,20 +1,36 @@
 # Durable Lambda Function
 
 This project contains a Lambda **durable execution** workflow built with the
-[Lambda Annotations](https://github.com/aws/aws-lambda-dotnet/tree/master/Libraries/src/Amazon.Lambda.Annotations)
-programming model.
+[Amazon.Lambda.DurableExecution](https://github.com/aws/aws-lambda-dotnet/tree/master/Libraries/src/Amazon.Lambda.DurableExecution)
+**static wrapper** programming model, deployed straight to Lambda with `dotnet lambda deploy-function`.
 
 Durable execution lets you write a multi-step workflow as a single straight-line method. The
 runtime checkpoints every operation, so the function can be **suspended** during waits and
 **resumed after a crash** without re-running completed work.
 
+> Looking for the CloudFormation/Annotations variant? Use the **`serverless.DurableFunction`**
+> template, which uses `[DurableExecution]` + a `serverless.template` and deploys with
+> `dotnet lambda deploy-serverless`.
+
 ## How it works
 
-`Function.ProcessOrder` is the workflow entry point. It is marked with two attributes:
+`Function.Handler` is the Lambda entry point. It delegates to `DurableFunction.WrapAsync`, which
+bridges the durable invocation envelope to the strongly-typed `ProcessOrder` workflow:
 
-* `[LambdaFunction]` — registers the method with the Annotations source generator.
-* `[DurableExecution]` — tells the generator to wrap the method with the durable runtime and to add
-  the durable configuration and IAM policy to `serverless.template`.
+```csharp
+public Task<DurableExecutionInvocationOutput> Handler(
+    DurableExecutionInvocationInput input, ILambdaContext context)
+    => DurableFunction.WrapAsync<OrderRequest, OrderResult>(ProcessOrder, input, context);
+```
+
+This is the **class-library** hosting model on the managed `dotnet10` runtime: there is no
+`Main`/`LambdaBootstrap` loop and no `[DurableExecution]` annotation. The runtime hosts the
+bootstrap and invokes `Handler` directly via the `Assembly::Type::Method` handler string in
+`aws-lambda-tools-defaults.json`. The serializer is declared with an assembly attribute:
+
+```csharp
+[assembly: LambdaSerializer(typeof(DefaultLambdaJsonSerializer))]
+```
 
 The workflow uses the core durable primitives on `IDurableContext`:
 
@@ -24,10 +40,7 @@ The workflow uses the core durable primitives on `IDurableContext`:
 | `StepAsync` + `StepConfig.RetryStrategy` | Retry a flaky step with exponential backoff; only the successful attempt is checkpointed. |
 | `StepSemantics.AtMostOncePerRetry` | Avoid re-running a side-effecting step (e.g. charging a card) if Lambda is re-invoked mid-attempt. |
 | `WaitAsync` | Suspend the workflow for a delay. There is no compute charge while suspended. |
-| `RunInChildContextAsync` | Group related steps into a single logical operation. |
-
-The class-library model is used (no `Main`): the managed `dotnet10` runtime hosts the bootstrap and
-invokes the generated handler wrapper directly.
+| `RunInChildContextAsync` | Group related operations into a single logical operation. |
 
 > **Note:** Durable execution requires the managed **`dotnet10`** runtime.
 
@@ -42,17 +55,21 @@ invokes the generated handler wrapper directly.
 
 ## Deploy
 
-The `[DurableExecution]` attribute drives the source generator, which keeps the function resource in
-`serverless.template` in sync (runtime, handler, `DurableConfig`, and the
-`AWSLambdaBasicDurableExecutionRolePolicy` managed policy). Deploy the serverless application with:
+`aws-lambda-tools-defaults.json` sets the runtime (`dotnet10`), handler, and the durable execution
+timeout (`durable-execution-timeout`). Deploy the function directly to Lambda with:
 
 ```bash
-dotnet lambda deploy-serverless
+dotnet lambda deploy-function
 ```
+
+When the tool creates the function's execution role for you, it automatically attaches the
+`AWSLambdaBasicDurableExecutionRolePolicy` managed policy, which grants the durable-execution
+checkpoint permissions the function needs at runtime. If you supply your own role
+(`--function-role`), make sure that policy is attached to it.
 
 ## Invoke
 
-After deploying, invoke the function with a sample order payload:
+Durable functions are invoked with a qualified function reference and a durable execution name:
 
 ```bash
 dotnet lambda invoke-function BlueprintBaseName.1 --payload '{"OrderId":"order-123","Items":["sku-1","sku-2"]}'

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/Readme.md
@@ -1,0 +1,71 @@
+# Durable Lambda Function
+
+This project contains a Lambda **durable execution** workflow built with the
+[Lambda Annotations](https://github.com/aws/aws-lambda-dotnet/tree/master/Libraries/src/Amazon.Lambda.Annotations)
+programming model.
+
+Durable execution lets you write a multi-step workflow as a single straight-line method. The
+runtime checkpoints every operation, so the function can be **suspended** during waits and
+**resumed after a crash** without re-running completed work.
+
+## How it works
+
+`Function.ProcessOrder` is the workflow entry point. It is marked with two attributes:
+
+* `[LambdaFunction]` — registers the method with the Annotations source generator.
+* `[DurableExecution]` — tells the generator to wrap the method with the durable runtime and to add
+  the durable configuration and IAM policy to `serverless.template`.
+
+The workflow uses the core durable primitives on `IDurableContext`:
+
+| Primitive | Used for |
+|-----------|----------|
+| `StepAsync` | A checkpointed unit of work. On replay the cached result is returned instead of re-running the body. |
+| `StepAsync` + `StepConfig.RetryStrategy` | Retry a flaky step with exponential backoff; only the successful attempt is checkpointed. |
+| `StepSemantics.AtMostOncePerRetry` | Avoid re-running a side-effecting step (e.g. charging a card) if Lambda is re-invoked mid-attempt. |
+| `WaitAsync` | Suspend the workflow for a delay. There is no compute charge while suspended. |
+| `RunInChildContextAsync` | Group related steps into a single logical operation. |
+
+The class-library model is used (no `Main`): the managed `dotnet10` runtime hosts the bootstrap and
+invokes the generated handler wrapper directly.
+
+> **Note:** Durable execution requires the managed **`dotnet10`** runtime.
+
+## Requirements
+
+* [.NET 10 SDK](https://dotnet.microsoft.com/download)
+* [Amazon.Lambda.Tools](https://github.com/aws/aws-extensions-for-dotnet-cli#aws-lambda-amazonlambdatools)
+
+  ```bash
+  dotnet tool install -g Amazon.Lambda.Tools
+  ```
+
+## Deploy
+
+The `[DurableExecution]` attribute drives the source generator, which keeps the function resource in
+`serverless.template` in sync (runtime, handler, `DurableConfig`, and the
+`AWSLambdaBasicDurableExecutionRolePolicy` managed policy). Deploy the serverless application with:
+
+```bash
+dotnet lambda deploy-serverless
+```
+
+## Invoke
+
+After deploying, invoke the function with a sample order payload:
+
+```bash
+dotnet lambda invoke-function BlueprintBaseName.1 --payload '{"OrderId":"order-123","Items":["sku-1","sku-2"]}'
+```
+
+The workflow validates the order, charges payment, waits out a short settlement period, ships the
+order in a child context, and returns the result.
+
+## Test
+
+The included test project drives the workflow locally with the
+`Amazon.Lambda.DurableExecution.Testing` runner — no AWS resources required:
+
+```bash
+dotnet test
+```

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/Readme.md
@@ -69,10 +69,11 @@ checkpoint permissions the function needs at runtime. If you supply your own rol
 
 ## Invoke
 
-Durable functions are invoked with a qualified function reference and a durable execution name:
+Durable functions are invoked asynchronously and then monitored until the execution completes. Pass
+`--invoke-mode DurableExecution` so the tool starts the execution and polls it to completion:
 
 ```bash
-dotnet lambda invoke-function BlueprintBaseName.1 --payload '{"OrderId":"order-123","Items":["sku-1","sku-2"]}'
+dotnet lambda invoke-function BlueprintBaseName.1 --invoke-mode DurableExecution --payload '{"OrderId":"order-123","Items":["sku-1","sku-2"]}'
 ```
 
 The workflow validates the order, charges payment, waits out a short settlement period, ships the
@@ -80,8 +81,11 @@ order in a child context, and returns the result.
 
 ## Test
 
-The included test project drives the workflow locally with the
-`Amazon.Lambda.DurableExecution.Testing` runner — no AWS resources required:
+You can drive the workflow locally with the `Amazon.Lambda.DurableExecution.Testing` package — no AWS
+resources required. Add a test project that references your function project and
+`Amazon.Lambda.DurableExecution.Testing`, then use its in-memory durable execution runner to invoke
+`ProcessOrder` and assert on the result. If you created this project from the Visual Studio template
+that includes a test project, run it with:
 
 ```bash
 dotnet test

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -1,0 +1,14 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+    "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+    "dotnet lambda help",
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+  "profile": "DefaultProfile",
+  "region": "DefaultRegion",
+  "configuration": "Release",
+  "s3-prefix": "BlueprintBaseName.1/",
+  "template": "serverless.template",
+  "template-parameters": ""
+}

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/serverless.template
@@ -1,0 +1,28 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Transform": "AWS::Serverless-2016-10-31",
+  "Description": "An AWS Serverless Application with a durable execution function. This template is partially managed by Amazon.Lambda.Annotations.",
+  "Resources": {
+    "BlueprintBaseName1FunctionProcessOrderGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations",
+        "SyncedDurableConfig": true,
+        "SyncedDurablePolicy": true
+      },
+      "Properties": {
+        "Runtime": "dotnet10",
+        "CodeUri": ".",
+        "MemorySize": 512,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole",
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy"
+        ],
+        "PackageType": "Zip",
+        "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function_ProcessOrder_Generated::ProcessOrder",
+        "DurableConfig": {}
+      }
+    }
+  }
+}

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="3.1.1" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="4.1.0" />
+    <PackageReference Include="Amazon.Lambda.DurableExecution.Testing" Version="0.0.1-preview" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\BlueprintBaseName.1\BlueprintBaseName.1.csproj" />
+  </ItemGroup>
+</Project>

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
@@ -1,0 +1,56 @@
+using Amazon.Lambda.DurableExecution.Testing;
+using Xunit;
+
+namespace BlueprintBaseName._1.Tests;
+
+public class FunctionTest
+{
+    [Fact]
+    public async Task ProcessOrder_ShipsOrder()
+    {
+        var function = new Function();
+
+        // The local runner drives the workflow to completion in-process using the real durable
+        // runtime with an in-memory backend. SkipTime collapses the settlement WaitAsync delay so
+        // the test does not actually block for 5 seconds.
+        await using var runner = new DurableTestRunner<OrderRequest, OrderResult>(
+            handler: function.ProcessOrder,
+            options: new TestRunnerOptions { SkipTime = true });
+
+        var input = new OrderRequest
+        {
+            OrderId = "order-123",
+            Items = new[] { "sku-1", "sku-2" },
+        };
+
+        var result = await runner.RunAsync(input, cancellationToken: TestContext.Current.CancellationToken);
+
+        result.EnsureSucceeded();
+        Assert.NotNull(result.Result);
+        Assert.Equal("order-123", result.Result!.OrderId);
+        Assert.Equal("shipped", result.Result.Status);
+        Assert.Equal(2, result.Result.ItemCount);
+        Assert.Equal("txn-order-123", result.Result.TransactionId);
+        Assert.Equal("trk-order-123", result.Result.TrackingId);
+
+        // Each named operation is checkpointed and inspectable.
+        Assert.Equal(OperationStatus.Succeeded, result.GetStep("validate_order").Status);
+        Assert.Equal(OperationStatus.Succeeded, result.GetStep("charge_payment").Status);
+    }
+
+    [Fact]
+    public async Task ProcessOrder_EmptyOrder_Fails()
+    {
+        var function = new Function();
+
+        await using var runner = new DurableTestRunner<OrderRequest, OrderResult>(
+            handler: function.ProcessOrder,
+            options: new TestRunnerOptions { SkipTime = true });
+
+        var input = new OrderRequest { OrderId = "order-456", Items = System.Array.Empty<string>() };
+
+        var result = await runner.RunAsync(input, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsFailed);
+    }
+}

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/blueprint-manifest.json
@@ -1,0 +1,13 @@
+{
+  "display-name": "Durable Function",
+  "system-name": "DurableFunction",
+  "description": "A durable execution workflow that checkpoints every step, so it can be suspended during waits and resumed after a crash without re-running completed work.",
+  "sort-order": 130,
+  "hidden-tags": [
+    "C#",
+    "ServerlessProject"
+  ],
+  "tags": [
+    "Durable"
+  ]
+}

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/blueprint-manifest.json
@@ -2,7 +2,7 @@
   "display-name": "Durable Function",
   "system-name": "DurableFunction",
   "description": "A durable execution workflow that checkpoints every step, so it can be suspended during waits and resumed after a crash without re-running completed work.",
-  "sort-order": 130,
+  "sort-order": 120,
   "hidden-tags": [
     "C#",
     "ServerlessProject"

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/.template.config/template.json
@@ -1,0 +1,39 @@
+{
+  "author": "AWS",
+  "classifications": [
+    "AWS",
+    "Lambda",
+    "Serverless"
+  ],
+  "name": "Serverless Durable Function",
+  "identity": "AWS.Serverless.Function.Durable.CSharp",
+  "groupIdentity": "AWS.Serverless.Function.Durable",
+  "shortName": "serverless.DurableFunction",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "BlueprintBaseName.1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "profile": {
+      "type": "parameter",
+      "description": "The AWS credentials profile set in aws-lambda-tools-defaults.json and used as the default profile when interacting with AWS.",
+      "datatype": "string",
+      "replaces": "DefaultProfile",
+      "defaultValue": ""
+    },
+    "region": {
+      "type": "parameter",
+      "description": "The AWS region set in aws-lambda-tools-defaults.json and used as the default region when interacting with AWS.",
+      "datatype": "string",
+      "replaces": "DefaultRegion",
+      "defaultValue": ""
+    }
+  },
+  "primaryOutputs": [
+    {
+      "path": "./BlueprintBaseName.1.csproj"
+    }
+  ]
+}

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="3.1.1" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.0" />
-    <PackageReference Include="Amazon.Lambda.Annotations" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.Annotations" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.DurableExecution" Version="0.1.1-preview" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="3.1.1" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.0" />
-    <PackageReference Include="Amazon.Lambda.Annotations" Version="2.0.1" />
+    <PackageReference Include="Amazon.Lambda.Annotations" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.DurableExecution" Version="0.1.1-preview" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <!--
       Class-library programming model: there is NO OutputType=Exe and NO hand-written Main.
-      The handler delegates to DurableFunction.WrapAsync (the static wrapper model), and the managed
-      dotnet10 runtime hosts its own bootstrap and invokes the handler via an
+      The Amazon.Lambda.Annotations source generator emits the durable handler wrapper, and the
+      managed dotnet10 runtime hosts its own bootstrap and invokes that wrapper via an
       Assembly::Type::Method handler string. Durable execution requires the managed dotnet10 runtime.
     -->
     <OutputType>Library</OutputType>
@@ -20,6 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="3.1.1" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.0" />
+    <PackageReference Include="Amazon.Lambda.Annotations" Version="2.0.1" />
     <PackageReference Include="Amazon.Lambda.DurableExecution" Version="0.1.1-preview" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/Function.cs
@@ -10,7 +10,7 @@ namespace BlueprintBaseName._1;
 public class Function
 {
     [LambdaFunction]
-    [DurableExecution]
+    [DurableExecution(executionTimeout: 86400)]
     public async Task<OrderResult> ProcessOrder(OrderRequest order, IDurableContext context)
     {
         // The durable logger is replay-aware: this line is emitted once, not once per replay.

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/Function.cs
@@ -7,20 +7,8 @@ using Microsoft.Extensions.Logging;
 
 namespace BlueprintBaseName._1;
 
-/// <summary>
-/// A durable order-processing workflow. A single invocation reads like one straight-line method,
-/// but durable execution checkpoints every operation, so the function can be suspended (during the
-/// settlement wait) and re-invoked without re-running completed work. If the process crashes
-/// mid-flight it resumes from the last checkpoint — no lost orders, no double charges.
-/// </summary>
 public class Function
 {
-    /// <summary>
-    /// The durable workflow entry point. The method signature is
-    /// <c>(TInput, IDurableContext) -&gt; Task&lt;TOutput&gt;</c>; the source generator wires it to the
-    /// durable runtime and emits the matching CloudFormation resource (with DurableConfig and the
-    /// durable IAM policy) in serverless.template.
-    /// </summary>
     [LambdaFunction]
     [DurableExecution]
     public async Task<OrderResult> ProcessOrder(OrderRequest order, IDurableContext context)

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/Function.cs
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/Function.cs
@@ -1,11 +1,9 @@
+using Amazon.Lambda.Annotations;
 using Amazon.Lambda.Core;
 using Amazon.Lambda.DurableExecution;
-using Amazon.Lambda.Serialization.SystemTextJson;
 using Microsoft.Extensions.Logging;
 
-// The durable runtime reads this serializer off ILambdaContext.Serializer to (de)serialize the
-// invocation envelope and every checkpointed step input/output.
-[assembly: LambdaSerializer(typeof(DefaultLambdaJsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 
 namespace BlueprintBaseName._1;
 
@@ -14,28 +12,17 @@ namespace BlueprintBaseName._1;
 /// but durable execution checkpoints every operation, so the function can be suspended (during the
 /// settlement wait) and re-invoked without re-running completed work. If the process crashes
 /// mid-flight it resumes from the last checkpoint — no lost orders, no double charges.
-///
-/// This template uses the <b>static wrapper</b> programming model and the class-library hosting
-/// model on the managed <c>dotnet10</c> runtime: there is no <c>[DurableExecution]</c> annotation and
-/// no <c>serverless.template</c>. The handler delegates to <see cref="DurableFunction.WrapAsync"/>,
-/// and the function deploys straight to Lambda with <c>dotnet lambda deploy-function</c>.
 /// </summary>
 public class Function
 {
     /// <summary>
-    /// The Lambda entry point. The managed runtime invokes this method directly (via the
-    /// <c>Assembly::Type::Method</c> handler string in aws-lambda-tools-defaults.json) and
-    /// <see cref="DurableFunction.WrapAsync"/> bridges the durable invocation envelope to the
-    /// strongly-typed <see cref="ProcessOrder"/> workflow below.
+    /// The durable workflow entry point. The method signature is
+    /// <c>(TInput, IDurableContext) -&gt; Task&lt;TOutput&gt;</c>; the source generator wires it to the
+    /// durable runtime and emits the matching CloudFormation resource (with DurableConfig and the
+    /// durable IAM policy) in serverless.template.
     /// </summary>
-    public Task<DurableExecutionInvocationOutput> Handler(
-        DurableExecutionInvocationInput input, ILambdaContext context)
-        => DurableFunction.WrapAsync<OrderRequest, OrderResult>(ProcessOrder, input, context);
-
-    /// <summary>
-    /// The durable workflow. The signature is <c>(TInput, IDurableContext) -&gt; Task&lt;TOutput&gt;</c>.
-    /// It is public so the test project can drive it directly with the durable test runner.
-    /// </summary>
+    [LambdaFunction]
+    [DurableExecution]
     public async Task<OrderResult> ProcessOrder(OrderRequest order, IDurableContext context)
     {
         // The durable logger is replay-aware: this line is emitted once, not once per replay.

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/Readme.md
@@ -1,0 +1,71 @@
+# Durable Lambda Function
+
+This project contains a Lambda **durable execution** workflow built with the
+[Lambda Annotations](https://github.com/aws/aws-lambda-dotnet/tree/master/Libraries/src/Amazon.Lambda.Annotations)
+programming model.
+
+Durable execution lets you write a multi-step workflow as a single straight-line method. The
+runtime checkpoints every operation, so the function can be **suspended** during waits and
+**resumed after a crash** without re-running completed work.
+
+## How it works
+
+`Function.ProcessOrder` is the workflow entry point. It is marked with two attributes:
+
+* `[LambdaFunction]` — registers the method with the Annotations source generator.
+* `[DurableExecution]` — tells the generator to wrap the method with the durable runtime and to add
+  the durable configuration and IAM policy to `serverless.template`.
+
+The workflow uses the core durable primitives on `IDurableContext`:
+
+| Primitive | Used for |
+|-----------|----------|
+| `StepAsync` | A checkpointed unit of work. On replay the cached result is returned instead of re-running the body. |
+| `StepAsync` + `StepConfig.RetryStrategy` | Retry a flaky step with exponential backoff; only the successful attempt is checkpointed. |
+| `StepSemantics.AtMostOncePerRetry` | Avoid re-running a side-effecting step (e.g. charging a card) if Lambda is re-invoked mid-attempt. |
+| `WaitAsync` | Suspend the workflow for a delay. There is no compute charge while suspended. |
+| `RunInChildContextAsync` | Group related steps into a single logical operation. |
+
+The class-library model is used (no `Main`): the managed `dotnet10` runtime hosts the bootstrap and
+invokes the generated handler wrapper directly.
+
+> **Note:** Durable execution requires the managed **`dotnet10`** runtime.
+
+## Requirements
+
+* [.NET 10 SDK](https://dotnet.microsoft.com/download)
+* [Amazon.Lambda.Tools](https://github.com/aws/aws-extensions-for-dotnet-cli#aws-lambda-amazonlambdatools)
+
+  ```bash
+  dotnet tool install -g Amazon.Lambda.Tools
+  ```
+
+## Deploy
+
+The `[DurableExecution]` attribute drives the source generator, which keeps the function resource in
+`serverless.template` in sync (runtime, handler, `DurableConfig`, and the
+`AWSLambdaBasicDurableExecutionRolePolicy` managed policy). Deploy the serverless application with:
+
+```bash
+dotnet lambda deploy-serverless
+```
+
+## Invoke
+
+After deploying, invoke the function with a sample order payload:
+
+```bash
+dotnet lambda invoke-function BlueprintBaseName.1 --payload '{"OrderId":"order-123","Items":["sku-1","sku-2"]}'
+```
+
+The workflow validates the order, charges payment, waits out a short settlement period, ships the
+order in a child context, and returns the result.
+
+## Test
+
+The included test project drives the workflow locally with the
+`Amazon.Lambda.DurableExecution.Testing` runner — no AWS resources required:
+
+```bash
+dotnet test
+```

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/Readme.md
@@ -52,10 +52,20 @@ dotnet lambda deploy-serverless
 
 ## Invoke
 
-After deploying, invoke the function with a sample order payload:
+CloudFormation generates the deployed function name, so it won't be `BlueprintBaseName.1`. Find it by
+looking at the deployed CloudFormation stack — either in the AWS Console (the stack's **Resources**
+tab) or with the CLI:
 
 ```bash
-dotnet lambda invoke-function BlueprintBaseName.1 --payload '{"OrderId":"order-123","Items":["sku-1","sku-2"]}'
+aws cloudformation describe-stack-resources --stack-name <stack-name> \
+    --query "StackResources[?ResourceType=='AWS::Serverless::Function' || ResourceType=='AWS::Lambda::Function'].PhysicalResourceId"
+```
+
+Durable functions are invoked asynchronously and then monitored until the execution completes. Pass
+`--invoke-mode DurableExecution` so the tool starts the execution and polls it to completion:
+
+```bash
+dotnet lambda invoke-function <generated-function-name> --invoke-mode DurableExecution --payload '{"OrderId":"order-123","Items":["sku-1","sku-2"]}'
 ```
 
 The workflow validates the order, charges payment, waits out a short settlement period, ships the
@@ -63,8 +73,11 @@ order in a child context, and returns the result.
 
 ## Test
 
-The included test project drives the workflow locally with the
-`Amazon.Lambda.DurableExecution.Testing` runner — no AWS resources required:
+You can drive the workflow locally with the `Amazon.Lambda.DurableExecution.Testing` package — no AWS
+resources required. Add a test project that references your function project and
+`Amazon.Lambda.DurableExecution.Testing`, then use its in-memory durable execution runner to invoke
+`ProcessOrder` and assert on the result. If you created this project from the Visual Studio template
+that includes a test project, run it with:
 
 ```bash
 dotnet test

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/Readme.md
@@ -13,8 +13,9 @@ runtime checkpoints every operation, so the function can be **suspended** during
 `Function.ProcessOrder` is the workflow entry point. It is marked with two attributes:
 
 * `[LambdaFunction]` — registers the method with the Annotations source generator.
-* `[DurableExecution]` — tells the generator to wrap the method with the durable runtime and to add
-  the durable configuration and IAM policy to `serverless.template`.
+* `[DurableExecution(executionTimeout: 86400)]` — tells the generator to wrap the method with the
+  durable runtime and to add the durable configuration and IAM policy to `serverless.template`.
+  `executionTimeout` (in seconds) is required.
 
 The workflow uses the core durable primitives on `IDurableContext`:
 

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,9 +8,7 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "function-runtime": "dotnet10",
-  "function-memory-size": 512,
-  "function-timeout": 30,
-  "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::Handler",
-  "durable-execution-timeout": 86400
+  "s3-prefix": "BlueprintBaseName.1/",
+  "template": "serverless.template",
+  "template-parameters": ""
 }

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/serverless.template
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "An AWS Serverless Application with a durable execution function. This template is partially managed by Amazon.Lambda.Annotations.",
+  "Description": "An AWS Serverless Application with a durable execution function. This template is partially managed by Amazon.Lambda.Annotations. This template is partially managed by Amazon.Lambda.Annotations (v2.0.1.0).",
   "Resources": {
     "BlueprintBaseName1FunctionProcessOrderGenerated": {
       "Type": "AWS::Serverless::Function",

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/serverless.template
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "An AWS Serverless Application with a durable execution function. This template is partially managed by Amazon.Lambda.Annotations. This template is partially managed by Amazon.Lambda.Annotations (v2.0.1.0).",
+  "Description": "An AWS Serverless Application with a durable execution function. This template is partially managed by Amazon.Lambda.Annotations (v2.2.0.0).",
   "Resources": {
     "BlueprintBaseName1FunctionProcessOrderGenerated": {
       "Type": "AWS::Serverless::Function",
@@ -21,7 +21,9 @@
         ],
         "PackageType": "Zip",
         "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function_ProcessOrder_Generated::ProcessOrder",
-        "DurableConfig": {}
+        "DurableConfig": {
+          "ExecutionTimeout": 86400
+        }
       }
     }
   }

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="3.1.1" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="4.1.0" />
+    <PackageReference Include="Amazon.Lambda.DurableExecution.Testing" Version="0.0.1-preview" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\BlueprintBaseName.1\BlueprintBaseName.1.csproj" />
+  </ItemGroup>
+</Project>

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/test/BlueprintBaseName.1.Tests/FunctionTest.cs
@@ -1,0 +1,56 @@
+using Amazon.Lambda.DurableExecution.Testing;
+using Xunit;
+
+namespace BlueprintBaseName._1.Tests;
+
+public class FunctionTest
+{
+    [Fact]
+    public async Task ProcessOrder_ShipsOrder()
+    {
+        var function = new Function();
+
+        // The local runner drives the workflow to completion in-process using the real durable
+        // runtime with an in-memory backend. SkipTime collapses the settlement WaitAsync delay so
+        // the test does not actually block for 5 seconds.
+        await using var runner = new DurableTestRunner<OrderRequest, OrderResult>(
+            handler: function.ProcessOrder,
+            options: new TestRunnerOptions { SkipTime = true });
+
+        var input = new OrderRequest
+        {
+            OrderId = "order-123",
+            Items = new[] { "sku-1", "sku-2" },
+        };
+
+        var result = await runner.RunAsync(input, cancellationToken: TestContext.Current.CancellationToken);
+
+        result.EnsureSucceeded();
+        Assert.NotNull(result.Result);
+        Assert.Equal("order-123", result.Result!.OrderId);
+        Assert.Equal("shipped", result.Result.Status);
+        Assert.Equal(2, result.Result.ItemCount);
+        Assert.Equal("txn-order-123", result.Result.TransactionId);
+        Assert.Equal("trk-order-123", result.Result.TrackingId);
+
+        // Each named operation is checkpointed and inspectable.
+        Assert.Equal(OperationStatus.Succeeded, result.GetStep("validate_order").Status);
+        Assert.Equal(OperationStatus.Succeeded, result.GetStep("charge_payment").Status);
+    }
+
+    [Fact]
+    public async Task ProcessOrder_EmptyOrder_Fails()
+    {
+        var function = new Function();
+
+        await using var runner = new DurableTestRunner<OrderRequest, OrderResult>(
+            handler: function.ProcessOrder,
+            options: new TestRunnerOptions { SkipTime = true });
+
+        var input = new OrderRequest { OrderId = "order-456", Items = System.Array.Empty<string>() };
+
+        var result = await runner.RunAsync(input, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsFailed);
+    }
+}

--- a/Blueprints/README.md
+++ b/Blueprints/README.md
@@ -39,6 +39,7 @@ Lambda Simple S3 Function            lambda.S3                     [C#]         
 Lambda ASP.NET Core Web API          lambda.AspNetCoreWebAPI       [C#]          AWS/Lambda/Serverless
 Lambda DynamoDB Blog API             lambda.DynamoDBBlogAPI        [C#]          AWS/Lambda/Serverless
 Lambda Empty Serverless              lambda.EmptyServerless        [C#]          AWS/Lambda/Serverless
+Lambda Durable Function              lambda.DurableFunction        [C#]          AWS/Lambda/Serverless
 Console Application                  console                       [C#], F#      Common/Console
 Class library                        classlib                      [C#], F#      Common/Library
 Unit Test Project                    mstest                        [C#], F#      Test/MSTest

--- a/buildtools/build.proj
+++ b/buildtools/build.proj
@@ -94,10 +94,12 @@
         <MSBuild Projects="$(MSBuildProjectFile)" Targets="run-blueprint-dotnetnew" Properties="TemplateName=serverless.EmptyServerless;ProjectName=EmptyServerlessF;Lang=F#;Version=vs2026"/>
         <MSBuild Projects="$(MSBuildProjectFile)" Targets="run-blueprint-dotnetnew" Properties="TemplateName=serverless.Giraffe;ProjectName=GiraffeF;Lang=F#;Version=vs2026"/>
         <MSBuild Projects="$(MSBuildProjectFile)" Targets="run-blueprint-dotnetnew" Properties="TemplateName=serverless.StepFunctionsHelloWorld;ProjectName=StepFunctionsHelloWorldC;Lang=C#;Version=vs2026"/>
-        <MSBuild Projects="$(MSBuildProjectFile)" Targets="run-blueprint-dotnetnew" Properties="TemplateName=serverless.StepFunctionsHelloWorld;ProjectName=StepFunctionsHelloWorldF;Lang=F#;Version=vs2026"/>				
-		
-		
-        <Exec Command="dotnet new uninstall Blueprints\BlueprintDefinitions\vs2022" WorkingDirectory="..\" IgnoreExitCode="true" />		
+        <MSBuild Projects="$(MSBuildProjectFile)" Targets="run-blueprint-dotnetnew" Properties="TemplateName=serverless.StepFunctionsHelloWorld;ProjectName=StepFunctionsHelloWorldF;Lang=F#;Version=vs2026"/>
+        <MSBuild Projects="$(MSBuildProjectFile)" Targets="run-blueprint-dotnetnew" Properties="TemplateName=lambda.DurableFunction;ProjectName=DurableFunctionC;Lang=C#;Version=vs2026"/>
+        <MSBuild Projects="$(MSBuildProjectFile)" Targets="run-blueprint-dotnetnew" Properties="TemplateName=serverless.DurableFunction;ProjectName=DurableFunctionServerlessC;Lang=C#;Version=vs2026"/>
+
+
+        <Exec Command="dotnet new uninstall Blueprints\BlueprintDefinitions\vs2022" WorkingDirectory="..\" IgnoreExitCode="true" />
         <Exec Command="dotnet new install Blueprints\BlueprintDefinitions\vs2022" WorkingDirectory="..\"/>
 		
 		<MSBuild Projects="$(MSBuildProjectFile)" Targets="run-blueprint-dotnetnew-legacy" Properties="TemplateName=lambda.image.EmptyFunction;ProjectName=ImageEmptyFunctionC;Lang=C#;Version=vs2022"/>


### PR DESCRIPTION
## Summary

Provides **two** `dotnet new` templates under `Blueprints/BlueprintDefinitions/vs2026` for Lambda **durable execution** workflows, following the existing `lambda.*` / `serverless.*` convention (e.g. `SimpleS3Function` / `SimpleS3FunctionServerless`):

| Template | Programming model | Deploys via | Ships |
|----------|-------------------|-------------|-------|
| **`lambda.DurableFunction`** | Static wrapper (`DurableFunction.WrapAsync`), class-library | `dotnet lambda deploy-function` | no CloudFormation |
| **`serverless.DurableFunction`** | Annotations (`[LambdaFunction]` + `[DurableExecution]`) | `dotnet lambda deploy-serverless` | `serverless.template` |

Both target the managed **dotnet10** runtime (durable execution requires dotnet10) and scaffold the same sample `ProcessOrder` workflow demonstrating the core durable primitives:
- `StepAsync` — checkpointed step
- `StepAsync` + `RetryStrategy.Exponential` with `StepSemantics.AtMostOncePerRetry`
- `WaitAsync` — suspend timer (no compute charge while suspended)
- `RunInChildContextAsync` — grouping related steps

Each ships a test project that drives the workflow locally via `Amazon.Lambda.DurableExecution.Testing` (no AWS resources needed). vs2026 only (matches the existing layout convention).

### Why two templates

The original single blueprint was labeled `lambda.DurableFunction` but shipped a `serverless.template` and deployed via `deploy-serverless` — a naming/convention mismatch. This splits it so the `lambda.*` name actually deploys straight to Lambda, and the CloudFormation path keeps its own `serverless.*` name.

## Using the templates

### `lambda.DurableFunction` — deploy straight to Lambda

```bash
dotnet new lambda.DurableFunction --name MyDurableApp
cd MyDurableApp/src/MyDurableApp
dotnet lambda deploy-function
```

- Class-library static-wrapper model: `Handler` delegates to `DurableFunction.WrapAsync<OrderRequest, OrderResult>(ProcessOrder, …)`; the serializer is declared with `[assembly: LambdaSerializer(typeof(DefaultLambdaJsonSerializer))]`. No `Main`, no `[DurableExecution]`, no `serverless.template`.
- `aws-lambda-tools-defaults.json` carries `function-runtime: dotnet10`, the `Assembly::Type::Method` `function-handler`, and `durable-execution-timeout`.
- When `deploy-function` creates the execution role for you, it auto-attaches `AWSLambdaBasicDurableExecutionRolePolicy` (the checkpoint permissions). If you pass `--function-role`, attach that policy yourself.
- **Requires the `deploy-function` durable support from `aws-extensions-for-dotnet-cli` [PR #447](https://github.com/aws/aws-extensions-for-dotnet-cli/pull/447)** (the `durable-execution-timeout` switch + IAM auto-attach). Until that ships in a released `Amazon.Lambda.Tools`, `deploy-function` won't apply the durable config.

### `serverless.DurableFunction` — deploy via CloudFormation

```bash
dotnet new serverless.DurableFunction --name MyDurableApp
cd MyDurableApp/src/MyDurableApp
dotnet lambda deploy-serverless
```

- Annotations model: annotate the workflow with `[LambdaFunction]` + `[DurableExecution]`. The source generator emits the handler wrapper and keeps `serverless.template` in sync — `DurableConfig` plus the `AWSLambdaBasicDurableExecutionRolePolicy` managed policy.
- No CLI dependency beyond a published `Amazon.Lambda.Annotations` that supports `[DurableExecution]`.

### Run the local tests (either template)

```bash
dotnet test
```

## Testing

- ✅ Both template projects build on net10.0; both test projects pass (2/2 each), no warnings.
- ✅ `lambda.DurableFunction` instantiated (placeholder substitution) and built against the **published** durable preview packages.
- ✅ **End-to-end on real AWS (managed dotnet10):** deployed the instantiated `lambda.DurableFunction` with the PR https://github.com/aws/aws-extensions-for-dotnet-cli/pull/447 CLI build → `DurableConfig.ExecutionTimeout` set, `AWSLambdaBasicDurableExecutionRolePolicy` auto-attached to the tool-created role, and the workflow ran to **SUCCEEDED** (all six operations checkpointed, including the `WaitAsync` suspend/resume). Resources torn down afterward.

## Notes

- `lambda.DurableFunction` is gated on `aws-extensions-for-dotnet-cli` PR [#447 landing in a released ](https://github.com/aws/aws-extensions-for-dotnet-cli/pull/447)`Amazon.Lambda.Tools`.
- `Amazon.Lambda.DurableExecution` / `.Testing` are preview packages; the templates reference `0.1.1-preview` / `0.0.1-preview`. Restores once those are published (or via a local feed).
- Blueprint-only change — no `.autover` change file needed (autover tracks `Libraries/src` projects only).
