### PR TITLE
Extract shared durable local-emulation kernel

### DIFF
--- a/.autover/changes/a3f6c9d2-7b41-4e08-9c5a-2d6f1e0b8a74.json
+++ b/.autover/changes/a3f6c9d2-7b41-4e08-9c5a-2d6f1e0b8a74.json
@@ -1,0 +1,18 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.DurableExecution.LocalEmulation",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add a shared local-emulation kernel for durable execution: the in-memory operation store and checkpoint state machine that drive durable workflows locally. Consumed by Amazon.Lambda.DurableExecution.Testing (and the Lambda Test Tool) via a transport-neutral OperationUpdateInput so the two cannot drift. Implementation detail; not intended for direct use."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.DurableExecution.Testing",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Refactor the in-memory checkpoint state machine and operation store into the shared Amazon.Lambda.DurableExecution.LocalEmulation package. No public API or behavior change."
+      ]
+    }
+  ]
+}

--- a/Libraries/Amazon.Lambda.DurableExecution.slnf
+++ b/Libraries/Amazon.Lambda.DurableExecution.slnf
@@ -7,9 +7,11 @@
       "src\\Amazon.Lambda.Serialization.SystemTextJson\\Amazon.Lambda.Serialization.SystemTextJson.csproj",
       "src\\Amazon.Lambda.TestUtilities\\Amazon.Lambda.TestUtilities.csproj",
       "src\\Amazon.Lambda.DurableExecution\\Amazon.Lambda.DurableExecution.csproj",
+      "src\\Amazon.Lambda.DurableExecution.LocalEmulation\\Amazon.Lambda.DurableExecution.LocalEmulation.csproj",
       "src\\Amazon.Lambda.DurableExecution.Testing\\Amazon.Lambda.DurableExecution.Testing.csproj",
       "test\\Amazon.Lambda.DurableExecution.Tests\\Amazon.Lambda.DurableExecution.Tests.csproj",
       "test\\Amazon.Lambda.DurableExecution.Testing.Tests\\Amazon.Lambda.DurableExecution.Testing.Tests.csproj",
+      "test\\Amazon.Lambda.DurableExecution.LocalEmulation.Tests\\Amazon.Lambda.DurableExecution.LocalEmulation.Tests.csproj",
       "test\\Amazon.Lambda.DurableExecution.IntegrationTests\\Amazon.Lambda.DurableExecution.IntegrationTests.csproj",
       "test\\Amazon.Lambda.DurableExecution.AotPublishTest\\Amazon.Lambda.DurableExecution.AotPublishTest.csproj"
     ]

--- a/Libraries/Libraries.sln
+++ b/Libraries/Libraries.sln
@@ -175,6 +175,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestDurableServerlessApp", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestDurableServerlessApp.IntegrationTests", "test\TestDurableServerlessApp.IntegrationTests\TestDurableServerlessApp.IntegrationTests.csproj", "{A89D56F9-63CC-4B47-BFED-693E3410993D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.Lambda.DurableExecution.LocalEmulation", "src\Amazon.Lambda.DurableExecution.LocalEmulation\Amazon.Lambda.DurableExecution.LocalEmulation.csproj", "{22AB1C70-26CB-443E-9ABD-3A6BF94743EB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.Lambda.DurableExecution.LocalEmulation.Tests", "test\Amazon.Lambda.DurableExecution.LocalEmulation.Tests\Amazon.Lambda.DurableExecution.LocalEmulation.Tests.csproj", "{3D323A2C-AD83-4CE1-A663-6FCC7AA44FC1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1109,6 +1113,30 @@ Global
 		{A89D56F9-63CC-4B47-BFED-693E3410993D}.Release|x64.Build.0 = Release|Any CPU
 		{A89D56F9-63CC-4B47-BFED-693E3410993D}.Release|x86.ActiveCfg = Release|Any CPU
 		{A89D56F9-63CC-4B47-BFED-693E3410993D}.Release|x86.Build.0 = Release|Any CPU
+		{22AB1C70-26CB-443E-9ABD-3A6BF94743EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22AB1C70-26CB-443E-9ABD-3A6BF94743EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22AB1C70-26CB-443E-9ABD-3A6BF94743EB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{22AB1C70-26CB-443E-9ABD-3A6BF94743EB}.Debug|x64.Build.0 = Debug|Any CPU
+		{22AB1C70-26CB-443E-9ABD-3A6BF94743EB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{22AB1C70-26CB-443E-9ABD-3A6BF94743EB}.Debug|x86.Build.0 = Debug|Any CPU
+		{22AB1C70-26CB-443E-9ABD-3A6BF94743EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22AB1C70-26CB-443E-9ABD-3A6BF94743EB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22AB1C70-26CB-443E-9ABD-3A6BF94743EB}.Release|x64.ActiveCfg = Release|Any CPU
+		{22AB1C70-26CB-443E-9ABD-3A6BF94743EB}.Release|x64.Build.0 = Release|Any CPU
+		{22AB1C70-26CB-443E-9ABD-3A6BF94743EB}.Release|x86.ActiveCfg = Release|Any CPU
+		{22AB1C70-26CB-443E-9ABD-3A6BF94743EB}.Release|x86.Build.0 = Release|Any CPU
+		{3D323A2C-AD83-4CE1-A663-6FCC7AA44FC1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3D323A2C-AD83-4CE1-A663-6FCC7AA44FC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3D323A2C-AD83-4CE1-A663-6FCC7AA44FC1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3D323A2C-AD83-4CE1-A663-6FCC7AA44FC1}.Debug|x64.Build.0 = Debug|Any CPU
+		{3D323A2C-AD83-4CE1-A663-6FCC7AA44FC1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3D323A2C-AD83-4CE1-A663-6FCC7AA44FC1}.Debug|x86.Build.0 = Debug|Any CPU
+		{3D323A2C-AD83-4CE1-A663-6FCC7AA44FC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3D323A2C-AD83-4CE1-A663-6FCC7AA44FC1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3D323A2C-AD83-4CE1-A663-6FCC7AA44FC1}.Release|x64.ActiveCfg = Release|Any CPU
+		{3D323A2C-AD83-4CE1-A663-6FCC7AA44FC1}.Release|x64.Build.0 = Release|Any CPU
+		{3D323A2C-AD83-4CE1-A663-6FCC7AA44FC1}.Release|x86.ActiveCfg = Release|Any CPU
+		{3D323A2C-AD83-4CE1-A663-6FCC7AA44FC1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1195,6 +1223,8 @@ Global
 		{0460CF9D-B5CC-47C5-9B30-CEA84695AB3B} = {1DE4EE60-45BA-4EF7-BE00-B9EB861E4C69}
 		{616E108A-9ED5-4282-B1D4-7FD49BC6DA2E} = {1DE4EE60-45BA-4EF7-BE00-B9EB861E4C69}
 		{A89D56F9-63CC-4B47-BFED-693E3410993D} = {1DE4EE60-45BA-4EF7-BE00-B9EB861E4C69}
+		{22AB1C70-26CB-443E-9ABD-3A6BF94743EB} = {AAB54E74-20B1-42ED-BC3D-CE9F7BC7FD12}
+		{3D323A2C-AD83-4CE1-A663-6FCC7AA44FC1} = {1DE4EE60-45BA-4EF7-BE00-B9EB861E4C69}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {503678A4-B8D1-4486-8915-405A3E9CF0EB}

--- a/Libraries/src/Amazon.Lambda.DurableExecution.LocalEmulation/Amazon.Lambda.DurableExecution.LocalEmulation.csproj
+++ b/Libraries/src/Amazon.Lambda.DurableExecution.LocalEmulation/Amazon.Lambda.DurableExecution.LocalEmulation.csproj
@@ -1,0 +1,52 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\..\buildtools\common.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>$(DefaultPackageTargets)</TargetFrameworks>
+    <Description>Shared in-memory emulation kernel for Amazon Lambda Durable Execution - the operation store and checkpoint state machine used to drive durable workflows locally (by the .Testing package and the Lambda Test Tool). Implementation detail; not intended for direct use.</Description>
+    <AssemblyTitle>Amazon.Lambda.DurableExecution.LocalEmulation</AssemblyTitle>
+    <Version>1.0.0</Version>
+    <AssemblyName>Amazon.Lambda.DurableExecution.LocalEmulation</AssemblyName>
+    <PackageId>Amazon.Lambda.DurableExecution.LocalEmulation</PackageId>
+    <PackageTags>AWS;Amazon;Lambda;Durable;Workflow;Testing</PackageTags>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <!--
+    The kernel types are an implementation detail shared with the two local-emulation consumers
+    (the .Testing package and the Lambda Test Tool) and this package's own tests, rather than a
+    public API. They stay internal and are surfaced via InternalsVisibleTo so we do not commit to
+    documenting/stabilizing them as a public surface. All these assemblies are strong-named with
+    buildtools/public.snk (via common.props), so each grant carries that shared public key.
+  -->
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Amazon.Lambda.DurableExecution.LocalEmulation.Tests, PublicKey="0024000004800000940000000602000000240000525341310004000001000100db5f59f098d27276c7833875a6263a3cc74ab17ba9a9df0b52aedbe7252745db7274d5271fd79c1f08f668ecfa8eaab5626fa76adc811d3c8fc55859b0d09d3bc0a84eecd0ba891f2b8a2fc55141cdcc37c2053d53491e650a479967c3622762977900eddbf1252ed08a2413f00a28f3a0752a81203f03ccb7f684db373518b4"</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Amazon.Lambda.DurableExecution.Testing, PublicKey="0024000004800000940000000602000000240000525341310004000001000100db5f59f098d27276c7833875a6263a3cc74ab17ba9a9df0b52aedbe7252745db7274d5271fd79c1f08f668ecfa8eaab5626fa76adc811d3c8fc55859b0d09d3bc0a84eecd0ba891f2b8a2fc55141cdcc37c2053d53491e650a479967c3622762977900eddbf1252ed08a2413f00a28f3a0752a81203f03ccb7f684db373518b4"</_Parameter1>
+    </AssemblyAttribute>
+    <!-- The .Testing package's tests exercise its SDK→OperationUpdateInput mapper, which names the
+         kernel's internal input type, so they need friend access here as well. -->
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Amazon.Lambda.DurableExecution.Testing.Tests, PublicKey="0024000004800000940000000602000000240000525341310004000001000100db5f59f098d27276c7833875a6263a3cc74ab17ba9a9df0b52aedbe7252745db7274d5271fd79c1f08f668ecfa8eaab5626fa76adc811d3c8fc55859b0d09d3bc0a84eecd0ba891f2b8a2fc55141cdcc37c2053d53491e650a479967c3622762977900eddbf1252ed08a2413f00a28f3a0752a81203f03ccb7f684db373518b4"</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Amazon.Lambda.TestTool, PublicKey="0024000004800000940000000602000000240000525341310004000001000100db5f59f098d27276c7833875a6263a3cc74ab17ba9a9df0b52aedbe7252745db7274d5271fd79c1f08f668ecfa8eaab5626fa76adc811d3c8fc55859b0d09d3bc0a84eecd0ba891f2b8a2fc55141cdcc37c2053d53491e650a479967c3622762977900eddbf1252ed08a2413f00a28f3a0752a81203f03ccb7f684db373518b4"</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <!--
+    The kernel depends only on the durable-execution runtime for its public wire model
+    (Operation, OperationTypes, OperationStatuses, ErrorObject). It intentionally does NOT
+    reference AWSSDK.Lambda's Model.OperationUpdate or any HTTP/STJ wire DTOs: consumers map
+    their own update representation to the neutral OperationUpdateInput at the boundary.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/src/Amazon.Lambda.DurableExecution.LocalEmulation/CheckpointProcessor.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution.LocalEmulation/CheckpointProcessor.cs
@@ -1,44 +1,53 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using Amazon.Lambda.Model;
-using SdkOperationUpdate = Amazon.Lambda.Model.OperationUpdate;
-
-namespace Amazon.Lambda.DurableExecution.Testing;
+namespace Amazon.Lambda.DurableExecution.LocalEmulation;
 
 /// <summary>
-/// Processes checkpoint updates against the in-memory operation store.
-/// Handles action-to-status mapping, callback ID minting, time skipping,
-/// and producing the "new operations" response the runtime expects.
+/// Processes checkpoint updates against the in-memory operation store. Handles action-to-status
+/// mapping, callback ID minting, time skipping, and producing the "new operations" the runtime
+/// expects back in the checkpoint response.
 /// </summary>
+/// <remarks>
+/// This is the shared local-emulation state machine used by both the durable-execution testing
+/// package (driving the workflow as an in-process delegate) and the Lambda Test Tool (driving a
+/// real, separately-running function over the Runtime API + HTTP data plane). Both feed it the
+/// same transport-neutral <see cref="OperationUpdateInput"/>; the state transitions below are the
+/// single source of truth for how a local checkpoint mutates recorded operations.
+/// </remarks>
 internal sealed class CheckpointProcessor
 {
     private readonly InMemoryOperationStore _store;
-    private readonly bool _skipTime;
+    // Read on each checkpoint (not captured) so a consumer's time-skip toggle can be flipped at
+    // runtime — e.g. the Test Tool's UI switch — and take effect for subsequent checkpoints.
+    private readonly Func<bool> _skipTimeProvider;
     private readonly object _pendingGate = new();
     private readonly List<PendingInvoke> _pendingInvokes = new();
 
+    /// <summary>Creates a processor whose time-skip mode is fixed for the run.</summary>
     public CheckpointProcessor(InMemoryOperationStore store, bool skipTime)
+        : this(store, () => skipTime)
+    {
+    }
+
+    /// <summary>Creates a processor whose time-skip mode is read live on each checkpoint.</summary>
+    public CheckpointProcessor(InMemoryOperationStore store, Func<bool> skipTimeProvider)
     {
         _store = store;
-        _skipTime = skipTime;
+        _skipTimeProvider = skipTimeProvider;
     }
 
     /// <summary>
-    /// A chained-invoke (<c>ctx.InvokeAsync</c>) that has been started by the
-    /// workflow but not yet resolved. The runtime suspends after emitting the
-    /// START and expects an external system to run the target function; in the
-    /// local harness the <see cref="ExecutionOrchestrator{TInput, TOutput}"/>
-    /// drains these between invocations and resolves them via the
-    /// <see cref="FunctionRegistry"/>. The target function name lives only on the
-    /// wire-format <c>OperationUpdate.ChainedInvokeOptions</c>, so it is captured
-    /// here rather than on the persisted <see cref="Operation"/>.
+    /// A chained-invoke (<c>ctx.InvokeAsync</c>) that has been started by the workflow but not yet
+    /// resolved. The runtime suspends after emitting the START and expects an external system to
+    /// run the target function; the local drivers drain these between invocations and resolve them
+    /// (the testing package via its function registry, the Test Tool by starting a nested durable
+    /// execution). The target function name lives only on the update, not on the persisted
+    /// <see cref="Operation"/>, so it is captured here.
     /// </summary>
     internal readonly record struct PendingInvoke(string OperationId, string FunctionName, string? Payload);
 
-    /// <summary>
-    /// Returns and clears the chained-invokes started since the last drain.
-    /// </summary>
+    /// <summary>Returns and clears the chained-invokes started since the last drain.</summary>
     public IReadOnlyList<PendingInvoke> DrainPendingInvokes()
     {
         lock (_pendingGate)
@@ -52,14 +61,13 @@ internal sealed class CheckpointProcessor
     }
 
     /// <summary>
-    /// Processes a batch of updates and returns the new checkpoint token
-    /// and any operations that were created or modified (to feed back to
-    /// the runtime's onNewOperations callback).
+    /// Processes a batch of updates and returns the new checkpoint token and any operations
+    /// created or modified (to feed back to the runtime's onNewOperations mechanism).
     /// </summary>
     public (string NewToken, IReadOnlyList<Operation> NewOperations) Process(
         string arn,
         string? currentToken,
-        IReadOnlyList<SdkOperationUpdate> updates)
+        IReadOnlyList<OperationUpdateInput> updates)
     {
         var newOperations = new List<Operation>();
 
@@ -73,29 +81,28 @@ internal sealed class CheckpointProcessor
         return (newToken, newOperations);
     }
 
-    private Operation ApplyUpdate(string arn, SdkOperationUpdate update)
+    private Operation ApplyUpdate(string arn, OperationUpdateInput update)
     {
-        var existing = _store.GetOperation(arn, update.Id);
+        var existing = _store.GetOperation(arn, update.Id!);
         var operation = existing ?? new Operation { Id = update.Id };
 
-        operation.Type = update.Type?.Value ?? operation.Type;
+        operation.Type = update.Type ?? operation.Type;
         operation.Name = update.Name ?? operation.Name;
         operation.ParentId = update.ParentId ?? operation.ParentId;
         operation.SubType = update.SubType ?? operation.SubType;
 
-        var action = update.Action?.Value;
+        var action = update.Action;
         ApplyAction(operation, action, update);
 
-        if (_skipTime)
+        if (_skipTimeProvider())
             ApplyTimeSkipping(operation, action);
 
-        // A chained-invoke START suspends the workflow until an external system
-        // resolves it. Record it so the orchestrator can run the registered
-        // sibling and stamp the result/error before the next replay. The function
-        // name is only carried on the wire-format update, not on the Operation.
+        // A chained-invoke START suspends the workflow until an external system resolves it.
+        // Record it so a driver can run the sibling and stamp the result/error before the next
+        // replay. The function name is only carried on the update, not on the Operation.
         if (action == "START"
             && operation.Type == OperationTypes.ChainedInvoke
-            && update.ChainedInvokeOptions?.FunctionName is { } functionName)
+            && update.ChainedInvokeFunctionName is { } functionName)
         {
             lock (_pendingGate)
             {
@@ -107,7 +114,7 @@ internal sealed class CheckpointProcessor
         return operation;
     }
 
-    private static void ApplyAction(Operation operation, string? action, SdkOperationUpdate update)
+    private static void ApplyAction(Operation operation, string? action, OperationUpdateInput update)
     {
         switch (action)
         {
@@ -141,23 +148,23 @@ internal sealed class CheckpointProcessor
         }
     }
 
-    private static void ApplyStartDetails(Operation operation, SdkOperationUpdate update)
+    private static void ApplyStartDetails(Operation operation, OperationUpdateInput update)
     {
         switch (operation.Type)
         {
             case OperationTypes.Step:
                 operation.StepDetails ??= new StepDetails();
-                // A plain step re-emits START before every attempt, so START owns
-                // the attempt count. WaitForCondition (Type=STEP, SubType=WaitForCondition)
-                // emits START only once and advances the count on each RETRY instead,
-                // so it must NOT increment here.
+                // A plain step re-emits START before every attempt, so START owns the attempt
+                // count. WaitForCondition (Type=STEP, SubType=WaitForCondition) emits START
+                // only once and advances the count on each RETRY instead, so it must NOT
+                // increment here.
                 if (operation.SubType != OperationSubTypes.WaitForCondition)
                     operation.StepDetails.Attempt = (operation.StepDetails.Attempt ?? 0) + 1;
                 break;
 
             case OperationTypes.Wait:
                 operation.WaitDetails ??= new WaitDetails();
-                if (update.WaitOptions?.WaitSeconds is { } seconds)
+                if (update.WaitSeconds is { } seconds)
                 {
                     operation.WaitDetails.ScheduledEndTimestamp =
                         DateTimeOffset.UtcNow.AddSeconds(seconds).ToUnixTimeMilliseconds();
@@ -183,7 +190,7 @@ internal sealed class CheckpointProcessor
         }
     }
 
-    private static void ApplySucceedDetails(Operation operation, SdkOperationUpdate update)
+    private static void ApplySucceedDetails(Operation operation, OperationUpdateInput update)
     {
         var payload = update.Payload;
         switch (operation.Type)
@@ -214,9 +221,9 @@ internal sealed class CheckpointProcessor
         }
     }
 
-    private static void ApplyFailDetails(Operation operation, SdkOperationUpdate update)
+    private static void ApplyFailDetails(Operation operation, OperationUpdateInput update)
     {
-        var error = MapSdkError(update.Error);
+        var error = update.Error;
         switch (operation.Type)
         {
             case OperationTypes.Step:
@@ -241,26 +248,26 @@ internal sealed class CheckpointProcessor
         }
     }
 
-    private static void ApplyRetryDetails(Operation operation, SdkOperationUpdate update)
+    private static void ApplyRetryDetails(Operation operation, OperationUpdateInput update)
     {
-        // Both retried steps and WaitForCondition polls are wire-encoded as
-        // Type=STEP (WaitForCondition uses SubType=WaitForCondition); the runtime
-        // never emits a WAIT-typed RETRY, so this single STEP branch covers both.
+        // Both retried steps and WaitForCondition polls are wire-encoded as Type=STEP
+        // (WaitForCondition uses SubType=WaitForCondition); the runtime never emits a
+        // WAIT-typed RETRY, so this single STEP branch covers both.
         if (operation.Type == OperationTypes.Step)
         {
             operation.StepDetails ??= new StepDetails();
-            if (update.StepOptions?.NextAttemptDelaySeconds is { } delaySeconds)
+            if (update.NextAttemptDelaySeconds is { } delaySeconds)
             {
                 operation.StepDetails.NextAttemptTimestamp =
                     DateTimeOffset.UtcNow.AddSeconds(delaySeconds).ToUnixTimeMilliseconds();
             }
-            operation.StepDetails.Error = MapSdkError(update.Error);
+            operation.StepDetails.Error = update.Error;
 
-            // WaitForCondition emits START once and advances per RETRY: it carries
-            // the next poll state in Payload and relies on the persistence layer to
-            // own the attempt count. Persist both so the next replay resumes from
-            // the latest state with an advanced attempt number (a plain step RETRY
-            // carries no Payload and owns its count via START, so leave it alone).
+            // WaitForCondition emits START once and advances per RETRY: it carries the next
+            // poll state in Payload and relies on the persistence layer to own the attempt
+            // count. Persist both so the next replay resumes from the latest state with an
+            // advanced attempt number (a plain step RETRY carries no Payload and owns its count
+            // via START, so leave it alone).
             if (operation.SubType == OperationSubTypes.WaitForCondition)
             {
                 if (update.Payload is not null)
@@ -283,9 +290,9 @@ internal sealed class CheckpointProcessor
             }
         }
 
-        // A retried step (or WaitForCondition poll, also Type=STEP) becomes
-        // immediately READY under time-skipping so the next replay runs the next
-        // attempt without waiting for the backoff/poll delay.
+        // A retried step (or WaitForCondition poll, also Type=STEP) becomes immediately READY
+        // under time-skipping so the next replay runs the next attempt without waiting for the
+        // backoff/poll delay.
         if (action == "RETRY" && operation.Type == OperationTypes.Step)
         {
             operation.Status = OperationStatuses.Ready;
@@ -295,17 +302,5 @@ internal sealed class CheckpointProcessor
                     DateTimeOffset.UtcNow.AddMilliseconds(-1).ToUnixTimeMilliseconds();
             }
         }
-    }
-
-    private static ErrorObject? MapSdkError(Amazon.Lambda.Model.ErrorObject? sdkError)
-    {
-        if (sdkError == null) return null;
-        return new ErrorObject
-        {
-            ErrorType = sdkError.ErrorType,
-            ErrorMessage = sdkError.ErrorMessage,
-            ErrorData = sdkError.ErrorData,
-            StackTrace = sdkError.StackTrace
-        };
     }
 }

--- a/Libraries/src/Amazon.Lambda.DurableExecution.LocalEmulation/DurableEmulationHelpers.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution.LocalEmulation/DurableEmulationHelpers.cs
@@ -1,0 +1,77 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace Amazon.Lambda.DurableExecution.LocalEmulation;
+
+/// <summary>
+/// Shared helpers for the local drive loops: seeding the top-level EXECUTION operation and
+/// computing when a suspended workflow can next make progress. Both the testing package's
+/// orchestrator and the Test Tool's driver use these so the semantics stay identical.
+/// </summary>
+internal static class DurableEmulationHelpers
+{
+    /// <summary>The operation id of the seeded top-level EXECUTION op.</summary>
+    public const string ExecutionOperationId = "exec-0";
+
+    /// <summary>
+    /// Seeds the top-level EXECUTION operation carrying the user input payload. Idempotent:
+    /// re-driving (e.g. a replay pass, or WaitForResultAsync after a callback) must not reset the
+    /// op back to Started or clobber recorded state.
+    /// </summary>
+    public static void SeedExecution(InMemoryOperationStore store, string arn, string? inputPayload)
+    {
+        if (store.GetOperation(arn, ExecutionOperationId) is not null)
+            return;
+
+        store.Upsert(arn, new Operation
+        {
+            Id = ExecutionOperationId,
+            Type = OperationTypes.Execution,
+            Status = OperationStatuses.Started,
+            ExecutionDetails = new ExecutionDetails { InputPayload = inputPayload }
+        });
+    }
+
+    /// <summary>
+    /// Computes how long to wait before the workflow can next make progress, based on the earliest
+    /// future <c>ScheduledEndTimestamp</c> (pending WAIT) or <c>NextAttemptTimestamp</c> (pending
+    /// STEP retry backoff) across all operations. Returns false when no operation carries a future
+    /// resume time.
+    /// </summary>
+    public static bool TryGetNextResumeDelay(InMemoryOperationStore store, string arn, out TimeSpan delay)
+        => TryGetNextResumeDelay(store.GetAllOperations(arn), out delay);
+
+    /// <summary>
+    /// Operation-list overload of <see cref="TryGetNextResumeDelay(InMemoryOperationStore, string, out TimeSpan)"/>
+    /// for callers that hold a snapshot rather than the store (e.g. the Test Tool driver, which
+    /// does not expose the underlying store).
+    /// </summary>
+    public static bool TryGetNextResumeDelay(IReadOnlyList<Operation> operations, out TimeSpan delay)
+    {
+        long? earliest = null;
+        foreach (var op in operations)
+        {
+            long? resumeAt = op.Type switch
+            {
+                OperationTypes.Wait when op.Status == OperationStatuses.Started
+                    => op.WaitDetails?.ScheduledEndTimestamp,
+                OperationTypes.Step when op.Status == OperationStatuses.Pending
+                    => op.StepDetails?.NextAttemptTimestamp,
+                _ => null,
+            };
+
+            if (resumeAt is { } ts && (earliest is null || ts < earliest))
+                earliest = ts;
+        }
+
+        if (earliest is null)
+        {
+            delay = TimeSpan.Zero;
+            return false;
+        }
+
+        var deltaMs = earliest.Value - DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        delay = deltaMs > 0 ? TimeSpan.FromMilliseconds(deltaMs) : TimeSpan.Zero;
+        return true;
+    }
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution.LocalEmulation/InMemoryOperationStore.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution.LocalEmulation/InMemoryOperationStore.cs
@@ -1,20 +1,21 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-namespace Amazon.Lambda.DurableExecution.Testing;
+namespace Amazon.Lambda.DurableExecution.LocalEmulation;
 
 /// <summary>
-/// In-memory store for operations recorded during a test execution.
-/// Each execution (keyed by ARN) maintains its own isolated operation set.
+/// In-memory store for operations recorded during a local durable execution. Each execution
+/// (keyed by ARN) maintains its own isolated operation set and checkpoint token. Operates on the
+/// public <see cref="Operation"/> wire type so consumers can serialize state responses directly.
 /// </summary>
 internal sealed class InMemoryOperationStore
 {
     private readonly Dictionary<string, ExecutionData> _executions = new();
 
-    // A single lock guards both the per-ARN dictionary and each ExecutionData's
-    // collections. Writes are normally serialized by the runtime's single-reader
-    // checkpoint batcher, but parallel/map workflows and the snapshot reads below
-    // can interleave, so we lock to keep the Dictionary/List internally consistent.
+    // A single lock guards both the per-ARN dictionary and each ExecutionData's collections.
+    // Writes are normally serialized by the runtime's single-reader checkpoint batcher, but
+    // parallel/map workflows and the snapshot reads below can interleave, so we lock to keep
+    // the Dictionary/List internally consistent.
     private readonly object _gate = new();
 
     public string CurrentToken(string arn)
@@ -24,9 +25,8 @@ internal sealed class InMemoryOperationStore
     }
 
     /// <summary>
-    /// Returns a snapshot copy of the operations for the execution. The copy is
-    /// detached from the backing list so callers can iterate safely while the
-    /// store continues to mutate.
+    /// Returns a snapshot copy of the operations for the execution. The copy is detached from
+    /// the backing list so callers can iterate safely while the store continues to mutate.
     /// </summary>
     public IReadOnlyList<Operation> GetAllOperations(string arn)
     {
@@ -77,6 +77,13 @@ internal sealed class InMemoryOperationStore
     {
         lock (_gate)
             return GetOrCreate(arn).Operations.Count;
+    }
+
+    /// <summary>True once an execution with this ARN has been created.</summary>
+    public bool Exists(string arn)
+    {
+        lock (_gate)
+            return _executions.ContainsKey(arn);
     }
 
     private ExecutionData GetOrCreate(string arn)

--- a/Libraries/src/Amazon.Lambda.DurableExecution.LocalEmulation/OperationUpdateInput.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution.LocalEmulation/OperationUpdateInput.cs
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace Amazon.Lambda.DurableExecution.LocalEmulation;
+
+/// <summary>
+/// A transport-neutral checkpoint update consumed by <see cref="CheckpointProcessor"/>.
+/// </summary>
+/// <remarks>
+/// The two local-emulation consumers receive checkpoint updates in different shapes:
+/// the testing package gets the AWSSDK <c>Amazon.Lambda.Model.OperationUpdate</c> (whose
+/// Type/Action/SubType are <c>ConstantClass</c> values), and the Test Tool gets a plain-STJ
+/// wire DTO deserialized from the HTTP data plane. Rather than make the state machine generic
+/// over those two shapes, each consumer flattens its own representation into this one record at
+/// the boundary — unwrapping enum-like members to plain strings and mapping nested option/error
+/// types up front. That keeps every branch of the shared state machine identical and free of
+/// <c>?.Value</c> ceremony.
+///
+/// Only the members the checkpoint state machine actually reads are carried here; option groups
+/// are flattened to their single relevant field (e.g. <see cref="WaitSeconds"/> from
+/// <c>WaitOptions</c>).
+/// </remarks>
+internal sealed class OperationUpdateInput
+{
+    /// <summary>Operation id the update targets.</summary>
+    public string? Id { get; init; }
+
+    /// <summary>Parent operation id (null for top-level operations).</summary>
+    public string? ParentId { get; init; }
+
+    /// <summary>Human-readable operation name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Operation type — compared against <c>OperationTypes</c> constants.</summary>
+    public string? Type { get; init; }
+
+    /// <summary>Operation sub-type — compared against <c>OperationSubTypes</c> constants.</summary>
+    public string? SubType { get; init; }
+
+    /// <summary>Lifecycle action: <c>START</c>, <c>SUCCEED</c>, <c>FAIL</c>, <c>RETRY</c>, or <c>CANCEL</c>.</summary>
+    public string? Action { get; init; }
+
+    /// <summary>Serialized result / carried state, depending on the action and operation type.</summary>
+    public string? Payload { get; init; }
+
+    /// <summary>Failure detail for a <c>FAIL</c>/<c>RETRY</c> action.</summary>
+    public ErrorObject? Error { get; init; }
+
+    /// <summary>Retry backoff (from <c>StepOptions.NextAttemptDelaySeconds</c>) for a STEP <c>RETRY</c>.</summary>
+    public int? NextAttemptDelaySeconds { get; init; }
+
+    /// <summary>Timer duration (from <c>WaitOptions.WaitSeconds</c>) for a WAIT <c>START</c>.</summary>
+    public long? WaitSeconds { get; init; }
+
+    /// <summary>
+    /// Target function of a <c>CHAINED_INVOKE</c> START (from <c>ChainedInvokeOptions.FunctionName</c>).
+    /// Carried on the update only — never persisted on the <see cref="Operation"/> — so the driver
+    /// captures it here to resolve the sibling.
+    /// </summary>
+    public string? ChainedInvokeFunctionName { get; init; }
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution.Testing/Amazon.Lambda.DurableExecution.Testing.csproj
+++ b/Libraries/src/Amazon.Lambda.DurableExecution.Testing/Amazon.Lambda.DurableExecution.Testing.csproj
@@ -33,6 +33,7 @@
   -->
   <ItemGroup>
     <ProjectReference Include="..\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+    <ProjectReference Include="..\Amazon.Lambda.DurableExecution.LocalEmulation\Amazon.Lambda.DurableExecution.LocalEmulation.csproj" />
     <ProjectReference Include="..\Amazon.Lambda.TestUtilities\Amazon.Lambda.TestUtilities.csproj" />
     <ProjectReference Include="..\Amazon.Lambda.Serialization.SystemTextJson\Amazon.Lambda.Serialization.SystemTextJson.csproj" />
   </ItemGroup>

--- a/Libraries/src/Amazon.Lambda.DurableExecution.Testing/DurableTestRunner.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution.Testing/DurableTestRunner.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution.LocalEmulation;
 using Amazon.Lambda.Serialization.SystemTextJson;
 using Amazon.Lambda.TestUtilities;
 

--- a/Libraries/src/Amazon.Lambda.DurableExecution.Testing/ExecutionOrchestrator.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution.Testing/ExecutionOrchestrator.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution.LocalEmulation;
 using Amazon.Lambda.DurableExecution.Services;
 
 namespace Amazon.Lambda.DurableExecution.Testing;
@@ -120,7 +121,7 @@ internal sealed class ExecutionOrchestrator<TInput, TOutput>
             // would actually elapse. If nothing has a scheduled resume time the
             // workflow cannot progress on its own, so re-drive immediately and let
             // MaxInvocations / the timeout surface the stall.
-            if (TryGetNextResumeDelay(arn, out var delay) && delay > TimeSpan.Zero)
+            if (DurableEmulationHelpers.TryGetNextResumeDelay(_store, arn, out var delay) && delay > TimeSpan.Zero)
             {
                 // Task.Delay surfaces cancellation as TaskCanceledException; swallow
                 // it so the loop-top ThrowIfCancellationRequested throws the canonical
@@ -134,41 +135,6 @@ internal sealed class ExecutionOrchestrator<TInput, TOutput>
                 }
             }
         }
-    }
-
-    /// <summary>
-    /// Computes how long to wait before the workflow can next make progress, based
-    /// on the earliest future <c>ScheduledEndTimestamp</c> (pending WAIT) or
-    /// <c>NextAttemptTimestamp</c> (pending STEP retry backoff) across all operations.
-    /// Returns false when no operation carries a future resume time.
-    /// </summary>
-    private bool TryGetNextResumeDelay(string arn, out TimeSpan delay)
-    {
-        long? earliest = null;
-        foreach (var op in _store.GetAllOperations(arn))
-        {
-            long? resumeAt = op.Type switch
-            {
-                OperationTypes.Wait when op.Status == OperationStatuses.Started
-                    => op.WaitDetails?.ScheduledEndTimestamp,
-                OperationTypes.Step when op.Status == OperationStatuses.Pending
-                    => op.StepDetails?.NextAttemptTimestamp,
-                _ => null,
-            };
-
-            if (resumeAt is { } ts && (earliest is null || ts < earliest))
-                earliest = ts;
-        }
-
-        if (earliest is null)
-        {
-            delay = TimeSpan.Zero;
-            return false;
-        }
-
-        var deltaMs = earliest.Value - DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-        delay = deltaMs > 0 ? TimeSpan.FromMilliseconds(deltaMs) : TimeSpan.Zero;
-        return true;
     }
 
     /// <summary>
@@ -231,19 +197,10 @@ internal sealed class ExecutionOrchestrator<TInput, TOutput>
 
     private void SeedExecutionOperation(string arn, TInput input)
     {
-        // Idempotent: re-driving (e.g. WaitForResultAsync after a callback) must
-        // not reset the EXECUTION op back to Started or clobber recorded state.
-        if (_store.GetOperation(arn, "exec-0") is not null)
-            return;
-
-        var serializedInput = SerializeToString(input);
-        _store.Upsert(arn, new Operation
-        {
-            Id = "exec-0",
-            Type = OperationTypes.Execution,
-            Status = OperationStatuses.Started,
-            ExecutionDetails = new ExecutionDetails { InputPayload = serializedInput }
-        });
+        // Idempotent seeding of the top-level EXECUTION op (exec-0) is owned by the shared kernel
+        // so the orchestrator and the Test Tool driver stay in lock-step; we only supply the
+        // serialized input payload.
+        DurableEmulationHelpers.SeedExecution(_store, arn, SerializeToString(input));
     }
 
     private DurableExecutionInvocationInput BuildInvocationInput(string arn)

--- a/Libraries/src/Amazon.Lambda.DurableExecution.Testing/InMemoryDurableServiceClient.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution.Testing/InMemoryDurableServiceClient.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using Amazon.Lambda.DurableExecution.LocalEmulation;
 using Amazon.Lambda.DurableExecution.Services;
 using SdkOperationUpdate = Amazon.Lambda.Model.OperationUpdate;
 
@@ -32,7 +33,8 @@ internal sealed class InMemoryDurableServiceClient : IDurableServiceClient
         if (pendingOperations.Count == 0)
             return Task.FromResult(checkpointToken);
 
-        var (newToken, newOps) = _processor.Process(durableExecutionArn, checkpointToken, pendingOperations);
+        var inputs = SdkOperationUpdateMapper.ToInputs(pendingOperations);
+        var (newToken, newOps) = _processor.Process(durableExecutionArn, checkpointToken, inputs);
 
         if (onNewOperations is not null && newOps.Count > 0)
             onNewOperations(newOps);

--- a/Libraries/src/Amazon.Lambda.DurableExecution.Testing/SdkOperationUpdateMapper.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution.Testing/SdkOperationUpdateMapper.cs
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Lambda.DurableExecution.LocalEmulation;
+using SdkOperationUpdate = Amazon.Lambda.Model.OperationUpdate;
+
+namespace Amazon.Lambda.DurableExecution.Testing;
+
+/// <summary>
+/// Maps the AWSSDK <c>Amazon.Lambda.Model.OperationUpdate</c> the in-process runtime emits into the
+/// transport-neutral <see cref="OperationUpdateInput"/> the shared checkpoint state machine consumes.
+/// This is where the SDK's <c>ConstantClass</c> enum-like members are unwrapped to plain strings and
+/// nested option/error types are flattened; the state machine itself stays representation-agnostic.
+/// </summary>
+internal static class SdkOperationUpdateMapper
+{
+    public static IReadOnlyList<OperationUpdateInput> ToInputs(IReadOnlyList<SdkOperationUpdate> updates)
+    {
+        var result = new List<OperationUpdateInput>(updates.Count);
+        foreach (var update in updates)
+            result.Add(ToInput(update));
+        return result;
+    }
+
+    public static OperationUpdateInput ToInput(SdkOperationUpdate update) => new()
+    {
+        Id = update.Id,
+        ParentId = update.ParentId,
+        Name = update.Name,
+        Type = update.Type?.Value,
+        SubType = update.SubType,
+        Action = update.Action?.Value,
+        Payload = update.Payload,
+        Error = MapSdkError(update.Error),
+        NextAttemptDelaySeconds = update.StepOptions?.NextAttemptDelaySeconds,
+        WaitSeconds = update.WaitOptions?.WaitSeconds,
+        ChainedInvokeFunctionName = update.ChainedInvokeOptions?.FunctionName,
+    };
+
+    private static ErrorObject? MapSdkError(Amazon.Lambda.Model.ErrorObject? sdkError)
+    {
+        if (sdkError == null) return null;
+        return new ErrorObject
+        {
+            ErrorType = sdkError.ErrorType,
+            ErrorMessage = sdkError.ErrorMessage,
+            ErrorData = sdkError.ErrorData,
+            StackTrace = sdkError.StackTrace
+        };
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.LocalEmulation.Tests/Amazon.Lambda.DurableExecution.LocalEmulation.Tests.csproj
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.LocalEmulation.Tests/Amazon.Lambda.DurableExecution.LocalEmulation.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\..\buildtools\common.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>$(DefaultPackageTargets)</TargetFrameworks>
+    <AssemblyName>Amazon.Lambda.DurableExecution.LocalEmulation.Tests</AssemblyName>
+    <PackageId>Amazon.Lambda.DurableExecution.LocalEmulation.Tests</PackageId>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyOriginatorKeyFile>..\..\..\buildtools\public.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Amazon.Lambda.DurableExecution.LocalEmulation\Amazon.Lambda.DurableExecution.LocalEmulation.csproj" />
+    <ProjectReference Include="..\..\src\Amazon.Lambda.DurableExecution\Amazon.Lambda.DurableExecution.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+  </ItemGroup>
+
+</Project>

--- a/Libraries/test/Amazon.Lambda.DurableExecution.LocalEmulation.Tests/CheckpointProcessorTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.LocalEmulation.Tests/CheckpointProcessorTests.cs
@@ -1,12 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using Amazon.Lambda.DurableExecution.Testing;
-using Amazon.Lambda.Model;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.DurableExecution.LocalEmulation;
 using Xunit;
-using SdkOperationUpdate = Amazon.Lambda.Model.OperationUpdate;
 
-namespace Amazon.Lambda.DurableExecution.Testing.Tests;
+namespace Amazon.Lambda.DurableExecution.LocalEmulation.Tests;
 
 public class CheckpointProcessorTests
 {
@@ -17,9 +16,9 @@ public class CheckpointProcessorTests
     {
         var (store, processor) = Create(skipTime: false);
 
-        var updates = new List<SdkOperationUpdate>
+        var updates = new List<OperationUpdateInput>
         {
-            new() { Id = "op-1", Type = OperationTypes.Step, Action = OperationAction.START, Name = "validate", SubType = OperationSubTypes.Step }
+            new() { Id = "op-1", Type = OperationTypes.Step, Action = "START", Name = "validate", SubType = OperationSubTypes.Step }
         };
 
         var (token, newOps) = processor.Process(Arn, null, updates);
@@ -37,14 +36,14 @@ public class CheckpointProcessorTests
     public void Process_StepSucceed_UpdatesStatus()
     {
         var (store, processor) = Create(skipTime: false);
-        processor.Process(Arn, null, new List<SdkOperationUpdate>
+        processor.Process(Arn, null, new List<OperationUpdateInput>
         {
-            new() { Id = "op-1", Type = OperationTypes.Step, Action = OperationAction.START, Name = "step1" }
+            new() { Id = "op-1", Type = OperationTypes.Step, Action = "START", Name = "step1" }
         });
 
-        processor.Process(Arn, "1", new List<SdkOperationUpdate>
+        processor.Process(Arn, "1", new List<OperationUpdateInput>
         {
-            new() { Id = "op-1", Type = OperationTypes.Step, Action = OperationAction.SUCCEED, Payload = """{"x":1}""" }
+            new() { Id = "op-1", Type = OperationTypes.Step, Action = "SUCCEED", Payload = """{"x":1}""" }
         });
 
         var op = store.GetOperation(Arn, "op-1");
@@ -58,17 +57,17 @@ public class CheckpointProcessorTests
     public void Process_StepFail_SetsError()
     {
         var (store, processor) = Create(skipTime: false);
-        processor.Process(Arn, null, new List<SdkOperationUpdate>
+        processor.Process(Arn, null, new List<OperationUpdateInput>
         {
-            new() { Id = "op-1", Type = OperationTypes.Step, Action = OperationAction.START }
+            new() { Id = "op-1", Type = OperationTypes.Step, Action = "START" }
         });
 
-        processor.Process(Arn, "1", new List<SdkOperationUpdate>
+        processor.Process(Arn, "1", new List<OperationUpdateInput>
         {
             new()
             {
-                Id = "op-1", Type = OperationTypes.Step, Action = OperationAction.FAIL,
-                Error = new Amazon.Lambda.Model.ErrorObject { ErrorType = "TestEx", ErrorMessage = "boom" }
+                Id = "op-1", Type = OperationTypes.Step, Action = "FAIL",
+                Error = new ErrorObject { ErrorType = "TestEx", ErrorMessage = "boom" }
             }
         });
 
@@ -82,18 +81,18 @@ public class CheckpointProcessorTests
     public void Process_StepRetry_SetsPendingWithDelay()
     {
         var (store, processor) = Create(skipTime: false);
-        processor.Process(Arn, null, new List<SdkOperationUpdate>
+        processor.Process(Arn, null, new List<OperationUpdateInput>
         {
-            new() { Id = "op-1", Type = OperationTypes.Step, Action = OperationAction.START }
+            new() { Id = "op-1", Type = OperationTypes.Step, Action = "START" }
         });
 
-        processor.Process(Arn, "1", new List<SdkOperationUpdate>
+        processor.Process(Arn, "1", new List<OperationUpdateInput>
         {
             new()
             {
-                Id = "op-1", Type = OperationTypes.Step, Action = OperationAction.RETRY,
-                StepOptions = new StepOptions { NextAttemptDelaySeconds = 5 },
-                Error = new Amazon.Lambda.Model.ErrorObject { ErrorType = "TransientEx" }
+                Id = "op-1", Type = OperationTypes.Step, Action = "RETRY",
+                NextAttemptDelaySeconds = 5,
+                Error = new ErrorObject { ErrorType = "TransientEx" }
             }
         });
 
@@ -107,17 +106,17 @@ public class CheckpointProcessorTests
     public void Process_StepRetry_WithSkipTime_SetsReady()
     {
         var (store, processor) = Create(skipTime: true);
-        processor.Process(Arn, null, new List<SdkOperationUpdate>
+        processor.Process(Arn, null, new List<OperationUpdateInput>
         {
-            new() { Id = "op-1", Type = OperationTypes.Step, Action = OperationAction.START }
+            new() { Id = "op-1", Type = OperationTypes.Step, Action = "START" }
         });
 
-        processor.Process(Arn, "1", new List<SdkOperationUpdate>
+        processor.Process(Arn, "1", new List<OperationUpdateInput>
         {
             new()
             {
-                Id = "op-1", Type = OperationTypes.Step, Action = OperationAction.RETRY,
-                StepOptions = new StepOptions { NextAttemptDelaySeconds = 60 }
+                Id = "op-1", Type = OperationTypes.Step, Action = "RETRY",
+                NextAttemptDelaySeconds = 60
             }
         });
 
@@ -131,12 +130,12 @@ public class CheckpointProcessorTests
     {
         var (store, processor) = Create(skipTime: false);
 
-        processor.Process(Arn, null, new List<SdkOperationUpdate>
+        processor.Process(Arn, null, new List<OperationUpdateInput>
         {
             new()
             {
-                Id = "op-1", Type = OperationTypes.Wait, Action = OperationAction.START,
-                WaitOptions = new WaitOptions { WaitSeconds = 300 }
+                Id = "op-1", Type = OperationTypes.Wait, Action = "START",
+                WaitSeconds = 300
             }
         });
 
@@ -152,12 +151,12 @@ public class CheckpointProcessorTests
     {
         var (store, processor) = Create(skipTime: true);
 
-        processor.Process(Arn, null, new List<SdkOperationUpdate>
+        processor.Process(Arn, null, new List<OperationUpdateInput>
         {
             new()
             {
-                Id = "op-1", Type = OperationTypes.Wait, Action = OperationAction.START,
-                WaitOptions = new WaitOptions { WaitSeconds = 86400 }
+                Id = "op-1", Type = OperationTypes.Wait, Action = "START",
+                WaitSeconds = 86400
             }
         });
 
@@ -171,9 +170,9 @@ public class CheckpointProcessorTests
     {
         var (store, processor) = Create(skipTime: false);
 
-        processor.Process(Arn, null, new List<SdkOperationUpdate>
+        processor.Process(Arn, null, new List<OperationUpdateInput>
         {
-            new() { Id = "op-cb-1", Type = OperationTypes.Callback, Action = OperationAction.START, Name = "approval" }
+            new() { Id = "op-cb-1", Type = OperationTypes.Callback, Action = "START", Name = "approval" }
         });
 
         var op = store.GetOperation(Arn, "op-cb-1");
@@ -186,13 +185,13 @@ public class CheckpointProcessorTests
     {
         var (store, processor) = Create(skipTime: false);
 
-        var (t1, _) = processor.Process(Arn, null, new List<SdkOperationUpdate>
+        var (t1, _) = processor.Process(Arn, null, new List<OperationUpdateInput>
         {
-            new() { Id = "op-1", Type = OperationTypes.Step, Action = OperationAction.START }
+            new() { Id = "op-1", Type = OperationTypes.Step, Action = "START" }
         });
-        var (t2, _) = processor.Process(Arn, t1, new List<SdkOperationUpdate>
+        var (t2, _) = processor.Process(Arn, t1, new List<OperationUpdateInput>
         {
-            new() { Id = "op-1", Type = OperationTypes.Step, Action = OperationAction.SUCCEED }
+            new() { Id = "op-1", Type = OperationTypes.Step, Action = "SUCCEED" }
         });
 
         Assert.NotEqual(t1, t2);
@@ -203,10 +202,10 @@ public class CheckpointProcessorTests
     {
         var (_, processor) = Create(skipTime: false);
 
-        var (_, newOps) = processor.Process(Arn, null, new List<SdkOperationUpdate>
+        var (_, newOps) = processor.Process(Arn, null, new List<OperationUpdateInput>
         {
-            new() { Id = "op-1", Type = OperationTypes.Step, Action = OperationAction.START, Name = "s1" },
-            new() { Id = "op-2", Type = OperationTypes.Wait, Action = OperationAction.START, WaitOptions = new WaitOptions { WaitSeconds = 10 } }
+            new() { Id = "op-1", Type = OperationTypes.Step, Action = "START", Name = "s1" },
+            new() { Id = "op-2", Type = OperationTypes.Wait, Action = "START", WaitSeconds = 10 }
         });
 
         Assert.Equal(2, newOps.Count);
@@ -219,9 +218,9 @@ public class CheckpointProcessorTests
     {
         var (store, processor) = Create(skipTime: false);
 
-        processor.Process(Arn, null, new List<SdkOperationUpdate>
+        processor.Process(Arn, null, new List<OperationUpdateInput>
         {
-            new() { Id = "op-ctx", Type = OperationTypes.Context, Action = OperationAction.START, Name = "parallel_batch", SubType = "Parallel" }
+            new() { Id = "op-ctx", Type = OperationTypes.Context, Action = "START", Name = "parallel_batch", SubType = "Parallel" }
         });
 
         var op = store.GetOperation(Arn, "op-ctx");
@@ -235,9 +234,9 @@ public class CheckpointProcessorTests
     {
         var (store, processor) = Create(skipTime: false);
 
-        processor.Process(Arn, null, new List<SdkOperationUpdate>
+        processor.Process(Arn, null, new List<OperationUpdateInput>
         {
-            new() { Id = "op-inv", Type = OperationTypes.ChainedInvoke, Action = OperationAction.START, Name = "process-payment" }
+            new() { Id = "op-inv", Type = OperationTypes.ChainedInvoke, Action = "START", Name = "process-payment" }
         });
 
         var op = store.GetOperation(Arn, "op-inv");
@@ -246,15 +245,40 @@ public class CheckpointProcessorTests
     }
 
     [Fact]
+    public void Process_ChainedInvokeStart_WithFunctionName_RecordsPendingInvoke()
+    {
+        var (_, processor) = Create(skipTime: false);
+
+        processor.Process(Arn, null, new List<OperationUpdateInput>
+        {
+            new()
+            {
+                Id = "op-inv", Type = OperationTypes.ChainedInvoke, Action = "START",
+                Name = "process-payment", Payload = """{"amount":10}""",
+                ChainedInvokeFunctionName = "payment-fn"
+            }
+        });
+
+        var pending = processor.DrainPendingInvokes();
+        var invoke = Assert.Single(pending);
+        Assert.Equal("op-inv", invoke.OperationId);
+        Assert.Equal("payment-fn", invoke.FunctionName);
+        Assert.Equal("""{"amount":10}""", invoke.Payload);
+
+        // Draining is one-shot: a second drain returns nothing.
+        Assert.Empty(processor.DrainPendingInvokes());
+    }
+
+    [Fact]
     public void Process_MultipleUpdatesInBatch_AllApplied()
     {
         var (store, processor) = Create(skipTime: true);
 
-        processor.Process(Arn, null, new List<SdkOperationUpdate>
+        processor.Process(Arn, null, new List<OperationUpdateInput>
         {
-            new() { Id = "op-1", Type = OperationTypes.Step, Action = OperationAction.START, Name = "a" },
-            new() { Id = "op-2", Type = OperationTypes.Step, Action = OperationAction.START, Name = "b" },
-            new() { Id = "op-3", Type = OperationTypes.Wait, Action = OperationAction.START, WaitOptions = new WaitOptions { WaitSeconds = 60 } }
+            new() { Id = "op-1", Type = OperationTypes.Step, Action = "START", Name = "a" },
+            new() { Id = "op-2", Type = OperationTypes.Step, Action = "START", Name = "b" },
+            new() { Id = "op-3", Type = OperationTypes.Wait, Action = "START", WaitSeconds = 60 }
         });
 
         Assert.Equal(3, store.OperationCount(Arn));
@@ -271,9 +295,9 @@ public class CheckpointProcessorTests
         // SubType=WaitForCondition (see WaitForConditionOperation.OperationType).
         // A STEP START is NOT time-skipped to Succeeded — only WAIT timers are —
         // so the op stays Started and the condition is genuinely re-evaluated.
-        processor.Process(Arn, null, new List<SdkOperationUpdate>
+        processor.Process(Arn, null, new List<OperationUpdateInput>
         {
-            new() { Id = "op-wfc", Type = OperationTypes.Step, Action = OperationAction.START, SubType = OperationSubTypes.WaitForCondition }
+            new() { Id = "op-wfc", Type = OperationTypes.Step, Action = "START", SubType = OperationSubTypes.WaitForCondition }
         });
 
         var op = store.GetOperation(Arn, "op-wfc");
@@ -281,13 +305,37 @@ public class CheckpointProcessorTests
 
         // A RETRY (condition not yet met) becomes immediately READY under SkipTime,
         // so the next replay re-runs the check without waiting for the poll delay.
-        processor.Process(Arn, "1", new List<SdkOperationUpdate>
+        processor.Process(Arn, "1", new List<OperationUpdateInput>
         {
-            new() { Id = "op-wfc", Type = OperationTypes.Step, Action = OperationAction.RETRY, SubType = OperationSubTypes.WaitForCondition, StepOptions = new StepOptions { NextAttemptDelaySeconds = 10 } }
+            new() { Id = "op-wfc", Type = OperationTypes.Step, Action = "RETRY", SubType = OperationSubTypes.WaitForCondition, NextAttemptDelaySeconds = 10 }
         });
 
         op = store.GetOperation(Arn, "op-wfc");
         Assert.Equal(OperationStatuses.Ready, op!.Status);
+    }
+
+    [Fact]
+    public void Process_LiveSkipTimeProvider_TogglesAtRuntime()
+    {
+        // The Func<bool> overload is read on each checkpoint, so flipping the flag between
+        // checkpoints changes whether subsequent WAIT starts are folded to Succeeded — this is
+        // the behavior the Test Tool's runtime time-skip toggle depends on.
+        var store = new InMemoryOperationStore();
+        var skipTime = false;
+        var processor = new CheckpointProcessor(store, () => skipTime);
+
+        processor.Process(Arn, null, new List<OperationUpdateInput>
+        {
+            new() { Id = "wait-1", Type = OperationTypes.Wait, Action = "START", WaitSeconds = 3600 }
+        });
+        Assert.Equal(OperationStatuses.Started, store.GetOperation(Arn, "wait-1")!.Status);
+
+        skipTime = true;
+        processor.Process(Arn, "1", new List<OperationUpdateInput>
+        {
+            new() { Id = "wait-2", Type = OperationTypes.Wait, Action = "START", WaitSeconds = 3600 }
+        });
+        Assert.Equal(OperationStatuses.Succeeded, store.GetOperation(Arn, "wait-2")!.Status);
     }
 
     private static (InMemoryOperationStore Store, CheckpointProcessor Processor) Create(bool skipTime)

--- a/Libraries/test/Amazon.Lambda.DurableExecution.LocalEmulation.Tests/InMemoryOperationStoreTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.LocalEmulation.Tests/InMemoryOperationStoreTests.cs
@@ -1,10 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using Amazon.Lambda.DurableExecution.Testing;
+using Amazon.Lambda.DurableExecution;
+using Amazon.Lambda.DurableExecution.LocalEmulation;
 using Xunit;
 
-namespace Amazon.Lambda.DurableExecution.Testing.Tests;
+namespace Amazon.Lambda.DurableExecution.LocalEmulation.Tests;
 
 public class InMemoryOperationStoreTests
 {
@@ -57,6 +58,17 @@ public class InMemoryOperationStoreTests
     {
         var store = new InMemoryOperationStore();
         Assert.Null(store.GetOperation("arn:test", "nonexistent"));
+    }
+
+    [Fact]
+    public void Exists_TrueOnceExecutionSeen()
+    {
+        var store = new InMemoryOperationStore();
+        Assert.False(store.Exists("arn:test"));
+
+        store.Upsert("arn:test", new Operation { Id = "op-1", Type = OperationTypes.Step });
+
+        Assert.True(store.Exists("arn:test"));
     }
 
     [Fact]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Testing.Tests/SdkOperationUpdateMapperTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Testing.Tests/SdkOperationUpdateMapperTests.cs
@@ -1,0 +1,101 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Lambda.DurableExecution.Testing;
+using Amazon.Lambda.Model;
+using Xunit;
+
+namespace Amazon.Lambda.DurableExecution.Testing.Tests;
+
+/// <summary>
+/// Covers the boundary adapter that flattens the AWSSDK <c>OperationUpdate</c> into the neutral
+/// <c>OperationUpdateInput</c> the shared kernel consumes. The state-machine behavior itself is
+/// tested in the LocalEmulation kernel test project; here we only assert the field-by-field mapping
+/// (ConstantClass unwrapping, nested option flattening, error conversion).
+/// </summary>
+public class SdkOperationUpdateMapperTests
+{
+    [Fact]
+    public void ToInput_UnwrapsConstantClassMembers()
+    {
+        var update = new OperationUpdate
+        {
+            Id = "op-1",
+            ParentId = "parent-1",
+            Name = "validate",
+            Type = OperationTypes.Step,
+            SubType = OperationSubTypes.WaitForCondition,
+            Action = OperationAction.RETRY,
+            Payload = """{"x":1}"""
+        };
+
+        var input = SdkOperationUpdateMapper.ToInput(update);
+
+        Assert.Equal("op-1", input.Id);
+        Assert.Equal("parent-1", input.ParentId);
+        Assert.Equal("validate", input.Name);
+        Assert.Equal(OperationTypes.Step, input.Type);
+        Assert.Equal(OperationSubTypes.WaitForCondition, input.SubType);
+        Assert.Equal("RETRY", input.Action);
+        Assert.Equal("""{"x":1}""", input.Payload);
+    }
+
+    [Fact]
+    public void ToInput_FlattensNestedOptions()
+    {
+        var update = new OperationUpdate
+        {
+            Id = "op-1",
+            Type = OperationTypes.Wait,
+            Action = OperationAction.START,
+            StepOptions = new StepOptions { NextAttemptDelaySeconds = 7 },
+            WaitOptions = new WaitOptions { WaitSeconds = 300 },
+            ChainedInvokeOptions = new ChainedInvokeOptions { FunctionName = "payment-fn" }
+        };
+
+        var input = SdkOperationUpdateMapper.ToInput(update);
+
+        Assert.Equal(7, input.NextAttemptDelaySeconds);
+        Assert.Equal(300, input.WaitSeconds);
+        Assert.Equal("payment-fn", input.ChainedInvokeFunctionName);
+    }
+
+    [Fact]
+    public void ToInput_MapsError()
+    {
+        var update = new OperationUpdate
+        {
+            Id = "op-1",
+            Type = OperationTypes.Step,
+            Action = OperationAction.FAIL,
+            Error = new Amazon.Lambda.Model.ErrorObject
+            {
+                ErrorType = "TestEx",
+                ErrorMessage = "boom",
+                ErrorData = "detail",
+                StackTrace = new List<string> { "frame-1", "frame-2" }
+            }
+        };
+
+        var input = SdkOperationUpdateMapper.ToInput(update);
+
+        Assert.NotNull(input.Error);
+        Assert.Equal("TestEx", input.Error!.ErrorType);
+        Assert.Equal("boom", input.Error.ErrorMessage);
+        Assert.Equal("detail", input.Error.ErrorData);
+        Assert.Equal(new[] { "frame-1", "frame-2" }, input.Error.StackTrace);
+    }
+
+    [Fact]
+    public void ToInput_NullOptionalsMapToNull()
+    {
+        var update = new OperationUpdate { Id = "op-1", Type = OperationTypes.Step, Action = OperationAction.START };
+
+        var input = SdkOperationUpdateMapper.ToInput(update);
+
+        Assert.Null(input.Error);
+        Assert.Null(input.NextAttemptDelaySeconds);
+        Assert.Null(input.WaitSeconds);
+        Assert.Null(input.ChainedInvokeFunctionName);
+    }
+}


### PR DESCRIPTION
## What

Extracts the durable-execution checkpoint state machine and in-memory operation store—today duplicated between `Amazon.Lambda.DurableExecution.Testing` and the Lambda Test Tool's durable emulator (a hand-maintained fork)—into a new internal package, **`Amazon.Lambda.DurableExecution.LocalEmulation`**, so the two can no longer silently drift on replay-critical logic.

- `InMemoryOperationStore` and `CheckpointProcessor` (state machine, callback minting, time-skip, pending-invoke tracking)
- `OperationUpdateInput`, a transport-neutral update record each consumer maps its own representation to at the boundary
- `DurableEmulationHelpers` for the shared `exec-0` seeding and `TryGetNextResumeDelay`

`Amazon.Lambda.DurableExecution.Testing` is rewired onto the kernel: it keeps a thin `SdkOperationUpdateMapper` (AWSSDK `OperationUpdate` → `OperationUpdateInput`) and drops its own processor/store. Kernel types stay internal, shared via `InternalsVisibleTo`. The forked processor/store unit tests move to a new kernel test project (rewritten against `OperationUpdateInput`); the testing package keeps focused coverage of its SDK-update adapter.

No public API or behavior change.

## Stack

This is **PR 1 of 2**, targeting the `feature/durable-testtool` integration branch.
- PR 2 (`feat/durable-testtool-on-kernel`) stacks on this and rewires the Test Tool emulator onto the kernel.

## Testing

- LocalEmulation kernel tests: 28/28 (net8.0 + net10.0)
- Testing package: 132/132 (net8.0 + net10.0), including the new SDK-mapper tests