### PR TITLE
Set AutoPublishAlias on serverless.DurableFunction blueprint

### DIFF
--- a/.autover/changes/durable-serverless-autopublishalias.json
+++ b/.autover/changes/durable-serverless-autopublishalias.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Templates",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Set AutoPublishAlias to 'live' on the function in the serverless.DurableFunction blueprint (vs2026). SAM now publishes a new function version and points the 'live' alias at it on every deploy, so the durable function can be invoked immediately after deployment instead of failing with a no-published-version error. Preview."
+      ]
+    }
+  ]
+}

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/Readme.md
@@ -51,6 +51,11 @@ The `[DurableExecution]` attribute drives the source generator, which keeps the 
 dotnet lambda deploy-serverless
 ```
 
+The template sets `AutoPublishAlias: live` on the function. On every deploy, SAM publishes a new
+function version and points the `live` alias at it, so the function can be invoked immediately after
+deployment. Without a published version, invoking a freshly deployed durable function fails because
+durable execution requires a specific function version to run against.
+
 ## Invoke
 
 CloudFormation generates the deployed function name, so it won't be `BlueprintBaseName.1`. Find it by

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/serverless.template
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/serverless.template
@@ -21,6 +21,7 @@
         ],
         "PackageType": "Zip",
         "Handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function_ProcessOrder_Generated::ProcessOrder",
+        "AutoPublishAlias": "live",
         "DurableConfig": {
           "ExecutionTimeout": 86400
         }


### PR DESCRIPTION
## Description

Adds `AutoPublishAlias: live` to the function resource in the `serverless.DurableFunction` blueprint (vs2026).

## Motivation

When deploying the durable serverless blueprint as-is and then invoking the function, the invocation fails with a **no version published** error. Durable execution runs against a specific published function version, but the template published none.

With `AutoPublishAlias: live`, SAM publishes a new function version and points the `live` alias at it on every deploy, so the function is immediately invokable after `dotnet lambda deploy-serverless`.

## Changes

- `serverless.template`: add `"AutoPublishAlias": "live"` to the function `Properties`. This is a user-authored property that the Annotations source generator preserves across re-sync (it only manages `DurableConfig` / durable policy tokens).
- `Readme.md`: document the alias behavior in the Deploy section.
- Added AutoVer changefile (`Amazon.Lambda.Templates`, Patch).

## Notes

- Targets `dev`.
- Only the serverless blueprint is affected; the class-library `lambda.DurableFunction` blueprint has no `serverless.template` (deploys via `deploy-function`).