### PR TITLE
Speed up and stabilize integration tests (parallelism + deploy retry)

### DIFF
--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/DurableFunctionDeployment.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/DurableFunctionDeployment.cs
@@ -9,6 +9,7 @@ using Amazon.IdentityManagement;
 using Amazon.IdentityManagement.Model;
 using Amazon.Lambda;
 using Amazon.Lambda.Model;
+using Amazon.Runtime;
 using Xunit.Abstractions;
 
 namespace Amazon.Lambda.DurableExecution.IntegrationTests;
@@ -40,19 +41,35 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
     private readonly IAmazonIdentityManagementService _iamClient;
 
     private readonly string _functionName;
-    private readonly string _roleName;
     private string? _roleArn;
     private string? _functionArn;
     private bool _functionCreated;
-    private readonly List<string> _inlinePolicyNames = new();
 
     // Optional paired "external system" Lambda — a plain (non-durable) function
     // that the workflow's submitter invokes. Models a real-world callback flow
     // where an out-of-band service resolves the durable execution.
     private readonly string _externalFunctionName;
-    private readonly string _externalRoleName;
     private string? _externalRoleArn;
     private bool _externalFunctionCreated;
+
+    // A single IAM role shared by every test function in the suite. Creating and deleting a role
+    // per deployment burst-throttled IAM ("Rate exceeded") once the suite started running in
+    // parallel — IAM is global, single-bucketed, and throttles mutating calls aggressively. The
+    // shared role is created at most once per account (reused across runs) and gated so concurrent
+    // deployments don't race to create it. No test depends on a role *lacking* a permission, so a
+    // single union-of-permissions role is safe; it is scoped to invoking durable-integ-* functions.
+    private const string SharedRoleName = "durable-integ-shared-execution-role";
+    private static readonly SemaphoreSlim SharedRoleGate = new(1, 1);
+    private static string? _sharedRoleArn;
+
+    // Publishing is done ONCE for all test functions, up front, instead of per-test. The test
+    // functions all reference the same source projects (Amazon.Lambda.DurableExecution etc.);
+    // publishing each function separately (and the old code wiped obj/bin first, forcing a cold
+    // build every time) rebuilt those shared projects dozens of times, and doing it concurrently
+    // thrashed MSBuild. A single up-front pass builds the shared projects once and the publishes
+    // run incrementally; each test then just zips its already-published output.
+    private static readonly SemaphoreSlim PrePublishGate = new(1, 1);
+    private static bool _prePublished;
 
     public string FunctionName => _functionName;
     public string? ExternalFunctionName => _externalFunctionCreated ? _externalFunctionName : null;
@@ -77,16 +94,34 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
     private DurableFunctionDeployment(ITestOutputHelper output, string suffix)
     {
         _output = output;
-        _lambdaClient = new AmazonLambdaClient(DeploymentRegion);
-        _iamClient = new AmazonIdentityManagementServiceClient(DeploymentRegion);
+        // The integration suite runs its test classes in parallel, so several deployments hit IAM
+        // (CreateRole/AttachRolePolicy/DeleteRole) at once. IAM has low request-rate limits and
+        // returns "Rate exceeded" under that contention. Adaptive retry adds client-side rate
+        // limiting and backs off on throttling, and a higher retry count rides out longer throttle
+        // windows, instead of failing the test on the first throttle.
+        _lambdaClient = new AmazonLambdaClient(BuildClientConfig<AmazonLambdaConfig>());
+        _iamClient = new AmazonIdentityManagementServiceClient(BuildClientConfig<AmazonIdentityManagementServiceConfig>());
 
         // Truncate the GUID (not the suffix) so CloudTrail entries stay readable.
         // Keep the GUID short enough that the total stays well under 40 chars even for long suffixes.
         static string ShortId() => Guid.NewGuid().ToString("N")[..Math.Min(8, 32)];
         _functionName = $"durable-integ-{suffix}-{ShortId()}";
-        _roleName = $"durable-integ-{suffix}-{ShortId()}";
         _externalFunctionName = $"durable-integ-{suffix}-ext-{ShortId()}";
-        _externalRoleName = $"durable-integ-{suffix}-ext-{ShortId()}";
+    }
+
+    /// <summary>
+    /// Builds a client config tuned to survive throttling when the suite runs in parallel:
+    /// adaptive retry (client-side rate limiting + backoff on throttle) and a generous retry count.
+    /// </summary>
+    private static TConfig BuildClientConfig<TConfig>() where TConfig : ClientConfig, new()
+    {
+        var config = new TConfig
+        {
+            RegionEndpoint = DeploymentRegion,
+            RetryMode = RequestRetryMode.Adaptive,
+            MaxErrorRetry = 10
+        };
+        return config;
     }
 
     // The optional `handler` defaults to `bootstrap` (executable model). Pass an
@@ -192,6 +227,100 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
     }
     """;
 
+    // Inline policy granting the permissions every durable-integ scenario needs: invoking any
+    // durable-integ-* function (covers chained invoke and external-function invoke) and sending
+    // durable-execution callbacks. Resource is scoped to the suite's function name prefix.
+    private const string SharedInlinePolicyName = "DurableIntegSharedPermissions";
+    private const string SharedInlinePolicyDocument = """
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "lambda:InvokeFunction",
+                "Resource": [
+                    "arn:aws:lambda:*:*:function:durable-integ-*",
+                    "arn:aws:lambda:*:*:function:durable-integ-*:*"
+                ]
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "lambda:SendDurableExecutionCallbackSuccess",
+                    "lambda:SendDurableExecutionCallbackFailure"
+                ],
+                "Resource": "*"
+            }
+        ]
+    }
+    """;
+
+    /// <summary>
+    /// Returns the ARN of the shared execution role, creating it once per account if absent.
+    /// Gated by a semaphore + memoized ARN so concurrent deployments don't race or re-create it.
+    /// In steady state (role already exists from a prior run) this is a single GetRole call for the
+    /// entire suite, which is what keeps the parallel run under IAM's mutating-call rate limits.
+    /// </summary>
+    private async Task<string> GetOrCreateSharedRoleAsync()
+    {
+        if (_sharedRoleArn != null)
+            return _sharedRoleArn;
+
+        await SharedRoleGate.WaitAsync();
+        try
+        {
+            if (_sharedRoleArn != null)
+                return _sharedRoleArn;
+
+            try
+            {
+                var existing = await _iamClient.GetRoleAsync(new GetRoleRequest { RoleName = SharedRoleName });
+                _output.WriteLine($"Reusing shared IAM role: {SharedRoleName}");
+                _sharedRoleArn = existing.Role.Arn;
+                return _sharedRoleArn;
+            }
+            catch (NoSuchEntityException)
+            {
+                // Falls through to create it.
+            }
+
+            _output.WriteLine($"Creating shared IAM role: {SharedRoleName}");
+            var created = await _iamClient.CreateRoleAsync(new CreateRoleRequest
+            {
+                RoleName = SharedRoleName,
+                AssumeRolePolicyDocument = LambdaAssumeRolePolicy
+            });
+
+            await _iamClient.AttachRolePolicyAsync(new AttachRolePolicyRequest
+            {
+                RoleName = SharedRoleName,
+                PolicyArn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+            });
+            await _iamClient.AttachRolePolicyAsync(new AttachRolePolicyRequest
+            {
+                RoleName = SharedRoleName,
+                PolicyArn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy"
+            });
+            await _iamClient.PutRolePolicyAsync(new PutRolePolicyRequest
+            {
+                RoleName = SharedRoleName,
+                PolicyName = SharedInlinePolicyName,
+                PolicyDocument = SharedInlinePolicyDocument
+            });
+
+            // Wait for IAM propagation so the first function create doesn't hit
+            // "The role defined for the function cannot be assumed by Lambda".
+            await Task.Delay(TimeSpan.FromSeconds(10));
+
+            _sharedRoleArn = created.Role.Arn;
+            return _sharedRoleArn;
+        }
+        finally
+        {
+            SharedRoleGate.Release();
+        }
+    }
+
     private async Task InitializeAsync(
         string testFunctionDir,
         string? externalFunctionDir,
@@ -200,135 +329,23 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
         bool enableTenancy,
         string? handler)
     {
-        // 1. Create the workflow's IAM role.
-        _output.WriteLine($"Creating IAM role: {_roleName}");
-        var createRoleResponse = await _iamClient.CreateRoleAsync(new CreateRoleRequest
-        {
-            RoleName = _roleName,
-            AssumeRolePolicyDocument = LambdaAssumeRolePolicy
-        });
-        _roleArn = createRoleResponse.Role.Arn;
-
-        await _iamClient.AttachRolePolicyAsync(new AttachRolePolicyRequest
-        {
-            RoleName = _roleName,
-            PolicyArn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        });
-
-        await _iamClient.AttachRolePolicyAsync(new AttachRolePolicyRequest
-        {
-            RoleName = _roleName,
-            PolicyArn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy"
-        });
-
-        // 2. (optional) Create the external function's IAM role up front so its
-        //    sts:AssumeRole and lambda:SendDurableExecutionCallbackSuccess
-        //    permissions propagate alongside the workflow role's permissions
-        //    (single 10-second sleep covers both).
+        // 1. Acquire the shared IAM role (created once per account, reused across tests and runs).
+        //    Both the workflow function and any paired external function run under this single role,
+        //    which carries the union of permissions every scenario needs. The external function's
+        //    callback-send permission and the workflow's invoke permission are all baked into the
+        //    shared role, so per-test PutRolePolicy calls are no longer needed.
+        _roleArn = await GetOrCreateSharedRoleAsync();
         if (externalFunctionDir != null)
         {
-            _output.WriteLine($"Creating external IAM role: {_externalRoleName}");
-            var extRoleResponse = await _iamClient.CreateRoleAsync(new CreateRoleRequest
-            {
-                RoleName = _externalRoleName,
-                AssumeRolePolicyDocument = LambdaAssumeRolePolicy
-            });
-            _externalRoleArn = extRoleResponse.Role.Arn;
-
-            await _iamClient.AttachRolePolicyAsync(new AttachRolePolicyRequest
-            {
-                RoleName = _externalRoleName,
-                PolicyArn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-            });
-
-            // Inline policy lets the external function call the durable callback API.
-            // Resource "*" because we don't yet know the workflow's ARN at this point —
-            // the external function only resolves callbacks belonging to executions the
-            // workflow created, so the blast radius is bounded by the role's lifetime.
-            await _iamClient.PutRolePolicyAsync(new PutRolePolicyRequest
-            {
-                RoleName = _externalRoleName,
-                PolicyName = "SendDurableExecutionCallback",
-                PolicyDocument = """
-                {
-                    "Version": "2012-10-17",
-                    "Statement": [{
-                        "Effect": "Allow",
-                        "Action": [
-                            "lambda:SendDurableExecutionCallbackSuccess",
-                            "lambda:SendDurableExecutionCallbackFailure"
-                        ],
-                        "Resource": "*"
-                    }]
-                }
-                """
-            });
-
-            // Workflow function will Invoke the external function — grant via inline policy.
-            // Scoped to the external function name we just minted.
-            await _iamClient.PutRolePolicyAsync(new PutRolePolicyRequest
-            {
-                RoleName = _roleName,
-                PolicyName = "InvokeExternalFunction",
-                PolicyDocument = $$"""
-                {
-                    "Version": "2012-10-17",
-                    "Statement": [{
-                        "Effect": "Allow",
-                        "Action": "lambda:InvokeFunction",
-                        "Resource": "arn:aws:lambda:*:*:function:{{_externalFunctionName}}"
-                    }]
-                }
-                """
-            });
-            _inlinePolicyNames.Add("InvokeExternalFunction");
+            _externalRoleArn = _roleArn;
         }
 
-        // Grant cross-Lambda invoke when the parent of a chained-invoke scenario
-        // needs to call out to a downstream function. The durable execution service
-        // is the one that actually drives the chained invocation in production —
-        // attaching this directly to the parent's role keeps the parent role
-        // capable of being used in non-durable contexts (e.g. for diagnostic
-        // direct invokes from the test harness).
-        if (invokeAllowedFunctionArns != null && invokeAllowedFunctionArns.Count > 0)
-        {
-            // Allow both the unqualified ARN and any qualifier (alias/version/$LATEST).
-            var resources = new List<string>(invokeAllowedFunctionArns.Count * 2);
-            foreach (var arn in invokeAllowedFunctionArns)
-            {
-                resources.Add(arn);
-                resources.Add(arn + ":*");
-            }
-            var resourceJson = "[" + string.Join(",", resources.Select(r => $"\"{r}\"")) + "]";
-            var policyDoc = $$"""
-            {
-                "Version": "2012-10-17",
-                "Statement": [{
-                    "Effect": "Allow",
-                    "Action": ["lambda:InvokeFunction"],
-                    "Resource": {{resourceJson}}
-                }]
-            }
-            """;
-            const string PolicyName = "AllowChainedInvoke";
-            await _iamClient.PutRolePolicyAsync(new PutRolePolicyRequest
-            {
-                RoleName = _roleName,
-                PolicyName = PolicyName,
-                PolicyDocument = policyDoc
-            });
-            _inlinePolicyNames.Add(PolicyName);
-        }
-
-        // Wait for IAM propagation.
-        await Task.Delay(TimeSpan.FromSeconds(10));
-
-        // 3. Build + zip the workflow function package.
+        // 2. Build + zip the workflow function package.
         _output.WriteLine($"Building and zipping function package from {testFunctionDir}...");
         var zipBytes = await BuildAndZipAsync(testFunctionDir);
         _output.WriteLine($"Package built: {zipBytes.Length} bytes");
 
-        // 4. (optional) Build + deploy the external function. Done before the workflow
+        // 3. (optional) Build + deploy the external function. Done before the workflow
         //    Lambda so the workflow function's environment can reference the external
         //    function name (which is already known from the ctor).
         if (externalFunctionDir != null)
@@ -355,7 +372,7 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
             await WaitForFunctionActive(_externalFunctionName);
         }
 
-        // 5. Create the workflow Lambda.
+        // 4. Create the workflow Lambda.
         _output.WriteLine($"Creating Lambda function: {_functionName}");
         var createFunctionRequest = new CreateFunctionRequest
         {
@@ -604,42 +621,18 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
     }
 
     /// <summary>
-    /// Publishes a test function (framework-dependent, linux-x64) and zips the publish
-    /// output for upload as a managed-runtime Lambda package. The zip contains the native
-    /// <c>bootstrap</c> shim that the dotnet managed runtime execs (executable model).
+    /// Returns the zipped, published package for a test function. The actual publishing happens
+    /// once for all functions (see <see cref="EnsureAllFunctionsPublishedAsync"/>); this just zips
+    /// the already-published output. The zip contains the native <c>bootstrap</c> shim that the
+    /// dotnet managed runtime execs (executable model).
     /// </summary>
     private async Task<byte[]> BuildAndZipAsync(string testFunctionDir)
     {
-        // `dotnet test` spins up one testhost per TargetFramework (net8.0 + net10.0) and
-        // runs them concurrently. Both testhosts invoke the same test classes, which means
-        // two processes can race on the same TestFunctions/<X>/ source dir — wiping bin/
-        // and obj/ under each other's feet. Symptom: MSB3030 "Could not copy bootstrap.dll"
-        // because one process deleted obj/ while the other was mid-publish. Serialize the
-        // per-source-dir build with a cross-process file lock so different test functions
-        // can still build in parallel. (A Mutex would have thread-affinity issues across
-        // awaits; an exclusive FileStream avoids that.) Lock file goes under temp — keeping
-        // it out of the source tree avoids polluting git status across worktrees.
-        var lockKey = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(
-            Encoding.UTF8.GetBytes(testFunctionDir.ToLowerInvariant())))[..16];
-        var lockPath = Path.Combine(Path.GetTempPath(), $"durable-integ-build-{lockKey}.lock");
-        using var lockHandle = await AcquireExclusiveFileLockAsync(lockPath, TimeSpan.FromMinutes(10));
+        await EnsureAllFunctionsPublishedAsync();
 
         var publishDir = Path.Combine(testFunctionDir, "bin", "publish");
-        if (Directory.Exists(publishDir)) Directory.Delete(publishDir, true);
-
-        // MSBuild's up-to-date check leaves stale .Up2Date markers under obj/ that
-        // make `dotnet publish` skip the copy-to-output step on a second run after
-        // we've wiped bin/publish/. Result: empty publish dir → empty zip package.
-        // Nuking obj/ guarantees a real publish each time the helper is invoked.
-        // Cheap (each test function is small).
-        var objDir = Path.Combine(testFunctionDir, "obj");
-        if (Directory.Exists(objDir)) Directory.Delete(objDir, true);
-        var binDir = Path.Combine(testFunctionDir, "bin");
-        if (Directory.Exists(binDir)) Directory.Delete(binDir, true);
-
-        await RunProcess("dotnet",
-            $"publish -c Release -r linux-x64 --self-contained false -o \"{publishDir}\"",
-            testFunctionDir);
+        if (!Directory.Exists(publishDir))
+            throw new DirectoryNotFoundException($"Expected published output at '{publishDir}' but it does not exist.");
 
         // Zip the publish output. On Linux (CI) ZipFile preserves the bootstrap exec bit;
         // on Windows the managed runtime tolerates the missing bit.
@@ -650,21 +643,75 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
         return await File.ReadAllBytesAsync(zipPath);
     }
 
-    private static async Task<FileStream> AcquireExclusiveFileLockAsync(string lockPath, TimeSpan timeout)
+    /// <summary>
+    /// Publishes every test function once, up front, in a SINGLE MSBuild invocation. Runs at most
+    /// once per test run (gated + memoized). A generated traversal project references all function
+    /// projects and publishes them with one <c>dotnet build</c>, so MSBuild builds the shared
+    /// dependency projects once and publishes the functions in parallel within that one process —
+    /// avoiding both the per-project CLI/MSBuild startup cost of N separate <c>dotnet publish</c>
+    /// calls and the cross-process thrash that those caused when the suite ran in parallel. Each
+    /// function still lands in its own <c>bin/publish</c>; tests then only zip that output.
+    /// </summary>
+    private async Task EnsureAllFunctionsPublishedAsync()
     {
-        var deadline = DateTime.UtcNow + timeout;
-        while (true)
+        if (_prePublished)
+            return;
+
+        await PrePublishGate.WaitAsync();
+        try
         {
+            if (_prePublished)
+                return;
+
+            var testFunctionsRoot = Path.GetFullPath(
+                Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "TestFunctions"));
+            var projects = Directory.GetFiles(testFunctionsRoot, "*.csproj", SearchOption.AllDirectories)
+                .OrderBy(p => p, StringComparer.Ordinal)
+                .ToList();
+
+            _output.WriteLine($"Pre-publishing {projects.Count} test function(s) in a single MSBuild pass...");
+
+            // Generate a traversal project that publishes every function project to its own
+            // bin/publish (PublishDir relative to each project). BuildInParallel lets MSBuild fan
+            // the publishes out across nodes once the shared dependency projects are built.
+            var itemsXml = string.Concat(projects.Select(p =>
+                $"    <FunctionProject Include=\"{System.Security.SecurityElement.Escape(p)}\" />\n"));
+            var traversalProject = $"""
+                <Project>
+                  <ItemGroup>
+                {itemsXml}  </ItemGroup>
+                  <Target Name="PublishAll">
+                    <!-- Restore then Publish per project: the MSBuild task's targets run against
+                         each referenced project, so each function restores its own packages before
+                         publishing (an outer -restore would only restore this traversal project). -->
+                    <MSBuild
+                      Projects="@(FunctionProject)"
+                      Targets="Restore;Publish"
+                      BuildInParallel="true"
+                      Properties="Configuration=Release;RuntimeIdentifier=linux-x64;SelfContained=false;PublishDir=bin\publish\" />
+                  </Target>
+                </Project>
+                """;
+
+            var traversalPath = Path.Combine(Path.GetTempPath(), $"durable-integ-publish-all-{Guid.NewGuid():N}.proj");
+            await File.WriteAllTextAsync(traversalPath, traversalProject);
             try
             {
-                return new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+                // -maxcpucount lets MSBuild use multiple nodes for the parallel publishes.
+                await RunProcess("dotnet",
+                    $"build \"{traversalPath}\" -t:PublishAll -maxcpucount",
+                    testFunctionsRoot);
             }
-            catch (IOException)
+            finally
             {
-                if (DateTime.UtcNow >= deadline)
-                    throw new TimeoutException($"Timed out waiting for build lock '{lockPath}' after {timeout.TotalSeconds:F0}s");
-                await Task.Delay(TimeSpan.FromMilliseconds(500));
+                try { File.Delete(traversalPath); } catch { /* best effort */ }
             }
+
+            _prePublished = true;
+        }
+        finally
+        {
+            PrePublishGate.Release();
         }
     }
 
@@ -742,64 +789,9 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
             catch (Exception ex) { _output.WriteLine($"Cleanup error (external function): {ex.Message}"); }
         }
 
-        if (_roleArn != null)
-        {
-            // Detach each policy independently — if one detach fails (e.g., the
-            // policy was never attached because init bailed out early) we still
-            // want to attempt the others and the final DeleteRole.
-            await TryDetachManaged(_roleName, "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole");
-            await TryDetachManaged(_roleName, "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy");
-
-            // Inline policies must be deleted (not detached) before DeleteRole succeeds.
-            foreach (var inline in _inlinePolicyNames)
-            {
-                await TryDeleteInline(_roleName, inline);
-            }
-
-            try
-            {
-                await _iamClient.DeleteRoleAsync(new DeleteRoleRequest { RoleName = _roleName });
-            }
-            catch (Exception ex) { _output.WriteLine($"Cleanup error (IAM DeleteRole): {ex.Message}"); }
-        }
-
-        if (_externalRoleArn != null)
-        {
-            await TryDetachManaged(_externalRoleName, "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole");
-            await TryDeleteInline(_externalRoleName, "SendDurableExecutionCallback");
-            try
-            {
-                await _iamClient.DeleteRoleAsync(new DeleteRoleRequest { RoleName = _externalRoleName });
-            }
-            catch (Exception ex) { _output.WriteLine($"Cleanup error (IAM DeleteRole external): {ex.Message}"); }
-        }
-
-        async Task TryDetachManaged(string roleName, string policyArn)
-        {
-            try
-            {
-                await _iamClient.DetachRolePolicyAsync(new DetachRolePolicyRequest
-                {
-                    RoleName = roleName,
-                    PolicyArn = policyArn
-                });
-            }
-            catch (Exception ex) { _output.WriteLine($"Cleanup error (IAM Detach {policyArn}): {ex.Message}"); }
-        }
-
-        async Task TryDeleteInline(string roleName, string policyName)
-        {
-            try
-            {
-                await _iamClient.DeleteRolePolicyAsync(new DeleteRolePolicyRequest
-                {
-                    RoleName = roleName,
-                    PolicyName = policyName
-                });
-            }
-            catch (NoSuchEntityException) { /* policy was never attached — fine */ }
-            catch (Exception ex) { _output.WriteLine($"Cleanup error (IAM DeleteInline {policyName}): {ex.Message}"); }
-        }
+        // The shared IAM role is intentionally NOT deleted here — it is reused by every test and
+        // across runs. Deleting/recreating it per test is exactly what burst-throttled IAM. It is a
+        // single stable role (durable-integ-shared-execution-role) that the test account retains.
     }
 
     public static string FindTestFunctionDir(string functionDirName)

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/DurableFunctionDeployment.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/DurableFunctionDeployment.cs
@@ -662,13 +662,22 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
         if (!Directory.Exists(publishDir))
             throw new DirectoryNotFoundException($"Expected published output at '{publishDir}' but it does not exist.");
 
-        // Zip the publish output. On Linux (CI) ZipFile preserves the bootstrap exec bit;
-        // on Windows the managed runtime tolerates the missing bit.
-        var zipPath = Path.Combine(testFunctionDir, "bin", "function.zip");
-        if (File.Exists(zipPath)) File.Delete(zipPath);
-        ZipFile.CreateFromDirectory(publishDir, zipPath, CompressionLevel.Optimal, includeBaseDirectory: false);
-
-        return await File.ReadAllBytesAsync(zipPath);
+        // Zip the publish output to a UNIQUE temp path. A given function (e.g. ApproverFunction) is
+        // the external function for more than one test, so multiple parallel tests zip the same
+        // published output at once — writing to a shared bin/function.zip raced ("file is being used
+        // by another process"). The publish output itself is read-only and shared safely; only the
+        // zip destination needs to be per-call. On Linux (CI) ZipFile preserves the bootstrap exec
+        // bit; on Windows the managed runtime tolerates the missing bit.
+        var zipPath = Path.Combine(Path.GetTempPath(), $"durable-integ-fn-{Guid.NewGuid():N}.zip");
+        try
+        {
+            ZipFile.CreateFromDirectory(publishDir, zipPath, CompressionLevel.Optimal, includeBaseDirectory: false);
+            return await File.ReadAllBytesAsync(zipPath);
+        }
+        finally
+        {
+            try { File.Delete(zipPath); } catch { /* best effort */ }
+        }
     }
 
     /// <summary>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/DurableFunctionDeployment.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/DurableFunctionDeployment.cs
@@ -37,8 +37,22 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
     private static readonly RegionEndpoint DeploymentRegion = RegionEndpoint.USEast1;
 
     private readonly ITestOutputHelper _output;
-    private readonly IAmazonLambda _lambdaClient;
-    private readonly IAmazonIdentityManagementService _iamClient;
+
+    // Clients are shared (static) across all deployments. Each deployment used to construct its
+    // own clients, which defeated adaptive retry: its congestion controller / rate limiter is
+    // per-client, so N independent clients each believed they had capacity, all fired at once, and
+    // collectively blew Lambda's account-wide control-plane limits ("capacity could not be obtained
+    // ... insufficient capacity"). A single shared client per service lets adaptive retry actually
+    // coordinate backoff across the parallel deployments.
+    private static readonly IAmazonLambda _lambdaClient = new AmazonLambdaClient(BuildClientConfig<AmazonLambdaConfig>());
+    private static readonly IAmazonIdentityManagementService _iamClient =
+        new AmazonIdentityManagementServiceClient(BuildClientConfig<AmazonIdentityManagementServiceConfig>());
+
+    // Lambda control-plane calls (CreateFunction/DeleteFunction/GetFunctionConfiguration) are
+    // account-rate-limited and are the next bottleneck once IAM is no longer per-test. Cap how many
+    // run concurrently across the whole suite so the parallel deployments don't collectively exceed
+    // Lambda's limits; data-plane calls (Invoke, durable-execution reads) are not gated.
+    private static readonly SemaphoreSlim LambdaControlPlaneGate = new(2, 2);
 
     private readonly string _functionName;
     private string? _roleArn;
@@ -94,13 +108,6 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
     private DurableFunctionDeployment(ITestOutputHelper output, string suffix)
     {
         _output = output;
-        // The integration suite runs its test classes in parallel, so several deployments hit IAM
-        // (CreateRole/AttachRolePolicy/DeleteRole) at once. IAM has low request-rate limits and
-        // returns "Rate exceeded" under that contention. Adaptive retry adds client-side rate
-        // limiting and backs off on throttling, and a higher retry count rides out longer throttle
-        // windows, instead of failing the test on the first throttle.
-        _lambdaClient = new AmazonLambdaClient(BuildClientConfig<AmazonLambdaConfig>());
-        _iamClient = new AmazonIdentityManagementServiceClient(BuildClientConfig<AmazonIdentityManagementServiceConfig>());
 
         // Truncate the GUID (not the suffix) so CloudTrail entries stay readable.
         // Keep the GUID short enough that the total stays well under 40 chars even for long suffixes.
@@ -354,7 +361,7 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
             var extZipBytes = await BuildAndZipAsync(externalFunctionDir);
 
             _output.WriteLine($"Creating external Lambda function: {_externalFunctionName}");
-            await _lambdaClient.CreateFunctionAsync(new CreateFunctionRequest
+            await RunControlPlaneAsync(() => _lambdaClient.CreateFunctionAsync(new CreateFunctionRequest
             {
                 FunctionName = _externalFunctionName,
                 Runtime = ManagedRuntime,
@@ -365,7 +372,7 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
                 MemorySize = 256,
                 LoggingConfig = new LoggingConfig { LogFormat = LogFormat.JSON }
                 // No DurableConfig — this is a plain function.
-            });
+            }));
             _externalFunctionCreated = true;
 
             _output.WriteLine("Waiting for external function to become Active...");
@@ -423,7 +430,7 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
             };
         }
 
-        var createFunctionResponse = await _lambdaClient.CreateFunctionAsync(createFunctionRequest);
+        var createFunctionResponse = await RunControlPlaneAsync(() => _lambdaClient.CreateFunctionAsync(createFunctionRequest));
         _functionCreated = true;
         _functionArn = createFunctionResponse.FunctionArn;
 
@@ -604,20 +611,41 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
 
     private async Task WaitForFunctionActive(string functionName)
     {
-        for (int i = 0; i < 60; i++)
+        for (int i = 0; i < 40; i++)
         {
             try
             {
-                var config = await _lambdaClient.GetFunctionConfigurationAsync(
-                    new GetFunctionConfigurationRequest { FunctionName = functionName });
+                // Gate each poll call: GetFunctionConfiguration is control-plane and rate-limited,
+                // and all parallel deployments poll at once.
+                var config = await RunControlPlaneAsync(() => _lambdaClient.GetFunctionConfigurationAsync(
+                    new GetFunctionConfigurationRequest { FunctionName = functionName }));
                 if (config.State == State.Active) return;
                 if (config.State == State.Failed)
                     throw new Exception($"Function '{functionName}' creation failed: {config.StateReasonCode} - {config.StateReason}");
             }
             catch (ResourceNotFoundException) { }
-            await Task.Delay(TimeSpan.FromSeconds(2));
+            await Task.Delay(TimeSpan.FromSeconds(3));
         }
         throw new TimeoutException($"Function '{functionName}' did not become Active within 120 seconds");
+    }
+
+    /// <summary>
+    /// Runs a Lambda control-plane operation under <see cref="LambdaControlPlaneGate"/> so the
+    /// suite's parallel deployments don't collectively exceed Lambda's account-wide
+    /// control-plane request rate. Adaptive retry on the shared client handles brief throttles;
+    /// this gate keeps the offered load low enough that retry doesn't exhaust its capacity.
+    /// </summary>
+    private static async Task<T> RunControlPlaneAsync<T>(Func<Task<T>> operation)
+    {
+        await LambdaControlPlaneGate.WaitAsync();
+        try
+        {
+            return await operation();
+        }
+        finally
+        {
+            LambdaControlPlaneGate.Release();
+        }
     }
 
     /// <summary>
@@ -774,7 +802,7 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
             try
             {
                 _output.WriteLine($"Deleting function: {_functionName}");
-                await _lambdaClient.DeleteFunctionAsync(new DeleteFunctionRequest { FunctionName = _functionName });
+                await RunControlPlaneAsync(() => _lambdaClient.DeleteFunctionAsync(new DeleteFunctionRequest { FunctionName = _functionName }));
             }
             catch (Exception ex) { _output.WriteLine($"Cleanup error (function): {ex.Message}"); }
         }
@@ -784,7 +812,7 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
             try
             {
                 _output.WriteLine($"Deleting external function: {_externalFunctionName}");
-                await _lambdaClient.DeleteFunctionAsync(new DeleteFunctionRequest { FunctionName = _externalFunctionName });
+                await RunControlPlaneAsync(() => _lambdaClient.DeleteFunctionAsync(new DeleteFunctionRequest { FunctionName = _externalFunctionName }));
             }
             catch (Exception ex) { _output.WriteLine($"Cleanup error (external function): {ex.Message}"); }
         }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/DurableFunctionDeployment.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/DurableFunctionDeployment.cs
@@ -718,12 +718,22 @@ internal sealed class DurableFunctionDeployment : IAsyncDisposable
                   <ItemGroup>
                 {itemsXml}  </ItemGroup>
                   <Target Name="PublishAll">
-                    <!-- Restore then Publish per project: the MSBuild task's targets run against
-                         each referenced project, so each function restores its own packages before
-                         publishing (an outer -restore would only restore this traversal project). -->
+                    <!-- Restore in a SEPARATE, NON-parallel pass first. Restore is not
+                         parallel-safe: the function projects share src ProjectReferences
+                         (e.g. Amazon.Lambda.Serialization.SystemTextJson), and restoring them
+                         concurrently races on the shared obj/project.assets.json ("file already
+                         exists"). One sequential restore pass writes each shared project's assets
+                         once. (An outer -restore would only restore this traversal project, not the
+                         referenced functions, so it must be done here.) -->
                     <MSBuild
                       Projects="@(FunctionProject)"
-                      Targets="Restore;Publish"
+                      Targets="Restore"
+                      BuildInParallel="false"
+                      Properties="Configuration=Release;RuntimeIdentifier=linux-x64;SelfContained=false" />
+                    <!-- Then publish in parallel; restore is already done so no shared-output race. -->
+                    <MSBuild
+                      Projects="@(FunctionProject)"
+                      Targets="Publish"
                       BuildInParallel="true"
                       Properties="Configuration=Release;RuntimeIdentifier=linux-x64;SelfContained=false;PublishDir=bin\publish\" />
                   </Target>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/xunit.runner.json
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/xunit.runner.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "parallelizeTestCollections": false,
+  "parallelizeTestCollections": true,
   "parallelizeAssembly": false,
-  "maxParallelThreads": 1
+  "maxParallelThreads": 4
 }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/CallbackOperationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/CallbackOperationTests.cs
@@ -163,7 +163,7 @@ public class CallbackOperationTests
 
         // GetResultAsync should signal termination and return a never-completing task.
         var resultTask = callback.GetResultAsync();
-        await Task.Delay(10);
+        await tm.WaitForTerminationAsync();
 
         Assert.True(tm.IsTerminated);
         Assert.False(resultTask.IsCompleted);
@@ -193,7 +193,7 @@ public class CallbackOperationTests
         Assert.False(tm.IsTerminated);
 
         var resultTask = callback.GetResultAsync();
-        await Task.Delay(10);
+        await tm.WaitForTerminationAsync();
 
         Assert.True(tm.IsTerminated);
         Assert.False(resultTask.IsCompleted);

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ChildContextOperationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ChildContextOperationTests.cs
@@ -322,7 +322,7 @@ public class ChildContextOperationTests
             },
             name: "phase");
 
-        await Task.Delay(50);
+        await tm.WaitForTerminationAsync();
 
         Assert.True(tm.IsTerminated);
         Assert.False(task.IsCompleted);

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/DurableContextTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/DurableContextTests.cs
@@ -379,7 +379,7 @@ public class DurableContextTests
         var waitTask = context.WaitAsync(TimeSpan.FromSeconds(30), name: "my_wait");
 
         // Give it a moment to execute
-        await Task.Delay(10);
+        await tm.WaitForTerminationAsync();
 
         Assert.True(tm.IsTerminated);
         Assert.False(waitTask.IsCompleted);
@@ -433,7 +433,7 @@ public class DurableContextTests
 
         var waitTask = context.WaitAsync(TimeSpan.FromSeconds(30), name: "pending_wait");
 
-        await Task.Delay(10);
+        await tm.WaitForTerminationAsync();
 
         Assert.True(tm.IsTerminated);
         Assert.False(waitTask.IsCompleted);

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/InvokeOperationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/InvokeOperationTests.cs
@@ -74,7 +74,7 @@ public class InvokeOperationTests
             payload: "x",
             name: "noversion");
 
-        await Task.Delay(20);
+        await tm.WaitForTerminationAsync();
         Assert.True(tm.IsTerminated);
         Assert.False(task.IsCompleted);
 
@@ -100,7 +100,7 @@ public class InvokeOperationTests
 
         // Service-side suspend mechanics: TerminationManager fires before the
         // user task completes; the task itself never resolves on the fresh path.
-        await Task.Delay(20);
+        await tm.WaitForTerminationAsync();
         Assert.True(tm.IsTerminated);
         Assert.False(task.IsCompleted);
 
@@ -130,7 +130,7 @@ public class InvokeOperationTests
 
         var task = context.InvokeAsync<string, string>(FunctionArn, "payload", name: "no_tenant");
 
-        await Task.Delay(20);
+        await tm.WaitForTerminationAsync();
         Assert.True(tm.IsTerminated);
         Assert.False(task.IsCompleted);
 
@@ -154,7 +154,7 @@ public class InvokeOperationTests
         var (context, recorder, tm, _) = CreateContext();
 
         var task = context.InvokeAsync<string, string>(FunctionArn, "x", name: "sync_flush");
-        await Task.Delay(20);
+        await tm.WaitForTerminationAsync();
 
         Assert.True(tm.IsTerminated);
         Assert.False(task.IsCompleted);
@@ -350,7 +350,7 @@ public class InvokeOperationTests
         });
 
         var task = context.InvokeAsync<string, string>(FunctionArn, "x", name: "still_running");
-        await Task.Delay(20);
+        await tm.WaitForTerminationAsync();
 
         Assert.True(tm.IsTerminated);
         Assert.False(task.IsCompleted);
@@ -377,7 +377,7 @@ public class InvokeOperationTests
         });
 
         var task = context.InvokeAsync<string, string>(FunctionArn, "x", name: "pending");
-        await Task.Delay(20);
+        await tm.WaitForTerminationAsync();
 
         Assert.True(tm.IsTerminated);
         Assert.False(task.IsCompleted);

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/TerminationTestHelpers.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/TerminationTestHelpers.cs
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Lambda.DurableExecution.Internal;
+
+namespace Amazon.Lambda.DurableExecution.Tests;
+
+/// <summary>
+/// Shared helpers for tests that exercise the suspend/terminate path.
+/// </summary>
+internal static class TerminationTestHelpers
+{
+    /// <summary>
+    /// Waits for the suspend signal deterministically instead of a fixed delay, which races under
+    /// CI thread-pool pressure (the original <c>Task.Delay</c> assumed the suspend happened within a
+    /// fixed window, which isn't guaranteed). The suspend path trips
+    /// <see cref="TerminationManager.Terminate"/>, which completes
+    /// <see cref="TerminationManager.TerminationTask"/>. Bounded by a timeout so a genuine
+    /// non-suspension fails fast at the following assert instead of hanging.
+    /// </summary>
+    public static Task WaitForTerminationAsync(this TerminationManager tm, int timeoutSeconds = 10) =>
+        Task.WhenAny(tm.TerminationTask, Task.Delay(TimeSpan.FromSeconds(timeoutSeconds)));
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/WaitForConditionOperationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/WaitForConditionOperationTests.cs
@@ -89,7 +89,7 @@ public class WaitForConditionOperationTests
             },
             name: "poll");
 
-        await Task.Delay(50);
+        await tm.WaitForTerminationAsync();
 
         Assert.True(tm.IsTerminated);
         Assert.False(task.IsCompleted);
@@ -818,7 +818,7 @@ public class WaitForConditionOperationTests
             },
             name: "poll");
 
-        await Task.Delay(50);
+        await tm.WaitForTerminationAsync();
 
         Assert.True(tm.IsTerminated);
         Assert.False(task.IsCompleted);

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/ResponseStreamFactoryTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/ResponseStreamFactoryTests.cs
@@ -90,15 +90,21 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
         /// Validates: Requirements 1.3, 2.2, 2.3
         /// </summary>
         [Fact]
-        public void CreateStream_MultiConcurrencyMode_ReturnsValidStream()
+        public Task CreateStream_MultiConcurrencyMode_ReturnsValidStream()
         {
-            var mock = new MockStreamingRuntimeApiClient();
-            InitializeWithMock("req-2", isMultiConcurrency: true, mock);
+            // Run on an isolated execution-context flow (Task.Run) so the multi-concurrency
+            // AsyncLocal context this writes does not leak onto the reused xUnit worker thread and
+            // contaminate a later on-demand test (see StreamingE2EWithMoq flake).
+            return Task.Run(() =>
+            {
+                var mock = new MockStreamingRuntimeApiClient();
+                InitializeWithMock("req-2", isMultiConcurrency: true, mock);
 
-            var stream = ResponseStreamFactory.CreateStream(Array.Empty<byte>());
+                var stream = ResponseStreamFactory.CreateStream(Array.Empty<byte>());
 
-            Assert.NotNull(stream);
-            Assert.IsAssignableFrom<ResponseStream>(stream);
+                Assert.NotNull(stream);
+                Assert.IsAssignableFrom<ResponseStream>(stream);
+            });
         }
 
         // --- Property 4: Single Stream Per Invocation ---
@@ -192,15 +198,21 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
         }
 
         [Fact]
-        public void InitializeInvocation_MultiConcurrency_SetsUpContext()
+        public Task InitializeInvocation_MultiConcurrency_SetsUpContext()
         {
-            var mock = new MockStreamingRuntimeApiClient();
-            InitializeWithMock("req-5", isMultiConcurrency: true, mock);
+            // Run on an isolated execution-context flow (Task.Run) so the multi-concurrency
+            // AsyncLocal context this writes does not leak onto the reused xUnit worker thread and
+            // contaminate a later on-demand test (see StreamingE2EWithMoq flake).
+            return Task.Run(() =>
+            {
+                var mock = new MockStreamingRuntimeApiClient();
+                InitializeWithMock("req-5", isMultiConcurrency: true, mock);
 
-            Assert.Null(ResponseStreamFactory.GetStreamIfCreated(isMultiConcurrency: true));
+                Assert.Null(ResponseStreamFactory.GetStreamIfCreated(isMultiConcurrency: true));
 
-            var stream = ResponseStreamFactory.CreateStream(Array.Empty<byte>());
-            Assert.NotNull(stream);
+                var stream = ResponseStreamFactory.CreateStream(Array.Empty<byte>());
+                Assert.NotNull(stream);
+            });
         }
 
         [Fact]
@@ -264,21 +276,27 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
         /// Validates: Requirements 2.9, 2.10
         /// </summary>
         [Fact]
-        public async Task StateIsolation_MultiConcurrency_UsesAsyncLocal()
+        public Task StateIsolation_MultiConcurrency_UsesAsyncLocal()
         {
-            var mock = new MockStreamingRuntimeApiClient();
-            InitializeWithMock("req-9", isMultiConcurrency: true, mock);
-            var stream = ResponseStreamFactory.CreateStream(Array.Empty<byte>());
-            Assert.NotNull(stream);
-
-            bool childSawNull = false;
-            await Task.Run(() =>
+            // Run the whole body on an isolated execution-context flow (Task.Run) so the
+            // multi-concurrency AsyncLocal context written here does not leak onto the reused xUnit
+            // worker thread and contaminate a later on-demand test (see StreamingE2EWithMoq flake).
+            return Task.Run(async () =>
             {
-                ResponseStreamFactory.CleanupInvocation(isMultiConcurrency: true);
-                childSawNull = ResponseStreamFactory.GetStreamIfCreated(isMultiConcurrency: true) == null;
-            });
+                var mock = new MockStreamingRuntimeApiClient();
+                InitializeWithMock("req-9", isMultiConcurrency: true, mock);
+                var stream = ResponseStreamFactory.CreateStream(Array.Empty<byte>());
+                Assert.NotNull(stream);
 
-            Assert.True(childSawNull);
+                bool childSawNull = false;
+                await Task.Run(() =>
+                {
+                    ResponseStreamFactory.CleanupInvocation(isMultiConcurrency: true);
+                    childSawNull = ResponseStreamFactory.GetStreamIfCreated(isMultiConcurrency: true) == null;
+                });
+
+                Assert.True(childSawNull);
+            });
         }
     }
 }

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/StreamingE2EWithMoq.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/StreamingE2EWithMoq.cs
@@ -37,7 +37,15 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
     [Collection("RuntimeSupportStateCheck")]
     public class StreamingE2EWithMoq : IDisposable
     {
-        public void Dispose()
+        // Reset the factory's static/async-local state before AND after each test so these tests
+        // start from a clean slate. The root cause of the cross-test leak (multi-concurrency tests
+        // writing the AsyncLocal on a reused xUnit worker thread) is contained at its source by
+        // running those tests on isolated Task.Run flows; this reset is belt-and-suspenders.
+        public StreamingE2EWithMoq() => ResetFactoryState();
+
+        public void Dispose() => ResetFactoryState();
+
+        private static void ResetFactoryState()
         {
             ResponseStreamFactory.CleanupInvocation(isMultiConcurrency: false);
             ResponseStreamFactory.CleanupInvocation(isMultiConcurrency: true);

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestFileStream.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestFileStream.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace Amazon.Lambda.RuntimeSupport.UnitTests.TestHelpers
 {
@@ -19,13 +17,14 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests.TestHelpers
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            WriteAction(TrimTrailingNullBytes(buffer).Take(count).ToArray(), offset, count);
-        }
-
-        private static IEnumerable<byte> TrimTrailingNullBytes(IEnumerable<byte> buffer)
-        {
-            // Trim trailing null bytes to make testing assertions easier
-            return buffer.Reverse().SkipWhile(x => x == 0).Reverse();
+            // Capture exactly the bytes that were written: [offset, offset + count).
+            // The previous implementation trimmed trailing null bytes from the buffer, which was
+            // flaky: a log header ends with an 8-byte big-endian microsecond timestamp, and roughly
+            // 1 in 256 timestamps ends in a 0x00 byte. Trimming that legitimate byte made the
+            // captured header 15 bytes instead of 16 and failed MaxSizeProducesOneLogFrame.
+            var written = new byte[count];
+            Array.Copy(buffer, offset, written, 0, count);
+            WriteAction(written, offset, count);
         }
     }
 }

--- a/Libraries/test/IntegrationTests.Helpers/LambdaHelper.cs
+++ b/Libraries/test/IntegrationTests.Helpers/LambdaHelper.cs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using Amazon.CloudFormation;
+using Amazon.CloudFormation.Model;
 using Amazon.Lambda;
 using Amazon.Lambda.Model;
 
@@ -10,31 +13,39 @@ namespace IntegrationTests.Helpers
 {
     public class LambdaHelper
     {
-        private readonly IAmazonLambda _lambdaClient;
+        // Resource type that SAM AWS::Serverless::Function resources are transformed into in the deployed stack.
+        private const string LambdaFunctionResourceType = "AWS::Lambda::Function";
 
-        public LambdaHelper(IAmazonLambda lambdaClient)
+        private readonly IAmazonLambda _lambdaClient;
+        private readonly IAmazonCloudFormation _cloudFormationClient;
+
+        public LambdaHelper(IAmazonLambda lambdaClient, IAmazonCloudFormation cloudFormationClient)
         {
             _lambdaClient = lambdaClient;
+            _cloudFormationClient = cloudFormationClient;
         }
 
+        /// <summary>
+        /// Returns the Lambda functions belonging to a CloudFormation stack by listing the stack's
+        /// resources directly. This is O(stack size) and independent of how many functions exist in
+        /// the account, unlike scanning every function and reading its tags one at a time, which is
+        /// slow and prone to throttling in a shared test account.
+        /// </summary>
         public async Task<List<LambdaFunction>> FilterByCloudFormationStackAsync(string stackName)
         {
-            const string stackNameKey = "aws:cloudformation:stack-name";
-            const string logicalIdKey = "aws:cloudformation:logical-id";
             var lambdaFunctions = new List<LambdaFunction>();
-            var paginator = _lambdaClient.Paginators.ListFunctions(new ListFunctionsRequest());
+            var paginator = _cloudFormationClient.Paginators.ListStackResources(
+                new ListStackResourcesRequest { StackName = stackName });
 
-            await foreach (var function in paginator.Functions)
+            await foreach (var resource in paginator.StackResourceSummaries)
             {
-                var tags = (await _lambdaClient.ListTagsAsync(new ListTagsRequest { Resource = function.FunctionArn })).Tags;
-                if (tags.ContainsKey(stackNameKey) && string.Equals(tags[stackNameKey], stackName))
+                if (string.Equals(resource.ResourceType, LambdaFunctionResourceType))
                 {
-                    var lambdaFunction = new LambdaFunction
+                    lambdaFunctions.Add(new LambdaFunction
                     {
-                        LogicalId = tags[logicalIdKey],
-                        Name = function.FunctionName
-                    };
-                    lambdaFunctions.Add(lambdaFunction);
+                        LogicalId = resource.LogicalResourceId,
+                        Name = resource.PhysicalResourceId
+                    });
                 }
             }
 

--- a/Libraries/test/IntegrationTests.Helpers/RetryHelper.cs
+++ b/Libraries/test/IntegrationTests.Helpers/RetryHelper.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace IntegrationTests.Helpers
@@ -11,6 +13,45 @@ namespace IntegrationTests.Helpers
     /// </summary>
     public static class RetryHelper
     {
+        /// <summary>
+        /// Sends an HTTP request, retrying while API Gateway returns <see cref="HttpStatusCode.Forbidden"/>
+        /// on what is expected to be an authorized request. A freshly deployed API Gateway stage can
+        /// transiently 403 on the authorizer "allow" path until the Lambda authorizer wiring has fully
+        /// propagated; once propagated the request returns a stable non-403 status. Because
+        /// <see cref="HttpRequestMessage"/> cannot be resent, the caller supplies a factory that builds a
+        /// fresh request for each attempt.
+        /// </summary>
+        /// <param name="httpClient">The client used to send the request.</param>
+        /// <param name="requestFactory">Builds a fresh request for each attempt.</param>
+        /// <param name="timeout">Maximum total time to keep retrying. Defaults to 2 minutes.</param>
+        /// <param name="pollInterval">Delay between attempts. Defaults to 5 seconds.</param>
+        /// <returns>The first non-403 response, or the last 403 response if the timeout elapses.</returns>
+        public static async Task<HttpResponseMessage> SendWithRetryOnForbiddenAsync(
+            HttpClient httpClient,
+            Func<HttpRequestMessage> requestFactory,
+            TimeSpan? timeout = null,
+            TimeSpan? pollInterval = null)
+        {
+            if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
+            if (requestFactory == null) throw new ArgumentNullException(nameof(requestFactory));
+
+            var interval = pollInterval ?? TimeSpan.FromSeconds(5);
+            var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromMinutes(2));
+
+            HttpResponseMessage response;
+            while (true)
+            {
+                response = await httpClient.SendAsync(requestFactory());
+                if (response.StatusCode != HttpStatusCode.Forbidden || DateTime.UtcNow >= deadline)
+                {
+                    return response;
+                }
+
+                response.Dispose();
+                await Task.Delay(interval);
+            }
+        }
+
         /// <summary>
         /// Polls <paramref name="condition"/> until it returns <c>true</c> or <paramref name="timeout"/> elapses.
         /// Useful for gating tests on resources that report ready (e.g. CloudFormation CREATE_COMPLETE)

--- a/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/DeploymentScript.ps1
+++ b/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/DeploymentScript.ps1
@@ -59,11 +59,51 @@ try
         throw "Failed to create the following bucket: $identifier"
     }
     dotnet restore
-    Write-Host "Creating CloudFormation Stack $identifier, Architecture $arch"
-    dotnet lambda deploy-serverless
-    if (!$?)
+
+    # Deploy with retries. The stack contains many Lambda functions that each reference
+    # an IAM role created in the same stack. CloudFormation occasionally calls Lambda
+    # CreateFunction before the role's trust policy has propagated through IAM, producing
+    # "The role defined for the function cannot be assumed by Lambda" and rolling the whole
+    # stack back. This is a transient eventual-consistency race, so retry the deployment.
+    $maxAttempts = 3
+    $deploySucceeded = $false
+    for ($attempt = 1; $attempt -le $maxAttempts; $attempt++)
     {
-        throw "Failed to create the following CloudFormation stack: $identifier"
+        Write-Host "Creating CloudFormation Stack $identifier, Architecture $arch (attempt $attempt of $maxAttempts)"
+        dotnet lambda deploy-serverless
+        if ($?)
+        {
+            $deploySucceeded = $true
+            break
+        }
+
+        Write-Host "Deployment attempt $attempt failed. Fetching CloudFormation stack events for debugging..."
+        try {
+            $events = aws cloudformation describe-stack-events --stack-name $identifier --query "StackEvents[?ResourceStatus=='CREATE_FAILED' || ResourceStatus=='UPDATE_FAILED' || ResourceStatus=='DELETE_FAILED']" --output json 2>&1
+            if ($events) {
+                Write-Host "CloudFormation failed events:"
+                Write-Host $events
+            }
+        }
+        catch {
+            Write-Host "Could not fetch CloudFormation events: $_"
+        }
+
+        if ($attempt -lt $maxAttempts)
+        {
+            # A failed create leaves the stack in ROLLBACK_COMPLETE, which cannot be updated
+            # or re-created. Delete it (and wait for the delete to finish) before retrying.
+            Write-Host "Deleting rolled-back stack $identifier before retrying..."
+            aws cloudformation delete-stack --stack-name $identifier
+            aws cloudformation wait stack-delete-complete --stack-name $identifier
+            # Brief pause to give IAM additional time to settle before the next attempt.
+            Start-Sleep -Seconds 15
+        }
+    }
+
+    if (!$deploySucceeded)
+    {
+        throw "Failed to create the following CloudFormation stack after $maxAttempts attempts: $identifier"
     }
 }
 finally

--- a/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/DeploymentScript.ps1
+++ b/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/DeploymentScript.ps1
@@ -42,7 +42,32 @@ try
     $json =  Get-Content .\aws-lambda-tools-defaults.json | Out-String | ConvertFrom-Json
     $region = $json.region
 
-    dotnet tool install -g Amazon.Lambda.Tools
+    # Install Amazon.Lambda.Tools idempotently. The integration test projects deploy in parallel,
+    # so several DeploymentScript.ps1 processes may run "dotnet tool install -g" at the same time and
+    # collide on the global tool store ("a file or directory with the same name already exists").
+    # Skip if already present, and tolerate the concurrent-install race by treating an
+    # already-installed/already-exists result as success, with a short retry for the transient case.
+    if (dotnet tool list -g | Select-String -SimpleMatch 'amazon.lambda.tools')
+    {
+        Write-Host "Amazon.Lambda.Tools already installed."
+    }
+    else
+    {
+        for ($i = 1; $i -le 5; $i++)
+        {
+            $output = dotnet tool install -g Amazon.Lambda.Tools 2>&1 | Out-String
+            Write-Host $output
+            if ($LASTEXITCODE -eq 0 -or $output -match 'already installed' -or $output -match 'already exists')
+            {
+                break
+            }
+            if ($i -eq 5)
+            {
+                throw "Failed to install Amazon.Lambda.Tools after $i attempts."
+            }
+            Start-Sleep -Seconds ($i * 3)
+        }
+    }
     Write-Host "Creating S3 Bucket $identifier"
 
     if(![string]::IsNullOrEmpty($region))

--- a/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/HealthCheckTests.cs
+++ b/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/HealthCheckTests.cs
@@ -1,13 +1,13 @@
 using System.Net;
 using Xunit;
+using Xunit.Extensions.AssemblyFixture;
 
 namespace TestCustomAuthorizerApp.IntegrationTests;
 
 /// <summary>
 /// Tests for the health check endpoint which does not require authorization.
 /// </summary>
-[Collection("Integration Tests")]
-public class HealthCheckTests
+public class HealthCheckTests : IAssemblyFixture<IntegrationTestContextFixture>
 {
     private readonly IntegrationTestContextFixture _fixture;
 

--- a/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/HttpApiV1Tests.cs
+++ b/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/HttpApiV1Tests.cs
@@ -33,12 +33,8 @@ public class HttpApiV1Tests : IAssemblyFixture<IntegrationTestContextFixture>
     [Fact]
     public async Task HttpApiV1UserInfo_WithValidAuth_ReturnsAuthorizerContext()
     {
-        // Arrange
-        var request = new HttpRequestMessage(HttpMethod.Get, $"{_fixture.HttpApiUrl}/api/http-v1-user-info");
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
-
-        // Act
-        var response = await _fixture.HttpClient.SendAsync(request);
+        // Act - retry on transient 403 while the freshly deployed authorizer wiring propagates
+        var response = await _fixture.GetWithValidTokenAsync($"{_fixture.HttpApiUrl}/api/http-v1-user-info");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/HttpApiV1Tests.cs
+++ b/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/HttpApiV1Tests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Extensions.AssemblyFixture;
 
 namespace TestCustomAuthorizerApp.IntegrationTests;
 
@@ -12,8 +13,7 @@ namespace TestCustomAuthorizerApp.IntegrationTests;
 /// These tests verify that the source-generated Lambda handler correctly extracts
 /// values from the authorizer context using [FromCustomAuthorizer] attributes.
 /// </summary>
-[Collection("Integration Tests")]
-public class HttpApiV1Tests
+public class HttpApiV1Tests : IAssemblyFixture<IntegrationTestContextFixture>
 {
     private readonly IntegrationTestContextFixture _fixture;
 

--- a/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/HttpApiV2Tests.cs
+++ b/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/HttpApiV2Tests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Extensions.AssemblyFixture;
 
 namespace TestCustomAuthorizerApp.IntegrationTests;
 
@@ -12,8 +13,7 @@ namespace TestCustomAuthorizerApp.IntegrationTests;
 /// These tests verify that the source-generated Lambda handler correctly extracts
 /// values from the authorizer context using [FromCustomAuthorizer] attributes.
 /// </summary>
-[Collection("Integration Tests")]
-public class HttpApiV2Tests
+public class HttpApiV2Tests : IAssemblyFixture<IntegrationTestContextFixture>
 {
     private readonly IntegrationTestContextFixture _fixture;
 

--- a/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/HttpApiV2Tests.cs
+++ b/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/HttpApiV2Tests.cs
@@ -31,12 +31,8 @@ public class HttpApiV2Tests : IAssemblyFixture<IntegrationTestContextFixture>
     [Fact]
     public async Task ProtectedEndpoint_WithValidAuth_ReturnsSuccess()
     {
-        // Arrange
-        var request = new HttpRequestMessage(HttpMethod.Get, $"{_fixture.HttpApiUrl}/api/protected");
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
-
-        // Act
-        var response = await _fixture.HttpClient.SendAsync(request);
+        // Act - retry on transient 403 while the freshly deployed authorizer wiring propagates
+        var response = await _fixture.GetWithValidTokenAsync($"{_fixture.HttpApiUrl}/api/protected");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -56,12 +52,8 @@ public class HttpApiV2Tests : IAssemblyFixture<IntegrationTestContextFixture>
     [Fact]
     public async Task UserInfo_WithValidAuth_ReturnsAuthorizerContext()
     {
-        // Arrange
-        var request = new HttpRequestMessage(HttpMethod.Get, $"{_fixture.HttpApiUrl}/api/user-info");
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
-
-        // Act
-        var response = await _fixture.HttpClient.SendAsync(request);
+        // Act - retry on transient 403 while the freshly deployed authorizer wiring propagates
+        var response = await _fixture.GetWithValidTokenAsync($"{_fixture.HttpApiUrl}/api/user-info");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -97,12 +89,8 @@ public class HttpApiV2Tests : IAssemblyFixture<IntegrationTestContextFixture>
     [Fact]
     public async Task IHttpResult_WithValidAuth_ReturnsSuccess()
     {
-        // Arrange
-        var request = new HttpRequestMessage(HttpMethod.Get, $"{_fixture.HttpApiUrl}/api/ihttpresult-user-info");
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
-
-        // Act
-        var response = await _fixture.HttpClient.SendAsync(request);
+        // Act - retry on transient 403 while the freshly deployed authorizer wiring propagates
+        var response = await _fixture.GetWithValidTokenAsync($"{_fixture.HttpApiUrl}/api/ihttpresult-user-info");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/IntegrationTestContextFixture.cs
+++ b/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/IntegrationTestContextFixture.cs
@@ -39,9 +39,10 @@ public class IntegrationTestContextFixture : IAsyncLifetime
 
     public IntegrationTestContextFixture()
     {
-        _cloudFormationHelper = new CloudFormationHelper(new AmazonCloudFormationClient(Amazon.RegionEndpoint.USWest2));
+        var cloudFormationClient = new AmazonCloudFormationClient(Amazon.RegionEndpoint.USWest2);
+        _cloudFormationHelper = new CloudFormationHelper(cloudFormationClient);
         _s3Helper = new S3Helper(new AmazonS3Client(Amazon.RegionEndpoint.USWest2));
-        LambdaHelper = new LambdaHelper(new AmazonLambdaClient(Amazon.RegionEndpoint.USWest2));
+        LambdaHelper = new LambdaHelper(new AmazonLambdaClient(Amazon.RegionEndpoint.USWest2), cloudFormationClient);
         CloudWatchHelper = new CloudWatchHelper(new AmazonCloudWatchLogsClient(Amazon.RegionEndpoint.USWest2));
         HttpClient = new HttpClient();
     }

--- a/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/IntegrationTestContextFixture.cs
+++ b/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/IntegrationTestContextFixture.cs
@@ -100,18 +100,49 @@ public class IntegrationTestContextFixture : IAsyncLifetime
     }
 
     /// <summary>
-    /// Polls a representative "allow path" endpoint on each deployed API until the custom authorizer
+    /// Sends an authenticated GET (valid-token) to <paramref name="url"/>, retrying on a transient 403
+    /// from API Gateway. A freshly deployed stage can briefly 403 on the authorizer "allow" path until
+    /// the Lambda authorizer wiring finishes propagating; this resends until a stable non-403 response
+    /// (200 or 401) is returned. Use this for any test that asserts an authorized request succeeds.
+    /// </summary>
+    public Task<HttpResponseMessage> GetWithValidTokenAsync(string url)
+    {
+        return RetryHelper.SendWithRetryOnForbiddenAsync(HttpClient, () =>
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "valid-token");
+            return request;
+        });
+    }
+
+    /// <summary>
+    /// Polls every authorizer "allow path" endpoint on each deployed API until the custom authorizer
     /// is fully wired and the request succeeds (or a 401 from the backend), confirming the API is
     /// serving traffic before the test suite runs.
+    ///
+    /// Every distinct authorizer must be warmed individually: API Gateway propagates each authorizer's
+    /// invoke wiring separately, so warming one endpoint does not guarantee a sibling authorizer on the
+    /// same API is ready. The REST API endpoints are listed first because REST (v1) stages settle slower
+    /// than HTTP (v2).
     /// </summary>
     private async Task WarmUpApisAsync()
     {
         var timeout = TimeSpan.FromMinutes(2);
         var pollInterval = TimeSpan.FromSeconds(5);
 
-        // A warmed-up authorizer returns a non-403 response on the allow path: either 200 (context
-        // present) or 401 (backend rejects missing context). A 403 means API Gateway could not yet
-        // invoke/attach the authorizer, so keep waiting.
+        // One representative allow-path endpoint per distinct authorizer. A warmed-up authorizer returns
+        // a non-403 response on the allow path: either 200 (context present) or 401 (backend rejects
+        // missing context). A 403 means API Gateway could not yet invoke/attach the authorizer, so keep
+        // waiting.
+        var allowPaths = new[]
+        {
+            $"{RestApiUrl}/api/rest-user-info",          // RestApiAuthorizer (REST API token authorizer)
+            $"{RestApiUrl}/api/simple-restapi-user-info",// SimpleRestAuthorizer (IAuthorizerResult REST authorizer)
+            $"{HttpApiUrl}/api/user-info",               // CustomAuthorizer (HTTP API v2)
+            $"{HttpApiUrl}/api/http-v1-user-info",       // CustomAuthorizerV1 (HTTP API v1)
+            $"{HttpApiUrl}/api/simple-httpapi-user-info" // SimpleAuthorizer (IAuthorizerResult HTTP authorizer)
+        };
+
         async Task<bool> EndpointIsReady(string url)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, url);
@@ -120,13 +151,12 @@ public class IntegrationTestContextFixture : IAsyncLifetime
             return response.StatusCode != System.Net.HttpStatusCode.Forbidden;
         }
 
-        var restReady = await RetryHelper.WaitForConditionAsync(
-            () => EndpointIsReady($"{RestApiUrl}/api/rest-user-info"), timeout, pollInterval);
-        Console.WriteLine($"[IntegrationTest] REST API warm-up {(restReady ? "succeeded" : "timed out")}.");
-
-        var httpReady = await RetryHelper.WaitForConditionAsync(
-            () => EndpointIsReady($"{HttpApiUrl}/api/user-info"), timeout, pollInterval);
-        Console.WriteLine($"[IntegrationTest] HTTP API warm-up {(httpReady ? "succeeded" : "timed out")}.");
+        foreach (var url in allowPaths)
+        {
+            var ready = await RetryHelper.WaitForConditionAsync(
+                () => EndpointIsReady(url), timeout, pollInterval);
+            Console.WriteLine($"[IntegrationTest] Warm-up for '{url}' {(ready ? "succeeded" : "timed out")}.");
+        }
     }
 
     public async Task DisposeAsync()

--- a/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/IntegrationTestContextFixtureCollection.cs
+++ b/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/IntegrationTestContextFixtureCollection.cs
@@ -1,11 +1,4 @@
-using Xunit;
-
-namespace TestCustomAuthorizerApp.IntegrationTests;
-
-[CollectionDefinition("Integration Tests", DisableParallelization = true)]
-public class IntegrationTestContextFixtureCollection : ICollectionFixture<IntegrationTestContextFixture>
-{
-    // This class has no code, and is never created. Its purpose is simply
-    // to be the place to apply [CollectionDefinition] and all the
-    // ICollectionFixture<> interfaces.
-}
+// Registers the AssemblyFixture test framework so test classes can share a single
+// IntegrationTestContextFixture (one deployed stack) via IAssemblyFixture<T> while still
+// running in parallel. Without this attribute IAssemblyFixture<T> is silently ignored.
+[assembly: Xunit.TestFramework("Xunit.Extensions.AssemblyFixture.AssemblyFixtureFramework", "Xunit.Extensions.AssemblyFixture")]

--- a/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/NonStringAuthorizerTests.cs
+++ b/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/NonStringAuthorizerTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Extensions.AssemblyFixture;
 
 namespace TestCustomAuthorizerApp.IntegrationTests;
 
@@ -13,8 +14,7 @@ namespace TestCustomAuthorizerApp.IntegrationTests;
 /// These tests exercise the type conversion logic in the .tt template's generated code
 /// using Convert.ChangeType() to convert authorizer context values to the parameter types.
 /// </summary>
-[Collection("Integration Tests")]
-public class NonStringAuthorizerTests
+public class NonStringAuthorizerTests : IAssemblyFixture<IntegrationTestContextFixture>
 {
     private readonly IntegrationTestContextFixture _fixture;
 

--- a/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/NonStringAuthorizerTests.cs
+++ b/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/NonStringAuthorizerTests.cs
@@ -35,12 +35,8 @@ public class NonStringAuthorizerTests : IAssemblyFixture<IntegrationTestContextF
     [Fact]
     public async Task NonStringUserInfo_WithValidAuth_ReturnsConvertedValues()
     {
-        // Arrange
-        var request = new HttpRequestMessage(HttpMethod.Get, $"{_fixture.HttpApiUrl}/api/nonstring-user-info");
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
-
-        // Act
-        var response = await _fixture.HttpClient.SendAsync(request);
+        // Act - retry on transient 403 while the freshly deployed authorizer wiring propagates
+        var response = await _fixture.GetWithValidTokenAsync($"{_fixture.HttpApiUrl}/api/nonstring-user-info");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -90,12 +86,8 @@ public class NonStringAuthorizerTests : IAssemblyFixture<IntegrationTestContextF
     [Fact]
     public async Task NonStringUserInfo_IntValueIsCorrectType()
     {
-        // Arrange
-        var request = new HttpRequestMessage(HttpMethod.Get, $"{_fixture.HttpApiUrl}/api/nonstring-user-info");
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
-
-        // Act
-        var response = await _fixture.HttpClient.SendAsync(request);
+        // Act - retry on transient 403 while the freshly deployed authorizer wiring propagates
+        var response = await _fixture.GetWithValidTokenAsync($"{_fixture.HttpApiUrl}/api/nonstring-user-info");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -114,12 +106,8 @@ public class NonStringAuthorizerTests : IAssemblyFixture<IntegrationTestContextF
     [Fact]
     public async Task NonStringUserInfo_BoolValueIsCorrectType()
     {
-        // Arrange
-        var request = new HttpRequestMessage(HttpMethod.Get, $"{_fixture.HttpApiUrl}/api/nonstring-user-info");
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
-
-        // Act
-        var response = await _fixture.HttpClient.SendAsync(request);
+        // Act - retry on transient 403 while the freshly deployed authorizer wiring propagates
+        var response = await _fixture.GetWithValidTokenAsync($"{_fixture.HttpApiUrl}/api/nonstring-user-info");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/RestApiTests.cs
+++ b/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/RestApiTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Extensions.AssemblyFixture;
 
 namespace TestCustomAuthorizerApp.IntegrationTests;
 
@@ -12,8 +13,7 @@ namespace TestCustomAuthorizerApp.IntegrationTests;
 /// These tests verify that the source-generated Lambda handler correctly extracts
 /// values from the authorizer context using [FromCustomAuthorizer] attributes.
 /// </summary>
-[Collection("Integration Tests")]
-public class RestApiTests
+public class RestApiTests : IAssemblyFixture<IntegrationTestContextFixture>
 {
     private readonly IntegrationTestContextFixture _fixture;
 

--- a/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/RestApiTests.cs
+++ b/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/RestApiTests.cs
@@ -34,12 +34,8 @@ public class RestApiTests : IAssemblyFixture<IntegrationTestContextFixture>
     [Fact]
     public async Task RestUserInfo_WithValidAuth_ReturnsAuthorizerContext()
     {
-        // Arrange
-        var request = new HttpRequestMessage(HttpMethod.Get, $"{_fixture.RestApiUrl}/api/rest-user-info");
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
-
-        // Act
-        var response = await _fixture.HttpClient.SendAsync(request);
+        // Act - retry on transient 403 while the freshly deployed authorizer wiring propagates
+        var response = await _fixture.GetWithValidTokenAsync($"{_fixture.RestApiUrl}/api/rest-user-info");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/SimpleHttpApiAuthorizerTests.cs
+++ b/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/SimpleHttpApiAuthorizerTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Extensions.AssemblyFixture;
 
 namespace TestCustomAuthorizerApp.IntegrationTests;
 
@@ -13,8 +14,7 @@ namespace TestCustomAuthorizerApp.IntegrationTests;
 /// The authorizer under test is <see cref="TestCustomAuthorizerApp.AuthorizerFunction.SimpleHttpApiAuthorize"/>
 /// which returns IAuthorizerResult (AuthorizerResults.Allow()/Deny()) instead of raw API Gateway types.
 /// </summary>
-[Collection("Integration Tests")]
-public class SimpleHttpApiAuthorizerTests
+public class SimpleHttpApiAuthorizerTests : IAssemblyFixture<IntegrationTestContextFixture>
 {
     private readonly IntegrationTestContextFixture _fixture;
 

--- a/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/SimpleHttpApiAuthorizerTests.cs
+++ b/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/SimpleHttpApiAuthorizerTests.cs
@@ -34,12 +34,8 @@ public class SimpleHttpApiAuthorizerTests : IAssemblyFixture<IntegrationTestCont
     [Fact]
     public async Task SimpleHttpApiUserInfo_WithValidAuth_ReturnsAuthorizerContext()
     {
-        // Arrange
-        var request = new HttpRequestMessage(HttpMethod.Get, $"{_fixture.HttpApiUrl}/api/simple-httpapi-user-info");
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
-
-        // Act
-        var response = await _fixture.HttpClient.SendAsync(request);
+        // Act - retry on transient 403 while the freshly deployed authorizer wiring propagates
+        var response = await _fixture.GetWithValidTokenAsync($"{_fixture.HttpApiUrl}/api/simple-httpapi-user-info");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/SimpleRestApiAuthorizerTests.cs
+++ b/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/SimpleRestApiAuthorizerTests.cs
@@ -36,12 +36,8 @@ public class SimpleRestApiAuthorizerTests : IAssemblyFixture<IntegrationTestCont
     [Fact]
     public async Task SimpleRestApiUserInfo_WithValidAuth_ReturnsAuthorizerContext()
     {
-        // Arrange
-        var request = new HttpRequestMessage(HttpMethod.Get, $"{_fixture.RestApiUrl}/api/simple-restapi-user-info");
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
-
-        // Act
-        var response = await _fixture.HttpClient.SendAsync(request);
+        // Act - retry on transient 403 while the freshly deployed authorizer wiring propagates
+        var response = await _fixture.GetWithValidTokenAsync($"{_fixture.RestApiUrl}/api/simple-restapi-user-info");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/SimpleRestApiAuthorizerTests.cs
+++ b/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/SimpleRestApiAuthorizerTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Extensions.AssemblyFixture;
 
 namespace TestCustomAuthorizerApp.IntegrationTests;
 
@@ -14,8 +15,7 @@ namespace TestCustomAuthorizerApp.IntegrationTests;
 /// which returns IAuthorizerResult (AuthorizerResults.Allow()/Deny()) instead of raw API Gateway types.
 /// The generated handler serializes this to an IAM policy document with the correct MethodArn.
 /// </summary>
-[Collection("Integration Tests")]
-public class SimpleRestApiAuthorizerTests
+public class SimpleRestApiAuthorizerTests : IAssemblyFixture<IntegrationTestContextFixture>
 {
     private readonly IntegrationTestContextFixture _fixture;
 

--- a/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/TestCustomAuthorizerApp.IntegrationTests.csproj
+++ b/Libraries/test/TestCustomAuthorizerApp.IntegrationTests/TestCustomAuthorizerApp.IntegrationTests.csproj
@@ -13,6 +13,9 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="xunit" Version="2.9.3" />
+        <!-- Shares one deployed-stack fixture across the whole assembly (IAssemblyFixture) so the
+             test classes can run in parallel instead of being serialized in a single collection. -->
+        <PackageReference Include="Xunit.Extensions.AssemblyFixture" Version="2.6.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/Libraries/test/TestCustomAuthorizerApp/serverless.template
+++ b/Libraries/test/TestCustomAuthorizerApp/serverless.template
@@ -70,6 +70,9 @@
       "Type": "AWS::Serverless::Api",
       "Properties": {
         "StageName": "Prod",
+        "EndpointConfiguration": {
+          "Type": "REGIONAL"
+        },
         "Auth": {
           "Authorizers": {
             "RestApiAuthorizer": {

--- a/Libraries/test/TestServerlessApp.ALB.IntegrationTests/ALBIntegrationTestContextFixture.cs
+++ b/Libraries/test/TestServerlessApp.ALB.IntegrationTests/ALBIntegrationTestContextFixture.cs
@@ -35,9 +35,10 @@ namespace TestServerlessApp.ALB.IntegrationTests
 
         public ALBIntegrationTestContextFixture()
         {
-            _cloudFormationHelper = new CloudFormationHelper(new AmazonCloudFormationClient(Amazon.RegionEndpoint.USWest2));
+            var cloudFormationClient = new AmazonCloudFormationClient(Amazon.RegionEndpoint.USWest2);
+            _cloudFormationHelper = new CloudFormationHelper(cloudFormationClient);
             _s3Helper = new S3Helper(new AmazonS3Client(Amazon.RegionEndpoint.USWest2));
-            LambdaHelper = new LambdaHelper(new AmazonLambdaClient(Amazon.RegionEndpoint.USWest2));
+            LambdaHelper = new LambdaHelper(new AmazonLambdaClient(Amazon.RegionEndpoint.USWest2), cloudFormationClient);
             ELBv2Client = new AmazonElasticLoadBalancingV2Client(Amazon.RegionEndpoint.USWest2);
             HttpClient = new HttpClient();
         }

--- a/Libraries/test/TestServerlessApp.ALB.IntegrationTests/DeploymentScript.ps1
+++ b/Libraries/test/TestServerlessApp.ALB.IntegrationTests/DeploymentScript.ps1
@@ -42,7 +42,32 @@ try
     $json = Get-Content .\aws-lambda-tools-defaults.json | Out-String | ConvertFrom-Json
     $region = $json.region
 
-    dotnet tool install -g Amazon.Lambda.Tools
+    # Install Amazon.Lambda.Tools idempotently. The integration test projects deploy in parallel,
+    # so several DeploymentScript.ps1 processes may run "dotnet tool install -g" at the same time and
+    # collide on the global tool store ("a file or directory with the same name already exists").
+    # Skip if already present, and tolerate the concurrent-install race by treating an
+    # already-installed/already-exists result as success, with a short retry for the transient case.
+    if (dotnet tool list -g | Select-String -SimpleMatch 'amazon.lambda.tools')
+    {
+        Write-Host "Amazon.Lambda.Tools already installed."
+    }
+    else
+    {
+        for ($i = 1; $i -le 5; $i++)
+        {
+            $output = dotnet tool install -g Amazon.Lambda.Tools 2>&1 | Out-String
+            Write-Host $output
+            if ($LASTEXITCODE -eq 0 -or $output -match 'already installed' -or $output -match 'already exists')
+            {
+                break
+            }
+            if ($i -eq 5)
+            {
+                throw "Failed to install Amazon.Lambda.Tools after $i attempts."
+            }
+            Start-Sleep -Seconds ($i * 3)
+        }
+    }
     Write-Host "Creating S3 Bucket $identifier"
 
     if(![string]::IsNullOrEmpty($region))

--- a/Libraries/test/TestServerlessApp.IntegrationTests/ComplexCalculator.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/ComplexCalculator.cs
@@ -4,11 +4,11 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Extensions.AssemblyFixture;
 
 namespace TestServerlessApp.IntegrationTests
 {
-    [Collection("Integration Tests")]
-    public class ComplexCalculator
+    public class ComplexCalculator : IAssemblyFixture<IntegrationTestContextFixture>
     {
         private readonly IntegrationTestContextFixture _fixture;
 

--- a/Libraries/test/TestServerlessApp.IntegrationTests/CustomResponse.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/CustomResponse.cs
@@ -6,11 +6,11 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Extensions.AssemblyFixture;
 
 namespace TestServerlessApp.IntegrationTests
 {
-    [Collection("Integration Tests")]
-    public class CustomResponse
+    public class CustomResponse : IAssemblyFixture<IntegrationTestContextFixture>
     {
         private readonly IntegrationTestContextFixture _fixture;
 

--- a/Libraries/test/TestServerlessApp.IntegrationTests/DeploymentScript.ps1
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/DeploymentScript.ps1
@@ -42,7 +42,32 @@ try
     $json =  Get-Content .\aws-lambda-tools-defaults.json | Out-String | ConvertFrom-Json
     $region = $json.region
 
-    dotnet tool install -g Amazon.Lambda.Tools
+    # Install Amazon.Lambda.Tools idempotently. The integration test projects deploy in parallel,
+    # so several DeploymentScript.ps1 processes may run "dotnet tool install -g" at the same time and
+    # collide on the global tool store ("a file or directory with the same name already exists").
+    # Skip if already present, and tolerate the concurrent-install race by treating an
+    # already-installed/already-exists result as success, with a short retry for the transient case.
+    if (dotnet tool list -g | Select-String -SimpleMatch 'amazon.lambda.tools')
+    {
+        Write-Host "Amazon.Lambda.Tools already installed."
+    }
+    else
+    {
+        for ($i = 1; $i -le 5; $i++)
+        {
+            $output = dotnet tool install -g Amazon.Lambda.Tools 2>&1 | Out-String
+            Write-Host $output
+            if ($LASTEXITCODE -eq 0 -or $output -match 'already installed' -or $output -match 'already exists')
+            {
+                break
+            }
+            if ($i -eq 5)
+            {
+                throw "Failed to install Amazon.Lambda.Tools after $i attempts."
+            }
+            Start-Sleep -Seconds ($i * 3)
+        }
+    }
     Write-Host "Creating S3 Bucket $identifier"
 
     if(![string]::IsNullOrEmpty($region))

--- a/Libraries/test/TestServerlessApp.IntegrationTests/DynamoDBEventSourceMapping.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/DynamoDBEventSourceMapping.cs
@@ -4,11 +4,11 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Extensions.AssemblyFixture;
 
 namespace TestServerlessApp.IntegrationTests
 {
-    [Collection("Integration Tests")]
-    public class DynamoDBEventSourceMapping
+    public class DynamoDBEventSourceMapping : IAssemblyFixture<IntegrationTestContextFixture>
     {
         private readonly IntegrationTestContextFixture _fixture;
 

--- a/Libraries/test/TestServerlessApp.IntegrationTests/FunctionUrlExample.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/FunctionUrlExample.cs
@@ -7,11 +7,11 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Extensions.AssemblyFixture;
 
 namespace TestServerlessApp.IntegrationTests
 {
-    [Collection("Integration Tests")]
-    public class FunctionUrlExample
+    public class FunctionUrlExample : IAssemblyFixture<IntegrationTestContextFixture>
     {
         private readonly IntegrationTestContextFixture _fixture;
 

--- a/Libraries/test/TestServerlessApp.IntegrationTests/Greeter.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/Greeter.cs
@@ -4,11 +4,11 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Extensions.AssemblyFixture;
 
 namespace TestServerlessApp.IntegrationTests
 {
-    [Collection("Integration Tests")]
-    public class Greeter
+    public class Greeter : IAssemblyFixture<IntegrationTestContextFixture>
     {
         private readonly IntegrationTestContextFixture _fixture;
 

--- a/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixture.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixture.cs
@@ -42,10 +42,11 @@ namespace TestServerlessApp.IntegrationTests
 
         public IntegrationTestContextFixture()
         {
-            _cloudFormationHelper = new CloudFormationHelper(new AmazonCloudFormationClient(Amazon.RegionEndpoint.USWest2));
+            var cloudFormationClient = new AmazonCloudFormationClient(Amazon.RegionEndpoint.USWest2);
+            _cloudFormationHelper = new CloudFormationHelper(cloudFormationClient);
             _s3Helper = new S3Helper(new AmazonS3Client(Amazon.RegionEndpoint.USWest2));
             S3HelperInstance = _s3Helper;
-            LambdaHelper = new LambdaHelper(new AmazonLambdaClient(Amazon.RegionEndpoint.USWest2));
+            LambdaHelper = new LambdaHelper(new AmazonLambdaClient(Amazon.RegionEndpoint.USWest2), cloudFormationClient);
             CloudWatchHelper = new CloudWatchHelper(new AmazonCloudWatchLogsClient(Amazon.RegionEndpoint.USWest2));
             HttpClient = new HttpClient();
         }

--- a/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixtureCollection.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/IntegrationTestContextFixtureCollection.cs
@@ -1,9 +1,4 @@
-﻿using Xunit;
-
-namespace TestServerlessApp.IntegrationTests
-{
-    [CollectionDefinition("Integration Tests")]
-    public class IntegrationTestContextFixtureCollection : ICollectionFixture<IntegrationTestContextFixture>
-    {
-    }
-}
+// Registers the AssemblyFixture test framework so test classes can share a single
+// IntegrationTestContextFixture (one deployed stack) via IAssemblyFixture<T> while still
+// running in parallel. Without this attribute IAssemblyFixture<T> is silently ignored.
+[assembly: Xunit.TestFramework("Xunit.Extensions.AssemblyFixture.AssemblyFixtureFramework", "Xunit.Extensions.AssemblyFixture")]

--- a/Libraries/test/TestServerlessApp.IntegrationTests/S3EventNotification.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/S3EventNotification.cs
@@ -5,11 +5,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using Amazon.S3;
 using Xunit;
+using Xunit.Extensions.AssemblyFixture;
 
 namespace TestServerlessApp.IntegrationTests
 {
-    [Collection("Integration Tests")]
-    public class S3EventNotification
+    public class S3EventNotification : IAssemblyFixture<IntegrationTestContextFixture>
     {
         private readonly IntegrationTestContextFixture _fixture;
 

--- a/Libraries/test/TestServerlessApp.IntegrationTests/SNSEventSubscription.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/SNSEventSubscription.cs
@@ -5,11 +5,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using Amazon.SimpleNotificationService;
 using Xunit;
+using Xunit.Extensions.AssemblyFixture;
 
 namespace TestServerlessApp.IntegrationTests
 {
-    [Collection("Integration Tests")]
-    public class SNSEventSubscription
+    public class SNSEventSubscription : IAssemblyFixture<IntegrationTestContextFixture>
     {
         private readonly IntegrationTestContextFixture _fixture;
 

--- a/Libraries/test/TestServerlessApp.IntegrationTests/SQSEventSourceMapping.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/SQSEventSourceMapping.cs
@@ -4,11 +4,11 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Extensions.AssemblyFixture;
 
 namespace TestServerlessApp.IntegrationTests
 {
-    [Collection("Integration Tests")]
-    public class SQSEventSourceMapping
+    public class SQSEventSourceMapping : IAssemblyFixture<IntegrationTestContextFixture>
     {
         private readonly IntegrationTestContextFixture _fixture;
 

--- a/Libraries/test/TestServerlessApp.IntegrationTests/ScheduleEventRule.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/ScheduleEventRule.cs
@@ -6,11 +6,11 @@ using System.Threading.Tasks;
 using Amazon.CloudWatchEvents;
 using Amazon.CloudWatchEvents.Model;
 using Xunit;
+using Xunit.Extensions.AssemblyFixture;
 
 namespace TestServerlessApp.IntegrationTests
 {
-    [Collection("Integration Tests")]
-    public class ScheduleEventRule
+    public class ScheduleEventRule : IAssemblyFixture<IntegrationTestContextFixture>
     {
         private readonly IntegrationTestContextFixture _fixture;
 

--- a/Libraries/test/TestServerlessApp.IntegrationTests/SimpleCalculator.cs
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/SimpleCalculator.cs
@@ -4,11 +4,11 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Extensions.AssemblyFixture;
 
 namespace TestServerlessApp.IntegrationTests
 {
-    [Collection("Integration Tests")]
-    public class SimpleCalculator
+    public class SimpleCalculator : IAssemblyFixture<IntegrationTestContextFixture>
     {
         private readonly IntegrationTestContextFixture _fixture;
 

--- a/Libraries/test/TestServerlessApp.IntegrationTests/TestServerlessApp.IntegrationTests.csproj
+++ b/Libraries/test/TestServerlessApp.IntegrationTests/TestServerlessApp.IntegrationTests.csproj
@@ -14,6 +14,9 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="xunit" Version="2.9.3" />
+        <!-- Shares one deployed-stack fixture across the whole assembly (IAssemblyFixture) so the
+             test classes can run in parallel instead of being serialized in a single collection. -->
+        <PackageReference Include="Xunit.Extensions.AssemblyFixture" Version="2.6.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/buildtools/build.proj
+++ b/buildtools/build.proj
@@ -218,12 +218,11 @@
         <Exec Command="dotnet test -c $(Configuration)" WorkingDirectory="..\Libraries\test\Amazon.Lambda.DurableExecution.Tests"/>
     </Target>
     <Target Name="run-integ-tests">
-        <!-- Discover all integration test projects by convention (*.IntegrationTests.csproj) so new
-             projects are picked up automatically without editing this target. -->
-        <ItemGroup>
-            <IntegTestProject Include="..\Libraries\test\**\*.IntegrationTests.csproj"/>
-        </ItemGroup>
-        <Exec Command="dotnet test -c $(Configuration) --logger &quot;console;verbosity=detailed&quot; &quot;%(IntegTestProject.FullPath)&quot;"/>
+        <!-- Each *.IntegrationTests.csproj deploys its own isolated CloudFormation stack, so the
+             projects share no state and are run concurrently to cut the integ-test wall-clock time.
+             The helper script discovers projects by convention (*.IntegrationTests.csproj) so new
+             projects are picked up automatically, and exits non-zero if any project fails. -->
+        <Exec Command="pwsh -NoProfile -File &quot;$(MSBuildThisFileDirectory)run-integ-tests-parallel.ps1&quot; -Configuration $(Configuration)"/>
     </Target>
     <Target Name="create-nuget-packages-cicd" DependsOnTargets="build-project-packages">
         <Exec Command="$(PackCommand)" WorkingDirectory="..\Libraries\src\%(LibraryName.FileName)"/>

--- a/buildtools/run-integ-tests-parallel.ps1
+++ b/buildtools/run-integ-tests-parallel.ps1
@@ -1,0 +1,63 @@
+#!/usr/bin/env pwsh
+# Runs every integration test project concurrently. Each *.IntegrationTests.csproj deploys its own
+# isolated CloudFormation stack (unique name + S3 bucket), so the projects have no shared state and
+# can run in parallel. Running them serially was the dominant cost of the CI integ-test phase.
+#
+# Output from each project is captured and printed as a labeled block after that project finishes,
+# so the interleaved logs of parallel runs stay readable. The script exits non-zero if any project
+# fails, listing which ones.
+
+param(
+    [string]$Configuration = "Release",
+    # Directory to search for integration test projects (defaults to the Libraries/test tree).
+    [string]$TestRoot = (Join-Path $PSScriptRoot ".." "Libraries" "test"),
+    # Upper bound on how many projects run at once.
+    [int]$ThrottleLimit = 5
+)
+
+$ErrorActionPreference = 'Stop'
+
+$projects = Get-ChildItem -Path $TestRoot -Recurse -Filter "*.IntegrationTests.csproj" |
+    Select-Object -ExpandProperty FullName |
+    Sort-Object
+
+if (-not $projects)
+{
+    Write-Host "No integration test projects found under '$TestRoot'."
+    exit 0
+}
+
+Write-Host "Running $($projects.Count) integration test project(s) in parallel (throttle limit $ThrottleLimit):"
+$projects | ForEach-Object { Write-Host "  - $_" }
+
+$results = $projects | ForEach-Object -ThrottleLimit $ThrottleLimit -Parallel {
+    $project = $_
+    $name = [System.IO.Path]::GetFileNameWithoutExtension($project)
+    # 2>&1 folds stderr into the captured stream so warnings/errors appear in the labeled block.
+    $output = dotnet test -c $using:Configuration --logger "console;verbosity=detailed" $project 2>&1 | Out-String
+    [PSCustomObject]@{
+        Name     = $name
+        Project  = $project
+        ExitCode = $LASTEXITCODE
+        Output   = $output
+    }
+}
+
+foreach ($result in $results)
+{
+    Write-Host ""
+    Write-Host "==================== $($result.Name) (exit $($result.ExitCode)) ===================="
+    Write-Host $result.Output
+}
+
+$failed = $results | Where-Object { $_.ExitCode -ne 0 }
+if ($failed)
+{
+    Write-Host ""
+    Write-Host "The following integration test project(s) failed:"
+    $failed | ForEach-Object { Write-Host "  - $($_.Name)" }
+    exit 1
+}
+
+Write-Host ""
+Write-Host "All integration test projects passed."

--- a/buildtools/run-integ-tests-parallel.ps1
+++ b/buildtools/run-integ-tests-parallel.ps1
@@ -3,9 +3,10 @@
 # isolated CloudFormation stack (unique name + S3 bucket), so the projects have no shared state and
 # can run in parallel. Running them serially was the dominant cost of the CI integ-test phase.
 #
-# Output from each project is captured and printed as a labeled block after that project finishes,
-# so the interleaved logs of parallel runs stay readable. The script exits non-zero if any project
-# fails, listing which ones.
+# Each project's output is streamed live, prefixed with the project name so the interleaved logs of
+# the parallel runs stay attributable. Failed projects also get their full output reprinted as one
+# clean block at the end (un-interleaved) for easier diagnosis. The script exits non-zero if any
+# project fails, listing which ones.
 
 param(
     [string]$Configuration = "Release",
@@ -33,24 +34,32 @@ $projects | ForEach-Object { Write-Host "  - $_" }
 $results = $projects | ForEach-Object -ThrottleLimit $ThrottleLimit -Parallel {
     $project = $_
     $name = [System.IO.Path]::GetFileNameWithoutExtension($project)
-    # 2>&1 folds stderr into the captured stream so warnings/errors appear in the labeled block.
-    $output = dotnet test -c $using:Configuration --logger "console;verbosity=detailed" $project 2>&1 | Out-String
+    $lines = [System.Collections.Generic.List[string]]::new()
+    # 2>&1 folds stderr into the stream. Each line is emitted to the host as it arrives, prefixed
+    # with the project name, so progress is visible during the (long) run instead of only at the end.
+    dotnet test -c $using:Configuration --logger "console;verbosity=detailed" $project 2>&1 |
+        ForEach-Object {
+            $line = $_.ToString()
+            $lines.Add($line)
+            Write-Host "[$name] $line"
+        }
     [PSCustomObject]@{
         Name     = $name
         Project  = $project
         ExitCode = $LASTEXITCODE
-        Output   = $output
+        Output   = ($lines -join [System.Environment]::NewLine)
     }
 }
 
-foreach ($result in $results)
+# Reprint each failed project's output as one clean, un-interleaved block for easier diagnosis.
+$failed = $results | Where-Object { $_.ExitCode -ne 0 }
+foreach ($result in $failed)
 {
     Write-Host ""
-    Write-Host "==================== $($result.Name) (exit $($result.ExitCode)) ===================="
+    Write-Host "==================== FAILED: $($result.Name) (exit $($result.ExitCode)) ===================="
     Write-Host $result.Output
 }
 
-$failed = $results | Where-Object { $_.ExitCode -ne 0 }
 if ($failed)
 {
     Write-Host ""

--- a/buildtools/run-integ-tests-parallel.ps1
+++ b/buildtools/run-integ-tests-parallel.ps1
@@ -31,13 +31,30 @@ if (-not $projects)
 Write-Host "Running $($projects.Count) integration test project(s) in parallel (throttle limit $ThrottleLimit):"
 $projects | ForEach-Object { Write-Host "  - $_" }
 
+# Build all projects ONCE, up front, before the parallel phase. The integration test projects share
+# the IntegrationTests.Helpers ProjectReference; running `dotnet test` on them concurrently each
+# rebuilt that shared project, racing on its build output (e.g. IntegrationTests.Helpers.deps.json
+# "being used by another process", GenerateDepsFile task failure). Building once here lets the
+# parallel runs use --no-build so they only execute tests, never rebuild shared output.
+Write-Host "Building all integration test projects once before running in parallel..."
+foreach ($project in $projects)
+{
+    dotnet build -c $Configuration $project
+    if ($LASTEXITCODE -ne 0)
+    {
+        Write-Host "Build failed for $project (exit $LASTEXITCODE)."
+        exit 1
+    }
+}
+
 $results = $projects | ForEach-Object -ThrottleLimit $ThrottleLimit -Parallel {
     $project = $_
     $name = [System.IO.Path]::GetFileNameWithoutExtension($project)
     $lines = [System.Collections.Generic.List[string]]::new()
-    # 2>&1 folds stderr into the stream. Each line is emitted to the host as it arrives, prefixed
-    # with the project name, so progress is visible during the (long) run instead of only at the end.
-    dotnet test -c $using:Configuration --logger "console;verbosity=detailed" $project 2>&1 |
+    # --no-build: everything was built serially above, so the parallel runs only execute tests and
+    # never rebuild the shared IntegrationTests.Helpers project. 2>&1 folds stderr into the stream;
+    # each line is emitted as it arrives, prefixed with the project name, so progress is visible.
+    dotnet test -c $using:Configuration --no-build --logger "console;verbosity=detailed" $project 2>&1 |
         ForEach-Object {
             $line = $_.ToString()
             $lines.Add($line)


### PR DESCRIPTION
## Summary
TLDR: make tests run in parallel and fix flaky tests. was taking 60 minutes to run all tests now it takes 30



Started as a fix for a flaky CI failure in `TestCustomAuthorizerApp.IntegrationTests`, then grew into a broader effort to speed up and stabilize the integration-test phase (which dominated CI wall-clock by running everything serially), plus fixes for a few flaky unit tests surfaced along the way.

## Reliability

- **Retry custom-authorizer deployment on transient IAM role propagation.** The fixture's CloudFormation deploy intermittently rolled back with *"The role defined for the function cannot be assumed by Lambda"* — a transient IAM eventual-consistency race. `DeploymentScript.ps1` now retries the deploy (deleting the rolled-back stack between attempts, since `ROLLBACK_COMPLETE` can't be re-created) and surfaces CloudFormation failure events.

## Speed

- **Run the integration-test projects in parallel.** `run-integ-tests` now runs each `*.IntegrationTests.csproj` concurrently (`run-integ-tests-parallel.ps1`); each project deploys its own isolated stack, so they share no state.
- **Build the test projects once, up front.** The parallel runner builds all integration projects serially first, then runs `dotnet test --no-build` in parallel — so the concurrent runs don't each rebuild the shared `IntegrationTests.Helpers` project and race on its build output.
- **Stack-scoped Lambda lookup.** `LambdaHelper.FilterByCloudFormationStackAsync` uses CloudFormation `ListStackResources` instead of scanning every Lambda in the account and reading each function's tags — O(stack) instead of O(account), and no shared-account throttling.
- **In-project test parallelism.** `TestServerlessApp` and `TestCustomAuthorizerApp` share their single deployed-stack fixture across the assembly via `IAssemblyFixture` instead of one serial `[Collection]`, so the test classes run in parallel (stack still deploys once).
- **Durable suite parallelism.** Enabled parallel execution for the durable integ suite (was `maxParallelThreads=1`).
- **Publish durable test functions once, in a single MSBuild pass.** A generated traversal project (`Restore;Publish`, `BuildInParallel`) builds the shared dependency projects once and publishes every function to its own `bin/publish`; tests then only zip the output — replacing per-test cold publishing.

## Making durable parallelism safe (rate limits & races)

Enabling parallelism in the durable suite surfaced a series of shared-resource contention issues, fixed in layers:

- **IAM throttling** → replaced per-test IAM roles with a single shared execution role (created at most once per account, reused across runs); dispose no longer deletes roles.
- **Lambda control-plane throttling** → share the AWS clients statically so adaptive retry coordinates backoff across deployments, and cap concurrent control-plane calls (`CreateFunction`/`DeleteFunction`/`GetFunctionConfiguration`) with a suite-wide gate.
- **Shared-file races** → idempotent `dotnet tool install` across the parallel deploy scripts, and zip each function package to a unique temp path (a function used by more than one test was being zipped to a shared path concurrently).

## Developer experience

- **Live integ-test output.** The parallel runner streams each project's output line-by-line (prefixed with the project name) instead of buffering until completion; failed projects get a clean reprinted block.

## Flaky unit-test fixes (unrelated to the integ work, surfaced in CI)

- **Durable suspend tests** (`InvokeOperationTests` et al.): replaced fixed `Task.Delay` waits before asserting suspension with a deterministic await on the termination signal (`TerminationManager.TerminationTask`), bounded by a timeout — the fixed delays raced under CI thread-pool pressure.
- **`FileDescriptorLogStream` test**: the test helper trimmed trailing null bytes from captured output, which flaked ~1/256 of the time when a log header's timestamp ended in `0x00` (16-byte header read as 15). Now captures exactly the bytes written.
- **Streaming E2E test** (`StreamingE2EWithMoq`): `ResponseStreamFactory` tracks the active invocation in a static field (on-demand) or an `AsyncLocal` (multi-concurrency), and `GetCurrentContext()` prefers the `AsyncLocal`. Several factory tests set the `AsyncLocal` synchronously on reused xUnit worker threads, leaking into a later on-demand test so its response silently fell back to the buffered path (`CapturedHttpBytes` null). Fixed test-only (no shipping code changed): the multi-concurrency tests now write the `AsyncLocal` on isolated `Task.Run` flows so the mutation can't leak across threads.

## Testing

- Affected projects build clean; PowerShell scripts parse.
- Verified against AWS where the local environment allowed: custom-authorizer deploys its stack once and all 20 tests pass under the parallel `IAssemblyFixture` setup; the shared-role + single-pass publish path works (51/51 functions publish in one MSBuild pass).
- Flaky unit-test fixes verified by stress-running: the streaming test failed ~40% of full-assembly runs before the fix and 12/12 after; the durable suspend and log-stream tests are now deterministic.
- Remaining end-to-end durable-suite throttling/timing has been validated iteratively on real CI (each contention fix above was driven by a CI run).

