### PR TITLE
Add virtual-context support to standalone RunInChildContextAsync

### DIFF
--- a/.autover/changes/durable-childcontext-virtual.json
+++ b/.autover/changes/durable-childcontext-virtual.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.DurableExecution",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Add virtual-context support to standalone RunInChildContextAsync via ChildContextConfig.NestingType. Setting NestingType.Flat runs the child in a virtual context that emits no CONTEXT checkpoint of its own (mirroring MapConfig/ParallelConfig), enabling manual fan-out with Task.WhenAll while reducing checkpoint volume."
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/ChildContextConfig.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/ChildContextConfig.cs
@@ -32,4 +32,26 @@ public sealed class ChildContextConfig
     /// <see cref="ChildContextException"/> is mapped before being thrown).
     /// </remarks>
     public Func<Exception, Exception>? ErrorMapping { get; set; }
+
+    /// <summary>
+    /// How the child context is represented in the checkpoint graph. Defaults to
+    /// <see cref="NestingType.Nested"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Under <see cref="NestingType.Flat"/> the child runs in a virtual context
+    /// that emits no <c>CONTEXT</c> checkpoint of its own — reducing checkpoint
+    /// volume at the cost of less granular execution traces. Operations inside
+    /// the child (steps, waits, callbacks) still checkpoint, re-parented to this
+    /// context's parent.
+    /// </para>
+    /// <para>
+    /// This mirrors the <c>NestingType.Flat</c> option on
+    /// <see cref="MapConfig"/> and <see cref="ParallelConfig"/>, letting a
+    /// standalone <see cref="IDurableContext.RunInChildContextAsync{T}(System.Func{IDurableContext, System.Threading.CancellationToken, System.Threading.Tasks.Task{T}}, string?, ChildContextConfig?, System.Threading.CancellationToken)"/>
+    /// call opt into virtual contexts — for example when manually fanning out
+    /// work and awaiting the returned tasks with <c>Task.WhenAll</c>.
+    /// </para>
+    /// </remarks>
+    public NestingType NestingType { get; set; } = NestingType.Nested;
 }

--- a/Libraries/src/Amazon.Lambda.DurableExecution/DurableContext.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/DurableContext.cs
@@ -167,7 +167,8 @@ internal sealed class DurableContext : IDurableContext
 
         var op = new ChildContextOperation<T>(
             operationId, name, _idGenerator.ParentId, func, config, serializer, MakeChildFactory(),
-            _state, _terminationManager, _workflowCancellation, _durableExecutionArn, _batcher);
+            _state, _terminationManager, _workflowCancellation, _durableExecutionArn, _batcher,
+            isVirtual: config?.NestingType == NestingType.Flat);
         return op.ExecuteAsync(cancellationToken);
     }
 

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ChildContextOperationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ChildContextOperationTests.cs
@@ -610,4 +610,107 @@ public class ChildContextOperationTests
         }
     }
 
+    [Fact]
+    public async Task RunInChildContextAsync_FlatNesting_EmitsNoContextCheckpointAndReparentsInnerOps()
+    {
+        var (context, recorder, tm, _) = CreateContext();
+
+        var executed = false;
+        var result = await context.RunInChildContextAsync(
+            async (childCtx, _) =>
+            {
+                executed = true;
+                return await childCtx.StepAsync(async (_, _) => { await Task.CompletedTask; return "inner"; }, name: "inner_step");
+            },
+            name: "phase",
+            config: new ChildContextConfig { NestingType = NestingType.Flat });
+
+        Assert.True(executed);
+        Assert.Equal("inner", result);
+        Assert.False(tm.IsTerminated);
+
+        await recorder.Batcher.DrainAsync();
+
+        // A virtual (Flat) child emits no CONTEXT checkpoint of its own — only
+        // the inner step's operations are recorded.
+        var actions = recorder.Flushed.Select(o => $"{o.Type}:{o.Action}").ToArray();
+        Assert.Equal(new[]
+        {
+            "STEP:START",
+            "STEP:SUCCEED"
+        }, actions);
+        Assert.DoesNotContain(recorder.Flushed, o => o.Type == "CONTEXT");
+
+        // Inner-op IDs still derive from the child's own operation ID (so sibling
+        // branches never collide), but they re-parent to the nearest non-virtual
+        // ancestor — here the root, whose ParentId is null — since the virtual
+        // branch has no CONTEXT checkpoint for them to reference.
+        var parentOpId = IdAt(1);
+        var innerStepId = ChildIdAt(parentOpId, 1);
+        var stepStart = recorder.Flushed.Single(o => o.Type == "STEP" && o.Action == "START");
+        Assert.Equal(innerStepId, stepStart.Id);
+        Assert.Null(stepStart.ParentId);
+    }
+
+    [Fact]
+    public async Task RunInChildContextAsync_FlatNesting_ReplayReExecutesBodyFromInnerCheckpoint()
+    {
+        // No CONTEXT checkpoint exists for a virtual child, so on replay the body
+        // re-executes; the inner step replays from its own SUCCEEDED checkpoint
+        // without re-running the step delegate.
+        var parentOpId = IdAt(1);
+        var innerStepId = ChildIdAt(parentOpId, 1);
+        var (context, recorder, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = innerStepId,
+                    Type = OperationTypes.Step,
+                    Status = OperationStatuses.Succeeded,
+                    Name = "inner_step",
+                    StepDetails = new StepDetails { Result = "\"cached\"" }
+                }
+            }
+        });
+
+        var stepRan = false;
+        var result = await context.RunInChildContextAsync(
+            async (childCtx, _) =>
+                await childCtx.StepAsync(async (_, _) =>
+                {
+                    stepRan = true;
+                    await Task.CompletedTask;
+                    return "fresh";
+                }, name: "inner_step"),
+            name: "phase",
+            config: new ChildContextConfig { NestingType = NestingType.Flat });
+
+        Assert.False(stepRan);
+        Assert.Equal("cached", result);
+
+        await recorder.Batcher.DrainAsync();
+        Assert.DoesNotContain(recorder.Flushed, o => o.Type == "CONTEXT");
+    }
+
+    [Fact]
+    public async Task RunInChildContextAsync_FlatNesting_FuncThrows_EmitsNoFailCheckpointButPropagates()
+    {
+        var (context, recorder, _, _) = CreateContext();
+
+        var ex = await Assert.ThrowsAsync<ChildContextException>(() =>
+            context.RunInChildContextAsync<string>(
+                (_, _) => throw new InvalidOperationException("boom"),
+                name: "phase",
+                config: new ChildContextConfig { NestingType = NestingType.Flat }));
+
+        Assert.Equal("boom", ex.Message);
+
+        await recorder.Batcher.DrainAsync();
+        // Virtual child suppresses the CONTEXT FAIL checkpoint; the exception
+        // still propagates to the caller.
+        Assert.DoesNotContain(recorder.Flushed, o => o.Type == "CONTEXT");
+    }
+
 }


### PR DESCRIPTION
## Issue

Closes #2461

The .NET Durable Execution SDK exposed virtual (flat) contexts only through the concurrent `MapAsync`/`ParallelAsync` paths (`NestingType.Flat`). There was no equivalent option for a standalone `RunInChildContextAsync`, so users porting Java/JS examples that manually fan out child contexts and await them with `Task.WhenAll` had to switch to `MapAsync`/`ParallelAsync`.

## Investigation

The SDK internals already fully supported virtual standalone child contexts:

- `ChildContextOperation<T>` takes an `isVirtual` flag and suppresses its own `CONTEXT` START/SUCCEED/FAIL checkpoints while still propagating results and exceptions.
- `DurableContext.MakeChildFactory` handles the virtual case via `OperationIdGenerator.CreateVirtualChild`, re-parenting inner operations to the nearest non-virtual ancestor.

The **only** missing piece was public API surface + wiring for the standalone entry point.

Referencing the **JS SDK as ground truth**, `ChildConfig.virtualContext?: boolean` drives `isVirtual = options?.virtualContext === true` in the run-in-child-context handler, which skips checkpoints and re-parents inner ops when virtual.

## Change

I chose the `NestingType` shape (the issue's first suggestion) rather than a `virtualContext`/`IsVirtual` bool, because it matches the existing convention on `MapConfig` and `ParallelConfig` — consistent for .NET consumers, identical wire behavior to the JS `virtualContext` bool.

- **`ChildContextConfig.NestingType`** — new property, defaults to `NestingType.Nested`.
- **`DurableContext.RunChildContext`** — passes `isVirtual: config?.NestingType == NestingType.Flat` to the operation.

Users can now write the exact shape requested in the issue:

```csharp
await context.RunInChildContextAsync(
    async (childContext, ct) =>
        await childContext.StepAsync(
            (_, stepCt) => Task.FromResult("result"),
            name: "compute",
            cancellationToken: ct),
    name: "child-0",
    config: new ChildContextConfig { NestingType = NestingType.Flat });
```

## Tests

Added 3 tests to `ChildContextOperationTests`:

- `RunInChildContextAsync_FlatNesting_EmitsNoContextCheckpointAndReparentsInnerOps` — Flat emits no `CONTEXT` checkpoint; inner ops re-parent to the non-virtual ancestor.
- `RunInChildContextAsync_FlatNesting_ReplayReExecutesBodyFromInnerCheckpoint` — with no `CONTEXT` checkpoint, replay re-executes the body while inner steps replay from their own checkpoints (mirrors JS "virtual: re-execute then round-trip").
- `RunInChildContextAsync_FlatNesting_FuncThrows_EmitsNoFailCheckpointButPropagates` — Flat suppresses the `CONTEXT FAIL` checkpoint but still propagates the exception.

**Build:** clean (0 warnings). **Tests:** 408/408 pass on net8.0 and net10.0.

## Change file

Included: `.autover/changes/durable-childcontext-virtual.json` (Minor, `Amazon.Lambda.DurableExecution`).
