### PR TITLE
Retry IAM calls on throttling in RuntimeSupport integration tests

### DIFF
--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/BaseCustomRuntimeTest.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/BaseCustomRuntimeTest.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Amazon.IdentityManagement;
 using Amazon.IdentityManagement.Model;
 using Amazon.Lambda.Model;
+using Amazon.Runtime;
 using Amazon.S3;
 using Amazon.S3.Model;
 
@@ -81,22 +82,22 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
                     {
                         RoleName = ExecutionRoleName
                     };
-                    var attachedPolicies = await iamClient.ListAttachedRolePoliciesAsync(listAttachedPoliciesRequest);
+                    var attachedPolicies = await RetryOnThrottleAsync(() => iamClient.ListAttachedRolePoliciesAsync(listAttachedPoliciesRequest));
 
                     foreach (var policy in attachedPolicies.AttachedPolicies)
                     {
-                        await iamClient.DetachRolePolicyAsync(new DetachRolePolicyRequest
+                        await RetryOnThrottleAsync(() => iamClient.DetachRolePolicyAsync(new DetachRolePolicyRequest
                         {
                             RoleName = ExecutionRoleName,
                             PolicyArn = policy.PolicyArn
-                        });
+                        }));
                     }
 
                     var deleteRoleRequest = new DeleteRoleRequest
                     {
                         RoleName = ExecutionRoleName
                     };
-                    await iamClient.DeleteRoleAsync(deleteRoleRequest);
+                    await RetryOnThrottleAsync(() => iamClient.DeleteRoleAsync(deleteRoleRequest));
                 }
                 catch (Exception)
                 {
@@ -130,7 +131,7 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
             };
             try
             {
-                ExecutionRoleArn = (await iamClient.GetRoleAsync(getRoleRequest)).Role.Arn;
+                ExecutionRoleArn = (await RetryOnThrottleAsync(() => iamClient.GetRoleAsync(getRoleRequest))).Role.Arn;
                 return true;
             }
             catch (NoSuchEntityException)
@@ -142,20 +143,72 @@ namespace Amazon.Lambda.RuntimeSupport.IntegrationTests
                     Description = "Test role for CustomRuntimeTests.",
                     AssumeRolePolicyDocument = LAMBDA_ASSUME_ROLE_POLICY
                 };
-                ExecutionRoleArn = (await iamClient.CreateRoleAsync(createRoleRequest)).Role.Arn;
+                ExecutionRoleArn = (await RetryOnThrottleAsync(() => iamClient.CreateRoleAsync(createRoleRequest))).Role.Arn;
 
                 // Wait for role to propagate.
                 await Task.Delay(10000);
 
-                await iamClient.AttachRolePolicyAsync(new AttachRolePolicyRequest
+                await RetryOnThrottleAsync(() => iamClient.AttachRolePolicyAsync(new AttachRolePolicyRequest
                 {
                     PolicyArn = "arn:aws:iam::aws:policy/AWSLambdaExecute",
                     RoleName = ExecutionRoleName,
-                });
+                }));
 
 
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Invokes an AWS SDK call, retrying with exponential backoff when the service throttles the request.
+        /// Because every test class provisions its own IAM role and these tests now run in parallel, the
+        /// IAM control-plane APIs (which have low request-rate limits) are easily throttled at startup and
+        /// teardown, surfacing as "Rate exceeded". Retrying smooths the parallel burst instead of failing the test.
+        /// </summary>
+        private static async Task<T> RetryOnThrottleAsync<T>(Func<Task<T>> action)
+        {
+            const int maxAttempts = 8;
+            var delay = TimeSpan.FromSeconds(2);
+
+            for (var attempt = 1; ; attempt++)
+            {
+                try
+                {
+                    return await action();
+                }
+                catch (AmazonServiceException e) when (IsThrottlingException(e) && attempt < maxAttempts)
+                {
+                    await Task.Delay(delay);
+                    // Exponential backoff, capped at 30s, to let the IAM request rate recover.
+                    delay = TimeSpan.FromSeconds(Math.Min(delay.TotalSeconds * 2, 30));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Overload of <see cref="RetryOnThrottleAsync{T}"/> for SDK calls whose response is not needed.
+        /// </summary>
+        private static async Task RetryOnThrottleAsync(Func<Task> action)
+        {
+            await RetryOnThrottleAsync<object>(async () =>
+            {
+                await action();
+                return null;
+            });
+        }
+
+        private static bool IsThrottlingException(AmazonServiceException e)
+        {
+            if (e.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
+            {
+                return true;
+            }
+
+            var errorCode = e.ErrorCode ?? string.Empty;
+            return errorCode.IndexOf("Throttl", StringComparison.OrdinalIgnoreCase) >= 0
+                || errorCode.IndexOf("TooManyRequests", StringComparison.OrdinalIgnoreCase) >= 0
+                || errorCode.Equals("RequestLimitExceeded", StringComparison.OrdinalIgnoreCase)
+                || (e.Message?.IndexOf("Rate exceeded", StringComparison.OrdinalIgnoreCase) >= 0);
         }
 
         private async Task CreateBucketWithDeploymentZipAsync(IAmazonS3 s3Client, string bucketName)


### PR DESCRIPTION
## Problem

The `Run Tests on AWS` CodeBuild step has been intermittently failing (e.g. [run 28538095638](https://github.com/aws/aws-lambda-dotnet/actions/runs/28538095638)) with 2 of 24 tests failing in `Amazon.Lambda.RuntimeSupport.IntegrationTests`:

- `CustomRuntimeNET10Tests.TestAllNET10HandlersAsync`
- `CustomRuntimeAspNetCoreMinimalApiCustomSerializerTest.TestThreadingLogging`

Both fail identically during **test setup**, not on any assertion:

```
Amazon.IdentityManagement.AmazonIdentityManagementServiceException : Rate exceeded
  at BaseCustomRuntimeTest.ValidateAndSetIamRoleArn(...)   BaseCustomRuntimeTest.cs:150
  at BaseCustomRuntimeTest.PrepareTestResources(...)       BaseCustomRuntimeTest.cs:111
```

## Root cause

The integration tests now run in parallel (#2451). Each test class uses a unique function name and sets `ExecutionRoleName = FunctionName`, so **every** test provisions its own IAM role — `GetRole` / `CreateRole` / `AttachRolePolicy` at startup and `ListAttachedRolePolicies` / `DetachRolePolicy` / `DeleteRole` at teardown. IAM's control-plane APIs have low request-rate limits, so the concurrent burst intermittently throttles with `Rate exceeded`, and the SDK's default retries aren't enough under this contention.

## Fix

Wrap the IAM calls in `BaseCustomRuntimeTest` with a throttle-aware retry (exponential backoff, 2s → capped 30s, up to 8 attempts). This smooths the parallel startup/teardown burst instead of failing the test. Throttling is detected via HTTP 429, throttle-family error codes, and the `Rate exceeded` message.

Follows the test-stabilization theme of #2451. Test-only change — no shipped package affected, so no change file (matching #2451).