### PR TITLE
Fix unresolved MapConfig XML doc cref in ChildContextConfig

### DIFF
--- a/Libraries/src/Amazon.Lambda.DurableExecution/ChildContextConfig.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/ChildContextConfig.cs
@@ -47,7 +47,7 @@ public sealed class ChildContextConfig
     /// </para>
     /// <para>
     /// This mirrors the <c>NestingType.Flat</c> option on
-    /// <see cref="MapConfig"/> and <see cref="ParallelConfig"/>, letting a
+    /// <see cref="MapConfig{TItem}"/> and <see cref="ParallelConfig"/>, letting a
     /// standalone <see cref="IDurableContext.RunInChildContextAsync{T}(System.Func{IDurableContext, System.Threading.CancellationToken, System.Threading.Tasks.Task{T}}, string?, ChildContextConfig?, System.Threading.CancellationToken)"/>
     /// call opt into virtual contexts — for example when manually fanning out
     /// work and awaiting the returned tasks with <c>Task.WhenAll</c>.


### PR DESCRIPTION
## Summary

Fixes a build break in `Amazon.Lambda.DurableExecution`. The XML doc comment in `ChildContextConfig.cs` referenced `<see cref="MapConfig"/>`, but `MapConfig` is now a generic type (`MapConfig<TItem>`). The bare cref no longer resolves, producing:

```
error CS1574: XML comment has cref attribute 'MapConfig' that could not be resolved
```

Under `TreatWarningsAsErrors` this fails the build on both `net8.0` and `net10.0`.

## Change

Reference the generic type as `MapConfig{TItem}` — the XML-doc syntax for a generic, matching the crefs already used in `CompletionConfig.cs` and `IDurableContext.cs`.

## Test plan

- [ ] `dotnet build` of the DurableExecution library succeeds (CS1574 gone).