### PR TITLE
Graduate ILambdaContext.Serializer to stable (remove AWSLAMBDA001)

### DIFF
--- a/.autover/changes/1bf02dc5-534e-4f49-a4d9-cf07daf4fde7.json
+++ b/.autover/changes/1bf02dc5-534e-4f49-a4d9-cf07daf4fde7.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Core",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Graduate ILambdaContext.Serializer from experimental to stable. The AWSLAMBDA001 experimental diagnostic is removed; the managed runtime now populates the serializer in both the executable and class-library programming models."
+      ]
+    }
+  ]
+}

--- a/.autover/changes/89f7d5f8-2c64-446f-b146-1dfdac656c86.json
+++ b/.autover/changes/89f7d5f8-2c64-446f-b146-1dfdac656c86.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.TestUtilities",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Graduate TestLambdaContext.Serializer from experimental to stable, mirroring the graduation of ILambdaContext.Serializer. The AWSLAMBDA001 experimental diagnostic is removed."
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.Core/ILambdaContext.cs
+++ b/Libraries/src/Amazon.Lambda.Core/ILambdaContext.cs
@@ -1,7 +1,6 @@
 namespace Amazon.Lambda.Core
 {
     using System;
-    using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
     /// Object that allows you to access useful information available within
@@ -107,13 +106,6 @@ namespace Amazon.Lambda.Core
         /// Can be null when the function did not register a serializer (e.g., raw-stream
         /// handlers).
         /// </summary>
-        /// <remarks>
-        /// <para><b>Preview API.</b> Class-library mode requires an updated managed
-        /// Lambda runtime to populate this property; until that ships, the value will
-        /// be null when running in class-library mode. The <see cref="ExperimentalAttribute"/>
-        /// is applied to surface this caveat at the call site.</para>
-        /// </remarks>
-        [Experimental("AWSLAMBDA001")]
         ILambdaSerializer Serializer { get { return null; } }
 #endif
     }

--- a/Libraries/src/Amazon.Lambda.DurableExecution.Testing/Amazon.Lambda.DurableExecution.Testing.csproj
+++ b/Libraries/src/Amazon.Lambda.DurableExecution.Testing/Amazon.Lambda.DurableExecution.Testing.csproj
@@ -13,7 +13,6 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);AWSLAMBDA001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Amazon.Lambda.DurableExecution.csproj
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Amazon.Lambda.DurableExecution.csproj
@@ -16,10 +16,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors>IL2026,IL2067,IL2075,IL3050</WarningsAsErrors>
-    <!-- DurableExecution intentionally consumes the preview ILambdaContext.Serializer
-         API. The whole package is in development (0.x), so suppressing project-wide
-         is appropriate; downstream users still see AWSLAMBDA001 in their own code. -->
-    <NoWarn>$(NoWarn);AWSLAMBDA001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libraries/src/Amazon.Lambda.TestUtilities/TestLambdaContext.cs
+++ b/Libraries/src/Amazon.Lambda.TestUtilities/TestLambdaContext.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -87,11 +86,6 @@ namespace Amazon.Lambda.TestUtilities
         /// to mirror the serializer that the Lambda runtime support library would attach
         /// in production.
         /// </summary>
-        /// <remarks>
-        /// <b>Preview API.</b> Mirrors the experimental <c>ILambdaContext.Serializer</c>
-        /// surface so test code opts in via the same <c>AWSLAMBDA001</c> diagnostic.
-        /// </remarks>
-        [Experimental("AWSLAMBDA001")]
         public ILambdaSerializer Serializer { get; set; }
     }
 }

--- a/Libraries/test/Amazon.Lambda.Core.Tests/TestLambdaContextSerializerTest.cs
+++ b/Libraries/test/Amazon.Lambda.Core.Tests/TestLambdaContextSerializerTest.cs
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-#pragma warning disable AWSLAMBDA001 // ILambdaContext.Serializer is preview; this is the test that proves it works.
 using System.IO;
 using Amazon.Lambda.Core;
 using Amazon.Lambda.TestUtilities;

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/CallbackOperationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/CallbackOperationTests.cs
@@ -16,9 +16,7 @@ public class CallbackOperationTests
     private static string IdAt(int position) => OperationIdGenerator.HashOperationId(position.ToString());
 
     private static TestLambdaContext CreateLambdaContext() =>
-#pragma warning disable AWSLAMBDA001 // TestLambdaContext.Serializer is experimental.
         new() { Serializer = new DefaultLambdaJsonSerializer() };
-#pragma warning restore AWSLAMBDA001
 
     private static (DurableContext context, RecordingBatcher recorder, TerminationManager tm, ExecutionState state)
         CreateContext(InitialExecutionState? initialState = null)

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ChildContextOperationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ChildContextOperationTests.cs
@@ -25,9 +25,7 @@ public class ChildContextOperationTests
         state.LoadFromCheckpoint(initialState);
         var tm = new TerminationManager();
         var idGen = new OperationIdGenerator();
-#pragma warning disable AWSLAMBDA001 // TestLambdaContext.Serializer is experimental.
         var lambdaContext = new TestLambdaContext { Serializer = new DefaultLambdaJsonSerializer() };
-#pragma warning restore AWSLAMBDA001
         var recorder = new RecordingBatcher();
         var context = new DurableContext(state, tm, new WorkflowCancellation(tm), idGen, "arn:test", lambdaContext, recorder.Batcher);
         return (context, recorder, tm, state);

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/DurableContextTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/DurableContextTests.cs
@@ -19,9 +19,7 @@ public class DurableContextTests
     private static string IdAt(int position) => OperationIdGenerator.HashOperationId(position.ToString());
 
     private static TestLambdaContext CreateLambdaContext() =>
-#pragma warning disable AWSLAMBDA001 // TestLambdaContext.Serializer is experimental.
         new() { Serializer = new DefaultLambdaJsonSerializer() };
-#pragma warning restore AWSLAMBDA001
 
     private static DurableContext CreateContext(
         InitialExecutionState? initialState = null,

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/DurableFunctionTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/DurableFunctionTests.cs
@@ -20,9 +20,7 @@ public class DurableFunctionTests
     private static string IdAt(int position) => OperationIdGenerator.HashOperationId(position.ToString());
 
     private static TestLambdaContext CreateLambdaContext() =>
-#pragma warning disable AWSLAMBDA001 // TestLambdaContext.Serializer is experimental.
         new() { Serializer = new DefaultLambdaJsonSerializer() };
-#pragma warning restore AWSLAMBDA001
 
     private readonly IAmazonLambda _mockClient = new MockLambdaClient();
 

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/InvokeOperationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/InvokeOperationTests.cs
@@ -23,9 +23,7 @@ public class InvokeOperationTests
         state.LoadFromCheckpoint(initialState);
         var tm = new TerminationManager();
         var idGen = new OperationIdGenerator();
-#pragma warning disable AWSLAMBDA001 // TestLambdaContext.Serializer is experimental.
         var lambdaContext = new TestLambdaContext { Serializer = new DefaultLambdaJsonSerializer() };
-#pragma warning restore AWSLAMBDA001
         var recorder = new RecordingBatcher();
         var context = new DurableContext(state, tm, new WorkflowCancellation(tm), idGen, "arn:test", lambdaContext, recorder.Batcher);
         return (context, recorder, tm, state);
@@ -475,9 +473,7 @@ public class InvokeOperationTests
         var state = new ExecutionState();
         state.LoadFromCheckpoint(null);
         var idGen = new OperationIdGenerator();
-#pragma warning disable AWSLAMBDA001
         var lambdaContext = new TestLambdaContext { Serializer = new DefaultLambdaJsonSerializer() };
-#pragma warning restore AWSLAMBDA001
         var batcher = new RecordingBatcher();
         var context = new DurableContext(state, tm, new WorkflowCancellation(tm), idGen, "arn:test", lambdaContext, batcher.Batcher);
 
@@ -527,9 +523,7 @@ public class InvokeOperationTests
         });
 
         var idGen = new OperationIdGenerator();
-#pragma warning disable AWSLAMBDA001
         var lambdaContext = new TestLambdaContext { Serializer = new DefaultLambdaJsonSerializer() };
-#pragma warning restore AWSLAMBDA001
         var context = new DurableContext(state, tm, new WorkflowCancellation(tm), idGen, "arn:test", lambdaContext);
         var finalizeRan = false;
 

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/MapOperationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/MapOperationTests.cs
@@ -22,9 +22,7 @@ public class MapOperationTests
         state.LoadFromCheckpoint(initialState);
         var tm = new TerminationManager();
         var idGen = new OperationIdGenerator();
-#pragma warning disable AWSLAMBDA001 // TestLambdaContext.Serializer is experimental.
         var lambdaContext = new TestLambdaContext { Serializer = new DefaultLambdaJsonSerializer() };
-#pragma warning restore AWSLAMBDA001
         var recorder = new RecordingBatcher();
         var context = new DurableContext(state, tm, new WorkflowCancellation(tm), idGen, "arn:test", lambdaContext, recorder.Batcher);
         return (context, recorder, tm, state);

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ParallelOperationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ParallelOperationTests.cs
@@ -25,9 +25,7 @@ public class ParallelOperationTests
         state.LoadFromCheckpoint(initialState);
         var tm = new TerminationManager();
         var idGen = new OperationIdGenerator();
-#pragma warning disable AWSLAMBDA001 // TestLambdaContext.Serializer is experimental.
         var lambdaContext = new TestLambdaContext { Serializer = new DefaultLambdaJsonSerializer() };
-#pragma warning restore AWSLAMBDA001
         var recorder = new RecordingBatcher();
         var context = new DurableContext(state, tm, new WorkflowCancellation(tm), idGen, "arn:test", lambdaContext, recorder.Batcher);
         return (context, recorder, tm, state);

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/WaitForCallbackTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/WaitForCallbackTests.cs
@@ -19,9 +19,7 @@ public class WaitForCallbackTests
         OperationIdGenerator.HashOperationId($"{parentOpId}-{position}");
 
     private static TestLambdaContext CreateLambdaContext() =>
-#pragma warning disable AWSLAMBDA001 // TestLambdaContext.Serializer is experimental.
         new() { Serializer = new DefaultLambdaJsonSerializer() };
-#pragma warning restore AWSLAMBDA001
 
     private static (DurableContext context, RecordingBatcher recorder, TerminationManager tm, ExecutionState state)
         CreateContext(InitialExecutionState? initialState = null)

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/WaitForConditionOperationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/WaitForConditionOperationTests.cs
@@ -15,9 +15,7 @@ public class WaitForConditionOperationTests
     private static string IdAt(int position) => OperationIdGenerator.HashOperationId(position.ToString());
 
     private static TestLambdaContext CreateLambdaContext(ILambdaSerializer? serializer = null) =>
-#pragma warning disable AWSLAMBDA001 // TestLambdaContext.Serializer is experimental.
         new() { Serializer = serializer ?? new DefaultLambdaJsonSerializer() };
-#pragma warning restore AWSLAMBDA001
 
     private static (DurableContext context, RecordingBatcher recorder, TerminationManager tm, ExecutionState state)
         CreateContext(InitialExecutionState? initialState = null, ILambdaSerializer? serializer = null)

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/WorkflowCancellationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/WorkflowCancellationTests.cs
@@ -17,9 +17,7 @@ namespace Amazon.Lambda.DurableExecution.Tests;
 public class WorkflowCancellationTests
 {
     private static TestLambdaContext CreateLambdaContext() =>
-#pragma warning disable AWSLAMBDA001 // TestLambdaContext.Serializer is experimental.
         new() { Serializer = new DefaultLambdaJsonSerializer() };
-#pragma warning restore AWSLAMBDA001
 
     private sealed record Harness(
         DurableContext Context,

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaContextSerializerTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaContextSerializerTests.cs
@@ -12,7 +12,6 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-#pragma warning disable AWSLAMBDA001 // ILambdaContext.Serializer is preview; this is the test that proves it works.
 using Amazon.Lambda.Core;
 using Amazon.Lambda.RuntimeSupport.Bootstrap;
 using Amazon.Lambda.RuntimeSupport.Helpers;


### PR DESCRIPTION
## Summary

Promotes `ILambdaContext.Serializer` from experimental to a **stable** public API by removing the `[Experimental("AWSLAMBDA001")]` attribute in `Amazon.Lambda.Core`, along with its mirror on `TestLambdaContext.Serializer` in `Amazon.Lambda.TestUtilities`.

The property was originally shipped experimental (added in #2378) because class-library mode required an updated managed Lambda runtime to populate it. **That runtime work has shipped and is covered end-to-end:**
- `Amazon.Lambda.RuntimeSupport` populates the property on every invocation (`LambdaBootstrap.SetSerializerOnContext` → `context.Serializer = _serializer`), including class-library mode after `[assembly: LambdaSerializer]` is resolved.
- `Amazon.Lambda.DurableExecution`'s `ClassLibraryTest` / `TestFunctions/ClassLibraryFunction` exercise it against the managed `dotnet10` runtime.

So the "requires an updated managed runtime… until that ships" caveat no longer applies, and the API can graduate. The property remains legitimately nullable (raw-stream handlers / no registered serializer), documented as normal API behavior.

## Changes

- Remove `[Experimental]` + the "Preview API" remarks from `ILambdaContext.Serializer` and `TestLambdaContext.Serializer`; drop the now-unused `System.Diagnostics.CodeAnalysis` usings.
- Remove the now-dead `<NoWarn>AWSLAMBDA001</NoWarn>` from `Amazon.Lambda.DurableExecution` and `Amazon.Lambda.DurableExecution.Testing`.
- Remove the now-dead `#pragma warning disable/restore AWSLAMBDA001` guards across Core, RuntimeSupport, and DurableExecution test files (45 pragma lines; no logic changed).
- Add `Minor` change files for `Amazon.Lambda.Core` and `Amazon.Lambda.TestUtilities` (public API graduation).

## Sequencing

This is the **prerequisite** for the Durable Execution GA (1.0.0) work in #2484 — it lands **first** so the GA PR no longer needs to carry the `AWSLAMBDA001` suppression. #2484 has been updated to drop its csproj-comment edit so the two PRs don't collide.

## Verification

Built clean (0 warnings, 0 errors) — the removed pragmas produced no "unnecessary pragma" warnings under `TreatWarningsAsErrors`:
- `Amazon.Lambda.Core`, `Amazon.Lambda.TestUtilities`, `Amazon.Lambda.DurableExecution`, `Amazon.Lambda.DurableExecution.Testing`
- Test projects: `Amazon.Lambda.Core.Tests`, `Amazon.Lambda.DurableExecution.Tests`, `Amazon.Lambda.RuntimeSupport.UnitTests`

## Note

`CA2252` suppressions in the Core/RuntimeSupport test csprojs are unrelated (they cover the separate `ConfigureStructuredLogging` preview feature) and are intentionally left in place.