### PR TITLE
Skip bin/obj when copying repo for integ-test packaging

### DIFF
--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/Helpers/LambdaToolsHelper.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests/Helpers/LambdaToolsHelper.cs
@@ -52,6 +52,16 @@ public static class LambdaToolsHelper
     }
 
     /// <summary>
+    /// Directories that are skipped when copying the repo into a temp location for packaging.
+    /// These are volatile build outputs / IDE state that <c>dotnet lambda package</c> regenerates
+    /// anyway. Copying them is not only wasteful but unsafe: when integration test projects run in
+    /// parallel, a concurrent build (or Roslyn loading an analyzer such as
+    /// Amazon.Lambda.DurableExecution.Analyzers) holds files under bin/obj open, causing
+    /// File.CopyTo to throw "being used by another process".
+    /// </summary>
+    private static readonly string[] SkippedDirectories = { ".vs", "bin", "obj" };
+
+    /// <summary>
     /// <see cref="https://docs.microsoft.com/en-us/dotnet/standard/io/how-to-copy-directories"/>
     /// </summary>
     private static void CopyDirectory(DirectoryInfo dir, string destDirName)
@@ -74,7 +84,7 @@ public static class LambdaToolsHelper
 
         foreach (var subdir in dirs)
         {
-            if (string.Equals(subdir.Name, ".vs", System.StringComparison.OrdinalIgnoreCase))
+            if (System.Array.Exists(SkippedDirectories, name => string.Equals(subdir.Name, name, System.StringComparison.OrdinalIgnoreCase)))
                 continue;
 
             var tempPath = Path.Combine(destDirName, subdir.Name);


### PR DESCRIPTION
## Problem

The RuntimeSupport integration tests were failing 24/24 in CI ([run](https://github.com/aws/aws-lambda-dotnet/actions/runs/28899110414/job/85731154758?pr=2465)) during fixture initialization with:

```
System.IO.IOException : The process cannot access the file
'.../Amazon.Lambda.DurableExecution.Analyzers/bin/Release/netstandard2.0/Amazon.Lambda.DurableExecution.Analyzers.runtimeconfig.json'
because it is being used by another process.
```

## Root cause

In `CicdRelease` (non-DEBUG) mode, `LambdaToolsHelper.GetTempTestAppDirectory` recursively copies the **entire repo root** into a temp directory so `dotnet lambda package` can resolve the test apps' `..\..\..\src\...` ProjectReferences. That recursive copy indiscriminately grabbed every `bin/` and `obj/` folder.

The integration test projects run in parallel (`run-integ-tests-parallel.ps1`). When one project's fixture copies the tree while a concurrent build — or Roslyn loading an analyzer — holds a `bin/obj` file open, `File.CopyTo` throws "being used by another process". This surfaced now because the newly added `Amazon.Lambda.DurableExecution.Analyzers` project (#2443) is an analyzer whose outputs get loaded/locked during concurrent builds.

## Fix

Skip `bin` and `obj` during the copy (alongside the existing `.vs` skip). `dotnet lambda package` regenerates these anyway, so excluding them removes the lock contention and makes the copy faster.

## Testing

- Reproduced CI state by building `Amazon.Lambda.DurableExecution.Analyzers` in Release so its `bin/` contained the locked-file outputs.
- Ran a Release-mode integration test (`RestApiStreamingTests.StreamingEndpoint_ContentTypeIsTextPlain`) which exercises the exact fixture copy+package path that was throwing. It now initializes cleanly and **passes** (real CloudFormation stack deployed to us-west-2, cleaned up afterward).

Test-only change — no change file needed.
