### PR TITLE
Retry TestCustomAuthorizerApp deployment on transient IAM role propagation failure

### DIFF
--- a/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/DeploymentScript.ps1
+++ b/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/DeploymentScript.ps1
@@ -59,11 +59,51 @@ try
         throw "Failed to create the following bucket: $identifier"
     }
     dotnet restore
-    Write-Host "Creating CloudFormation Stack $identifier, Architecture $arch"
-    dotnet lambda deploy-serverless
-    if (!$?)
+
+    # Deploy with retries. The stack contains many Lambda functions that each reference
+    # an IAM role created in the same stack. CloudFormation occasionally calls Lambda
+    # CreateFunction before the role's trust policy has propagated through IAM, producing
+    # "The role defined for the function cannot be assumed by Lambda" and rolling the whole
+    # stack back. This is a transient eventual-consistency race, so retry the deployment.
+    $maxAttempts = 3
+    $deploySucceeded = $false
+    for ($attempt = 1; $attempt -le $maxAttempts; $attempt++)
     {
-        throw "Failed to create the following CloudFormation stack: $identifier"
+        Write-Host "Creating CloudFormation Stack $identifier, Architecture $arch (attempt $attempt of $maxAttempts)"
+        dotnet lambda deploy-serverless
+        if ($?)
+        {
+            $deploySucceeded = $true
+            break
+        }
+
+        Write-Host "Deployment attempt $attempt failed. Fetching CloudFormation stack events for debugging..."
+        try {
+            $events = aws cloudformation describe-stack-events --stack-name $identifier --query "StackEvents[?ResourceStatus=='CREATE_FAILED' || ResourceStatus=='UPDATE_FAILED' || ResourceStatus=='DELETE_FAILED']" --output json 2>&1
+            if ($events) {
+                Write-Host "CloudFormation failed events:"
+                Write-Host $events
+            }
+        }
+        catch {
+            Write-Host "Could not fetch CloudFormation events: $_"
+        }
+
+        if ($attempt -lt $maxAttempts)
+        {
+            # A failed create leaves the stack in ROLLBACK_COMPLETE, which cannot be updated
+            # or re-created. Delete it (and wait for the delete to finish) before retrying.
+            Write-Host "Deleting rolled-back stack $identifier before retrying..."
+            aws cloudformation delete-stack --stack-name $identifier
+            aws cloudformation wait stack-delete-complete --stack-name $identifier
+            # Brief pause to give IAM additional time to settle before the next attempt.
+            Start-Sleep -Seconds 15
+        }
+    }
+
+    if (!$deploySucceeded)
+    {
+        throw "Failed to create the following CloudFormation stack after $maxAttempts attempts: $identifier"
     }
 }
 finally


### PR DESCRIPTION
## Problem

The `durabletesting3` CI job ([run 28258443522](https://github.com/aws/aws-lambda-dotnet/actions/runs/28258443522/job/83727461061?pr=2447)) failed in the `TestCustomAuthorizerApp.IntegrationTests` project — all 20 tests failed because the fixture's CloudFormation deployment rolled back:

```
SimpleHttpApiUserInfo   CREATE_FAILED
Resource handler returned message: "The role defined for the function cannot be assumed by Lambda.
(Service: Lambda, Status Code: 400 ...)" (HandlerErrorCode: InvalidRequest)
```

This is a transient **IAM eventual-consistency race**: the stack creates a per-function IAM role and immediately calls Lambda `CreateFunction`, but the role's trust policy hasn't propagated through IAM yet. Once one function fails, CloudFormation cancels the other in-flight resources and rolls the whole stack back (`ROLLBACK_COMPLETE`), failing every test in the project. It is unrelated to the PR's code changes and typically passes on re-run.

## Fix

Wrap `dotnet lambda deploy-serverless` in `DeploymentScript.ps1` with a retry loop (3 attempts):

- Between attempts, **delete the rolled-back stack** — a `ROLLBACK_COMPLETE` stack cannot be updated or re-created — and `wait stack-delete-complete` before retrying.
- Add a brief pause to give IAM additional time to settle.
- Surface CloudFormation failed-resource events on each failure for easier debugging.

This makes the integration test resilient to the transient IAM propagation failure instead of failing the whole CI job.

## Testing

- PowerShell script parses cleanly (`[Parser]::ParseFile`).
- The retry path only triggers on deployment failure; the happy path is unchanged (single deploy, then `break`).
