### PR TITLE
Promote Durable Execution SDK to GA (1.0.0)

### DIFF
--- a/.autover/autover.json
+++ b/.autover/autover.json
@@ -52,13 +52,11 @@
       "Paths": [
         "Libraries/src/Amazon.Lambda.DurableExecution/Amazon.Lambda.DurableExecution.csproj",
         "Libraries/src/Amazon.Lambda.DurableExecution.Analyzers/Amazon.Lambda.DurableExecution.Analyzers.csproj"
-      ],
-      "PrereleaseLabel": "preview"
+      ]
     },
     {
       "Name": "Amazon.Lambda.DurableExecution.Testing",
-      "Path": "Libraries/src/Amazon.Lambda.DurableExecution.Testing/Amazon.Lambda.DurableExecution.Testing.csproj",
-      "PrereleaseLabel": "preview"
+      "Path": "Libraries/src/Amazon.Lambda.DurableExecution.Testing/Amazon.Lambda.DurableExecution.Testing.csproj"
     },
     {
       "Name": "Amazon.Lambda.DynamoDBEvents",

--- a/.autover/changes/485d9d8d-8f78-4e72-8385-e799f0b2a3c1.json
+++ b/.autover/changes/485d9d8d-8f78-4e72-8385-e799f0b2a3c1.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Templates",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update the durable function blueprints (DurableFunction and serverless.DurableFunction) to reference the GA 1.0.0 Amazon.Lambda.DurableExecution and Amazon.Lambda.DurableExecution.Testing packages instead of the preview versions."
+      ]
+    }
+  ]
+}

--- a/.autover/changes/a1a6ed2d-0ba2-4456-8c63-32cfb7edfa43.json
+++ b/.autover/changes/a1a6ed2d-0ba2-4456-8c63-32cfb7edfa43.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.DurableExecution",
+      "Type": "Major",
+      "ChangelogMessages": [
+        "General availability release. Amazon.Lambda.DurableExecution is now GA and stable at 1.0.0; the SDK is no longer preview."
+      ]
+    }
+  ]
+}

--- a/.autover/changes/afc895e8-8170-4e40-8bae-b8368ff4ff8d.json
+++ b/.autover/changes/afc895e8-8170-4e40-8bae-b8368ff4ff8d.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.DurableExecution.Testing",
+      "Type": "Major",
+      "ChangelogMessages": [
+        "General availability release. Amazon.Lambda.DurableExecution.Testing is now GA and stable at 1.0.0; the package is no longer preview."
+      ]
+    }
+  ]
+}

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -20,6 +20,6 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="3.1.1" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.0" />
-    <PackageReference Include="Amazon.Lambda.DurableExecution" Version="0.1.1-preview" />
+    <PackageReference Include="Amazon.Lambda.DurableExecution" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunction/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="3.1.1" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="4.1.0" />
-    <PackageReference Include="Amazon.Lambda.DurableExecution.Testing" Version="0.0.1-preview" />
+    <PackageReference Include="Amazon.Lambda.DurableExecution.Testing" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj
@@ -21,6 +21,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="3.1.1" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.0" />
     <PackageReference Include="Amazon.Lambda.Annotations" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.DurableExecution" Version="0.1.1-preview" />
+    <PackageReference Include="Amazon.Lambda.DurableExecution" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
+++ b/Blueprints/BlueprintDefinitions/vs2026/DurableFunctionServerless/template/test/BlueprintBaseName.1.Tests/BlueprintBaseName.1.Tests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="3.1.1" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="4.1.0" />
-    <PackageReference Include="Amazon.Lambda.DurableExecution.Testing" Version="0.0.1-preview" />
+    <PackageReference Include="Amazon.Lambda.DurableExecution.Testing" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/Libraries/src/Amazon.Lambda.DurableExecution.Testing/README.md
+++ b/Libraries/src/Amazon.Lambda.DurableExecution.Testing/README.md
@@ -1,7 +1,5 @@
 # AWS Lambda Durable Execution Testing for .NET
 
-> **Preview.** `Amazon.Lambda.DurableExecution.Testing` tracks the `Amazon.Lambda.DurableExecution` runtime package (0.x). Public APIs may change before 1.0.
-
 `Amazon.Lambda.DurableExecution.Testing` lets you test [durable workflows](../Amazon.Lambda.DurableExecution/README.md) without deploying to AWS. It drives your workflow handler to a terminal state in-process using the real durable runtime engine backed by an in-memory store, and then exposes the result and every recorded operation for assertions.
 
 You write a test against the `IDurableTestRunner<TInput, TOutput>` interface; the same test runs unchanged against the in-memory `DurableTestRunner` (fast, no AWS) or the `CloudDurableTestRunner` (a deployed function).

--- a/Libraries/src/Amazon.Lambda.DurableExecution/CLAUDE.md
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-`Amazon.Lambda.DurableExecution` is the .NET SDK (preview, 0.x) for resilient, long-running AWS Lambda
+`Amazon.Lambda.DurableExecution` is the .NET SDK (GA, 1.x) for resilient, long-running AWS Lambda
 workflows that checkpoint progress after each step and resume after failures or waits. A workflow can run
 for up to ~1 year (the WAIT cap is 31,622,400 seconds) and is only billed for active compute. The SDK is
 client-side glue: the *durable execution service* (part of Lambda) owns the checkpoint store, fires timers,

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/DurableUserAgent.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/DurableUserAgent.cs
@@ -23,7 +23,7 @@ internal static partial class DurableUserAgent
 {
     /// <summary>
     /// The user-agent component appended to every durable-execution request, e.g.
-    /// <c>aws-durable-execution-sdk-dotnet/0.1.0-preview</c>.
+    /// <c>aws-durable-execution-sdk-dotnet/1.0.0</c>.
     /// </summary>
     internal static readonly string UserAgentString =
         $"aws-durable-execution-sdk-dotnet/{AssemblyVersion}";

--- a/Libraries/src/Amazon.Lambda.DurableExecution/README.md
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/README.md
@@ -1,7 +1,5 @@
 # AWS Lambda Durable Execution SDK for .NET
 
-> **Preview.** `Amazon.Lambda.DurableExecution` is in active development (0.x). Public APIs may change before 1.0.
-
 `Amazon.Lambda.DurableExecution` is the .NET SDK for building resilient, long-running AWS Lambda functions that automatically checkpoint progress and resume after failures. Workflows can run for up to one year, with charges only for active compute time.
 
 ## Key Features

--- a/Libraries/src/Amazon.Lambda.DurableExecution/docs/analyzers.md
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/docs/analyzers.md
@@ -127,4 +127,4 @@ dotnet_diagnostic.DE004.severity = none
 
 Note: if your project sets `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`, the Warning-level
 rules (DE001–DE003) will fail the build. Lower their severity in `.editorconfig` if you prefer them as
-warnings during the preview.
+warnings.


### PR DESCRIPTION
## Summary

Marks `Amazon.Lambda.DurableExecution` and `Amazon.Lambda.DurableExecution.Testing` as generally available and removes the preview label ahead of the 1.0.0 release

https://github.com/aws/aws-lambda-dotnet/issues/2418.

## Changes

**Versioning**
- Remove `"PrereleaseLabel": "preview"` from both durable projects in `.autover/autover.json` (this is what appended `-preview`).
- Add `Major` change files for `Amazon.Lambda.DurableExecution` and `Amazon.Lambda.DurableExecution.Testing`. Verified via `autover version` dry-run that `0.x-preview` → **`1.0.0`** (not `0.4.0`), with no `-preview` suffix.
- Add a `Patch` change file for `Amazon.Lambda.Templates` covering the blueprint updates below.
- csproj `<Version>` tags are intentionally left at their released values so the Release PR doesn't double-bump.

**Docs & references**
- Remove the Preview banners from both package READMEs.
- Bump the durable blueprint templates (`DurableFunction` + `serverless.DurableFunction`, src + test) to reference the GA `1.0.0` packages instead of the preview versions.
- Update remaining preview/0.x wording in `docs/analyzers.md`, `DurableUserAgent.cs`, and the package `CLAUDE.md`.

**Intentionally left alone**
- References to the `ILambdaContext.Serializer` API — #2485 graduates it from experimental, so no suppression or preview wording is needed here anymore.
- The "Accepted-for-preview" heading in the annotations-integration design doc (historical record).

## Verification
- `Amazon.Lambda.DurableExecution` (+ bundled `.Analyzers`) — build succeeded, 0 warnings (net8.0 + net10.0).
- `Amazon.Lambda.DurableExecution.Testing` — build succeeded, 0 warnings (net10.0).