### PR TITLE
Add Version tag to DurableExecution.Analyzers csproj

### DIFF
--- a/Libraries/src/Amazon.Lambda.DurableExecution.Analyzers/Amazon.Lambda.DurableExecution.Analyzers.csproj
+++ b/Libraries/src/Amazon.Lambda.DurableExecution.Analyzers/Amazon.Lambda.DurableExecution.Analyzers.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
 
+    <Version>0.1.2-preview</Version>
     <Description>Roslyn analyzers and code fixes for Amazon.Lambda.DurableExecution — catches durable-execution determinism and authoring mistakes (DE001-DE004) at build time.</Description>
     <AssemblyTitle>Amazon.Lambda.DurableExecution.Analyzers</AssemblyTitle>
     <AssemblyName>Amazon.Lambda.DurableExecution.Analyzers</AssemblyName>


### PR DESCRIPTION
## Issue

The [Create Release PR workflow](https://github.com/aws/aws-lambda-dotnet/actions/runs/28551813459) fails at the **Increment Version** step:

```
The project 'Amazon.Lambda.DurableExecution' does not have a 'Version' tag. Add a 'Version' tag and run the tool again.
```

## Root cause

In `.autover/autover.json`, `Amazon.Lambda.DurableExecution` is a multi-path group:

```json
"Name": "Amazon.Lambda.DurableExecution",
"Paths": [
  ".../Amazon.Lambda.DurableExecution.csproj",           // has <Version>0.1.2-preview</Version>
  ".../Amazon.Lambda.DurableExecution.Analyzers.csproj"  // had no <Version>
]
```

The `.Analyzers` project (added in #2443) was grouped here but never got a `<Version>` tag. AutoVer requires one on every path in a group, so `autover version` aborts. The error names the group, not the offending file, which is why it's misleading — the main csproj does have a version.

## Fix

Add `<Version>0.1.2-preview</Version>` to `Amazon.Lambda.DurableExecution.Analyzers.csproj` to match its group's main package. This mirrors the existing `Amazon.Lambda.Annotations` group, where both `Annotations` and `.SourceGenerator` carry the same version.

No change file is included; the analyzer is bundled inside the existing DurableExecution package (`IsPackable=false`) and this is a build-config fix, not a shipped behavior change.