### PR TITLE
Lambda-Runtime-Invocation-Id

### DIFF
--- a/.autover/changes/4133a18f-b6f9-4f24-886e-217756fbb670.json
+++ b/.autover/changes/4133a18f-b6f9-4f24-886e-217756fbb670.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.RuntimeSupport",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Add support for the Lambda-Runtime-Invocation-Id header for cross-wiring invoke protection. The runtime echoes the header back on the response and error calls when the Runtime API provides it, and treats an HTTP 410 Gone (invoke timeout) response as a non-fatal condition, logging it and continuing to the next invocation."
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
@@ -380,11 +380,17 @@ namespace Amazon.Lambda.RuntimeSupport
 
             Func<Task> processingFunc = async () =>
             {
+                // Per-invocation id echoed back on /response and /error for cross-wiring protection.
+                // Null when the Runtime API did not send the Lambda-Runtime-Invocation-Id header, in
+                // which case nothing is echoed. Captured as a local so concurrent invocations in
+                // multi-concurrency mode each carry their own id.
+                string invocationId = null;
                 if (invocation.LambdaContext is LambdaContext impl)
                 {
                     Client.ConsoleLogger.SetRuntimeHeaders(impl.RuntimeApiHeaders);
                     SetInvocationTraceId(impl.RuntimeApiHeaders.TraceId);
                     SetSerializerOnContext(impl);
+                    invocationId = impl.InvocationId;
                 }
 
                 // Initialize ResponseStreamFactory — includes RuntimeApiClient reference
@@ -420,7 +426,7 @@ namespace Amazon.Lambda.RuntimeSupport
                         }
                         else
                         {
-                        await Client.ReportInvocationErrorAsync(invocation.LambdaContext.AwsRequestId, exception, cancellationToken);
+                        await Client.ReportInvocationErrorAsync(invocation.LambdaContext.AwsRequestId, invocationId, exception, cancellationToken);
                     }
                     }
                     finally
@@ -450,7 +456,7 @@ namespace Amazon.Lambda.RuntimeSupport
                         _logger.LogInformation("Starting sending response");
                         try
                         {
-                            await Client.SendResponseAsync(invocation.LambdaContext.AwsRequestId, response?.OutputStream, cancellationToken);
+                            await Client.SendResponseAsync(invocation.LambdaContext.AwsRequestId, invocationId, response?.OutputStream, cancellationToken);
                         }
                         finally
                         {
@@ -464,6 +470,15 @@ namespace Amazon.Lambda.RuntimeSupport
                     }
 
                     _logger.LogInformation("Finished InvokeOnceAsync");
+                }
+                catch (RuntimeApiInvokeTimeoutException timeout)
+                {
+                    // The Runtime API rejected the response or error with HTTP 410 Gone because the
+                    // invocation had already timed out (cross-wiring protection). This is expected and
+                    // not fatal — the response would have been discarded anyway. Log via the internal
+                    // logger (not the customer log) and loop back to /next in both on-demand and
+                    // multi-concurrency modes rather than crashing the process.
+                    _logger.LogInformation($"Invocation {timeout.AwsRequestId} timed out before its response was submitted; the Runtime API rejected it. Continuing to the next invocation.");
                 }
                 catch(Exception ex)
                 {

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs
@@ -401,7 +401,8 @@ namespace Amazon.Lambda.RuntimeSupport
                         invocation.LambdaContext.AwsRequestId,
                         isMultiConcurrency,
                         runtimeApiClient,
-                        cancellationToken);
+                        cancellationToken,
+                        invocationId);
                 }
 
                 try

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/ResponseStreaming/RawStreamingHttpClient.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/ResponseStreaming/RawStreamingHttpClient.cs
@@ -23,6 +23,8 @@ using System.Threading.Tasks;
 using Amazon.Lambda.RuntimeSupport.Helpers;
 
 namespace Amazon.Lambda.RuntimeSupport.Client.ResponseStreaming
+// RuntimeApiHeaders lives in the Amazon.Lambda.RuntimeSupport namespace, which encloses this one,
+// so its HeaderInvocationId constant is in scope without an extra using.
 {
     /// <summary>
     /// A raw HTTP/1.1 client for sending streaming responses to the Lambda Runtime API
@@ -62,11 +64,13 @@ namespace Amazon.Lambda.RuntimeSupport.Client.ResponseStreaming
         /// for error reporting.
         /// </summary>
         /// <param name="awsRequestId">The Lambda request ID.</param>
+        /// <param name="invocationId">The unique-per-invocation id to echo back for cross-wiring protection. When null, the header is not sent.</param>
         /// <param name="responseStream">The response stream that provides data and error state.</param>
         /// <param name="userAgent">The User-Agent header value.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         public async Task SendStreamingResponseAsync(
             string awsRequestId,
+            string invocationId,
             ResponseStream responseStream,
             string userAgent,
             CancellationToken cancellationToken = default)
@@ -86,6 +90,11 @@ namespace Amazon.Lambda.RuntimeSupport.Client.ResponseStreaming
             headers.Append($"{StreamingConstants.ResponseModeHeader}: {StreamingConstants.StreamingResponseMode}\r\n");
             headers.Append("Transfer-Encoding: chunked\r\n");
             headers.Append($"Trailer: {StreamingConstants.ErrorTypeTrailer}, {StreamingConstants.ErrorBodyTrailer}\r\n");
+            // Echo the per-invocation id back for cross-wiring protection. Only sent when the
+            // Runtime API provided it on /next. Must be added before the terminating blank line
+            // so it stays part of the header block rather than the body.
+            if (!string.IsNullOrEmpty(invocationId))
+                headers.Append($"{RuntimeApiHeaders.HeaderInvocationId}: {invocationId}\r\n");
             headers.Append("\r\n");
 
             var headerBytes = Encoding.ASCII.GetBytes(headers.ToString());

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/ResponseStreaming/RawStreamingHttpClient.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/ResponseStreaming/RawStreamingHttpClient.cs
@@ -23,8 +23,6 @@ using System.Threading.Tasks;
 using Amazon.Lambda.RuntimeSupport.Helpers;
 
 namespace Amazon.Lambda.RuntimeSupport.Client.ResponseStreaming
-// RuntimeApiHeaders lives in the Amazon.Lambda.RuntimeSupport namespace, which encloses this one,
-// so its HeaderInvocationId constant is in scope without an extra using.
 {
     /// <summary>
     /// A raw HTTP/1.1 client for sending streaming responses to the Lambda Runtime API
@@ -91,8 +89,7 @@ namespace Amazon.Lambda.RuntimeSupport.Client.ResponseStreaming
             headers.Append("Transfer-Encoding: chunked\r\n");
             headers.Append($"Trailer: {StreamingConstants.ErrorTypeTrailer}, {StreamingConstants.ErrorBodyTrailer}\r\n");
             // Echo the per-invocation id back for cross-wiring protection. Only sent when the
-            // Runtime API provided it on /next. Must be added before the terminating blank line
-            // so it stays part of the header block rather than the body.
+            // Runtime API provided it on /next.
             if (!string.IsNullOrEmpty(invocationId))
                 headers.Append($"{RuntimeApiHeaders.HeaderInvocationId}: {invocationId}\r\n");
             headers.Append("\r\n");

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/ResponseStreaming/ResponseStreamContext.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/ResponseStreaming/ResponseStreamContext.cs
@@ -31,6 +31,12 @@ namespace Amazon.Lambda.RuntimeSupport.Client.ResponseStreaming
         public string AwsRequestId { get; set; }
 
         /// <summary>
+        /// The unique-per-invocation id echoed back on the streaming response for cross-wiring
+        /// protection. Null when the Runtime API did not provide it, in which case nothing is echoed.
+        /// </summary>
+        public string InvocationId { get; set; }
+
+        /// <summary>
         /// Whether CreateStream() has been called for this invocation.
         /// </summary>
         public bool StreamCreated { get; set; }

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/ResponseStreaming/ResponseStreamFactory.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/ResponseStreaming/ResponseStreamFactory.cs
@@ -62,7 +62,7 @@ namespace Amazon.Lambda.RuntimeSupport.Client.ResponseStreaming
             // This runs concurrently — SerializeToStreamAsync will block
             // until the handler finishes writing or reports an error.
             context.SendTask = context.RuntimeApiClient.StartStreamingResponseAsync(
-                context.AwsRequestId, lambdaStream, context.CancellationToken);
+                context.AwsRequestId, context.InvocationId, lambdaStream, context.CancellationToken);
 
             return lambdaStream;
         }
@@ -71,11 +71,13 @@ namespace Amazon.Lambda.RuntimeSupport.Client.ResponseStreaming
 
         internal static void InitializeInvocation(
             string awsRequestId, bool isMultiConcurrency,
-            RuntimeApiClient runtimeApiClient, CancellationToken cancellationToken)
+            RuntimeApiClient runtimeApiClient, CancellationToken cancellationToken,
+            string invocationId = null)
         {
             var context = new ResponseStreamContext
             {
                 AwsRequestId = awsRequestId,
+                InvocationId = invocationId,
                 StreamCreated = false,
                 Stream = null,
                 RuntimeApiClient = runtimeApiClient,

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/IRuntimeApiClient.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/IRuntimeApiClient.cs
@@ -65,7 +65,19 @@ namespace Amazon.Lambda.RuntimeSupport
         /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>A Task representing the asynchronous operation.</returns>
         Task ReportInvocationErrorAsync(string awsRequestId, Exception exception, CancellationToken cancellationToken = default);
-        
+
+        /// <summary>
+        /// Report an invocation error as an asynchronous operation, echoing the invocation id for
+        /// cross-wiring protection.
+        /// </summary>
+        /// <param name="awsRequestId">The ID of the function request that caused the error.</param>
+        /// <param name="invocationId">The unique-per-invocation id to echo back to the Runtime API. When null, the header is not sent.</param>
+        /// <param name="exception">The exception to report.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
+        /// <returns>A Task representing the asynchronous operation.</returns>
+        /// <exception cref="RuntimeApiInvokeTimeoutException">The invocation timed out before the error was submitted (cross-wiring protection).</exception>
+        Task ReportInvocationErrorAsync(string awsRequestId, string invocationId, Exception exception, CancellationToken cancellationToken = default);
+
         /// <summary>
         ///  Triggers the snapshot to be taken, and then after resume, restores the lambda
         /// context from the Runtime API as an asynchronous operation when SnapStart is enabled.
@@ -91,5 +103,17 @@ namespace Amazon.Lambda.RuntimeSupport
         /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns></returns>
         Task SendResponseAsync(string awsRequestId, Stream outputStream, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Send a response to a function invocation to the Runtime API as an asynchronous operation,
+        /// echoing the invocation id for cross-wiring protection.
+        /// </summary>
+        /// <param name="awsRequestId">The ID of the function request being responded to.</param>
+        /// <param name="invocationId">The unique-per-invocation id to echo back to the Runtime API. When null, the header is not sent.</param>
+        /// <param name="outputStream">The content of the response to the function invocation.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
+        /// <returns></returns>
+        /// <exception cref="RuntimeApiInvokeTimeoutException">The invocation timed out before the response was submitted (cross-wiring protection).</exception>
+        Task SendResponseAsync(string awsRequestId, string invocationId, Stream outputStream, CancellationToken cancellationToken = default);
     }
 }

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/InternalClientAdapted.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/InternalClientAdapted.cs
@@ -468,6 +468,7 @@ namespace Amazon.Lambda.RuntimeSupport
         /// <param name="lambda_Runtime_Function_Error_Type"></param>
         /// <param name="errorJson"></param>
         /// <param name="xrayCause"></param>
+        /// <param name="invocationId">The unique-per-invocation id to echo back for cross-wiring protection. When null, the header is not sent.</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public async System.Threading.Tasks.Task<SwaggerResponse<StatusResponse>> ErrorWithXRayCauseAsync(string awsRequestId, string lambda_Runtime_Function_Error_Type, string errorJson, string xrayCause, string invocationId, System.Threading.CancellationToken cancellationToken)

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/InternalClientAdapted.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/InternalClientAdapted.cs
@@ -59,10 +59,12 @@ namespace Amazon.Lambda.RuntimeSupport
         /// <summary>Runtime makes this request in order to submit a response.</summary>
         /// <returns>Accepted</returns>
         /// <exception cref="RuntimeApiClientException">A server side error occurred.</exception>
+        /// <exception cref="RuntimeApiInvokeTimeoutException">The invocation timed out before the response was submitted (cross-wiring protection).</exception>
         /// <param name="awsRequestId"></param>
         /// <param name="outputStream"></param>
+        /// <param name="invocationId">The unique-per-invocation id to echo back for cross-wiring protection. When null, the header is not sent.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        System.Threading.Tasks.Task<SwaggerResponse<StatusResponse>> ResponseAsync(string awsRequestId, System.IO.Stream outputStream, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<SwaggerResponse<StatusResponse>> ResponseAsync(string awsRequestId, System.IO.Stream outputStream, string invocationId, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
         /// Runtime makes this request in order to submit an error response. It can be either a function error, or a runtime error. Error will be served in response to the invoke.
@@ -71,9 +73,11 @@ namespace Amazon.Lambda.RuntimeSupport
         /// <param name="lambda_Runtime_Function_Error_Type"></param>
         /// <param name="errorJson"></param>
         /// <param name="xrayCause"></param>
+        /// <param name="invocationId">The unique-per-invocation id to echo back for cross-wiring protection. When null, the header is not sent.</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        System.Threading.Tasks.Task<SwaggerResponse<StatusResponse>> ErrorWithXRayCauseAsync(string awsRequestId, string lambda_Runtime_Function_Error_Type, string errorJson, string xrayCause, System.Threading.CancellationToken cancellationToken);
+        /// <exception cref="RuntimeApiInvokeTimeoutException">The invocation timed out before the error was submitted (cross-wiring protection).</exception>
+        System.Threading.Tasks.Task<SwaggerResponse<StatusResponse>> ErrorWithXRayCauseAsync(string awsRequestId, string lambda_Runtime_Function_Error_Type, string errorJson, string xrayCause, string invocationId, System.Threading.CancellationToken cancellationToken);
 
 
     }
@@ -311,16 +315,18 @@ namespace Amazon.Lambda.RuntimeSupport
         /// <exception cref="RuntimeApiClientException">A server side error occurred.</exception>
         public System.Threading.Tasks.Task<SwaggerResponse<StatusResponse>> ResponseAsync(string awsRequestId, System.IO.Stream outputStream)
         {
-            return ResponseAsync(awsRequestId, outputStream, System.Threading.CancellationToken.None);
+            return ResponseAsync(awsRequestId, outputStream, null, System.Threading.CancellationToken.None);
         }
 
         /// <summary>Runtime makes this request in order to submit a response.</summary>
         /// <returns>Accepted</returns>
         /// <exception cref="RuntimeApiClientException">A server side error occurred.</exception>
+        /// <exception cref="RuntimeApiInvokeTimeoutException">The invocation timed out before the response was submitted (cross-wiring protection).</exception>
         /// <param name="awsRequestId"></param>
         /// <param name="outputStream"></param>
+        /// <param name="invocationId">The unique-per-invocation id to echo back for cross-wiring protection. When null, the header is not sent.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        public async System.Threading.Tasks.Task<SwaggerResponse<StatusResponse>> ResponseAsync(string awsRequestId, System.IO.Stream outputStream, System.Threading.CancellationToken cancellationToken)
+        public async System.Threading.Tasks.Task<SwaggerResponse<StatusResponse>> ResponseAsync(string awsRequestId, System.IO.Stream outputStream, string invocationId, System.Threading.CancellationToken cancellationToken)
         {
             _logger.LogInformation("Starting InternalClient.ResponseAsync");
 
@@ -343,6 +349,12 @@ namespace Amazon.Lambda.RuntimeSupport
                         request_.Method = new System.Net.Http.HttpMethod("POST");
                         request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
 
+                        // Echo the per-invocation id back for cross-wiring protection. Only sent when the
+                        // Runtime API provided it on /next; added to this request message (never the shared
+                        // HttpClient) so concurrent invocations cannot echo each other's id.
+                        if (!string.IsNullOrEmpty(invocationId))
+                            request_.Headers.TryAddWithoutValidation(RuntimeApiHeaders.HeaderInvocationId, invocationId);
+
                         var url_ = $"{BaseUrl.TrimEnd('/')}/runtime/invocation/{awsRequestId}/response";
                         request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
 
@@ -360,6 +372,16 @@ namespace Amazon.Lambda.RuntimeSupport
                             if (response_.StatusCode == HttpStatusCode.Accepted)
                             {
                                 return new SwaggerResponse<StatusResponse>((int)response_.StatusCode, headers_, new StatusResponse());
+                            }
+                            else
+                            if (response_.StatusCode == HttpStatusCode.Gone)
+                            {
+                                // 410 Gone means the invocation timed out before this response was submitted.
+                                // The Runtime API rejects the response to prevent it being cross-wired to a
+                                // different invocation reusing the same request id. This is not a fatal error;
+                                // the caller logs it and moves on to the next invocation.
+                                var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                                throw new RuntimeApiInvokeTimeoutException(awsRequestId, responseData_);
                             }
                             else
                             if (response_.StatusCode == HttpStatusCode.BadRequest)
@@ -448,7 +470,7 @@ namespace Amazon.Lambda.RuntimeSupport
         /// <param name="xrayCause"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async System.Threading.Tasks.Task<SwaggerResponse<StatusResponse>> ErrorWithXRayCauseAsync(string awsRequestId, string lambda_Runtime_Function_Error_Type, string errorJson, string xrayCause, System.Threading.CancellationToken cancellationToken)
+        public async System.Threading.Tasks.Task<SwaggerResponse<StatusResponse>> ErrorWithXRayCauseAsync(string awsRequestId, string lambda_Runtime_Function_Error_Type, string errorJson, string xrayCause, string invocationId, System.Threading.CancellationToken cancellationToken)
         {
             if (awsRequestId == null)
                 throw new System.ArgumentNullException("awsRequestId");
@@ -464,6 +486,12 @@ namespace Amazon.Lambda.RuntimeSupport
                 {
                     if (lambda_Runtime_Function_Error_Type != null)
                         request_.Headers.TryAddWithoutValidation("Lambda-Runtime-Function-Error-Type", ConvertToString(lambda_Runtime_Function_Error_Type, System.Globalization.CultureInfo.InvariantCulture));
+
+                    // Echo the per-invocation id back for cross-wiring protection. Only sent when the
+                    // Runtime API provided it on /next; added to this request message (never the shared
+                    // HttpClient) so concurrent invocations cannot echo each other's id.
+                    if (!string.IsNullOrEmpty(invocationId))
+                        request_.Headers.TryAddWithoutValidation(RuntimeApiHeaders.HeaderInvocationId, invocationId);
 
                     // This is the unmodeled X-Ray header to report back the cause of errors.
                     if (xrayCause != null && System.Text.Encoding.UTF8.GetByteCount(xrayCause) < MAX_HEADER_SIZE_BYTES)
@@ -514,6 +542,15 @@ namespace Amazon.Lambda.RuntimeSupport
                                 {
                                     throw new RuntimeApiClientException("Could not deserialize the response body.", (int)response_.StatusCode, responseData_, headers_, exception_);
                                 }
+                            }
+                            else
+                            if (response_.StatusCode == HttpStatusCode.Gone)
+                            {
+                                // 410 Gone means the invocation timed out before this error was submitted.
+                                // The Runtime API rejects it to prevent cross-wiring to a different invocation
+                                // reusing the same request id. Not fatal; the caller logs it and moves on.
+                                var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                                throw new RuntimeApiInvokeTimeoutException(awsRequestId, responseData_);
                             }
                             else
                             if (response_.StatusCode == HttpStatusCode.BadRequest)
@@ -683,6 +720,42 @@ namespace Amazon.Lambda.RuntimeSupport
             : base(message, statusCode, response, headers, innerException)
         {
             Result = result;
+        }
+    }
+
+    /// <summary>
+    /// Thrown when the Runtime API responds to a /response or /error call with HTTP 410 Gone,
+    /// indicating the invocation had already timed out. This is part of the cross-wiring protection:
+    /// the Runtime API rejects the late response so it cannot be delivered to a different invocation
+    /// that reused the same request id. It is not a fatal error — the invoke loop logs it and
+    /// continues to the next invocation.
+    /// </summary>
+    /// <remarks>
+    /// Intentionally derives directly from <see cref="System.Exception"/> rather than
+    /// <see cref="RuntimeApiClientException"/>, whose constructor dereferences the response body.
+    /// </remarks>
+    public class RuntimeApiInvokeTimeoutException : System.Exception
+    {
+        /// <summary>
+        /// The AWS request id of the invocation that timed out.
+        /// </summary>
+        public string AwsRequestId { get; private set; }
+
+        /// <summary>
+        /// The raw response body returned by the Runtime API, if any.
+        /// </summary>
+        public string Response { get; private set; }
+
+        /// <summary>
+        /// Constructs a new <see cref="RuntimeApiInvokeTimeoutException"/>.
+        /// </summary>
+        /// <param name="awsRequestId">The AWS request id of the invocation that timed out.</param>
+        /// <param name="response">The raw response body returned by the Runtime API, if any.</param>
+        public RuntimeApiInvokeTimeoutException(string awsRequestId, string response)
+            : base($"The invocation with request id '{awsRequestId}' timed out before its response was submitted. The Runtime API rejected the response with HTTP 410 Gone to prevent cross-wiring to another invocation.")
+        {
+            AwsRequestId = awsRequestId;
+            Response = response;
         }
     }
 

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/RuntimeApiClient.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/RuntimeApiClient.cs
@@ -198,11 +198,12 @@ namespace Amazon.Lambda.RuntimeSupport
         /// This Task completes when the stream is finalized (MarkCompleted or error).
         /// </summary>
         /// <param name="awsRequestId">The ID of the function request being responded to.</param>
+        /// <param name="invocationId">The unique-per-invocation id to echo back for cross-wiring protection. When null, the header is not sent.</param>
         /// <param name="responseStream">The ResponseStream that will provide the streaming data.</param>
         /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>A Task representing the in-flight HTTP POST. The returned IDisposable is the RawStreamingHttpClient that owns the TCP connection.</returns>
         internal virtual async Task<IDisposable> StartStreamingResponseAsync(
-            string awsRequestId, ResponseStream responseStream, CancellationToken cancellationToken = default)
+            string awsRequestId, string invocationId, ResponseStream responseStream, CancellationToken cancellationToken = default)
         {
             if (awsRequestId == null) throw new ArgumentNullException(nameof(awsRequestId));
             if (responseStream == null) throw new ArgumentNullException(nameof(responseStream));
@@ -210,7 +211,7 @@ namespace Amazon.Lambda.RuntimeSupport
             var userAgent = _httpClient.DefaultRequestHeaders.UserAgent.ToString();
             var rawClient = new RawStreamingHttpClient(LambdaEnvironment.RuntimeServerHostAndPort);
 
-            await rawClient.SendStreamingResponseAsync(awsRequestId, responseStream, userAgent, cancellationToken);
+            await rawClient.SendStreamingResponseAsync(awsRequestId, invocationId, responseStream, userAgent, cancellationToken);
 
             return rawClient;
         }

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/RuntimeApiClient.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/RuntimeApiClient.cs
@@ -132,8 +132,6 @@ namespace Amazon.Lambda.RuntimeSupport
             if (exception == null)
                 throw new ArgumentNullException(nameof(exception));
 
-            var exceptionInfo = ExceptionInfo.GetExceptionInfo(exception);
-
             return ReportInvocationErrorAsync(awsRequestId, null, exception, cancellationToken);
         }
 

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/RuntimeApiClient.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/RuntimeApiClient.cs
@@ -134,10 +134,33 @@ namespace Amazon.Lambda.RuntimeSupport
 
             var exceptionInfo = ExceptionInfo.GetExceptionInfo(exception);
 
+            return ReportInvocationErrorAsync(awsRequestId, null, exception, cancellationToken);
+        }
+
+        /// <summary>
+        /// Report an invocation error as an asynchronous operation, echoing the invocation id for
+        /// cross-wiring protection.
+        /// </summary>
+        /// <param name="awsRequestId">The ID of the function request that caused the error.</param>
+        /// <param name="invocationId">The unique-per-invocation id to echo back to the Runtime API. When null, the header is not sent.</param>
+        /// <param name="exception">The exception to report.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
+        /// <returns>A Task representing the asynchronous operation.</returns>
+        /// <exception cref="RuntimeApiInvokeTimeoutException">The invocation timed out before the error was submitted (cross-wiring protection).</exception>
+        public Task ReportInvocationErrorAsync(string awsRequestId, string invocationId, Exception exception, CancellationToken cancellationToken = default)
+        {
+            if (awsRequestId == null)
+                throw new ArgumentNullException(nameof(awsRequestId));
+
+            if (exception == null)
+                throw new ArgumentNullException(nameof(exception));
+
+            var exceptionInfo = ExceptionInfo.GetExceptionInfo(exception);
+
             var exceptionInfoJson = LambdaJsonExceptionWriter.WriteJson(exceptionInfo);
             var exceptionInfoXRayJson = LambdaXRayExceptionWriter.WriteJson(exceptionInfo);
 
-            return _internalClient.ErrorWithXRayCauseAsync(awsRequestId, exceptionInfo.ErrorType, exceptionInfoJson, exceptionInfoXRayJson, cancellationToken);
+            return _internalClient.ErrorWithXRayCauseAsync(awsRequestId, exceptionInfo.ErrorType, exceptionInfoJson, exceptionInfoXRayJson, invocationId, cancellationToken);
         }
 
         /// <summary>
@@ -201,7 +224,22 @@ namespace Amazon.Lambda.RuntimeSupport
         /// <returns></returns>
         public async Task SendResponseAsync(string awsRequestId, Stream outputStream, CancellationToken cancellationToken = default)
         {
-            await _internalClient.ResponseAsync(awsRequestId, outputStream, cancellationToken);
+            await SendResponseAsync(awsRequestId, null, outputStream, cancellationToken);
+        }
+
+        /// <summary>
+        /// Send a response to a function invocation to the Runtime API as an asynchronous operation,
+        /// echoing the invocation id for cross-wiring protection.
+        /// </summary>
+        /// <param name="awsRequestId">The ID of the function request being responded to.</param>
+        /// <param name="invocationId">The unique-per-invocation id to echo back to the Runtime API. When null, the header is not sent.</param>
+        /// <param name="outputStream">The content of the response to the function invocation.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
+        /// <returns></returns>
+        /// <exception cref="RuntimeApiInvokeTimeoutException">The invocation timed out before the response was submitted (cross-wiring protection).</exception>
+        public async Task SendResponseAsync(string awsRequestId, string invocationId, Stream outputStream, CancellationToken cancellationToken = default)
+        {
+            await _internalClient.ResponseAsync(awsRequestId, outputStream, invocationId, cancellationToken);
         }
     }
 }

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/RuntimeApiHeaders.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Client/RuntimeApiHeaders.cs
@@ -39,6 +39,15 @@ namespace Amazon.Lambda.RuntimeSupport
         /// Gets the tenant id for the Lambda function.
         /// </summary>
         string TenantId { get; }
+
+        /// <summary>
+        /// A unique-per-invocation identifier used for cross-wiring protection.
+        /// Unlike <see cref="AwsRequestId"/>, this value is never reused across retries.
+        /// It is echoed back on the response and error calls so the Runtime API can reject
+        /// responses that belong to a timed-out invocation. May be null when the Runtime API
+        /// does not provide the header, in which case nothing is echoed back.
+        /// </summary>
+        string InvocationId { get; }
     }
 
     internal class RuntimeApiHeaders : IRuntimeApiHeaders
@@ -50,6 +59,7 @@ namespace Amazon.Lambda.RuntimeSupport
         internal const string HeaderDeadlineMs = "Lambda-Runtime-Deadline-Ms";
         internal const string HeaderInvokedFunctionArn = "Lambda-Runtime-Invoked-Function-Arn";
         internal const string HeaderAwsTenantId = "Lambda-Runtime-Aws-Tenant-Id";
+        internal const string HeaderInvocationId = "Lambda-Runtime-Invocation-Id";
 
         public RuntimeApiHeaders(Dictionary<string, IEnumerable<string>> headers)
         {
@@ -62,6 +72,7 @@ namespace Amazon.Lambda.RuntimeSupport
             InvokedFunctionArn = GetHeaderValueOrNull(caseInsensitiveHeaders, HeaderInvokedFunctionArn);
             TraceId = GetHeaderValueOrNull(caseInsensitiveHeaders, HeaderTraceId);
             TenantId = GetHeaderValueOrNull(caseInsensitiveHeaders, HeaderAwsTenantId);
+            InvocationId = GetHeaderValueOrNull(caseInsensitiveHeaders, HeaderInvocationId);
         }
 
         public string AwsRequestId { get; private set; }
@@ -71,6 +82,7 @@ namespace Amazon.Lambda.RuntimeSupport
         public string CognitoIdentityJson { get; private set; }
         public string DeadlineMs { get; private set; }
         public string TenantId { get; private set; }
+        public string InvocationId { get; private set; }
 
         private string GetHeaderValueRequired(Dictionary<string, IEnumerable<string>> headers, string header)
         {

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/Context/LambdaContext.cs
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/Context/LambdaContext.cs
@@ -85,5 +85,12 @@ namespace Amazon.Lambda.RuntimeSupport
         public ILambdaSerializer Serializer { get; internal set; }
 
         internal IRuntimeApiHeaders RuntimeApiHeaders => _runtimeApiHeaders;
+
+        /// <summary>
+        /// The unique-per-invocation identifier echoed back to the Runtime API on the response
+        /// and error calls for cross-wiring protection. Null when the Runtime API did not provide
+        /// the <c>Lambda-Runtime-Invocation-Id</c> header, in which case nothing is echoed.
+        /// </summary>
+        internal string InvocationId => _runtimeApiHeaders.InvocationId;
     }
 }

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/SourceGeneratorTests.cs
@@ -2389,18 +2389,18 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
             return new[]
             {
                 // These are here because the System.Text.Json source generator isn't included in test compilations, so these members aren't generated.
-                DiagnosticResult.CompilerError("CS0534").WithSpan(clientFile, 85, 30, 85, 60).WithArguments(runtimeApiContext, "System.Text.Json.Serialization.JsonSerializerContext.GeneratedSerializerOptions.get"),
-                DiagnosticResult.CompilerError("CS0534").WithSpan(clientFile, 85, 30, 85, 60).WithArguments(runtimeApiContext, "System.Text.Json.Serialization.JsonSerializerContext.GetTypeInfo(System.Type)"),
-                DiagnosticResult.CompilerError("CS7036").WithSpan(clientFile, 85, 30, 85, 60).WithArguments("options", "System.Text.Json.Serialization.JsonSerializerContext.JsonSerializerContext(System.Text.Json.JsonSerializerOptions?)"),
-                DiagnosticResult.CompilerError("CS0117").WithSpan(clientFile, 157, 136, 157, 143).WithArguments(runtimeApiContext, "Default"),
-                DiagnosticResult.CompilerError("CS0117").WithSpan(clientFile, 172, 135, 172, 142).WithArguments(runtimeApiContext, "Default"),
-                DiagnosticResult.CompilerError("CS0117").WithSpan(clientFile, 275, 131, 275, 138).WithArguments(runtimeApiContext, "Default"),
-                DiagnosticResult.CompilerError("CS0117").WithSpan(clientFile, 371, 135, 371, 142).WithArguments(runtimeApiContext, "Default"),
-                DiagnosticResult.CompilerError("CS0117").WithSpan(clientFile, 386, 135, 386, 142).WithArguments(runtimeApiContext, "Default"),
-                DiagnosticResult.CompilerError("CS0117").WithSpan(clientFile, 401, 135, 401, 142).WithArguments(runtimeApiContext, "Default"),
-                DiagnosticResult.CompilerError("CS0117").WithSpan(clientFile, 510, 136, 510, 143).WithArguments(runtimeApiContext, "Default"),
-                DiagnosticResult.CompilerError("CS0117").WithSpan(clientFile, 525, 135, 525, 142).WithArguments(runtimeApiContext, "Default"),
-                DiagnosticResult.CompilerError("CS0117").WithSpan(clientFile, 540, 135, 540, 142).WithArguments(runtimeApiContext, "Default"),
+                DiagnosticResult.CompilerError("CS0534").WithSpan(clientFile, 89, 30, 89, 60).WithArguments(runtimeApiContext, "System.Text.Json.Serialization.JsonSerializerContext.GeneratedSerializerOptions.get"),
+                DiagnosticResult.CompilerError("CS0534").WithSpan(clientFile, 89, 30, 89, 60).WithArguments(runtimeApiContext, "System.Text.Json.Serialization.JsonSerializerContext.GetTypeInfo(System.Type)"),
+                DiagnosticResult.CompilerError("CS7036").WithSpan(clientFile, 89, 30, 89, 60).WithArguments("options", "System.Text.Json.Serialization.JsonSerializerContext.JsonSerializerContext(System.Text.Json.JsonSerializerOptions?)"),
+                DiagnosticResult.CompilerError("CS0117").WithSpan(clientFile, 161, 136, 161, 143).WithArguments(runtimeApiContext, "Default"),
+                DiagnosticResult.CompilerError("CS0117").WithSpan(clientFile, 176, 135, 176, 142).WithArguments(runtimeApiContext, "Default"),
+                DiagnosticResult.CompilerError("CS0117").WithSpan(clientFile, 279, 131, 279, 138).WithArguments(runtimeApiContext, "Default"),
+                DiagnosticResult.CompilerError("CS0117").WithSpan(clientFile, 393, 135, 393, 142).WithArguments(runtimeApiContext, "Default"),
+                DiagnosticResult.CompilerError("CS0117").WithSpan(clientFile, 408, 135, 408, 142).WithArguments(runtimeApiContext, "Default"),
+                DiagnosticResult.CompilerError("CS0117").WithSpan(clientFile, 423, 135, 423, 142).WithArguments(runtimeApiContext, "Default"),
+                DiagnosticResult.CompilerError("CS0117").WithSpan(clientFile, 539, 136, 539, 143).WithArguments(runtimeApiContext, "Default"),
+                DiagnosticResult.CompilerError("CS0117").WithSpan(clientFile, 563, 135, 563, 142).WithArguments(runtimeApiContext, "Default"),
+                DiagnosticResult.CompilerError("CS0117").WithSpan(clientFile, 578, 135, 578, 142).WithArguments(runtimeApiContext, "Default"),
 
 
                 // These are here because the internalvisibleto attribute isn't included in test compilations, so these types are inaccessible.

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaBootstrapTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaBootstrapTests.cs
@@ -182,6 +182,60 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
         }
 
         [Fact]
+        public async Task InvocationIdIsEchoedOnResponse()
+        {
+            var headers = new Dictionary<string, IEnumerable<string>>
+            {
+                { RuntimeApiHeaders.HeaderAwsRequestId, new List<string> { "request_id" } },
+                { RuntimeApiHeaders.HeaderInvocationId, new List<string> { "invocation_id" } }
+            };
+            var client = new TestRuntimeApiClient(_environmentVariables, headers);
+
+            using (var bootstrap = new LambdaBootstrap(_testFunction.BaseHandlerAsync, null, null, _environmentVariables))
+            {
+                bootstrap.Client = client;
+                await bootstrap.InvokeOnceAsync();
+            }
+
+            Assert.True(client.SendResponseAsyncCalled);
+            Assert.Equal("invocation_id", client.LastInvocationId);
+        }
+
+        [Fact]
+        public async Task InvokeTimeoutOnResponseDoesNotThrow()
+        {
+            _testRuntimeApiClient.ThrowInvokeTimeoutOnResponse = true;
+
+            using (var bootstrap = new LambdaBootstrap(_testFunction.BaseHandlerAsync, null, null, _environmentVariables))
+            {
+                bootstrap.Client = _testRuntimeApiClient;
+
+                // A 410 Gone on the response POST must be swallowed (logged and continue), not thrown.
+                await bootstrap.InvokeOnceAsync();
+            }
+
+            Assert.True(_testRuntimeApiClient.SendResponseAsyncCalled);
+            Assert.True(_testFunction.HandlerWasCalled);
+        }
+
+        [Fact]
+        public async Task InvokeTimeoutOnErrorDoesNotThrow()
+        {
+            _testRuntimeApiClient.ThrowInvokeTimeoutOnError = true;
+
+            using (var bootstrap = new LambdaBootstrap(_testFunction.BaseHandlerThrowsAsync, null, null, _environmentVariables))
+            {
+                bootstrap.Client = _testRuntimeApiClient;
+
+                // A 410 Gone on the error POST must be swallowed (logged and continue), not thrown.
+                await bootstrap.InvokeOnceAsync();
+            }
+
+            Assert.True(_testRuntimeApiClient.ReportInvocationErrorAsyncExceptionCalled);
+            Assert.True(_testFunction.HandlerWasCalled);
+        }
+
+        [Fact]
         public async Task HandlerInputAndOutputWork()
         {
             const string testInput = "a MiXeD cAsE sTrInG";

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaContextTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaContextTests.cs
@@ -55,5 +55,40 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             Assert.Equal("my-function-arn", context.InvokedFunctionArn);
             Assert.Equal("tenant-generated-id", context.TenantId);
         }
+
+        [Fact]
+        public void InvocationIdIsReadWhenHeaderPresent()
+        {
+            var headers = new Dictionary<string, IEnumerable<string>>
+            {
+                ["Lambda-Runtime-Aws-Request-Id"] = new[] { "request-generated-id" },
+                ["Lambda-Runtime-Invocation-Id"] = new[] { "invocation-generated-id" }
+            };
+
+            var runtimeApiHeaders = new RuntimeApiHeaders(headers);
+            var lambdaEnvironment = new LambdaEnvironment(_environmentVariables);
+
+            var context = new LambdaContext(runtimeApiHeaders, lambdaEnvironment, new Helpers.LogLevelLoggerWriter(new SystemEnvironmentVariables()));
+
+            Assert.Equal("invocation-generated-id", runtimeApiHeaders.InvocationId);
+            Assert.Equal("invocation-generated-id", context.InvocationId);
+        }
+
+        [Fact]
+        public void InvocationIdIsNullWhenHeaderAbsent()
+        {
+            var headers = new Dictionary<string, IEnumerable<string>>
+            {
+                ["Lambda-Runtime-Aws-Request-Id"] = new[] { "request-generated-id" }
+            };
+
+            var runtimeApiHeaders = new RuntimeApiHeaders(headers);
+            var lambdaEnvironment = new LambdaEnvironment(_environmentVariables);
+
+            var context = new LambdaContext(runtimeApiHeaders, lambdaEnvironment, new Helpers.LogLevelLoggerWriter(new SystemEnvironmentVariables()));
+
+            Assert.Null(runtimeApiHeaders.InvocationId);
+            Assert.Null(context.InvocationId);
+        }
     }
 }

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaResponseStreamingCoreTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/LambdaResponseStreamingCoreTests.cs
@@ -429,7 +429,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 : base(envVars, new TestHelpers.NoOpInternalRuntimeApiClient()) { }
 
             internal override async Task<IDisposable> StartStreamingResponseAsync(
-                string awsRequestId, ResponseStream responseStream, CancellationToken cancellationToken = default)
+                string awsRequestId, string invocationId, ResponseStream responseStream, CancellationToken cancellationToken = default)
             {
                 // Provide the HTTP output stream so writes don't block
                 await responseStream.SetHttpOutputStreamAsync(new MemoryStream(), cancellationToken);

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/ResponseStreamFactoryTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/ResponseStreamFactoryTests.cs
@@ -49,11 +49,14 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             {
             }
 
+            public string LastInvocationId { get; private set; }
+
             internal override async Task<IDisposable> StartStreamingResponseAsync(
-                string awsRequestId, ResponseStream responseStream, CancellationToken cancellationToken = default)
+                string awsRequestId, string invocationId, ResponseStream responseStream, CancellationToken cancellationToken = default)
             {
                 StartStreamingCalled = true;
                 LastAwsRequestId = awsRequestId;
+                LastInvocationId = invocationId;
                 LastResponseStream = responseStream;
                 await SendTaskCompletion.Task;
                 return new NoOpDisposable();
@@ -147,6 +150,24 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             Assert.True(mock.StartStreamingCalled);
             Assert.Equal("req-start", mock.LastAwsRequestId);
             Assert.NotNull(mock.LastResponseStream);
+        }
+
+        /// <summary>
+        /// Validates that the invocation id stored on the context is passed through to
+        /// StartStreamingResponseAsync so the streaming response echoes it for cross-wiring protection.
+        /// </summary>
+        [Fact]
+        public void CreateStream_PassesInvocationIdToStartStreaming()
+        {
+            var mock = new MockStreamingRuntimeApiClient();
+            ResponseStreamFactory.InitializeInvocation(
+                "req-inv", isMultiConcurrency: false,
+                mock, CancellationToken.None, "invocation_id");
+
+            ResponseStreamFactory.CreateStream(Array.Empty<byte>());
+
+            Assert.True(mock.StartStreamingCalled);
+            Assert.Equal("invocation_id", mock.LastInvocationId);
         }
 
         // --- GetSendTask ---

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/RuntimeApiClientTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/RuntimeApiClientTests.cs
@@ -84,7 +84,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             var stream = new ResponseStream(Array.Empty<byte>());
             var client = CreateClientWithMockHandler(stream, out var handler);
 
-            await client.StartStreamingResponseAsync("req-1", stream, CancellationToken.None);
+            await client.StartStreamingResponseAsync("req-1", null, stream, CancellationToken.None);
 
             Assert.NotNull(handler.CapturedRequest);
             Assert.True(handler.CapturedRequest.Headers.Contains(StreamingConstants.ResponseModeHeader));
@@ -107,7 +107,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             var stream = new ResponseStream(Array.Empty<byte>());
             var client = CreateClientWithMockHandler(stream, out var handler);
 
-            await client.StartStreamingResponseAsync("req-2", stream, CancellationToken.None);
+            await client.StartStreamingResponseAsync("req-2", null, stream, CancellationToken.None);
 
             Assert.NotNull(handler.CapturedRequest);
             Assert.True(handler.CapturedRequest.Headers.TransferEncodingChunked);
@@ -128,7 +128,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             var stream = new ResponseStream(Array.Empty<byte>());
             var client = CreateClientWithMockHandler(stream, out var handler);
 
-            await client.StartStreamingResponseAsync("req-3", stream, CancellationToken.None);
+            await client.StartStreamingResponseAsync("req-3", null, stream, CancellationToken.None);
 
             Assert.NotNull(handler.CapturedRequest);
             Assert.True(handler.CapturedRequest.Headers.Contains("Trailer"));
@@ -301,7 +301,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             var client = CreateClientWithMockHandler(stream, out _);
 
             await Assert.ThrowsAsync<ArgumentNullException>(
-                () => client.StartStreamingResponseAsync(null, stream, CancellationToken.None));
+                () => client.StartStreamingResponseAsync(null, null, stream, CancellationToken.None));
         }
 
         [Fact]
@@ -311,7 +311,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             var client = CreateClientWithMockHandler(stream, out _);
 
             await Assert.ThrowsAsync<ArgumentNullException>(
-                () => client.StartStreamingResponseAsync("req-5", null, CancellationToken.None));
+                () => client.StartStreamingResponseAsync("req-5", null, null, CancellationToken.None));
         }
     }
 }

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/RuntimeApiClientTests.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/RuntimeApiClientTests.cs
@@ -186,6 +186,114 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
 
         // --- Argument validation ---
 
+        // --- Cross-wiring: Lambda-Runtime-Invocation-Id echo + 410 handling ---
+
+        /// <summary>
+        /// Mock handler that captures the request and returns a configurable status code.
+        /// </summary>
+        private class ConfigurableMockHttpMessageHandler : HttpMessageHandler
+        {
+            public HttpRequestMessage CapturedRequest { get; private set; }
+            private readonly HttpStatusCode _statusCode;
+            private readonly string _body;
+
+            public ConfigurableMockHttpMessageHandler(HttpStatusCode statusCode, string body = null)
+            {
+                _statusCode = statusCode;
+                _body = body;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                CapturedRequest = request;
+                var response = new HttpResponseMessage(_statusCode);
+                if (_body != null)
+                {
+                    response.Content = new StringContent(_body);
+                }
+                return Task.FromResult(response);
+            }
+        }
+
+        private static RuntimeApiClient CreateClientWith(ConfigurableMockHttpMessageHandler handler)
+        {
+            var httpClient = new HttpClient(handler);
+            var envVars = new TestEnvironmentVariables();
+            envVars.SetEnvironmentVariable("AWS_LAMBDA_RUNTIME_API", "localhost:9001");
+            return new RuntimeApiClient(envVars, httpClient);
+        }
+
+        [Fact]
+        public async Task SendResponseAsync_WithInvocationId_EchoesHeader()
+        {
+            var handler = new ConfigurableMockHttpMessageHandler(HttpStatusCode.Accepted);
+            var client = CreateClientWith(handler);
+
+            var outputStream = new MemoryStream(new byte[] { 1, 2, 3 });
+            await client.SendResponseAsync("req-1", "inv-uuid-abc", outputStream, CancellationToken.None);
+
+            Assert.NotNull(handler.CapturedRequest);
+            Assert.True(handler.CapturedRequest.Headers.Contains("Lambda-Runtime-Invocation-Id"));
+            Assert.Equal("inv-uuid-abc",
+                handler.CapturedRequest.Headers.GetValues("Lambda-Runtime-Invocation-Id").Single());
+        }
+
+        [Fact]
+        public async Task SendResponseAsync_WithoutInvocationId_OmitsHeader()
+        {
+            var handler = new ConfigurableMockHttpMessageHandler(HttpStatusCode.Accepted);
+            var client = CreateClientWith(handler);
+
+            var outputStream = new MemoryStream(new byte[] { 1, 2, 3 });
+            await client.SendResponseAsync("req-1", null, outputStream, CancellationToken.None);
+
+            Assert.NotNull(handler.CapturedRequest);
+            Assert.False(handler.CapturedRequest.Headers.Contains("Lambda-Runtime-Invocation-Id"),
+                "Response should not include the invocation id header when none was provided.");
+        }
+
+        [Fact]
+        public async Task SendResponseAsync_410Gone_ThrowsRuntimeApiInvokeTimeoutException()
+        {
+            var handler = new ConfigurableMockHttpMessageHandler(HttpStatusCode.Gone,
+                "{\"errorMessage\":\"Invoke timeout\",\"errorType\":\"InvokeTimeout\"}");
+            var client = CreateClientWith(handler);
+
+            var outputStream = new MemoryStream(new byte[] { 1, 2, 3 });
+            var ex = await Assert.ThrowsAsync<RuntimeApiInvokeTimeoutException>(
+                () => client.SendResponseAsync("req-timeout", "inv-uuid-abc", outputStream, CancellationToken.None));
+
+            Assert.Equal("req-timeout", ex.AwsRequestId);
+        }
+
+        [Fact]
+        public async Task ReportInvocationErrorAsync_WithInvocationId_EchoesHeader()
+        {
+            var handler = new ConfigurableMockHttpMessageHandler(HttpStatusCode.Accepted, "{}");
+            var client = CreateClientWith(handler);
+
+            await client.ReportInvocationErrorAsync("req-1", "inv-uuid-abc", new Exception("boom"), CancellationToken.None);
+
+            Assert.NotNull(handler.CapturedRequest);
+            Assert.True(handler.CapturedRequest.Headers.Contains("Lambda-Runtime-Invocation-Id"));
+            Assert.Equal("inv-uuid-abc",
+                handler.CapturedRequest.Headers.GetValues("Lambda-Runtime-Invocation-Id").Single());
+        }
+
+        [Fact]
+        public async Task ReportInvocationErrorAsync_410Gone_ThrowsRuntimeApiInvokeTimeoutException()
+        {
+            var handler = new ConfigurableMockHttpMessageHandler(HttpStatusCode.Gone,
+                "{\"errorMessage\":\"Invoke timeout\",\"errorType\":\"InvokeTimeout\"}");
+            var client = CreateClientWith(handler);
+
+            var ex = await Assert.ThrowsAsync<RuntimeApiInvokeTimeoutException>(
+                () => client.ReportInvocationErrorAsync("req-timeout", "inv-uuid-abc", new Exception("boom"), CancellationToken.None));
+
+            Assert.Equal("req-timeout", ex.AwsRequestId);
+        }
+
         [Fact]
         public async Task StartStreamingResponseAsync_NullRequestId_ThrowsArgumentNullException()
         {

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/StreamingE2EWithMoq.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/StreamingE2EWithMoq.cs
@@ -105,10 +105,13 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 };
             }
 
+            public string LastInvocationId { get; private set; }
+
             internal override async Task<IDisposable> StartStreamingResponseAsync(
-                string awsRequestId, ResponseStream responseStream, CancellationToken cancellationToken = default)
+                string awsRequestId, string invocationId, ResponseStream responseStream, CancellationToken cancellationToken = default)
             {
                 StartStreamingCalled = true;
+                LastInvocationId = invocationId;
                 LastResponseStream = responseStream;
 
                 // Use a real MemoryStream as the HTTP output stream so we capture actual bytes
@@ -404,7 +407,7 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 : base(new TestEnvironmentVariables(), new NoOpInternalRuntimeApiClient()) { }
 
             internal override async Task<IDisposable> StartStreamingResponseAsync(
-                string awsRequestId, ResponseStream responseStream, CancellationToken cancellationToken = default)
+                string awsRequestId, string invocationId, ResponseStream responseStream, CancellationToken cancellationToken = default)
             {
                 // Provide the HTTP output stream so writes don't block
                 await responseStream.SetHttpOutputStreamAsync(new MemoryStream());

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/StreamingE2EWithMoq.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/StreamingE2EWithMoq.cs
@@ -123,7 +123,12 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
                 return new NoOpDisposable();
             }
 
-            public new async Task SendResponseAsync(string awsRequestId, Stream outputStream, CancellationToken cancellationToken = default)
+            public new Task SendResponseAsync(string awsRequestId, Stream outputStream, CancellationToken cancellationToken = default)
+            {
+                return SendResponseAsync(awsRequestId, null, outputStream, cancellationToken);
+            }
+
+            public new async Task SendResponseAsync(string awsRequestId, string invocationId, Stream outputStream, CancellationToken cancellationToken = default)
             {
                 SendResponseCalled = true;
                 if (outputStream != null)
@@ -136,6 +141,11 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             }
 
             public new Task ReportInvocationErrorAsync(string awsRequestId, Exception exception, CancellationToken cancellationToken = default)
+            {
+                return ReportInvocationErrorAsync(awsRequestId, null, exception, cancellationToken);
+            }
+
+            public new Task ReportInvocationErrorAsync(string awsRequestId, string invocationId, Exception exception, CancellationToken cancellationToken = default)
             {
                 ReportInvocationErrorCalled = true;
                 return Task.CompletedTask;

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/NoOpInternalRuntimeApiClient.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/NoOpInternalRuntimeApiClient.cs
@@ -40,12 +40,12 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests.TestHelpers
             => Task.FromResult(EmptyStatusResponse);
 
         public Task<SwaggerResponse<StatusResponse>> ResponseAsync(
-            string awsRequestId, Stream outputStream, CancellationToken cancellationToken)
+            string awsRequestId, Stream outputStream, string invocationId, CancellationToken cancellationToken)
             => Task.FromResult(EmptyStatusResponse);
 
         public Task<SwaggerResponse<StatusResponse>> ErrorWithXRayCauseAsync(
             string awsRequestId, string lambda_Runtime_Function_Error_Type,
-            string errorJson, string xrayCause, CancellationToken cancellationToken)
+            string errorJson, string xrayCause, string invocationId, CancellationToken cancellationToken)
             => Task.FromResult(EmptyStatusResponse);
 
         public Task<SwaggerResponse<Stream>> RestoreNextAsync(CancellationToken cancellationToken)

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestMultiConcurrencyRuntimeApiClient.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestMultiConcurrencyRuntimeApiClient.cs
@@ -100,6 +100,11 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests.TestHelpers
 
         public Task SendResponseAsync(string awsRequestId, Stream outputStream, CancellationToken cancellationToken = default)
         {
+            return SendResponseAsync(awsRequestId, null, outputStream, cancellationToken);
+        }
+
+        public Task SendResponseAsync(string awsRequestId, string invocationId, Stream outputStream, CancellationToken cancellationToken = default)
+        {
             if (ProcessInvocationEvents.TryGetValue(awsRequestId, out var data))
             {
                 data.Complete = true;
@@ -137,6 +142,11 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests.TestHelpers
         }
 
         public Task ReportInvocationErrorAsync(string awsRequestId, string errorType, CancellationToken cancellationToken = default)
+        {
+            return Task.Run(() => { });
+        }
+
+        public Task ReportInvocationErrorAsync(string awsRequestId, string invocationId, Exception exception, CancellationToken cancellationToken = default)
         {
             return Task.Run(() => { });
         }

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestRuntimeApiClient.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestRuntimeApiClient.cs
@@ -124,6 +124,14 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
 
         public Task ReportInvocationErrorAsync(string awsRequestId, Exception exception, CancellationToken cancellationToken = default)
         {
+            return ReportInvocationErrorAsync(awsRequestId, null, exception, cancellationToken);
+        }
+
+        public string LastInvocationId { get; private set; }
+
+        public Task ReportInvocationErrorAsync(string awsRequestId, string invocationId, Exception exception, CancellationToken cancellationToken = default)
+        {
+            LastInvocationId = invocationId;
             LastRecordedException = exception;
             ReportInvocationErrorAsyncExceptionCalled = true;
             return Task.Run(() => { });
@@ -144,6 +152,13 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
 
         public Task SendResponseAsync(string awsRequestId, Stream outputStream, CancellationToken cancellationToken = default)
         {
+            return SendResponseAsync(awsRequestId, null, outputStream, cancellationToken);
+        }
+
+        public Task SendResponseAsync(string awsRequestId, string invocationId, Stream outputStream, CancellationToken cancellationToken = default)
+        {
+            LastInvocationId = invocationId;
+
             if (outputStream != null)
             {
                 // copy the stream because it gets disposed by the bootstrap

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestRuntimeApiClient.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestRuntimeApiClient.cs
@@ -48,6 +48,12 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
         public bool ReportInvocationErrorAsyncTypeCalled { get; private set; }
         public bool SendResponseAsyncCalled { get; private set; }
 
+        /// <summary>When set, SendResponseAsync throws RuntimeApiInvokeTimeoutException to simulate a 410 Gone.</summary>
+        public bool ThrowInvokeTimeoutOnResponse { get; set; }
+
+        /// <summary>When set, ReportInvocationErrorAsync throws RuntimeApiInvokeTimeoutException to simulate a 410 Gone.</summary>
+        public bool ThrowInvokeTimeoutOnError { get; set; }
+
         public string LastTraceId { get; private set; }
         public byte[] FunctionInput { get; set; }
         public Stream LastOutputStream { get; internal set; }
@@ -134,6 +140,10 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
             LastInvocationId = invocationId;
             LastRecordedException = exception;
             ReportInvocationErrorAsyncExceptionCalled = true;
+            if (ThrowInvokeTimeoutOnError)
+            {
+                throw new RuntimeApiInvokeTimeoutException(awsRequestId, "{\"errorMessage\":\"Invoke timeout\",\"errorType\":\"InvokeTimeout\"}");
+            }
             return Task.Run(() => { });
         }
 
@@ -158,6 +168,12 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
         public Task SendResponseAsync(string awsRequestId, string invocationId, Stream outputStream, CancellationToken cancellationToken = default)
         {
             LastInvocationId = invocationId;
+
+            if (ThrowInvokeTimeoutOnResponse)
+            {
+                SendResponseAsyncCalled = true;
+                throw new RuntimeApiInvokeTimeoutException(awsRequestId, "{\"errorMessage\":\"Invoke timeout\",\"errorType\":\"InvokeTimeout\"}");
+            }
 
             if (outputStream != null)
             {

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestStreamingRuntimeApiClient.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestStreamingRuntimeApiClient.cs
@@ -124,9 +124,10 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
         }
 
         internal override async Task<IDisposable> StartStreamingResponseAsync(
-            string awsRequestId, ResponseStream responseStream, CancellationToken cancellationToken = default)
+            string awsRequestId, string invocationId, ResponseStream responseStream, CancellationToken cancellationToken = default)
         {
             StartStreamingResponseAsyncCalled = true;
+            LastInvocationId = invocationId;
             LastStreamingResponseStream = responseStream;
 
             // Simulate the HTTP stream being available

--- a/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestStreamingRuntimeApiClient.cs
+++ b/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.UnitTests/TestHelpers/TestStreamingRuntimeApiClient.cs
@@ -91,13 +91,28 @@ namespace Amazon.Lambda.RuntimeSupport.UnitTests
 
         public new Task ReportInvocationErrorAsync(string awsRequestId, Exception exception, CancellationToken cancellationToken = default)
         {
+            return ReportInvocationErrorAsync(awsRequestId, null, exception, cancellationToken);
+        }
+
+        public string LastInvocationId { get; private set; }
+
+        public new Task ReportInvocationErrorAsync(string awsRequestId, string invocationId, Exception exception, CancellationToken cancellationToken = default)
+        {
+            LastInvocationId = invocationId;
             LastRecordedException = exception;
             ReportInvocationErrorAsyncExceptionCalled = true;
             return Task.CompletedTask;
         }
 
-        public new async Task SendResponseAsync(string awsRequestId, Stream outputStream, CancellationToken cancellationToken = default)
+        public new Task SendResponseAsync(string awsRequestId, Stream outputStream, CancellationToken cancellationToken = default)
         {
+            return SendResponseAsync(awsRequestId, null, outputStream, cancellationToken);
+        }
+
+        public new async Task SendResponseAsync(string awsRequestId, string invocationId, Stream outputStream, CancellationToken cancellationToken = default)
+        {
+            LastInvocationId = invocationId;
+
             if (outputStream != null)
             {
                 LastOutputStream = new MemoryStream((int)outputStream.Length);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

## What this adds

Support for Lambda's **cross-wiring-on-invoke-id** protection in the .NET runtime client (`Amazon.Lambda.RuntimeSupport`).

The Runtime API now sends a new per-invoke header, `Lambda-Runtime-Invocation-Id`, on `GET /runtime/invocation/next`. This change makes the .NET runtime client:

1. **Read** that header from `/next`.
2. **Echo** it back on `POST /response` and `POST /error` — only when it was present (backward compatible).
3. On an `ErrorRuntimeInvokeTimeout` rejection (HTTP **410 Gone**), **log via the internal logger and continue to the next invocation** instead of crashing.

## Why it's needed (plain terms + example)

Lambda reuses an execution environment for many invocations, and two behaviors combine badly:

- When an invocation **times out**, Lambda reports the timeout but **does not kill the still-running handler** — your code keeps executing in the background.
- Responses were matched to invocations **only by the request id in the URL path**.

Because customers can supply their own request id (and upstream retries can reuse it), this race was possible:

```
1. Invoke A (requestId = abc) times out. Its handler keeps running.
2. Invoke B arrives reusing requestId = abc, and starts running.
3. A's handler finally finishes and POSTs its result to /invocation/abc/response.
4. Lambda matches "abc" to the currently-active invoke — B —
   and delivers A's response to B's caller.   ← WRONG: cross-wired response
```

The fix gives every invocation a unique nonce (`Lambda-Runtime-Invocation-Id`) that is **separate from the reusable request id**. The runtime echoes it back; if it doesn't match the invocation the platform currently has active (or that invocation already timed out), the platform rejects the response with a 410 instead of misdelivering it. This PR is the .NET runtime's half of that contract.

Backward compatible: if the header is absent from `/next` (older platform), the runtime doesn't echo anything and behaves exactly as before.

## Testing

### Unit tests — 8/8 passing
`Amazon.Lambda.RuntimeSupport.UnitTests`, covering: invocation-id echoed on `/response` and `/error`; header omitted when absent (back-compat); 410 → `RuntimeApiInvokeTimeoutException`; and the bootstrap loop swallowing that exception (log + continue) on both the `/response` and `/error` paths.

```
Passed!  - Failed: 0, Passed: 8, Skipped: 0, Total: 8
```

### Manual / integration testing

**How this was tested.** I used a custom RIE (one that implements the invoke timeout and 410 rejection) to run the real .NET runtime client, triggered invocations with `curl`, and captured the client's socket traffic with `strace` to confirm the header is actually on the wire. The scenarios below were run against the .NET 10 build of the client; the happy-path echo was also re-verified against the .NET 8 build, since the library targets both.

In the captures below, `recvfrom` = bytes the client *received* from the API (the `/next` response) and `sendto` = bytes the client *sent* back (its `/response` or `/error`). Note the echoed `Lambda-Runtime-Invocation-Id` is a different value from the request id in the URL path — that's the whole point: the id is a separate per-invoke nonce, not the reusable request id.

#### 1. Normal invocation still works, and the id round-trips
A handler that just returns a value (input `"ping"` → `"pong"`), HTTP 200. Confirms the new header handling didn't break the normal path, and that the client reads the id from `/next` and echoes it on the response:
```
recvfrom (from /next):     Lambda-Runtime-Invocation-Id: 3ebffaf2-...bb5f
sendto   (to /response):   POST .../invocation/f0c37d75-.../response
                           Lambda-Runtime-Invocation-Id: 3ebffaf2-...bb5f   ← same value echoed
```

#### 2. The id is echoed on the error path too
A handler that throws, so the client reports the failure to `/error` instead of `/response`. Confirms the echo happens on the error path as well:
```
recvfrom (from /next):   Lambda-Runtime-Invocation-Id: 8c40a5da-...5f59
sendto   (to /error):    POST .../invocation/a026d6ce-.../error
                         Lambda-Runtime-Invocation-Id: 8c40a5da-...5f59   ← same value echoed
```

#### 3. When a timed-out response is rejected (410), the client logs it and keeps going
This is the core behavior. I needed the invocation to time out *while the handler was still running*, so that the handler finishes and posts its response **after** the platform already gave up on it. To arrange that, I used a handler that deliberately runs for a fixed ~10 seconds regardless of the Lambda deadline:
```csharp
// busy-runs ~10s on its own timer, ignoring the function timeout
var source = new CancellationTokenSource(TimeSpan.FromSeconds(10));
var token = source.Token;
while (!token.IsCancellationRequested) { /* do work */ }
return /* "success" */;
```
Setting the function timeout to 2 seconds guarantees the timeout fires first. Observed sequence:
```
t=2s   platform times out the invoke → caller gets Sandbox.Timedout; the invoke id is remembered
t=10s  handler finishes; client posts its (now stale) response
       platform: "response is too late for timed out invoke"  →  HTTP 410
       client:  "[Info] Invocation <id> timed out before its response was submitted;
                 the Runtime API rejected it. Continuing to the next invocation."
```
The client logged the rejection and went back to asking for the next invocation — **the process stayed alive and did not crash.** (Before this change, that 410 would have surfaced as an unhandled error.)

#### 4. The id is echoed on the response-streaming path too
Response streaming sends the reply a different way — it builds the HTTP request by hand over a raw socket (chunked transfer), separately from the normal buffered path — so the echo had to be added there independently and is worth verifying on its own. Using a streaming handler (writes `"Hello, World!"`), HTTP 200. Confirms the id is echoed on the streaming response:
```
recvfrom (from /next):     Lambda-Runtime-Invocation-Id: 0f7ea9af-...c4f4
sendto   (to /response):   POST .../invocation/2370c6e9-.../response
                           Lambda-Runtime-Function-Response-Mode: streaming
                           Transfer-Encoding: chunked
                           Lambda-Runtime-Invocation-Id: 0f7ea9af-...c4f4   ← same value echoed
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
