### PR TITLE
Add internal IDurableServiceClient abstraction

### DIFF
--- a/.autover/changes/d1aac188-2a54-46dd-a764-4c326589cef5.json
+++ b/.autover/changes/d1aac188-2a54-46dd-a764-4c326589cef5.json
@@ -4,7 +4,7 @@
       "Name": "Amazon.Lambda.DurableExecution",
       "Type": "Patch",
       "ChangelogMessages": [
-        "Add internal IDurableServiceClient abstraction over the durable execution service RPCs so the testing package can inject an in-memory implementation; route DurableFunction.WrapAsync overloads through it. Preview."
+        "Add internal IDurableServiceClient abstraction over the durable execution service RPCs so the testing package can inject an in-memory implementation; route DurableFunction.WrapAsync overloads through it."
       ]
     }
   ]

--- a/.autover/changes/d1aac188-2a54-46dd-a764-4c326589cef5.json
+++ b/.autover/changes/d1aac188-2a54-46dd-a764-4c326589cef5.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.DurableExecution",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add internal IDurableServiceClient abstraction over the durable execution service RPCs so the testing package can inject an in-memory implementation; route DurableFunction.WrapAsync overloads through it. Preview."
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/DurableFunction.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/DurableFunction.cs
@@ -37,7 +37,8 @@ public static class DurableFunction
         Func<TInput, IDurableContext, Task<TOutput>> workflow,
         DurableExecutionInvocationInput invocationInput,
         ILambdaContext lambdaContext)
-        => WrapAsyncCore(workflow, invocationInput, lambdaContext, _cachedLambdaClient.Value);
+        => WrapAsyncCore(workflow, invocationInput, lambdaContext,
+            new LambdaDurableServiceClient(_cachedLambdaClient.Value));
 
     /// <summary>
     /// Wrap a workflow (typed input + output) with explicit Lambda client.
@@ -47,7 +48,8 @@ public static class DurableFunction
         DurableExecutionInvocationInput invocationInput,
         ILambdaContext lambdaContext,
         IAmazonLambda lambdaClient)
-        => WrapAsyncCore(workflow, invocationInput, lambdaContext, lambdaClient);
+        => WrapAsyncCore(workflow, invocationInput, lambdaContext,
+            new LambdaDurableServiceClient(lambdaClient));
 
     /// <summary>
     /// Wrap a void workflow (typed input, no output).
@@ -68,20 +70,32 @@ public static class DurableFunction
         IAmazonLambda lambdaClient)
         => WrapAsyncCore<TInput, object?>(
             async (input, ctx) => { await workflow(input, ctx); return null; },
-            invocationInput, lambdaContext, lambdaClient);
+            invocationInput, lambdaContext,
+            new LambdaDurableServiceClient(lambdaClient));
+
+    /// <summary>
+    /// Internal overload for the testing package — accepts an
+    /// <see cref="IDurableServiceClient"/> directly so the testing SDK can
+    /// inject an in-memory implementation.
+    /// </summary>
+    internal static Task<DurableExecutionInvocationOutput> WrapAsync<TInput, TOutput>(
+        Func<TInput, IDurableContext, Task<TOutput>> workflow,
+        DurableExecutionInvocationInput invocationInput,
+        ILambdaContext lambdaContext,
+        IDurableServiceClient serviceClient)
+        => WrapAsyncCore(workflow, invocationInput, lambdaContext, serviceClient);
 
     private static async Task<DurableExecutionInvocationOutput> WrapAsyncCore<TInput, TOutput>(
         Func<TInput, IDurableContext, Task<TOutput>> workflow,
         DurableExecutionInvocationInput invocationInput,
         ILambdaContext lambdaContext,
-        IAmazonLambda lambdaClient)
+        IDurableServiceClient serviceClient)
     {
         var serializer = LambdaSerializerHelper.GetRequired(lambdaContext);
 
         var state = new ExecutionState();
         state.LoadFromCheckpoint(invocationInput.InitialExecutionState);
 
-        var serviceClient = new LambdaDurableServiceClient(lambdaClient);
         var checkpointToken = invocationInput.CheckpointToken;
 
         var nextMarker = invocationInput.InitialExecutionState?.NextMarker;

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Services/IDurableServiceClient.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Services/IDurableServiceClient.cs
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using SdkOperationUpdate = Amazon.Lambda.Model.OperationUpdate;
+
+namespace Amazon.Lambda.DurableExecution.Services;
+
+/// <summary>
+/// Abstraction over the durable execution service RPCs. The production
+/// implementation (<see cref="LambdaDurableServiceClient"/>) calls the real
+/// AWS Lambda APIs; the testing package injects an in-memory fake.
+/// </summary>
+internal interface IDurableServiceClient
+{
+    Task<string?> CheckpointAsync(
+        string durableExecutionArn,
+        string? checkpointToken,
+        IReadOnlyList<SdkOperationUpdate> pendingOperations,
+        Action<IReadOnlyList<Operation>>? onNewOperations = null,
+        CancellationToken cancellationToken = default);
+
+    Task<(List<Operation> Operations, string? NextMarker)> GetExecutionStateAsync(
+        string durableExecutionArn,
+        string? checkpointToken,
+        string marker,
+        CancellationToken cancellationToken = default);
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Services/LambdaDurableServiceClient.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Services/LambdaDurableServiceClient.cs
@@ -19,7 +19,7 @@ namespace Amazon.Lambda.DurableExecution.Services;
 /// <summary>
 /// Calls the real AWS Lambda Durable Execution APIs via the AWSSDK.Lambda client.
 /// </summary>
-internal sealed class LambdaDurableServiceClient
+internal sealed class LambdaDurableServiceClient : IDurableServiceClient
 {
     private readonly IAmazonLambda _lambdaClient;
 


### PR DESCRIPTION
## Description

Introduces an internal `IDurableServiceClient` abstraction over the durable execution service RPCs (`CheckpointAsync` / `GetExecutionStateAsync`) in `Amazon.Lambda.DurableExecution`. The production `LambdaDurableServiceClient` calls the real AWS Lambda APIs; the abstraction lets the testing package inject an in-memory implementation.

`DurableFunction.WrapAsync` overloads now route through the interface, and a new internal overload accepts an `IDurableServiceClient` directly.

## Motivation

Decouples `DurableFunction` from the concrete Lambda client so durable workflows can be tested with an in-memory fake.

Preview.