### PR TITLE
Fix durable execution conformance issues found via cross-SDK testing

### DIFF
--- a/.autover/changes/durable-conformance-fixes.json
+++ b/.autover/changes/durable-conformance-fixes.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.DurableExecution",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fix durable execution conformance issues found via cross-SDK testing. WaitForCondition now re-emits a fresh START on each poll iteration (READY/PENDING replays), matching the Python/JS/Java SDKs and the spec; only a STARTED-status replay skips it. Preview."
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/CallbackOperation.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/CallbackOperation.cs
@@ -103,6 +103,7 @@ internal sealed class CallbackOperation<T> : DurableOperation<ICallback<T>>, ICa
         await EnqueueAsync(new SdkOperationUpdate
         {
             Id = OperationId,
+            ParentId = ParentId,
             Type = OperationTypes.Callback,
             Action = OperationAction.START,
             SubType = OperationSubTypes.Callback,

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/ConcurrentOperation.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/ConcurrentOperation.cs
@@ -123,6 +123,7 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
         await EnqueueAsync(new SdkOperationUpdate
         {
             Id = OperationId,
+            ParentId = ParentId,
             Type = OperationTypes.Context,
             Action = OperationAction.START,
             SubType = ParentSubType,
@@ -341,34 +342,28 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
         // FailureToleranceExceeded verdict from units that merely unwound.
         controlToken.ThrowIfCancellationRequested();
 
-        // Build BatchItems for every unit in original order.
+        // Build BatchItems ONLY for units that were dispatched — matching the JS
+        // SDK, whose sparse resultItems array never records a never-dispatched
+        // branch. A dispatched-then-bailed unit (cooperative short-circuit) keeps
+        // its Started slot and stays in All; a never-dispatched unit is omitted
+        // entirely. This makes TotalCount = started(in-flight) + succeeded + failed
+        // and excludes branches that a CompletionConfig short-circuit skipped.
         var items = new List<IBatchItem<T>>(unitCount);
         for (var i = 0; i < unitCount; i++)
         {
+            if (!dispatched[i])
+                continue;
+
             var (unitName, _) = GetUnit(i);
-            if (dispatched[i])
+            var outcome = slots[i];
+            items.Add(new BatchItem<T>
             {
-                var outcome = slots[i];
-                items.Add(new BatchItem<T>
-                {
-                    Index = i,
-                    Name = unitName,
-                    Status = outcome.Status,
-                    Result = outcome.Status == BatchItemStatus.Succeeded ? outcome.Result : default,
-                    Error = outcome.Status == BatchItemStatus.Failed ? outcome.Error : null
-                });
-            }
-            else
-            {
-                items.Add(new BatchItem<T>
-                {
-                    Index = i,
-                    Name = unitName,
-                    Status = BatchItemStatus.Started,
-                    Result = default,
-                    Error = null
-                });
-            }
+                Index = i,
+                Name = unitName,
+                Status = outcome.Status,
+                Result = outcome.Status == BatchItemStatus.Succeeded ? outcome.Result : default,
+                Error = outcome.Status == BatchItemStatus.Failed ? outcome.Error : null
+            });
         }
 
         var completionReason = ComputeCompletionReason(items, unitCount);
@@ -422,12 +417,17 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
             }
             var resolvedName = checkpointedName ?? unitName;
 
+            // STARTED units in the frozen summary were short-circuited (never
+            // dispatched) originally — exclude them from the reconstructed All to
+            // match the fresh-run view and the JS SDK. (The name-drift check above
+            // still runs over the complete summary before we skip.)
+            if (status == BatchItemStatus.Started)
+                continue;
+
             T? unitResult = default;
             DurableExecutionException? unitError = null;
 
             // Re-execute only completed units to recover the stripped value/error.
-            // STARTED units were short-circuited (never dispatched) originally —
-            // do NOT run their bodies, so there are no spurious side effects.
             if (status == BatchItemStatus.Succeeded || status == BatchItemStatus.Failed)
             {
                 var outcome = await RunSingleUnitAsync(i, cancellationToken).ConfigureAwait(false);
@@ -663,7 +663,6 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
     {
         var succeeded = 0;
         var failed = 0;
-        var started = 0;
 
         foreach (var item in items)
         {
@@ -671,9 +670,16 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
             {
                 case BatchItemStatus.Succeeded: succeeded++; break;
                 case BatchItemStatus.Failed:    failed++;    break;
-                case BatchItemStatus.Started:   started++;   break;
             }
         }
+
+        // "started" for the policy is the DECLARED total minus what settled — this
+        // captures BOTH genuinely in-flight units AND never-dispatched units (which
+        // are no longer materialised in items). It preserves the early-stop signal
+        // (started > 0 => a CompletionConfig short-circuit skipped work) that drives
+        // MinSuccessfulReached, and totalCount stays the declared count so
+        // ToleratedFailurePercentage divides by the true branch count.
+        var started = totalCount - succeeded - failed;
 
         return _policy.Evaluate(succeeded, failed, started, totalCount);
     }
@@ -686,23 +692,35 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
         // Local builder: includeInline=true writes per-unit Result/Error inline
         // (Flat only); includeInline=false writes the minimal index/name/status
         // map (the shape Nested always uses, and the Flat overflow fallback).
+        // The persisted summary keeps EVERY declared unit — including
+        // never-dispatched ones tagged STARTED — even though result.All now omits
+        // them from the user-facing view. Replay/reconstruct and the unit-name
+        // drift check both loop the declared UnitCount and read per-unit
+        // status/name from this summary, so it must stay complete. Dispatched
+        // units are looked up by Index in result.All; the gaps are the
+        // never-dispatched branches.
         BatchSummary BuildSummary(bool includeInline)
         {
+            var byIndex = new Dictionary<int, IBatchItem<T>>(result.All.Count);
+            foreach (var it in result.All)
+                byIndex[it.Index] = it;
+
             var s = new BatchSummary
             {
                 CompletionReason = SerializeCompletionReason(completionReason),
-                Units = new List<BatchUnitSummary>(result.All.Count)
+                Units = new List<BatchUnitSummary>(UnitCount)
             };
-            for (var i = 0; i < result.All.Count; i++)
+            for (var i = 0; i < UnitCount; i++)
             {
-                var item = result.All[i];
+                var (unitName, _) = GetUnit(i);
+                byIndex.TryGetValue(i, out var item);
                 var unit = new BatchUnitSummary
                 {
-                    Index = item.Index,
-                    Name = item.Name,
-                    Status = SerializeStatus(item.Status)
+                    Index = i,
+                    Name = item?.Name ?? unitName,
+                    Status = SerializeStatus(item?.Status ?? BatchItemStatus.Started)
                 };
-                if (includeInline && _isVirtual)
+                if (includeInline && _isVirtual && item != null)
                 {
                     if (item.Status == BatchItemStatus.Succeeded)
                         unit.Result = SerializeResult(item.Result);
@@ -735,6 +753,7 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
         await EnqueueAsync(new SdkOperationUpdate
         {
             Id = OperationId,
+            ParentId = ParentId,
             Type = OperationTypes.Context,
             Action = OperationAction.SUCCEED,
             SubType = ParentSubType,
@@ -776,6 +795,14 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
                     $"units between deployments.");
             }
             var resolvedName = checkpointedName ?? unitName;
+
+            // A never-dispatched unit (Started status with no per-unit child
+            // checkpoint) is excluded from the reconstructed All, matching the
+            // fresh-run view and the JS SDK. A dispatched-then-bailed unit is also
+            // Started but HAS a child op, so it stays. The name-drift check above
+            // still runs over the complete summary before we skip.
+            if (status == BatchItemStatus.Started && childOp == null)
+                continue;
 
             T? unitResult = default;
             DurableExecutionException? unitError = null;

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/WaitForConditionOperation.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/WaitForConditionOperation.cs
@@ -82,7 +82,7 @@ internal sealed class WaitForConditionOperation<TState> : DurableOperation<TStat
     protected override string OperationType => OperationTypes.Step;
 
     protected override Task<TState> StartAsync(CancellationToken cancellationToken)
-        => ExecuteIteration(_config.InitialState, attemptNumber: 1, cancellationToken);
+        => ExecuteIteration(_config.InitialState, attemptNumber: 1, existingStatus: null, cancellationToken);
 
     protected override Task<TState> ReplayAsync(Operation existing, CancellationToken cancellationToken)
     {
@@ -106,7 +106,7 @@ internal sealed class WaitForConditionOperation<TState> : DurableOperation<TStat
                 // START emitted but no RETRY/SUCCEED yet — the very first
                 // check attempt was lost. Re-execute with InitialState. Do
                 // NOT re-emit START (the original is authoritative).
-                return ExecuteIteration(_config.InitialState, attemptNumber: 1, cancellationToken);
+                return ExecuteIteration(_config.InitialState, attemptNumber: 1, existingStatus: existing.Status, cancellationToken);
 
             default:
                 throw new NonDeterministicExecutionException(
@@ -133,7 +133,7 @@ internal sealed class WaitForConditionOperation<TState> : DurableOperation<TStat
 
         var priorState = DeserializeStateOrInitial(pending.StepDetails?.Result);
         var attemptNumber = (pending.StepDetails?.Attempt ?? 0) + 1;
-        return ExecuteIteration(priorState, attemptNumber, cancellationToken);
+        return ExecuteIteration(priorState, attemptNumber, existingStatus: pending.Status, cancellationToken);
     }
 
     /// <summary>
@@ -145,21 +145,32 @@ internal sealed class WaitForConditionOperation<TState> : DurableOperation<TStat
     {
         var priorState = DeserializeStateOrInitial(ready.StepDetails?.Result);
         var attemptNumber = (ready.StepDetails?.Attempt ?? 0) + 1;
-        return ExecuteIteration(priorState, attemptNumber, cancellationToken);
+        return ExecuteIteration(priorState, attemptNumber, existingStatus: ready.Status, cancellationToken);
     }
 
-    private async Task<TState> ExecuteIteration(TState currentState, int attemptNumber, CancellationToken cancellationToken)
+    private async Task<TState> ExecuteIteration(TState currentState, int attemptNumber, string? existingStatus, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        // Emit START on the very first attempt only — and sync-flush so the
-        // service has a record of the polling op even if the check function
-        // drives termination via, e.g., a wait inside it. Subsequent
-        // iterations resume from a RETRY/READY/PENDING checkpoint and skip
-        // START.
-        if (State.GetOperation(OperationId) == null)
+        // Emit a fresh START before every poll iteration, matching the spec and
+        // the Python/JS/Java SDKs. The ONLY case we skip is when the persisted
+        // status is already STARTED: the START was written but the first check
+        // attempt was lost (crash/timeout), so the original START is
+        // authoritative. On a normal resume the status is READY/PENDING (not
+        // STARTED), so each poll gets its own StepStarted checkpoint.
+        //
+        // START is fire-and-forget (NOT awaited), mirroring StepOperation and the
+        // Python/JS reference SDKs. Awaiting it would force two back-to-back
+        // synchronous checkpoint round-trips (START then terminal FAIL) with no
+        // suspension between them when the check throws on the first attempt,
+        // which hangs the invocation. START is telemetry-only for
+        // wait_for_condition — replay correctness depends solely on the terminal
+        // RETRY/SUCCEED/FAIL checkpoints, which remain awaited. Any flush error
+        // still surfaces deterministically via the batcher's terminal error on
+        // the next awaited checkpoint.
+        if (existingStatus != OperationStatuses.Started)
         {
-            await EnqueueAsync(new SdkOperationUpdate
+            FireAndForget(EnqueueAsync(new SdkOperationUpdate
             {
                 Id = OperationId,
                 ParentId = ParentId,
@@ -167,7 +178,7 @@ internal sealed class WaitForConditionOperation<TState> : DurableOperation<TStat
                 Action = OperationAction.START,
                 SubType = OperationSubTypes.WaitForCondition,
                 Name = Name
-            }, cancellationToken);
+            }, cancellationToken));
         }
 
         // Link the caller's token with the workflow-shutdown token. The check
@@ -381,6 +392,21 @@ internal sealed class WaitForConditionOperation<TState> : DurableOperation<TStat
         ErrorMessage = ex.Message,
         StackTrace = ex.StackTrace?.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).ToList()
     };
+
+    /// <summary>
+    /// Discards a Task but observes any exception so it doesn't surface as an
+    /// <c>UnobservedTaskException</c>. Used for fire-and-forget START checkpoints.
+    /// The actual error still propagates via the batcher's terminal error: the
+    /// next sync EnqueueAsync or DrainAsync rethrows with the original cause.
+    /// </summary>
+    private static void FireAndForget(Task task)
+    {
+        _ = task.ContinueWith(
+            static t => _ = t.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
 }
 
 /// <summary>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/WaitForConditionHappyPathTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/WaitForConditionHappyPathTest.cs
@@ -45,15 +45,19 @@ public class WaitForConditionHappyPathTest
             TimeSpan.FromSeconds(60));
         var events = history.Events ?? new List<Event>();
 
-        // Exactly one START emitted on the first iteration (subsequent
-        // iterations resume from a RETRY checkpoint and skip START).
-        Assert.Equal(1, events.Count(e => e.EventType == EventType.StepStarted && e.Name == "happy_poll"));
+        // A fresh START is emitted per poll iteration (READY/PENDING replays
+        // re-emit START to match the spec and Python/JS/Java SDKs), so there
+        // is one StepStarted per StepSucceeded. Require the pairing rather
+        // than a fixed count since the iteration total is timing-dependent.
+        var startedEvents = events.Where(e => e.EventType == EventType.StepStarted && e.Name == "happy_poll").ToList();
+        var succeededEvents = events.Where(e => e.StepSucceededDetails != null && e.Name == "happy_poll").ToList();
+        Assert.NotEmpty(startedEvents);
+        Assert.NotEmpty(succeededEvents);
+        Assert.Equal(succeededEvents.Count, startedEvents.Count);
 
         // Each polling iteration surfaces as a StepSucceeded event (one per
         // RETRY plus one for the terminal SUCCEED). The last one carries the
         // terminal state.
-        var succeededEvents = events.Where(e => e.StepSucceededDetails != null && e.Name == "happy_poll").ToList();
-        Assert.NotEmpty(succeededEvents);
         var succeeded = succeededEvents.Last();
 
         var finalPayload = succeeded.StepSucceededDetails.Result?.Payload;

--- a/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/WaitForConditionReplayDeterminismTest.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/WaitForConditionReplayDeterminismTest.cs
@@ -50,12 +50,15 @@ public class WaitForConditionReplayDeterminismTest
             TimeSpan.FromSeconds(60));
         var events = history.Events ?? new List<Event>();
 
-        // Each named step / polling op started exactly once. The leading and
-        // trailing steps each have one StepStarted; the polling op also has
-        // one (sub-iterations replay from RETRY/READY/PENDING and skip START).
+        // Plain steps start exactly once — the leading and trailing steps
+        // each have one StepStarted. The polling op re-emits a fresh START
+        // per iteration (READY/PENDING replays re-emit START to match the
+        // spec and Python/JS/Java SDKs), so it has one StepStarted per
+        // StepSucceeded rather than a single one.
         Assert.Single(events.Where(e => e.EventType == EventType.StepStarted && e.Name == "before_poll"));
         Assert.Single(events.Where(e => e.EventType == EventType.StepStarted && e.Name == "after_poll"));
-        Assert.Single(events.Where(e => e.EventType == EventType.StepStarted && e.Name == "determinism_poll"));
+        var pollStarted = events.Where(e => e.EventType == EventType.StepStarted && e.Name == "determinism_poll").ToList();
+        Assert.NotEmpty(pollStarted);
 
         // Plain steps SUCCEED exactly once (replay returns cached values).
         // The polling op surfaces one StepSucceeded per iteration (RETRYs +
@@ -63,7 +66,10 @@ public class WaitForConditionReplayDeterminismTest
         var stepSucceededEvents = events.Where(e => e.StepSucceededDetails != null).ToList();
         Assert.Single(stepSucceededEvents.Where(e => e.Name == "before_poll"));
         Assert.Single(stepSucceededEvents.Where(e => e.Name == "after_poll"));
-        Assert.NotEmpty(stepSucceededEvents.Where(e => e.Name == "determinism_poll"));
+        var pollSucceeded = stepSucceededEvents.Where(e => e.Name == "determinism_poll").ToList();
+        Assert.NotEmpty(pollSucceeded);
+        // One START per SUCCEED for the polling op across all iterations.
+        Assert.Equal(pollSucceeded.Count, pollStarted.Count);
 
         // Verify the trailing step received the GUID from the leading step
         // verbatim, AND the final counter — proves the cached step value and

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/MapOperationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/MapOperationTests.cs
@@ -293,8 +293,8 @@ public class MapOperationTests
         var (context, _, _, _) = CreateContext();
 
         // MaxConcurrency = 1 so dispatch order is deterministic: item 0 fires
-        // first and succeeds; items 1 and 2 are never dispatched and remain
-        // BatchItemStatus.Started.
+        // first and succeeds; items 1 and 2 are never dispatched and are
+        // EXCLUDED from the user-facing All list entirely.
         var result = await context.MapAsync(
             new[] { 1, 2, 3 },
             async (ctx, item, index, all, _) => { await Task.Yield(); return item; },
@@ -306,13 +306,12 @@ public class MapOperationTests
 
         Assert.Equal(CompletionReason.MinSuccessfulReached, result.CompletionReason);
         Assert.Equal(1, result.SuccessCount);
-        Assert.Equal(2, result.StartedCount);
+        Assert.Equal(0, result.StartedCount);
         Assert.Equal(0, result.FailureCount);
-        Assert.Equal(3, result.TotalCount);
+        Assert.Equal(1, result.TotalCount);
 
+        Assert.Single(result.All);
         Assert.Equal(BatchItemStatus.Succeeded, result.All[0].Status);
-        Assert.Equal(BatchItemStatus.Started,   result.All[1].Status);
-        Assert.Equal(BatchItemStatus.Started,   result.All[2].Status);
     }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -639,10 +638,12 @@ public class MapOperationTests
         Assert.Equal(0, calls);
         Assert.Equal(CompletionReason.MinSuccessfulReached, result.CompletionReason);
         Assert.Equal(2, result.SuccessCount);
-        Assert.Equal(1, result.StartedCount);
+        // Item 2 was never dispatched (STARTED in the summary, no child
+        // checkpoint) so it is excluded from the reconstructed All.
+        Assert.Equal(0, result.StartedCount);
+        Assert.Equal(2, result.All.Count);
         Assert.Equal(BatchItemStatus.Succeeded, result.All[0].Status);
         Assert.Equal(BatchItemStatus.Succeeded, result.All[1].Status);
-        Assert.Equal(BatchItemStatus.Started, result.All[2].Status);
         Assert.Equal(new[] { 10, 20 }, result.GetResults());
 
         await recorder.Batcher.DrainAsync();

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ParallelOperationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ParallelOperationTests.cs
@@ -352,7 +352,8 @@ public class ParallelOperationTests
 
         // MaxConcurrency = 1 so we know the dispatch order is deterministic:
         // branch 0 fires first and succeeds; branches 1 and 2 are never
-        // dispatched at all, so they remain in BatchItemStatus.Started.
+        // dispatched at all, so they are EXCLUDED from the user-facing All list
+        // entirely (they are not Started, don't count in TotalCount/StartedCount).
         var result = await context.ParallelAsync(
             new Func<IDurableContext, CancellationToken, Task<int>>[]
             {
@@ -368,13 +369,12 @@ public class ParallelOperationTests
 
         Assert.Equal(CompletionReason.MinSuccessfulReached, result.CompletionReason);
         Assert.Equal(1, result.SuccessCount);
-        Assert.Equal(2, result.StartedCount);
+        Assert.Equal(0, result.StartedCount);
         Assert.Equal(0, result.FailureCount);
-        Assert.Equal(3, result.TotalCount);
+        Assert.Equal(1, result.TotalCount);
 
+        Assert.Single(result.All);
         Assert.Equal(BatchItemStatus.Succeeded, result.All[0].Status);
-        Assert.Equal(BatchItemStatus.Started,   result.All[1].Status);
-        Assert.Equal(BatchItemStatus.Started,   result.All[2].Status);
     }
 
     [Fact]
@@ -398,7 +398,10 @@ public class ParallelOperationTests
 
         Assert.Equal(CompletionReason.MinSuccessfulReached, result.CompletionReason);
         Assert.Equal(2, result.SuccessCount);
-        Assert.Equal(2, result.StartedCount);
+        // MaxConcurrency = 1: branches 2 and 3 are never dispatched once
+        // MinSuccessful = 2 is reached, so they are excluded from All.
+        Assert.Equal(0, result.StartedCount);
+        Assert.Equal(2, result.TotalCount);
     }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -820,10 +823,11 @@ public class ParallelOperationTests
         Assert.Equal(2, executions);
         Assert.False(startedBodyRan);
 
-        // Per-item statuses come from the frozen summary.
+        // Per-item statuses come from the frozen summary. The never-dispatched
+        // STARTED unit (index 2, no child checkpoint) is excluded from All.
+        Assert.Equal(2, result.All.Count);
         Assert.Equal(BatchItemStatus.Succeeded, result.All[0].Status);
         Assert.Equal(BatchItemStatus.Succeeded, result.All[1].Status);
-        Assert.Equal(BatchItemStatus.Started, result.All[2].Status);
 
         // Recovered values for the two succeeded units.
         Assert.Equal(new[] { 100, 200 }, result.GetResults());
@@ -1521,9 +1525,10 @@ public class ParallelOperationTests
     {
         // Parent SUCCEEDED with MinSuccessful short-circuit: branch 0
         // SUCCEEDED, branch 1 SUCCEEDED, branch 2 was never dispatched
-        // (still STARTED in the summary). Replay must reproduce the original
-        // BatchResult shape — including the un-dispatched STARTED entry —
-        // without re-executing any branch.
+        // (still STARTED in the summary, but has NO child checkpoint). Replay
+        // must reconstruct the user-facing BatchResult WITHOUT re-executing any
+        // branch and must EXCLUDE the never-dispatched STARTED entry (no child
+        // op) from All — matching a fresh run.
         var parentOpId = IdAt(1);
         var b0 = ChildIdAt(parentOpId, 1);
         var b1 = ChildIdAt(parentOpId, 2);
@@ -1584,10 +1589,10 @@ public class ParallelOperationTests
         Assert.Equal(0, calls);
         Assert.Equal(CompletionReason.MinSuccessfulReached, result.CompletionReason);
         Assert.Equal(2, result.SuccessCount);
-        Assert.Equal(1, result.StartedCount);
+        Assert.Equal(0, result.StartedCount);
+        Assert.Equal(2, result.All.Count);
         Assert.Equal(BatchItemStatus.Succeeded, result.All[0].Status);
         Assert.Equal(BatchItemStatus.Succeeded, result.All[1].Status);
-        Assert.Equal(BatchItemStatus.Started, result.All[2].Status);
         Assert.Equal(new[] { 10, 20 }, result.GetResults());
 
         await recorder.Batcher.DrainAsync();
@@ -1675,11 +1680,13 @@ public class ParallelOperationTests
     [Fact]
     public async Task ParallelAsync_ReplayUsesCheckpointedBranchName_NotCurrentName()
     {
-        // The checkpointed name is authoritative on replay. Even when a branch
-        // has no per-branch checkpoint (STARTED / never dispatched), the name
-        // from the parent summary must flow through to the reconstructed item.
+        // The checkpointed name is authoritative on replay. For a
+        // dispatched-then-bailed branch (STARTED with a per-branch START
+        // checkpoint), the reconstructed item is kept in All and its name must
+        // come from the parent summary, not from current code.
         var parentOpId = IdAt(1);
         var b0 = ChildIdAt(parentOpId, 1);
+        var b1 = ChildIdAt(parentOpId, 2);
 
         var summaryJson = """
             {"CompletionReason":"MIN_SUCCESSFUL_REACHED","Units":[
@@ -1709,6 +1716,16 @@ public class ParallelOperationTests
                     SubType = OperationSubTypes.ParallelBranch,
                     Name = "alpha",
                     ContextDetails = new ContextDetails { Result = "10" }
+                },
+                new()
+                {
+                    // Dispatched-then-bailed: has a START checkpoint (STARTED)
+                    // so the reconstructed item stays in All.
+                    Id = b1,
+                    Type = OperationTypes.Context,
+                    Status = OperationStatuses.Started,
+                    SubType = OperationSubTypes.ParallelBranch,
+                    Name = "beta"
                 }
             }
         });

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/WaitForConditionOperationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/WaitForConditionOperationTests.cs
@@ -315,8 +315,11 @@ public class WaitForConditionOperationTests
 
         await recorder.Batcher.DrainAsync();
 
-        // No new START — original is authoritative.
-        Assert.DoesNotContain(recorder.Flushed, o => o.Action == "START");
+        // Each poll iteration emits its own START (StepStarted), matching the
+        // spec and the Python/JS/Java SDKs. START is only skipped when the
+        // persisted status is STARTED (see Replay_Started_*); a PENDING resume
+        // gets a fresh START.
+        Assert.Contains(recorder.Flushed, o => o.Action == "START");
         Assert.Contains(recorder.Flushed, o => o.Action == "SUCCEED");
     }
 
@@ -365,7 +368,11 @@ public class WaitForConditionOperationTests
         Assert.Equal(22, result);
 
         await recorder.Batcher.DrainAsync();
-        Assert.DoesNotContain(recorder.Flushed, o => o.Action == "START");
+        // Each poll iteration emits its own START (StepStarted), matching the
+        // spec and the Python/JS/Java SDKs. START is only skipped when the
+        // persisted status is STARTED (see Replay_Started_*); a READY resume
+        // gets a fresh START.
+        Assert.Contains(recorder.Flushed, o => o.Action == "START");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes five behavioral bugs in the `Amazon.Lambda.DurableExecution` operations, surfaced by running the multi-language durable-execution conformance suite against the .NET SDK and comparing the emitted execution history / results against the JS, Python, and Java reference SDKs.

All five were confirmed as divergences from the reference SDKs (one matches a known open bug in the Python SDK, [issue #279](https://github.com/aws/aws-durable-execution-sdk-python/issues/279)).

## Fixes

1. **`ConcurrentOperation` — missing `ParentId` on parent CONTEXT checkpoints.** Parallel/Map did not set `ParentId` on their `START`/`SUCCEED` checkpoints (every other operation type does). This dropped the parent linkage for a nested parallel/map — its child events lost their `ParentId`.

2. **`CallbackOperation` — missing `ParentId` on the callback `START`.** Nested callbacks (e.g. the inner callback created by `WaitForCallbackAsync`) lost their `ParentId`.

3. **`WaitForConditionOperation` — `StepStarted` only emitted on the first poll.** Now emits a fresh `StepStarted` before every poll iteration, matching Python/JS/Java. On resume the persisted status is `READY`/`PENDING`, so each poll gets its own `START`; the only skip is when the status is already `STARTED` (crash-recovery, where the original `START` is authoritative).

4. **`WaitForConditionOperation` — `START` checkpoint was awaited instead of fire-and-forget.** Awaiting it forced two back-to-back synchronous flushes (`START` then terminal `FAIL`) with no suspension when the check throws on the first attempt, which could hang the invocation. Now fire-and-forget, mirroring `StepOperation` and the reference SDKs. Replay correctness depends only on the terminal `RETRY`/`SUCCEED`/`FAIL` checkpoints.

5. **`ConcurrentOperation`/`BatchResult` — `TotalCount` counted never-dispatched branches.** Never-dispatched branches (skipped by a `CompletionConfig` short-circuit before they ever started) are now excluded from the user-facing `All` list, so `TotalCount = started(in-flight) + succeeded + failed`, matching the JS SDK (same bug as Python #279). A dispatched-then-bailed (genuinely in-flight) branch still appears as `Started`. The completion policy still reasons over the declared branch count (so `ToleratedFailurePercentage` and the early-stop / min-successful signal are unchanged), and the persisted checkpoint summary still records every declared unit for replay/reconstruct. The replay and reconstruct paths were updated to keep the reconstructed `All` consistent with the fresh run.

## Tests

Updated the affected `ParallelOperationTests` and `MapOperationTests` to reflect the corrected never-dispatched semantics. Dispatched-then-bailed (in-flight) cases are deliberately unchanged. All 72 parallel + map operation unit tests pass.

Validated end-to-end against the conformance harness: all implementable .NET conformance tests pass across step, wait, callback, child, invoke, parallel, wait_for_callback, and wait_for_condition operations.

> Draft: opening for review of the SDK behavior changes. Three conformance cases (per-operation custom serdes for child/parallel/invoke) remain unimplementable in .NET and are tracked separately as a capability gap, not addressed here.