### PR TITLE
chore: drop retired dev branch from GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-update-Dockerfiles.yml
+++ b/.github/workflows/auto-update-Dockerfiles.yml
@@ -34,7 +34,7 @@ jobs:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: 'dev'
+          ref: 'master'
 
       # Update .NET 8 AMD64 Dockerfile
       - name: Update .NET 8 AMD64
@@ -205,7 +205,7 @@ jobs:
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2
         with:
           source_branch: ${{ steps.commit-push.outputs.BRANCH }}
-          destination_branch: "dev"
+          destination_branch: "master"
           pr_title: 'chore: Daily ASP.NET Core version update in Dockerfiles'
           pr_body: "This PR automatically updates the Dockerfiles to use the latest ASP.NET Core version.
 

--- a/.github/workflows/aws-ci.yml
+++ b/.github/workflows/aws-ci.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     branches:
       - master
-      - dev
       - "feature/**"
 
 permissions: {}

--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -10,7 +10,7 @@ name: Durable Execution Conformance Tests
 
 on:
   pull_request:
-    branches: [dev, master]
+    branches: [master]
     paths:
       - "Libraries/src/Amazon.Lambda.DurableExecution/**"
       - "Libraries/test/Amazon.Lambda.DurableExecution.IntegrationTests/Conformance/**"

--- a/.github/workflows/semgrep-analysis.yml
+++ b/.github/workflows/semgrep-analysis.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
   push:
-    branches: ["dev", "master"]
+    branches: ["master"]
 
   schedule:
     - cron: '23 20 * * 1'

--- a/.github/workflows/update-Dockerfiles.yml
+++ b/.github/workflows/update-Dockerfiles.yml
@@ -89,7 +89,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: 'dev'
+          ref: 'master'
 
       - name: Update .NET 8 AMD64
         id: update-net8-amd64
@@ -193,7 +193,7 @@ jobs:
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2
         with:
           source_branch: ${{ steps.commit-push.outputs.BRANCH }}
-          destination_branch: "dev"
+          destination_branch: "master"
           pr_title: 'chore: ASP.NET Core version update in Dockerfiles'
           pr_body: "This PR updates the Dockerfiles to use the latest ASP.NET Core version.
             Verify listed Dockerfiles that they have correct version and matching SHA512 checksum for ASP.NET Core runtime.


### PR DESCRIPTION
## Description

The `dev` integration branch is no longer used; the repo now follows a single-trunk flow on `master` (see the Execute Release workflow, commit `f5bbe7d9f`). This updates all GitHub Actions workflows that still referenced `dev`.

## Changes

| Workflow | Change |
|---|---|
| `auto-update-Dockerfiles.yml` | checkout `ref: 'dev'` → `'master'`; PR `destination_branch: "dev"` → `"master"` |
| `update-Dockerfiles.yml` | checkout `ref: 'dev'` → `'master'`; PR `destination_branch: "dev"` → `"master"` |
| `aws-ci.yml` | removed `- dev` from PR trigger branches |
| `conformance-tests.yml` | PR trigger `branches: [dev, master]` → `[master]` |
| `semgrep-analysis.yml` | push trigger `branches: ["dev", "master"]` → `["master"]` |

Remaining `dev` matches in `.github/workflows` are false positives (a historical comment in `execute-release.yml`, the `prod/devops` secret path, and the `semgrep.dev` URL) and were left untouched.