### PR TITLE
Fix Lambda Test Tool handling of missing start options

### DIFF
--- a/.autover/changes/f18b48b1-83b3-4d62-accf-4dbfa4373537.json
+++ b/.autover/changes/f18b48b1-83b3-4d62-accf-4dbfa4373537.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.TestTool",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Report missing Test Tool startup options as a user error"
+      ]
+    }
+  ]
+}

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/RunCommand.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Commands/RunCommand.cs
@@ -42,8 +42,8 @@ public sealed class RunCommand(
 
             if (!settings.LambdaEmulatorPort.HasValue && !settings.ApiGatewayEmulatorPort.HasValue && !settings.ApiGatewayEmulatorHttpsPort.HasValue && string.IsNullOrEmpty(settings.SQSEventSourceConfig) && string.IsNullOrEmpty(settings.DynamoDBStreamsEventSourceConfig))
             {
-                throw new ArgumentException("At least one of the following parameters must be set: " +
-                                            "--lambda-emulator-port, --api-gateway-emulator-port, --api-gateway-emulator-https-port, --sqs-eventsource-config or --dynamodbstreams-eventsource-config");
+                throw new InvalidRunCommandSettingsException("At least one of the following parameters must be set: " +
+                                                             "--lambda-emulator-port, --api-gateway-emulator-port, --api-gateway-emulator-https-port, --sqs-eventsource-config or --dynamodbstreams-eventsource-config");
             }
 
             var tasks = new List<Task>();

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Models/Exceptions.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Models/Exceptions.cs
@@ -12,6 +12,14 @@ public abstract class TestToolException(string message, Exception? innerExceptio
     : Exception(message, innerException);
 
 /// <summary>
+/// Thrown if the run command settings are invalid.
+/// </summary>
+/// <param name="message">The message used in the exception.</param>
+/// <param name="innerException">The inner exception, if any.</param>
+public class InvalidRunCommandSettingsException(string message, Exception? innerException = null)
+    : TestToolException(message, innerException);
+
+/// <summary>
 /// Thrown if the API Gateway Emulator mode was not provided,
 /// </summary>
 /// <param name="message">The message used in the exception.</param>

--- a/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Commands/RunCommandTests.cs
+++ b/Tools/LambdaTestTool-v2/tests/Amazon.Lambda.TestTool.UnitTests/Commands/RunCommandTests.cs
@@ -22,6 +22,30 @@ public class RunCommandTests
     private readonly Mock<IRemainingArguments> _mockRemainingArgs = new Mock<IRemainingArguments>();
 
     [Fact]
+    public async Task ExecuteAsync_NoEmulatorConfiguration_ReturnsUserError()
+    {
+        // Arrange
+        var cancellationSource = new CancellationTokenSource();
+        var settings = new RunCommandSettings();
+        var command = new RunCommand(_mockInteractiveService.Object, _mockEnvironmentManager.Object);
+        var context = new CommandContext(new List<string>(), _mockRemainingArgs.Object, "run", null);
+
+        // Act
+        var result = await command.ExecuteAsync(context, settings, cancellationSource);
+
+        // Assert
+        Assert.Equal(CommandReturnCodes.UserError, result);
+        _mockInteractiveService.Verify(
+            service => service.WriteErrorLine(It.Is<string?>(message =>
+                message != null && message.Contains("At least one of the following parameters must be set"))),
+            Times.Once);
+        _mockInteractiveService.Verify(
+            service => service.WriteErrorLine(It.Is<string?>(message =>
+                message != null && message.Contains("This is a bug"))),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_LambdaRuntimeApi_SuccessfulLaunch()
     {
         // Arrange
@@ -54,7 +78,7 @@ public class RunCommandTests
         cancellationSource.CancelAfter(5000);
         var lambdaPort = TestHelpers.GetNextLambdaRuntimePort();
         var gatewayPort = TestHelpers.GetNextApiGatewayPort();
-        var settings = new RunCommandSettings { LambdaEmulatorPort = lambdaPort, ApiGatewayEmulatorPort = gatewayPort, ApiGatewayEmulatorMode = ApiGatewayEmulatorMode.HttpV2, NoLaunchWindow = true};
+        var settings = new RunCommandSettings { LambdaEmulatorPort = lambdaPort, ApiGatewayEmulatorPort = gatewayPort, ApiGatewayEmulatorMode = ApiGatewayEmulatorMode.HttpV2, NoLaunchWindow = true };
         var command = new RunCommand(_mockInteractiveService.Object, _mockEnvironmentManager.Object);
         var context = new CommandContext(new List<string>(), _mockRemainingArgs.Object, "run", null);
         var apiUrl = $"http://{settings.LambdaEmulatorHost}:{settings.ApiGatewayEmulatorPort}/__lambda_test_tool_apigateway_health__";


### PR DESCRIPTION
*Issue #, if available:*

Fixes #2523

*Description of changes:*

- Treat missing emulator or event source options as an expected user error instead of an unhandled exception.
- Preserve the actionable parameter message without displaying the “This is a bug” banner.
- Add regression coverage and a patch change file.

*Testing:*

- .NET 8 unit tests: 197 passed, 1 skipped (198 total)
- .NET 10 unit tests: 197 passed, 1 skipped (198 total)
- Verified that `start` with no options exits with code `1` and displays only the parameter guidance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
