### PR TITLE
Update System.Security.Cryptography.Xml dependency on Amazon.Lambda.PowerShellHost

### DIFF
--- a/.autover/changes/75140818-2797-4234-aff7-3e0eea5d54ba.json
+++ b/.autover/changes/75140818-2797-4234-aff7-3e0eea5d54ba.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.PowerShellHost",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update System.Security.Cryptography.Xml dependency to 8.0.4 for .NET 8 and 10.0.10 for .NET 10"
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.PowerShellHost/Amazon.Lambda.PowerShellHost.csproj
+++ b/Libraries/src/Amazon.Lambda.PowerShellHost/Amazon.Lambda.PowerShellHost.csproj
@@ -14,11 +14,11 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.14" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Amazon.Lambda.Core\Amazon.Lambda.Core.csproj" />

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Analyzers.Tests/Amazon.Lambda.DurableExecution.Analyzers.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Analyzers.Tests/Amazon.Lambda.DurableExecution.Analyzers.Tests.csproj
@@ -13,6 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Libraries/test/EventsTests.NET8/EventsTests.NET8.csproj
+++ b/Libraries/test/EventsTests.NET8/EventsTests.NET8.csproj
@@ -48,6 +48,8 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.15.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Libraries/test/TestFunctionFSharp/TestFunctionCSharp/TestFunctionCSharp.csproj
+++ b/Libraries/test/TestFunctionFSharp/TestFunctionCSharp/TestFunctionCSharp.csproj
@@ -11,6 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/Libraries/test/TestFunctionFSharp/TestFunctionFSharp/TestFunctionFSharp.fsproj
+++ b/Libraries/test/TestFunctionFSharp/TestFunctionFSharp/TestFunctionFSharp.fsproj
@@ -15,6 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />


### PR DESCRIPTION
*Description of changes:*
Updated the `System.Security.Cryptography.Xml` dependency for Amazon.Lambda.PowerShellHost because the current version has reported vulnerabilities.

A follow PR after this has been released will be done to update the Lambda PS module to use the new version of Amazon.Lambda.PowerShellHost.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
