### PR TITLE
Fix formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For a history of releases view the [release change log](CHANGELOG.md)
     - [Amazon.Lambda.TestUtilities](#amazonlambdatestutilities)
     - [Amazon.Lambda.DurableExecution](#amazonlambdadurableexecution)
   - [Blueprints](#blueprints)
-    - [Dotnet CLI Templates](#dotnet-cli-templates)
+    - [Dotnet CLI Templates](#dotnet-cli-templates)fdafdas
     - [Yeoman (Deprecated)](#yeoman-deprecated)
   - [Getting Help](#getting-help)
   - [Feedback and Contributing](#feedback-and-contributing)


### PR DESCRIPTION
Removed extraneous characters from the Dotnet CLI Templates section.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
