### PR TITLE
Add PQC opt-out in Lambda bootstrap

### DIFF
--- a/LambdaRuntimeDockerfiles/build.ps1
+++ b/LambdaRuntimeDockerfiles/build.ps1
@@ -2,7 +2,7 @@ param(
     [ValidateSet('amd64','arm64')]
     [string]$Architecture = "amd64",
 
-    [ValidateSet('net6', 'net8', 'net9')]
+    [ValidateSet('net8', 'net9', 'net10', 'net11')]
     [string]$TargetFramework = "net6"
 )
 

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/bootstrap.net8.sh
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/bootstrap.net8.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# PQC TLS keyshares are enabled by default via the AL2023 base-OS crypto policy. Customers can opt
+# out by setting AWS_LAMBDA_DISABLE_PQC_KEYSHARES (presence-based, including an empty value), which
+# selects the shipped classical-only openssl_non_pqc.cnf and takes precedence over a customer OPENSSL_CONF.
+if [ -n "${AWS_LAMBDA_DISABLE_PQC_KEYSHARES+x}" ]; then
+  export OPENSSL_CONF=/var/runtime/openssl_conf/openssl_non_pqc.cnf
+fi
+
 # .NET on Linux uses OpenSSL to handle certificates. The .NET runtime will load the certs by first reading
 # the default cert bundle file which can be overriden by the SSL_CERT_FILE env var. Then it will load the
 # certs in the default cert directory which can be overriden by the SSL_CERT_DIR env var. On AL2023

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/bootstrap.sh
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/bootstrap.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# PQC TLS keyshares are enabled by default via the AL2023 base-OS crypto policy. Customers can opt
+# out by setting AWS_LAMBDA_DISABLE_PQC_KEYSHARES (presence-based, including an empty value), which
+# selects the shipped classical-only openssl_non_pqc.cnf and takes precedence over a customer OPENSSL_CONF.
+if [ -n "${AWS_LAMBDA_DISABLE_PQC_KEYSHARES+x}" ]; then
+  export OPENSSL_CONF=/var/runtime/openssl_conf/openssl_non_pqc.cnf
+fi
+
 # This script is used to locate 2 files in the /var/task folder, where the end-user assembly is located
 # The 2 files are <assembly name>.deps.json and <assembly name>.runtimeconfig.json
 # These files are used to add the end-user assembly into context and make the code reachable to the dotnet process


### PR DESCRIPTION
*Description of changes:*
As part of Lambda's upcoming PQC support they all bootstrap scripts for managed runtimes are being updated to add an opt-out for PQC via the `AWS_LAMBDA_DISABLE_PQC_KEYSHARES` environment variable. This is the same change being done in other runtimes.

Testing:
Will go through CI checks but I have also built the image locally and built a function based on the image and confirmed no issue to the bootstrap script.

No change file is added and the `Release Not Needed` because the bootstrap scripts are not included in the NuGet package. This will only go out in the OCI images which has a different release flow then change files.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
