### PR TITLE
Change log level for starting response streaming from info to debug

### DIFF
--- a/.autover/changes/deda4452-2843-4944-b72c-3af33e780432.json
+++ b/.autover/changes/deda4452-2843-4944-b72c-3af33e780432.json
@@ -1,0 +1,18 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.AspNetCoreServer",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Change log level for starting response streaming from info to debug"
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.AspNetCoreServer.Hosting",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Change log level for starting response streaming from info to debug"
+      ]
+    }	
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/StreamingResponseBodyFeature.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/StreamingResponseBodyFeature.cs
@@ -85,7 +85,7 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
         /// </remarks>
         public async Task StartAsync(CancellationToken cancellationToken = default)
         {
-            _logger?.LogInformation("Starting response streaming");
+            _logger?.LogDebug("Starting response streaming");
 
             if (_started)
                 return;


### PR DESCRIPTION
*Description of changes:*
Notice while playing with ASP.NET Core Lambda response streaming that we were always adding a info log statement that should only be there if using debug. Made the simple switch.

Amazon.Lambda.AspNetCoreServer.Hosting is in the list of projects to be released but there are no changes. The point is t release taking in the new dependency of Amazon.Lambda.AspNetCoreServer from it's project reference.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
