### PR TITLE
Fix Test Tool v2 Blazor UI non-interactive on .NET 10 (static assets 404)

### DIFF
--- a/.autover/changes/156dd8b1-1af2-45fc-b051-b94dc51fc56f.json
+++ b/.autover/changes/156dd8b1-1af2-45fc-b051-b94dc51fc56f.json
@@ -1,0 +1,12 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.TestTool",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fix Blazor web UI being non-interactive on .NET 9+/net10.0. Framework static assets (_framework/blazor.web.js) and the scoped-CSS bundle are now served via MapStaticAssets, the static web assets manifest is composed regardless of hosting environment, and the content root is pinned to the tool's install directory so the assets resolve correctly when running as an installed global tool.",
+        "Fix Razor class library content (e.g. the BlazorMonaco code-editor assets under _content/**) returning 404 on .NET 8 when running from a build output (dotnet run), which left the request/response editor uninitialized so selecting an example request could not populate the input. The static web assets manifest is now composed on all target frameworks, and .NET 8 additionally serves static files from the web root file provider so manifest-mapped _content/** assets resolve. Verified across .NET 8/.NET 10, Development/Production, and dotnet-run/installed-tool."
+      ]
+    }
+  ]
+}

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/TestToolProcess.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/TestToolProcess.cs
@@ -36,9 +36,40 @@ public class TestToolProcess
     /// </summary>
     public static TestToolProcess Startup(RunCommandSettings settings, CancellationToken cancellationToken = default)
     {
-        var builder = WebApplication.CreateBuilder();
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            // Pin the content root to the tool's install directory rather than the current
+            // working directory. As an installed global tool the process is launched from an
+            // arbitrary cwd, and the default content root is the cwd. On .NET 9+ the framework
+            // and scoped-CSS assets are served by MapStaticAssets from the WebRootFileProvider,
+            // which is derived from the content root (contentRoot/wwwroot). If the content root
+            // is a foreign cwd, that provider points at a nonexistent wwwroot and MapStaticAssets
+            // returns empty (0-byte) 200 responses, leaving the Blazor UI non-interactive.
+            ContentRootPath = AppContext.BaseDirectory
+        });
 
         Utils.ConfigureWebApplicationBuilder(builder);
+
+        // Static web assets (the *.staticwebassets.runtime.json manifest) map two kinds of files
+        // that do NOT physically live under wwwroot when running from a build output (dotnet run /
+        // dotnet build): the Blazor framework files (_framework/blazor.web.js) and Razor class
+        // library content such as BlazorMonaco's _content/BlazorMonaco/** editor assets. Both live
+        // in the NuGet cache and are surfaced via that manifest. ASP.NET Core only composes the
+        // manifest into the WebRootFileProvider automatically in the Development environment, but
+        // this tool runs in the Production environment by default, so without the call below the
+        // WebRootFileProvider is a bare wwwroot provider and those assets are unreachable.
+        //
+        // On .NET 9+ that leaves MapStaticAssets (added below) unable to find the framework files —
+        // it serves an empty (0-byte) HTTP 200, window.Blazor is never defined, and the whole UI is
+        // non-interactive. On .NET 8 the framework files are served by Blazor's own middleware, but
+        // the RCL _content/** assets are served through UseStaticFiles + WebRootFileProvider, so
+        // without the manifest the Monaco editor assets 404 and the code editor never initializes
+        // (e.g. selecting an example request cannot populate the input). Either way the fix is the
+        // same, so this runs on all target frameworks.
+        //
+        // When running as an installed global tool the manifest is absent (the framework and RCL
+        // content are published directly into wwwroot instead), so this is a harmless no-op there.
+        builder.WebHost.UseStaticWebAssets();
 
         builder.Services.AddSingleton<IRuntimeApiDataStoreManager, RuntimeApiDataStoreManager>();
         builder.Services.AddSingleton<IThemeService, ThemeService>();
@@ -91,14 +122,60 @@ public class TestToolProcess
             app.UseDeveloperExceptionPage();
         }
 
-        // Always use the explicit file provider to serve static files from the tool's install
-        // directory. Without this, non-Production environments attempt to use the static web
-        // assets manifest which contains absolute paths from the build machine and will fail
-        // when running as an installed global tool on a different machine.
+        // Serve classic static files from the tool's install directory (wwwroot). This is the
+        // authoritative provider for an installed global tool, where every asset — app.css, the
+        // Blazor framework files, and RCL _content/** (e.g. BlazorMonaco) — is published directly
+        // into wwwroot. Pinning an explicit provider (rather than the default WebRootFileProvider)
+        // also avoids depending on the static-web-assets manifest, whose absolute build-machine
+        // paths would not resolve on another machine.
         app.UseStaticFiles(new StaticFileOptions
         {
             FileProvider = wwwrootFileProvider
         });
+
+#if !NET9_0_OR_GREATER
+        // On .NET 8 there is no MapStaticAssets endpoint pipeline (added below for net9+), and the
+        // explicit provider above sees only the physical wwwroot. When running from a build output
+        // (dotnet run / dotnet build), RCL _content/** assets are NOT physically in wwwroot — they
+        // are surfaced through the static-web-assets manifest that UseStaticWebAssets() composes
+        // into the WebRootFileProvider. Without a second pass over that provider, BlazorMonaco's
+        // _content/BlazorMonaco/** editor assets 404 and the code editor never initializes (so, for
+        // example, selecting an example request cannot populate the input). Serve from the
+        // WebRootFileProvider as well to cover that case. For an installed tool the WebRootFile
+        // provider resolves to the same wwwroot as above, so this is a harmless second lookup.
+        if (app.Environment.WebRootFileProvider is not null)
+        {
+            app.UseStaticFiles(new StaticFileOptions
+            {
+                FileProvider = app.Environment.WebRootFileProvider
+            });
+        }
+#endif
+
+#if NET9_0_OR_GREATER
+        // On .NET 9+ the Blazor framework files (_framework/blazor.web.js) and the scoped-CSS
+        // bundle (Amazon.Lambda.TestTool.styles.css) are served through the endpoint-routing
+        // static assets API backed by the *.staticwebassets.endpoints.json manifest, not the
+        // classic static-files middleware above. Without this call those assets return 404, so
+        // window.Blazor is never defined and the interactive server circuit is never established,
+        // leaving the entire Blazor UI non-interactive. The bytes are resolved from the web host's
+        // WebRootFileProvider, which is why UseStaticWebAssets() is also required above (see the
+        // comment there). Guarded so net8.0 (which serves these assets via the classic static-web-
+        // assets middleware) keeps its existing behavior.
+        //
+        // MapStaticAssets() throws if the manifest is absent. That manifest is named after the
+        // entry assembly, so when Startup is invoked from within a test host (unit tests call it
+        // directly) the tool's manifest isn't next to the running 'testhost' assembly. Only map
+        // static assets when the expected manifest exists — the running tool has it; the test host
+        // does not (and those tests only exercise the Runtime API, not the Blazor assets).
+        var staticAssetsManifest = Path.Combine(
+            AppContext.BaseDirectory,
+            $"{System.Reflection.Assembly.GetEntryAssembly()?.GetName().Name}.staticwebassets.endpoints.json");
+        if (File.Exists(staticAssetsManifest))
+        {
+            app.MapStaticAssets();
+        }
+#endif
 
         app.UseAntiforgery();
 

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/TestToolProcess.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/TestToolProcess.cs
@@ -38,37 +38,20 @@ public class TestToolProcess
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
-            // Pin the content root to the tool's install directory rather than the current
-            // working directory. As an installed global tool the process is launched from an
-            // arbitrary cwd, and the default content root is the cwd. On .NET 9+ the framework
-            // and scoped-CSS assets are served by MapStaticAssets from the WebRootFileProvider,
-            // which is derived from the content root (contentRoot/wwwroot). If the content root
-            // is a foreign cwd, that provider points at a nonexistent wwwroot and MapStaticAssets
-            // returns empty (0-byte) 200 responses, leaving the Blazor UI non-interactive.
+            // Pin the content root to the install dir. As a global tool the process launches from
+            // an arbitrary cwd, and WebRootFileProvider (= contentRoot/wwwroot) defaults to it. A
+            // foreign cwd points that provider at a nonexistent wwwroot, so assets 404 / serve empty.
             ContentRootPath = AppContext.BaseDirectory
         });
 
         Utils.ConfigureWebApplicationBuilder(builder);
 
-        // Static web assets (the *.staticwebassets.runtime.json manifest) map two kinds of files
-        // that do NOT physically live under wwwroot when running from a build output (dotnet run /
-        // dotnet build): the Blazor framework files (_framework/blazor.web.js) and Razor class
-        // library content such as BlazorMonaco's _content/BlazorMonaco/** editor assets. Both live
-        // in the NuGet cache and are surfaced via that manifest. ASP.NET Core only composes the
-        // manifest into the WebRootFileProvider automatically in the Development environment, but
-        // this tool runs in the Production environment by default, so without the call below the
-        // WebRootFileProvider is a bare wwwroot provider and those assets are unreachable.
-        //
-        // On .NET 9+ that leaves MapStaticAssets (added below) unable to find the framework files —
-        // it serves an empty (0-byte) HTTP 200, window.Blazor is never defined, and the whole UI is
-        // non-interactive. On .NET 8 the framework files are served by Blazor's own middleware, but
-        // the RCL _content/** assets are served through UseStaticFiles + WebRootFileProvider, so
-        // without the manifest the Monaco editor assets 404 and the code editor never initializes
-        // (e.g. selecting an example request cannot populate the input). Either way the fix is the
-        // same, so this runs on all target frameworks.
-        //
-        // When running as an installed global tool the manifest is absent (the framework and RCL
-        // content are published directly into wwwroot instead), so this is a harmless no-op there.
+        // Under `dotnet run`, the Blazor framework files (_framework/*) and RCL content
+        // (_content/BlazorMonaco/**) don't live in wwwroot — they're surfaced from the NuGet cache
+        // via the static-web-assets manifest. ASP.NET Core only composes that manifest into
+        // WebRootFileProvider automatically in Development, but this tool runs as Production, so we
+        // compose it explicitly here. Without it net9+ serves empty framework files (UI dead) and
+        // net8 404s the Monaco editor assets. No-op for the installed tool (everything's in wwwroot).
         builder.WebHost.UseStaticWebAssets();
 
         builder.Services.AddSingleton<IRuntimeApiDataStoreManager, RuntimeApiDataStoreManager>();
@@ -122,58 +105,41 @@ public class TestToolProcess
             app.UseDeveloperExceptionPage();
         }
 
-        // Serve classic static files from the tool's install directory (wwwroot). This is the
-        // authoritative provider for an installed global tool, where every asset — app.css, the
-        // Blazor framework files, and RCL _content/** (e.g. BlazorMonaco) — is published directly
-        // into wwwroot. Pinning an explicit provider (rather than the default WebRootFileProvider)
-        // also avoids depending on the static-web-assets manifest, whose absolute build-machine
-        // paths would not resolve on another machine.
+        // --- Static assets: a base layer for every TFM, then per-TFM handling for manifest assets ---
+
+        // Base layer (all TFMs, all deployments): classic wwwroot files (app.css, images, favicon).
+        // Authoritative for the installed tool, where every asset is published into wwwroot. Pinned to
+        // an explicit provider so it never depends on the manifest's absolute build-machine paths.
         app.UseStaticFiles(new StaticFileOptions
         {
             FileProvider = wwwrootFileProvider
         });
 
-#if !NET9_0_OR_GREATER
-        // On .NET 8 there is no MapStaticAssets endpoint pipeline (added below for net9+), and the
-        // explicit provider above sees only the physical wwwroot. When running from a build output
-        // (dotnet run / dotnet build), RCL _content/** assets are NOT physically in wwwroot — they
-        // are surfaced through the static-web-assets manifest that UseStaticWebAssets() composes
-        // into the WebRootFileProvider. Without a second pass over that provider, BlazorMonaco's
-        // _content/BlazorMonaco/** editor assets 404 and the code editor never initializes (so, for
-        // example, selecting an example request cannot populate the input). Serve from the
-        // WebRootFileProvider as well to cover that case. For an installed tool the WebRootFile
-        // provider resolves to the same wwwroot as above, so this is a harmless second lookup.
-        if (app.Environment.WebRootFileProvider is not null)
-        {
-            app.UseStaticFiles(new StaticFileOptions
-            {
-                FileProvider = app.Environment.WebRootFileProvider
-            });
-        }
-#endif
-
+        // Manifest-mapped assets (framework files, scoped CSS, RCL _content/** e.g. Monaco) aren't in
+        // wwwroot under `dotnet run` — they're surfaced via the static-web-assets manifest that
+        // UseStaticWebAssets() composed above. How they're served differs by TFM:
 #if NET9_0_OR_GREATER
-        // On .NET 9+ the Blazor framework files (_framework/blazor.web.js) and the scoped-CSS
-        // bundle (Amazon.Lambda.TestTool.styles.css) are served through the endpoint-routing
-        // static assets API backed by the *.staticwebassets.endpoints.json manifest, not the
-        // classic static-files middleware above. Without this call those assets return 404, so
-        // window.Blazor is never defined and the interactive server circuit is never established,
-        // leaving the entire Blazor UI non-interactive. The bytes are resolved from the web host's
-        // WebRootFileProvider, which is why UseStaticWebAssets() is also required above (see the
-        // comment there). Guarded so net8.0 (which serves these assets via the classic static-web-
-        // assets middleware) keeps its existing behavior.
-        //
-        // MapStaticAssets() throws if the manifest is absent. That manifest is named after the
-        // entry assembly, so when Startup is invoked from within a test host (unit tests call it
-        // directly) the tool's manifest isn't next to the running 'testhost' assembly. Only map
-        // static assets when the expected manifest exists — the running tool has it; the test host
-        // does not (and those tests only exercise the Runtime API, not the Blazor assets).
+        // net9+: framework files + scoped CSS are served through the endpoint-routing static-assets
+        // API, not the classic middleware above. Without this, window.Blazor is never defined and the
+        // whole UI is non-interactive. MapStaticAssets() throws if the manifest (named after the entry
+        // assembly) is absent, as under a test host — so only map when it exists.
         var staticAssetsManifest = Path.Combine(
             AppContext.BaseDirectory,
             $"{System.Reflection.Assembly.GetEntryAssembly()?.GetName().Name}.staticwebassets.endpoints.json");
         if (File.Exists(staticAssetsManifest))
         {
             app.MapStaticAssets();
+        }
+#else
+        // net8: no MapStaticAssets, and the base provider sees only the physical wwwroot. Serve the
+        // manifest-composed WebRootFileProvider too, or the RCL _content/** (Monaco) assets 404 under
+        // `dotnet run`. For the installed tool this resolves to the same wwwroot — a harmless second pass.
+        if (app.Environment.WebRootFileProvider is not null)
+        {
+            app.UseStaticFiles(new StaticFileOptions
+            {
+                FileProvider = app.Environment.WebRootFileProvider
+            });
         }
 #endif
 


### PR DESCRIPTION
## Symptom

The AWS Lambda Test Tool v2 Blazor web UI had two static-asset serving bugs that broke interactivity, each specific to a target framework:

**(A) Non-interactive on .NET 10 (any .NET 9+).** Buttons don't respond, `@onclick`/`@bind` never fire; `window.Blazor` is `undefined`. The tell is subtle — the framework script returns HTTP **200 with a 0-byte body**, so status-code checks alone look green while the browser downloads nothing:

```
# net10, before this fix
_framework/blazor.web.js          -> HTTP 200, 0 bytes      <-- EMPTY
Amazon.Lambda.TestTool.styles.css -> HTTP 200, 0 bytes      <-- EMPTY
```

**(B) Code editor dead on .NET 8 (`dotnet run`).** The Razor class library assets for the Monaco code editor (`_content/BlazorMonaco/**`) return **404**, so the request/response editor never initializes — e.g. selecting an **example request does not populate the input**, and typing/formatting in the editor doesn't work:

```
# net8, dotnet run, before this fix
_framework/blazor.web.js                              -> HTTP 200, 187162 bytes  (ok)
_content/BlazorMonaco/lib/monaco-editor/min/vs/loader.js -> HTTP 404, 0 bytes    <-- MISSING
```

## Root cause

Static-asset serving changed in .NET 9: framework assets (`_framework/*`) and scoped CSS are served by the endpoint-routing **`app.MapStaticAssets()`** pipeline, which reads bytes from `IWebHostEnvironment.WebRootFileProvider`. Under `dotnet run`, neither the framework files nor RCL `_content/**` assets physically live in `wwwroot` — they live in the NuGet cache and are surfaced through the `*.staticwebassets.runtime.json` manifest. Two things kept that manifest from being reachable:

1. **Manifest not composed outside Development.** ASP.NET Core only composes the static-web-assets manifest into `WebRootFileProvider` automatically **when the environment is Development** (`WebHost.ConfigureWebDefaults` calls `StaticWebAssetsLoader.UseStaticWebAssets` only under `IsDevelopment()`). This tool runs as **Production by default**, so the web root was a bare `wwwroot` provider.
   - On **net9+** this meant `MapStaticAssets` served empty (0-byte) 200s for `_framework/*` → symptom (A).
   - On **net8** (no `MapStaticAssets`), the manifest was likewise never composed, and — see below — nothing read it anyway → symptom (B).

2. **Content root followed the current working directory.** As an installed global tool the process launches from an arbitrary cwd; `WebRootFileProvider` defaulted to `cwd/wwwroot`, a nonexistent path, so every asset returned empty 200s.

3. **The classic `UseStaticFiles` used an explicit bare-wwwroot provider.** It was pinned to a `PhysicalFileProvider(wwwroot)` and never read the manifest-composed `WebRootFileProvider`. On net9+ this was masked because `MapStaticAssets` reads `WebRootFileProvider`; on **net8 there is no such reader**, so manifest-mapped `_content/**` assets were unreachable → symptom (B).

## Fix

All in `Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Processes/TestToolProcess.cs`:

- **Pin the content root** to the install dir so `WebRootFileProvider` resolves regardless of launching cwd:
  ```csharp
  var builder = WebApplication.CreateBuilder(new WebApplicationOptions
  {
      ContentRootPath = AppContext.BaseDirectory
  });
  ```
- **Compose the static-web-assets manifest on all target frameworks** (previously net9+-only). ASP.NET Core only does this automatically in Development; the tool runs as Production:
  ```csharp
  builder.WebHost.UseStaticWebAssets();   // now unconditional
  ```
- **Serve `_framework/*` + scoped CSS via the endpoints manifest on net9+:**
  ```csharp
  #if NET9_0_OR_GREATER
  app.MapStaticAssets();   // guarded: only when the manifest exists (test host has none)
  #endif
  ```
- **On .NET 8, add a second `UseStaticFiles` over `WebRootFileProvider`** so manifest-mapped RCL `_content/**` assets (BlazorMonaco) resolve. There is no `MapStaticAssets` on net8, and the explicit wwwroot provider can't see the composed manifest:
  ```csharp
  #if !NET9_0_OR_GREATER
  if (app.Environment.WebRootFileProvider is not null)
  {
      app.UseStaticFiles(new StaticFileOptions
      {
          FileProvider = app.Environment.WebRootFileProvider
      });
  }
  #endif
  ```

The existing wwwroot `UseStaticFiles` provider is preserved (authoritative for the installed tool, where all assets are published directly into `wwwroot`). For an installed tool the second net8 lookup resolves to the same `wwwroot`, so it is a harmless second pass.

## Verification — full 8-case matrix

Probed the three assets whose absence breaks the UI — `_framework/blazor.web.js` (interactive circuit), `_content/BlazorMonaco/.../loader.js` (Monaco editor → example-request fill), and `app.css` — asserting HTTP 200 **with non-zero bytes** across every combination of **{.NET 8, .NET 10} × {Production, Development} × {`dotnet run`, installed tool}**:

| Case | blazor.web.js | monaco loader.js | app.css | Result |
|---|---|---|---|---|
| run / net8.0 / Production | 200, 187162 | 200, 30061 | 200, 3946 | ✅ PASS |
| run / net8.0 / Development | 200, 187162 | 200, 30061 | 200, 3946 | ✅ PASS |
| run / net10.0 / Production | 200, 200575 | 200, 30061 | 200, 3946 | ✅ PASS |
| run / net10.0 / Development | 200, 200575 | 200, 30061 | 200, 3946 | ✅ PASS |
| installed / net8.0 / Production | 200, 187162 | 200, 30061 | 200, 3946 | ✅ PASS |
| installed / net8.0 / Development | 200, 187162 | 200, 30061 | 200, 3946 | ✅ PASS |
| installed / net10.0 / Production | 200, 200575 | 200, 30061 | 200, 3946 | ✅ PASS |
| installed / net10.0 / Development | 200, 200575 | 200, 30061 | 200, 3946 | ✅ PASS |

(Before this change: `run/net8.0/*` had `monaco loader.js -> 404` and `run/net10.0/*` had `blazor.web.js -> 200, 0 bytes`.) Real-browser confirmation via headless Chromium: `window.Blazor=true` and no console errors on `/`, `/documentation`, and `/durable-execution`. Both TFMs build with 0 warnings / 0 errors; the Test Tool unit tests (which invoke `Startup` directly) pass on net8.
