### PR TITLE
feat(CloudWatchEvents): add Step Functions Execution Status Change event model

### DIFF
--- a/.autover/changes/add-stepfunctions-execution-status-change-event.json
+++ b/.autover/changes/add-stepfunctions-execution-status-change-event.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.CloudWatchEvents",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Add Step Functions Execution Status Change event model (StepFunctionsExecutionStatusChangeEvent) for EventBridge-delivered Step Functions execution events"
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.CloudWatchEvents/StepFunctionsEvents/StepFunctionsExecutionStatusChange.cs
+++ b/Libraries/src/Amazon.Lambda.CloudWatchEvents/StepFunctionsEvents/StepFunctionsExecutionStatusChange.cs
@@ -78,10 +78,10 @@ namespace Amazon.Lambda.CloudWatchEvents.StepFunctionsEvents
         public int RedriveCount { get; set; }
 
         /// <summary>
-        /// The date the execution was last redriven.
+        /// The date the execution was last redriven, in Unix epoch milliseconds.
         /// This is null if the execution has not been redriven.
         /// </summary>
-        public string RedriveDate { get; set; }
+        public long? RedriveDate { get; set; }
 
         /// <summary>
         /// Indicates whether the execution can be redriven.

--- a/Libraries/src/Amazon.Lambda.CloudWatchEvents/StepFunctionsEvents/StepFunctionsExecutionStatusChange.cs
+++ b/Libraries/src/Amazon.Lambda.CloudWatchEvents/StepFunctionsEvents/StepFunctionsExecutionStatusChange.cs
@@ -1,0 +1,121 @@
+namespace Amazon.Lambda.CloudWatchEvents.StepFunctionsEvents
+{
+    /// <summary>
+    /// This class represents the details of a Step Functions Execution Status Change sent via EventBridge.
+    /// For more see - https://docs.aws.amazon.com/step-functions/latest/dg/eventbridge-integration.html#event-detail-execution-status-change
+    /// </summary>
+    public class StepFunctionsExecutionStatusChange
+    {
+        /// <summary>
+        /// The Amazon Resource Name (ARN) that identifies the execution.
+        /// </summary>
+        public string ExecutionArn { get; set; }
+
+        /// <summary>
+        /// The Amazon Resource Name (ARN) that identifies the state machine.
+        /// </summary>
+        public string StateMachineArn { get; set; }
+
+        /// <summary>
+        /// The name of the execution.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The current status of the execution.
+        /// Possible values are RUNNING, SUCCEEDED, FAILED, TIMED_OUT, ABORTED and PENDING_REDRIVE.
+        /// </summary>
+        public string Status { get; set; }
+
+        /// <summary>
+        /// The date the execution started, in Unix epoch milliseconds.
+        /// </summary>
+        public long StartDate { get; set; }
+
+        /// <summary>
+        /// The date the execution stopped, in Unix epoch milliseconds.
+        /// This is null while the execution is still running.
+        /// </summary>
+        public long? StopDate { get; set; }
+
+        /// <summary>
+        /// The string that contains the JSON input data of the execution.
+        /// This can be excluded when the combined escaped input and output exceeds the EventBridge payload quota.
+        /// </summary>
+        public string Input { get; set; }
+
+        /// <summary>
+        /// Provides details about the input, such as whether it was included in the event.
+        /// </summary>
+        public StepFunctionsExecutionDataDetails InputDetails { get; set; }
+
+        /// <summary>
+        /// The JSON output data of the execution.
+        /// This is null while the execution is still running and can be excluded when it exceeds the EventBridge payload quota.
+        /// </summary>
+        public string Output { get; set; }
+
+        /// <summary>
+        /// Provides details about the output, such as whether it was included in the event.
+        /// </summary>
+        public StepFunctionsExecutionDataDetails OutputDetails { get; set; }
+
+        /// <summary>
+        /// The Amazon Resource Name (ARN) that identifies the state machine version associated with the execution.
+        /// This is null if the execution was not associated with a version.
+        /// </summary>
+        public string StateMachineVersionArn { get; set; }
+
+        /// <summary>
+        /// The Amazon Resource Name (ARN) that identifies the state machine alias associated with the execution.
+        /// This is null if the execution was not associated with an alias.
+        /// </summary>
+        public string StateMachineAliasArn { get; set; }
+
+        /// <summary>
+        /// The number of times the execution has been redriven.
+        /// </summary>
+        public int RedriveCount { get; set; }
+
+        /// <summary>
+        /// The date the execution was last redriven.
+        /// This is null if the execution has not been redriven.
+        /// </summary>
+        public string RedriveDate { get; set; }
+
+        /// <summary>
+        /// Indicates whether the execution can be redriven.
+        /// Possible values are NOT_REDRIVABLE, REDRIVABLE and REDRIVE_IN_PROGRESS.
+        /// </summary>
+        public string RedriveStatus { get; set; }
+
+        /// <summary>
+        /// Provides a reason for the value of the <see cref="RedriveStatus"/> field.
+        /// </summary>
+        public string RedriveStatusReason { get; set; }
+
+        /// <summary>
+        /// The error code of the failure, present when the status is FAILED or TIMED_OUT.
+        /// </summary>
+        public string Error { get; set; }
+
+        /// <summary>
+        /// A more detailed explanation of the cause of the failure, present when the status is FAILED or TIMED_OUT.
+        /// </summary>
+        public string Cause { get; set; }
+    }
+
+    /// <summary>
+    /// Provides details about execution input or output, mirroring the Step Functions
+    /// CloudWatchEventsExecutionDataDetails data type.
+    /// For more see - https://docs.aws.amazon.com/step-functions/latest/apireference/API_CloudWatchEventsExecutionDataDetails.html
+    /// </summary>
+    public class StepFunctionsExecutionDataDetails
+    {
+        /// <summary>
+        /// Indicates whether the input or output was included in the response.
+        /// This is false when the data was truncated because it exceeded the EventBridge payload quota.
+        /// </summary>
+        public bool Included { get; set; }
+    }
+}

--- a/Libraries/src/Amazon.Lambda.CloudWatchEvents/StepFunctionsEvents/StepFunctionsExecutionStatusChangeEvent.cs
+++ b/Libraries/src/Amazon.Lambda.CloudWatchEvents/StepFunctionsEvents/StepFunctionsExecutionStatusChangeEvent.cs
@@ -1,0 +1,8 @@
+namespace Amazon.Lambda.CloudWatchEvents.StepFunctionsEvents
+{
+    /// <summary>
+    /// This class represents a Step Functions Execution Status Change sent via EventBridge.
+    /// For more see - https://docs.aws.amazon.com/step-functions/latest/dg/eventbridge-integration.html
+    /// </summary>
+    public class StepFunctionsExecutionStatusChangeEvent : CloudWatchEvent<StepFunctionsExecutionStatusChange> { }
+}

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -3799,6 +3799,26 @@ namespace Amazon.Lambda.Tests
         [InlineData(typeof(JsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
         [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+        public void CloudWatchStepFunctionsExecutionStatusChangeRedriven(Type serializerType)
+        {
+            var serializer = Activator.CreateInstance(serializerType) as ILambdaSerializer;
+            using (var fileStream = LoadJsonTestFile("cloudwatchevents-stepfunctionsexecutionstatuschange-redriven.json"))
+            {
+                var request = serializer.Deserialize<StepFunctionsExecutionStatusChangeEvent>(fileStream);
+
+                var detail = request.Detail;
+                Assert.NotNull(detail);
+                Assert.Equal(1, detail.RedriveCount);
+                // redriveDate is delivered as Unix epoch milliseconds (a JSON number), not a string.
+                Assert.Equal(1551225271984, detail.RedriveDate);
+                Assert.Equal("REDRIVE_IN_PROGRESS", detail.RedriveStatus);
+            }
+        }
+
+        [Theory]
+        [InlineData(typeof(JsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
         public void CloudWatchTranslateTextTranslationJobStateChange(Type serializerType)
         {
             var serializer = Activator.CreateInstance(serializerType) as ILambdaSerializer;

--- a/Libraries/test/EventsTests.Shared/EventTests.cs
+++ b/Libraries/test/EventsTests.Shared/EventTests.cs
@@ -6,6 +6,7 @@ using Amazon.Lambda.CloudWatchEvents.ECSEvents;
 using Amazon.Lambda.CloudWatchEvents.S3Events;
 using Amazon.Lambda.CloudWatchEvents.ScheduledEvents;
 using Amazon.Lambda.CloudWatchEvents.TranscribeEvents;
+using Amazon.Lambda.CloudWatchEvents.StepFunctionsEvents;
 using Amazon.Lambda.CloudWatchEvents.TranslateEvents;
 using Amazon.Lambda.CloudWatchLogsEvents;
 using Amazon.Lambda.CognitoEvents;
@@ -3729,6 +3730,68 @@ namespace Amazon.Lambda.Tests
                 Assert.Equal("d43d0b58-2129-46ba-b2e2-b53ec9d1b210", detail.TranscriptionJobName);
                 Assert.Equal("FAILED", detail.TranscriptionJobStatus);
                 Assert.Equal("The media format that you specified doesn't match the detected media format. Check the media format and try your request again.", detail.FailureReason);
+            }
+        }
+
+        [Theory]
+        [InlineData(typeof(JsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+        public void CloudWatchStepFunctionsExecutionStatusChangeStarted(Type serializerType)
+        {
+            var serializer = Activator.CreateInstance(serializerType) as ILambdaSerializer;
+            using (var fileStream = LoadJsonTestFile("cloudwatchevents-stepfunctionsexecutionstatuschange-started.json"))
+            {
+                var request = serializer.Deserialize<StepFunctionsExecutionStatusChangeEvent>(fileStream);
+                Assert.Equal("315c1398-40ff-a850-213b-158f73e60175", request.Id);
+                Assert.Equal("Step Functions Execution Status Change", request.DetailType);
+                Assert.Equal("aws.states", request.Source);
+
+                var detail = request.Detail;
+                Assert.NotNull(detail);
+                Assert.Equal("arn:aws:states:us-east-2:123456789012:execution:state-machine-name:execution-name", detail.ExecutionArn);
+                Assert.Equal("arn:aws:states:us-east-2:123456789012:stateMachine:state-machine", detail.StateMachineArn);
+                Assert.Equal("execution-name", detail.Name);
+                Assert.Equal("RUNNING", detail.Status);
+                Assert.Equal(1551225271984, detail.StartDate);
+                Assert.Null(detail.StopDate);
+                Assert.Equal("{}", detail.Input);
+                Assert.NotNull(detail.InputDetails);
+                Assert.True(detail.InputDetails.Included);
+                Assert.Null(detail.Output);
+                Assert.Null(detail.OutputDetails);
+                Assert.Null(detail.StateMachineVersionArn);
+                Assert.Null(detail.StateMachineAliasArn);
+                Assert.Equal(0, detail.RedriveCount);
+                Assert.Null(detail.RedriveDate);
+                Assert.Equal("NOT_REDRIVABLE", detail.RedriveStatus);
+                Assert.Equal("Execution is RUNNING and cannot be redriven", detail.RedriveStatusReason);
+                Assert.Null(detail.Error);
+                Assert.Null(detail.Cause);
+            }
+        }
+
+        [Theory]
+        [InlineData(typeof(JsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.LambdaJsonSerializer))]
+        [InlineData(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+        public void CloudWatchStepFunctionsExecutionStatusChangeFailed(Type serializerType)
+        {
+            var serializer = Activator.CreateInstance(serializerType) as ILambdaSerializer;
+            using (var fileStream = LoadJsonTestFile("cloudwatchevents-stepfunctionsexecutionstatuschange-failed.json"))
+            {
+                var request = serializer.Deserialize<StepFunctionsExecutionStatusChangeEvent>(fileStream);
+                Assert.Equal("315c1398-40ff-a850-213b-158f73e60175", request.Id);
+
+                var detail = request.Detail;
+                Assert.NotNull(detail);
+                Assert.Equal("execution-name", detail.Name);
+                Assert.Equal("FAILED", detail.Status);
+                Assert.Equal(1551225146847, detail.StartDate);
+                Assert.Equal(1551225151881, detail.StopDate);
+                Assert.Equal("REDRIVABLE", detail.RedriveStatus);
+                Assert.Equal("ErrorCode", detail.Error);
+                Assert.Equal("An error occurred.", detail.Cause);
             }
         }
 

--- a/Libraries/test/EventsTests.Shared/cloudwatchevents-stepfunctionsexecutionstatuschange-failed.json
+++ b/Libraries/test/EventsTests.Shared/cloudwatchevents-stepfunctionsexecutionstatuschange-failed.json
@@ -1,0 +1,34 @@
+{
+    "version": "0",
+    "id": "315c1398-40ff-a850-213b-158f73e60175",
+    "detail-type": "Step Functions Execution Status Change",
+    "source": "aws.states",
+    "account": "123456789012",
+    "time": "2019-02-26T19:42:21Z",
+    "region": "us-east-2",
+    "resources": [
+        "arn:aws:states:us-east-2:123456789012:execution:state-machine-name:execution-name"
+    ],
+    "detail": {
+        "executionArn": "arn:aws:states:us-east-2:123456789012:execution:state-machine-name:execution-name",
+        "stateMachineArn": "arn:aws:states:us-east-2:123456789012:stateMachine:state-machine",
+        "name": "execution-name",
+        "status": "FAILED",
+        "startDate": 1551225146847,
+        "stopDate": 1551225151881,
+        "input": "{}",
+        "inputDetails": {
+            "included": true
+        },
+        "output": null,
+        "outputDetails": null,
+        "stateMachineVersionArn": null,
+        "stateMachineAliasArn": null,
+        "redriveCount": 0,
+        "redriveDate": null,
+        "redriveStatus": "REDRIVABLE",
+        "redriveStatusReason": "Execution is FAILED and is redrivable",
+        "error": "ErrorCode",
+        "cause": "An error occurred."
+    }
+}

--- a/Libraries/test/EventsTests.Shared/cloudwatchevents-stepfunctionsexecutionstatuschange-redriven.json
+++ b/Libraries/test/EventsTests.Shared/cloudwatchevents-stepfunctionsexecutionstatuschange-redriven.json
@@ -1,0 +1,34 @@
+{
+    "version": "0",
+    "id": "315c1398-40ff-a850-213b-158f73e60175",
+    "detail-type": "Step Functions Execution Status Change",
+    "source": "aws.states",
+    "account": "123456789012",
+    "time": "2019-02-26T19:42:21Z",
+    "region": "us-east-2",
+    "resources": [
+        "arn:aws:states:us-east-2:123456789012:execution:state-machine-name:execution-name"
+    ],
+    "detail": {
+        "executionArn": "arn:aws:states:us-east-2:123456789012:execution:state-machine-name:execution-name",
+        "stateMachineArn": "arn:aws:states:us-east-2:123456789012:stateMachine:state-machine",
+        "name": "execution-name",
+        "status": "RUNNING",
+        "startDate": 1551225146847,
+        "stopDate": null,
+        "input": "{}",
+        "inputDetails": {
+            "included": true
+        },
+        "output": null,
+        "outputDetails": null,
+        "stateMachineVersionArn": null,
+        "stateMachineAliasArn": null,
+        "redriveCount": 1,
+        "redriveDate": 1551225271984,
+        "redriveStatus": "REDRIVE_IN_PROGRESS",
+        "redriveStatusReason": "Execution is RUNNING and cannot be redriven",
+        "error": null,
+        "cause": null
+    }
+}

--- a/Libraries/test/EventsTests.Shared/cloudwatchevents-stepfunctionsexecutionstatuschange-started.json
+++ b/Libraries/test/EventsTests.Shared/cloudwatchevents-stepfunctionsexecutionstatuschange-started.json
@@ -1,0 +1,34 @@
+{
+    "version": "0",
+    "id": "315c1398-40ff-a850-213b-158f73e60175",
+    "detail-type": "Step Functions Execution Status Change",
+    "source": "aws.states",
+    "account": "123456789012",
+    "time": "2019-02-26T19:42:21Z",
+    "region": "us-east-2",
+    "resources": [
+        "arn:aws:states:us-east-2:123456789012:execution:state-machine-name:execution-name"
+    ],
+    "detail": {
+        "executionArn": "arn:aws:states:us-east-2:123456789012:execution:state-machine-name:execution-name",
+        "stateMachineArn": "arn:aws:states:us-east-2:123456789012:stateMachine:state-machine",
+        "name": "execution-name",
+        "status": "RUNNING",
+        "startDate": 1551225271984,
+        "stopDate": null,
+        "input": "{}",
+        "inputDetails": {
+            "included": true
+        },
+        "output": null,
+        "outputDetails": null,
+        "stateMachineVersionArn": null,
+        "stateMachineAliasArn": null,
+        "redriveCount": 0,
+        "redriveDate": null,
+        "redriveStatus": "NOT_REDRIVABLE",
+        "redriveStatusReason": "Execution is RUNNING and cannot be redriven",
+        "error": null,
+        "cause": null
+    }
+}


### PR DESCRIPTION
## Description

Adds an event model for the EventBridge-delivered **Step Functions Execution Status Change** event to `Amazon.Lambda.CloudWatchEvents`, so customers no longer need to hand-roll it.

Resolves #2126.

### Changes
- `StepFunctionsExecutionStatusChangeEvent : CloudWatchEvent<StepFunctionsExecutionStatusChange>` following the existing `TranscribeEvents`/`ECSEvents` pattern.
- `StepFunctionsExecutionStatusChange` detail type covering the full event shape: execution/state-machine ARNs, name, status, start/stop dates (epoch millis), input/output (+ `inputDetails`/`outputDetails`), version/alias ARNs, redrive fields, error, and cause.
- `StepFunctionsExecutionDataDetails` for the `included` sub-object.
- Unit tests for started, failed, and redriven cases, verified across all three serializers.
- `.autover` change file (Minor).

### Notes
- Field shapes follow the [Step Functions EventBridge integration docs](https://docs.aws.amazon.com/step-functions/latest/dg/eventbridge-integration.html#event-detail-execution-status-change).
- **`redriveDate` is modeled as `long?` (Unix epoch milliseconds), not `string`.** The AWS docs' structure reference annotates it as `"string"`, but the actual EventBridge event delivers it as a JSON number, consistent with `startDate`/`stopDate`. Typing it as `string` would throw a `JsonException` on a real redriven-execution event. (Note: the `DescribeExecution` **API** returns `redriveDate` as an ISO string — a different surface from the EventBridge event.)
- PascalCase properties bind the camelCase event JSON via the serializers' case-insensitive matching, consistent with the other detail models.

## Testing

- **Unit tests:** `CloudWatchStepFunctionsExecutionStatusChange{Started,Failed,Redriven}` in `EventTests`, each run against all three serializers (`Amazon.Lambda.Serialization.Json.JsonSerializer`, `LambdaJsonSerializer`, `DefaultLambdaJsonSerializer`). 9/9 pass. The `Redriven` case uses a numeric `redriveDate` and guards against a regression to `string`.
- **End-to-end validation against real AWS events:** Deployed a Standard state machine and an EventBridge rule (`source: aws.states`, `detail-type: "Step Functions Execution Status Change"`) targeting an SQS queue, then ran a succeeding execution, a failing execution, and redrove the failed one. All 6 captured events (SUCCEEDED / FAILED / RUNNING, redriven and non-redriven) deserialized cleanly with this model. The redriven event confirmed `redriveDate` arrives as a bare JSON number (e.g. `1787772473708`) and parses into the `long?` property. Temporary AWS resources were torn down after the run.

Representative captured event (`FAILED`, after redrive):
```json
{
  "version": "0",
  "detail-type": "Step Functions Execution Status Change",
  "source": "aws.states",
  "region": "us-west-2",
  "detail": {
    "executionArn": "arn:aws:states:us-west-2:...:execution:sfn-event-val-sm:fail-run",
    "stateMachineArn": "arn:aws:states:us-west-2:...:stateMachine:sfn-event-val-sm",
    "name": "fail-run",
    "status": "FAILED",
    "startDate": 1787772463248,
    "stopDate": 1787772473747,
    "input": "{\"fail\":true}",
    "output": null,
    "stateMachineVersionArn": null,
    "stateMachineAliasArn": null,
    "redriveCount": 1,
    "redriveDate": 1787772473708,
    "redriveStatus": "REDRIVABLE",
    "redriveStatusReason": null,
    "inputDetails": { "included": true },
    "outputDetails": null,
    "error": "ErrorCode",
    "cause": "An error occurred."
  }
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
