### PR TITLE
Resolve Semgrep findings on dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every quarter
       interval: "quarterly"
+    # Wait a few days after a release before opening an update PR, to avoid
+    # picking up versions that are pulled shortly after publishing.
+    cooldown:
+      default-days: 7
     labels:
       - "Release Not Needed"
     target-branch: "dev"

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -7,6 +7,14 @@
 **/*.min.js
 **/env.configs.yml
 
+# Ignore the ASP.NET integration-test host app. Its controllers are intentionally
+# unauthenticated fixtures used to exercise the Lambda bridge and are never shipped.
+**/test/TestWebApp/**
+
+# Ignore the v1 (preview) test tool's Blazor debug UI. It intentionally shows the
+# developer exception page since its purpose is local debugging of Lambda code.
+**/Amazon.Lambda.TestTool.BlazorTester/**
+
 # Ignore third-party libraries
 **/node_modules/**
 **/vendor/**

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Services/LambdaRequestManager.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Services/LambdaRequestManager.cs
@@ -85,7 +85,8 @@ public class LambdaRequestManager(IOptions<LambdaOptions> lambdaOptions, IDirect
         if(requestName.StartsWith(Constants.SavedRequestDirectory + "@"))
         {
             requestName = requestName.Substring(requestName.IndexOf("@", StringComparison.Ordinal) + 1);
-            var path = Path.Combine(requestDirectory, requestName);
+            // Use only the file name so a crafted request name cannot escape requestDirectory.
+            var path = Path.Combine(requestDirectory, Path.GetFileName(requestName));
             return File.ReadAllText(path);
         }
         return GetEmbeddedResource(requestName);

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Services/LambdaRequestManager.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Services/LambdaRequestManager.cs
@@ -82,7 +82,7 @@ public class LambdaRequestManager(IOptions<LambdaOptions> lambdaOptions, IDirect
         if (requestDirectory is null)
             return string.Empty;
 
-        if(requestName.StartsWith(Constants.SavedRequestDirectory + "@"))
+        if(requestName.StartsWith(Constants.SavedRequestDirectory + "@", StringComparison.Ordinal))
         {
             requestName = requestName.Substring(requestName.IndexOf("@", StringComparison.Ordinal) + 1);
             // Use only the file name so a crafted request name cannot escape requestDirectory.

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/SampleRequests/SampleRequestManager.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/SampleRequests/SampleRequestManager.cs
@@ -102,7 +102,8 @@ namespace Amazon.Lambda.TestTool.SampleRequests
             if(name.StartsWith(SAVED_REQUEST_DIRECTORY + "@"))
             {
                 name = name.Substring(name.IndexOf("@") + 1);
-                var path = Path.Combine(this.GetSavedRequestDirectory(), name);
+                // Use only the file name so a crafted request name cannot escape the saved-request directory.
+                var path = Path.Combine(this.GetSavedRequestDirectory(), Path.GetFileName(name));
                 return File.ReadAllText(path);
             }
             return GetEmbeddedResource(name);

--- a/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/SampleRequests/SampleRequestManager.cs
+++ b/Tools/LambdaTestTool/src/Amazon.Lambda.TestTool/SampleRequests/SampleRequestManager.cs
@@ -99,9 +99,9 @@ namespace Amazon.Lambda.TestTool.SampleRequests
 
         public string GetRequest(string name)
         {
-            if(name.StartsWith(SAVED_REQUEST_DIRECTORY + "@"))
+            if(name.StartsWith(SAVED_REQUEST_DIRECTORY + "@", StringComparison.Ordinal))
             {
-                name = name.Substring(name.IndexOf("@") + 1);
+                name = name.Substring(name.IndexOf('@') + 1);
                 // Use only the file name so a crafted request name cannot escape the saved-request directory.
                 var path = Path.Combine(this.GetSavedRequestDirectory(), Path.GetFileName(name));
                 return File.ReadAllText(path);

--- a/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests/SampleRequestTests.cs
+++ b/Tools/LambdaTestTool/tests/Amazon.Lambda.TestTool.Tests/SampleRequestTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using Xunit;
 
@@ -24,6 +25,29 @@ namespace Amazon.Lambda.TestTool.Tests
             else
             {
                 Assert.Null(expected);
+            }
+        }
+
+        [Fact]
+        public void GetRequest_WithTraversalName_StaysWithinSavedRequestDirectory()
+        {
+            var preferenceDirectory = Path.Combine(Path.GetTempPath(), "LambdaTestToolTests", Guid.NewGuid().ToString());
+            var savedRequestDirectory = Path.Combine(preferenceDirectory, SampleRequestManager.SAVED_REQUEST_DIRECTORY);
+            Directory.CreateDirectory(savedRequestDirectory);
+            try
+            {
+                File.WriteAllText(Path.Combine(savedRequestDirectory, "target.json"), "INSIDE");
+                File.WriteAllText(Path.Combine(preferenceDirectory, "target.json"), "OUTSIDE");
+
+                var manager = new SampleRequestManager(preferenceDirectory);
+
+                var content = manager.GetRequest($"{SampleRequestManager.SAVED_REQUEST_DIRECTORY}@../target.json");
+
+                Assert.Equal("INSIDE", content);
+            }
+            finally
+            {
+                Directory.Delete(preferenceDirectory, recursive: true);
             }
         }
     }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Fixes / ignores the findings that are causing the `semgrep-analysis.yml` action to fail.
- Sanitize saved-request file names with Path.GetFileName in both test tools so a crafted name cannot escape the request directory (unsafe-path-combine).
- Add a cooldown to the github-actions dependabot config (dependabot-missing-cooldown).
- Ignore the TestWebApp integration-test host (intentionally unauthenticated fixtures) and the v1 preview test tool's Blazor debug UI (developer exception page is intended) in .semgrepignore


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
