### PR TITLE
Fix JSON log parameter ordering

### DIFF
--- a/.autover/changes/58593c38-0c20-4fee-993c-15ea9f1f49fb.json
+++ b/.autover/changes/58593c38-0c20-4fee-993c-15ea9f1f49fb.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Logging.AspNetCore",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fix JSON structured logs whose state values use a different order than their message template."
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.Logging.AspNetCore/LambdaILogger.cs
+++ b/Libraries/src/Amazon.Lambda.Logging.AspNetCore/LambdaILogger.cs
@@ -1,10 +1,19 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Microsoft.Extensions.Logging
 {
     internal class LambdaILogger : ILogger
     {
+        private const string ORIGINAL_FORMAT_KEY = "{OriginalFormat}";
+        private const int MESSAGE_TEMPLATE_PARSE_CACHE_MAXSIZE = 1024;
+
+        private static readonly ConcurrentDictionary<string, IReadOnlyList<string>> MESSAGE_TEMPLATE_PARSE_CACHE =
+            new ConcurrentDictionary<string, IReadOnlyList<string>>();
+        private static readonly char[] PROPERTY_NAME_DELIMITERS = { ',', ':' };
+
         // Private fields
         private readonly string _categoryName;
         private readonly LambdaLoggerOptions _options;
@@ -57,25 +66,31 @@ namespace Microsoft.Extensions.Logging
             if (IsLambdaJsonFormatEnabled && state is IEnumerable<KeyValuePair<string, object>> structure)
             {
                 string messageTemplate = null;
-                var parameters = new List<object>();
+                var properties = new List<KeyValuePair<string, object>>();
                 foreach (var property in structure)
                 {
-                    if (property is { Key: "{OriginalFormat}", Value: string value })
+                    if (property is { Key: ORIGINAL_FORMAT_KEY, Value: string value })
                     {
                         messageTemplate = value;
                     }
                     else
                     {
-                        parameters.Add(property.Value);
+                        properties.Add(property);
                     }
                 }
 
+                object[] parameters;
                 if (messageTemplate == null)
                 {
                     messageTemplate = formatter.Invoke(state, exception);
+                    parameters = GetPropertyValues(properties);
+                }
+                else
+                {
+                    parameters = OrderParametersByMessageTemplate(messageTemplate, properties);
                 }
 
-                Amazon.Lambda.Core.LambdaLogger.Log(lambdaLogLevel, exception, messageTemplate, parameters.ToArray());
+                Amazon.Lambda.Core.LambdaLogger.Log(lambdaLogLevel, exception, messageTemplate, parameters);
             }
             else
             {
@@ -112,6 +127,231 @@ namespace Microsoft.Extensions.Logging
 
                 Amazon.Lambda.Core.LambdaLogger.Log(lambdaLogLevel, finalText);
             }
+        }
+
+        private static object[] OrderParametersByMessageTemplate(
+            string messageTemplate,
+            IReadOnlyList<KeyValuePair<string, object>> properties)
+        {
+            var templateProperties = ParseTemplateProperties(messageTemplate);
+            if (templateProperties.Count == 0)
+            {
+                return GetPropertyValues(properties);
+            }
+
+            if (PropertiesMatchTemplateOrder(templateProperties, properties))
+            {
+                return GetPropertyValues(properties);
+            }
+
+            if (UsesPositionalArguments(templateProperties))
+            {
+                return GetPropertyValues(properties);
+            }
+
+            var parameters = new List<object>(Math.Max(templateProperties.Count, properties.Count));
+            var consumedProperties = new bool[properties.Count];
+            var propertyIndexes = new Dictionary<string, List<int>>(StringComparer.Ordinal);
+            var propertyOccurrences = new Dictionary<string, int>(StringComparer.Ordinal);
+
+            for (var i = 0; i < properties.Count; i++)
+            {
+                if (properties[i].Key == null)
+                {
+                    continue;
+                }
+
+                if (!propertyIndexes.TryGetValue(properties[i].Key, out var indexes))
+                {
+                    indexes = new List<int>();
+                    propertyIndexes.Add(properties[i].Key, indexes);
+                }
+
+                indexes.Add(i);
+            }
+
+            foreach (var templateProperty in templateProperties)
+            {
+                var propertyName = GetStatePropertyName(templateProperty);
+                if (!propertyIndexes.TryGetValue(propertyName, out var indexes) &&
+                    (propertyName.Length <= 1 ||
+                     (propertyName[0] != '@' && propertyName[0] != '$') ||
+                     !propertyIndexes.TryGetValue(propertyName.Substring(1), out indexes)))
+                {
+                    // Keep the slot so a missing value cannot shift subsequent properties.
+                    parameters.Add(null);
+                    continue;
+                }
+
+                var matchedName = properties[indexes[0]].Key;
+                propertyOccurrences.TryGetValue(matchedName, out var occurrence);
+                propertyOccurrences[matchedName] = occurrence + 1;
+
+                // A custom state can expose one value for a repeated placeholder. Reuse
+                // that sole value; multiple same-name values are consumed in order.
+                var propertyIndex = indexes.Count == 1
+                    ? indexes[0]
+                    : occurrence < indexes.Count ? indexes[occurrence] : -1;
+                if (propertyIndex < 0)
+                {
+                    parameters.Add(null);
+                    continue;
+                }
+
+                consumedProperties[propertyIndex] = true;
+                parameters.Add(properties[propertyIndex].Value);
+            }
+
+            // Preserve state values that are not represented in the template. The JSON
+            // formatter ignores trailing arguments, but custom LambdaLogger callbacks may
+            // still inspect them.
+            for (var i = 0; i < properties.Count; i++)
+            {
+                if (!consumedProperties[i])
+                {
+                    parameters.Add(properties[i].Value);
+                }
+            }
+
+            return parameters.ToArray();
+        }
+
+        private static bool PropertiesMatchTemplateOrder(
+            IReadOnlyList<string> templateProperties,
+            IReadOnlyList<KeyValuePair<string, object>> properties)
+        {
+            if (templateProperties.Count != properties.Count)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < templateProperties.Count; i++)
+            {
+                var propertyName = GetStatePropertyName(templateProperties[i]);
+                if (string.Equals(properties[i].Key, propertyName, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (propertyName.Length <= 1 ||
+                    (propertyName[0] != '@' && propertyName[0] != '$') ||
+                    !string.Equals(properties[i].Key, propertyName.Substring(1), StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static object[] GetPropertyValues(IReadOnlyList<KeyValuePair<string, object>> properties)
+        {
+            var parameters = new object[properties.Count];
+            for (var i = 0; i < properties.Count; i++)
+            {
+                parameters[i] = properties[i].Value;
+            }
+
+            return parameters;
+        }
+
+        private static IReadOnlyList<string> ParseTemplateProperties(string messageTemplate)
+        {
+            if (MESSAGE_TEMPLATE_PARSE_CACHE.TryGetValue(messageTemplate, out var cachedProperties))
+            {
+                return cachedProperties;
+            }
+
+            var properties = new List<string>();
+            var parserState = LogFormatParserState.InMessage;
+            var propertyStartIndex = -1;
+
+            for (var i = 0; i < messageTemplate.Length; i++)
+            {
+                switch (messageTemplate[i])
+                {
+                    case '{':
+                        if (parserState == LogFormatParserState.InMessage)
+                        {
+                            parserState = LogFormatParserState.PossiblePropertyOpen;
+                        }
+                        else if (parserState == LogFormatParserState.PossiblePropertyOpen)
+                        {
+                            // Escaped "{{" is message text, not a property.
+                            parserState = LogFormatParserState.InMessage;
+                        }
+                        break;
+                    case '}':
+                        if (parserState != LogFormatParserState.InMessage)
+                        {
+                            if (propertyStartIndex >= 0)
+                            {
+                                properties.Add(messageTemplate.Substring(propertyStartIndex, i - propertyStartIndex));
+                            }
+
+                            parserState = LogFormatParserState.InMessage;
+                            propertyStartIndex = -1;
+                        }
+                        break;
+                    default:
+                        if (parserState == LogFormatParserState.PossiblePropertyOpen)
+                        {
+                            propertyStartIndex = i;
+                            parserState = LogFormatParserState.InProperty;
+                        }
+                        break;
+                }
+            }
+
+            var parsedProperties = properties.AsReadOnly();
+            if (MESSAGE_TEMPLATE_PARSE_CACHE.Count < MESSAGE_TEMPLATE_PARSE_CACHE_MAXSIZE)
+            {
+                MESSAGE_TEMPLATE_PARSE_CACHE.TryAdd(messageTemplate, parsedProperties);
+            }
+
+            return parsedProperties;
+        }
+
+        private static string GetStatePropertyName(string templateProperty)
+        {
+            var delimiterIndex = templateProperty.IndexOfAny(PROPERTY_NAME_DELIMITERS);
+            var propertyName = delimiterIndex >= 0
+                ? templateProperty.Substring(0, delimiterIndex)
+                : templateProperty;
+            return propertyName.Trim();
+        }
+
+        private static bool UsesPositionalArguments(IReadOnlyList<string> templateProperties)
+        {
+            var minimumPosition = int.MaxValue;
+            var maximumPosition = int.MinValue;
+            var positions = new HashSet<int>();
+
+            foreach (var templateProperty in templateProperties)
+            {
+                var propertyName = templateProperty;
+                if (propertyName.Length > 0 && propertyName[0] == '@')
+                {
+                    propertyName = propertyName.Substring(1);
+                }
+
+                var formatDelimiterIndex = propertyName.IndexOf(':');
+                if (formatDelimiterIndex >= 0)
+                {
+                    propertyName = propertyName.Substring(0, formatDelimiterIndex);
+                }
+
+                if (!int.TryParse(propertyName.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var position))
+                {
+                    return false;
+                }
+
+                positions.Add(position);
+                minimumPosition = Math.Min(minimumPosition, position);
+                maximumPosition = Math.Max(maximumPosition, position);
+            }
+
+            return minimumPosition == 0 && positions.Count == maximumPosition + 1;
         }
 
         private static Amazon.Lambda.Core.LogLevel ConvertLogLevel(LogLevel logLevel)
@@ -161,6 +401,13 @@ namespace Microsoft.Extensions.Logging
             {
                 return string.Equals(Environment.GetEnvironmentVariable("AWS_LAMBDA_LOG_FORMAT"), "JSON", StringComparison.InvariantCultureIgnoreCase);
             }
+        }
+
+        private enum LogFormatParserState : byte
+        {
+            InMessage,
+            PossiblePropertyOpen,
+            InProperty
         }
 
         // Private classes	       

--- a/Libraries/test/Amazon.Lambda.Logging.AspNetCore.Tests/LoggingTests.cs
+++ b/Libraries/test/Amazon.Lambda.Logging.AspNetCore.Tests/LoggingTests.cs
@@ -575,6 +575,131 @@ namespace Amazon.Lambda.Tests
         }
 
         [Fact]
+        public void JsonLoggingOrdersParametersByTemplatePlaceholderName()
+        {
+            const string template =
+                "Request starting {Protocol} {Method} {Scheme}://{Host}{PathBase}{Path}{QueryString} - {ContentType} {ContentLength}";
+
+            var state = new List<KeyValuePair<string, object>>
+            {
+                new KeyValuePair<string, object>("Protocol", "HTTP/1.1"),
+                new KeyValuePair<string, object>("Method", "DELETE"),
+                new KeyValuePair<string, object>("ContentType", "application/json"),
+                new KeyValuePair<string, object>("ContentLength", 0L),
+                new KeyValuePair<string, object>("Scheme", "https"),
+                new KeyValuePair<string, object>("Host", "api.example.com"),
+                new KeyValuePair<string, object>("PathBase", string.Empty),
+                new KeyValuePair<string, object>("Path", "/events/123"),
+                new KeyValuePair<string, object>("QueryString", "?preserve=true"),
+                new KeyValuePair<string, object>("{OriginalFormat}", template)
+            };
+
+            var capturedLog = CaptureJsonLog(state);
+
+            Assert.Equal(template, capturedLog.MessageTemplate);
+            Assert.Equal(
+                new object[]
+                {
+                    "HTTP/1.1",
+                    "DELETE",
+                    "https",
+                    "api.example.com",
+                    string.Empty,
+                    "/events/123",
+                    "?preserve=true",
+                    "application/json",
+                    0L
+                },
+                capturedLog.Parameters);
+        }
+
+        [Fact]
+        public void JsonLoggingPreservesOrderedDuplicateParameters()
+        {
+            const string template = "{Name} then {Name}";
+            var capturedLog = CaptureJsonLog(logger =>
+                logger.LogInformation(template, "first", "second"));
+
+            Assert.Equal(template, capturedLog.MessageTemplate);
+            Assert.Equal(new object[] { "first", "second" }, capturedLog.Parameters);
+        }
+
+        [Fact]
+        public void JsonLoggingHandlesTemplateSyntaxAndMissingProperties()
+        {
+            const string template = "{{literal}} {@Payload} {$Cost} {Count,8:N0} {Missing} {Tail}";
+            var payload = new object();
+            var state = new List<KeyValuePair<string, object>>
+            {
+                new KeyValuePair<string, object>("Tail", "done"),
+                new KeyValuePair<string, object>("Extra", "unused"),
+                new KeyValuePair<string, object>("Count", 1234),
+                new KeyValuePair<string, object>("Payload", payload),
+                new KeyValuePair<string, object>("Cost", 9.5m),
+                new KeyValuePair<string, object>("{OriginalFormat}", template)
+            };
+
+            var capturedLog = CaptureJsonLog(state);
+
+            Assert.Equal(template, capturedLog.MessageTemplate);
+            Assert.Equal(
+                new object[] { payload, 9.5m, 1234, null, "done", "unused" },
+                capturedLog.Parameters);
+        }
+
+        [Fact]
+        public void JsonLoggingReusesSingleValueForRepeatedPlaceholder()
+        {
+            const string template = "{Name} {Tail} {Name}";
+            var state = new List<KeyValuePair<string, object>>
+            {
+                new KeyValuePair<string, object>("Tail", "done"),
+                new KeyValuePair<string, object>("Name", "reused"),
+                new KeyValuePair<string, object>("{OriginalFormat}", template)
+            };
+
+            var capturedLog = CaptureJsonLog(state);
+
+            Assert.Equal(template, capturedLog.MessageTemplate);
+            Assert.Equal(new object[] { "reused", "done", "reused" }, capturedLog.Parameters);
+        }
+
+        [Fact]
+        public void JsonLoggingOrdersMultipleValuesForRepeatedPlaceholder()
+        {
+            const string template = "{Name} {Tail} {Name}";
+            var state = new List<KeyValuePair<string, object>>
+            {
+                new KeyValuePair<string, object>("Tail", "done"),
+                new KeyValuePair<string, object>("Name", "first"),
+                new KeyValuePair<string, object>("Name", "second"),
+                new KeyValuePair<string, object>("{OriginalFormat}", template)
+            };
+
+            var capturedLog = CaptureJsonLog(state);
+
+            Assert.Equal(template, capturedLog.MessageTemplate);
+            Assert.Equal(new object[] { "first", "done", "second" }, capturedLog.Parameters);
+        }
+
+        [Fact]
+        public void JsonLoggingPreservesPositionalParameterOrder()
+        {
+            const string template = "{1} before {0}";
+            var state = new List<KeyValuePair<string, object>>
+            {
+                new KeyValuePair<string, object>("1", "first argument"),
+                new KeyValuePair<string, object>("0", "second argument"),
+                new KeyValuePair<string, object>("{OriginalFormat}", template)
+            };
+
+            var capturedLog = CaptureJsonLog(state);
+
+            Assert.Equal(template, capturedLog.MessageTemplate);
+            Assert.Equal(new object[] { "first argument", "second argument" }, capturedLog.Parameters);
+        }
+
+        [Fact]
         public void JsonLoggingWithNoOriginalFormat()
         {
             Environment.SetEnvironmentVariable("AWS_LAMBDA_LOG_FORMAT", "JSON");
@@ -618,6 +743,50 @@ namespace Amazon.Lambda.Tests
 		{
 			return Path.Combine(APPSETTINGS_DIR, fileName);
 		}
+
+        private static (string MessageTemplate, object[] Parameters) CaptureJsonLog(
+            IReadOnlyList<KeyValuePair<string, object>> state)
+        {
+            return CaptureJsonLog(logger =>
+                logger.Log(LogLevel.Information, new EventId(0), state, null, (value, error) => string.Empty));
+        }
+
+        private static (string MessageTemplate, object[] Parameters) CaptureJsonLog(Action<ILogger> writeLog)
+        {
+            var lambdaLoggerType = typeof(Amazon.Lambda.Core.LambdaLogger);
+            var loggingField = lambdaLoggerType
+                .GetTypeInfo()
+                .GetField("_loggingWithLevelAndExceptionAction", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(loggingField);
+
+            var previousLogFormat = Environment.GetEnvironmentVariable("AWS_LAMBDA_LOG_FORMAT");
+            var previousLoggingAction = loggingField.GetValue(null);
+            string capturedTemplate = null;
+            object[] capturedParameters = null;
+
+            try
+            {
+                Environment.SetEnvironmentVariable("AWS_LAMBDA_LOG_FORMAT", "JSON");
+                loggingField.SetValue(null, new Action<string, Exception, string, object[]>((level, exception, message, parameters) =>
+                {
+                    capturedTemplate = message;
+                    capturedParameters = parameters;
+                }));
+
+                var logger = new TestLoggerFactory()
+                    .AddLambdaLogger(new LambdaLoggerOptions())
+                    .CreateLogger("JSONLogging");
+
+                writeLog(logger);
+                return (capturedTemplate, capturedParameters);
+            }
+            finally
+            {
+                loggingField.SetValue(null, previousLoggingAction);
+                Environment.SetEnvironmentVariable("AWS_LAMBDA_LOG_FORMAT", previousLogFormat);
+            }
+        }
+
 		private static void ConnectLoggingActionToLogger(Action<string> loggingAction)
 		{
 			var lambdaLoggerType = typeof(Amazon.Lambda.Core.LambdaLogger);


### PR DESCRIPTION
*Issue #, if available:*

Fixes #2468

*Description of changes:*

When the JSON logging path receives a custom `ILogger` state whose enumeration
order differs from `{OriginalFormat}`, order the callback arguments by message
template placeholder name instead of by state position.

The implementation:

- preserves missing placeholder slots and handles duplicate placeholder names;
- supports destructuring hints, alignment, format specifiers, escaped braces,
  and positional templates;
- keeps the existing fast path when state is already aligned, and uses the same
  1,024-entry soft cache cap as RuntimeSupport; and
- adds focused regressions for the ASP.NET Core hosting-log shape and the edge
  cases above, plus the required AutoVer patch change file.

Validation:

- `dotnet test Libraries/test/Amazon.Lambda.Logging.AspNetCore.Tests/Amazon.Lambda.Logging.AspNetCore.Tests.csproj --framework net10.0 --configuration Debug` (20 passed)
- `dotnet test Libraries/test/Amazon.Lambda.Logging.AspNetCore.Tests/Amazon.Lambda.Logging.AspNetCore.Tests.csproj --framework net10.0 --configuration Release` (20 passed)
- `dotnet build Libraries/test/Amazon.Lambda.Logging.AspNetCore.Tests/Amazon.Lambda.Logging.AspNetCore.Tests.csproj --configuration Release --framework net8.0` (0 warnings, 0 errors)
- repeated the same checks after applying the commit cleanly to current `master` (`fdb84c71`)
- AutoVer change-file validation and `git -c core.whitespace=cr-at-eol diff --check`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.