### PR TITLE
Fix NativeAOT IL3050/IL3053 warnings from net10.0 assemblies

### DIFF
--- a/.autover/changes/038901ab-8453-4e79-a5b0-82b2ffa55d3a.json
+++ b/.autover/changes/038901ab-8453-4e79-a5b0-82b2ffa55d3a.json
@@ -1,0 +1,39 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Serialization.SystemTextJson",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fixed NativeAOT IL3050/IL3053 analysis warnings by marking all target frameworks as trimmable. Previously only the net8.0 target was marked, so the net10.0 assembly was not trimmable."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.APIGatewayEvents",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Marked all target frameworks as trimmable. Previously only the net8.0 target was marked, so the net10.0 assembly was not trimmable."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.SQSEvents",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Marked all target frameworks as trimmable. Previously only the net8.0 target was marked, so the net10.0 assembly was not trimmable."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.SNSEvents",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Marked all target frameworks as trimmable. Previously only the net8.0 target was marked, so the net10.0 assembly was not trimmable."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.SimpleEmailEvents",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Marked all target frameworks as trimmable. Previously only the net8.0 target was marked, so the net10.0 assembly was not trimmable."
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.APIGatewayEvents/Amazon.Lambda.APIGatewayEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.APIGatewayEvents/Amazon.Lambda.APIGatewayEvents.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+  <PropertyGroup>
     <WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>

--- a/Libraries/src/Amazon.Lambda.SNSEvents/Amazon.Lambda.SNSEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.SNSEvents/Amazon.Lambda.SNSEvents.csproj
@@ -12,7 +12,7 @@
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
   </PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+	<PropertyGroup>
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>

--- a/Libraries/src/Amazon.Lambda.SQSEvents/Amazon.Lambda.SQSEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.SQSEvents/Amazon.Lambda.SQSEvents.csproj
@@ -12,7 +12,7 @@
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
   </PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+	<PropertyGroup>
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>

--- a/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/Amazon.Lambda.Serialization.SystemTextJson.csproj
+++ b/Libraries/src/Amazon.Lambda.Serialization.SystemTextJson/Amazon.Lambda.Serialization.SystemTextJson.csproj
@@ -26,7 +26,7 @@
         <ProjectReference Include="..\Amazon.Lambda.Core\Amazon.Lambda.Core.csproj" />
     </ItemGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+	<PropertyGroup>
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
 		<EnableTrimAnalyzer>true</EnableTrimAnalyzer>

--- a/Libraries/src/Amazon.Lambda.SimpleEmailEvents/Amazon.Lambda.SimpleEmailEvents.csproj
+++ b/Libraries/src/Amazon.Lambda.SimpleEmailEvents/Amazon.Lambda.SimpleEmailEvents.csproj
@@ -12,7 +12,7 @@
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
   </PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+	<PropertyGroup>
 		<WarningsAsErrors>IL2026,IL2067,IL2075</WarningsAsErrors>
 		<IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-lambda-dotnet/issues/2531

*Description of changes:* Removes the hard-coded `Condition="'$(TargetFramework)' == 'net8.0'"` that was causing .NET 10 applications to throw warnings when AOT is enabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
