### PR TITLE
Fix flaky durable Annotations diagnostic tests racing on serverless.template

### DIFF
--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/DurableExecutionDiagnosticsTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/DurableExecutionDiagnosticsTests.cs
@@ -10,6 +10,11 @@ using VerifyCS = Amazon.Lambda.Annotations.SourceGenerators.Tests.CSharpSourceGe
 
 namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
 {
+    // Most cases here report a fatal error (which skips the CloudFormation sync), but the non-fatal cases
+    // (e.g. ExplicitRole_ReportsCheckpointPolicyInfo) let the generator run the sync and write a generated
+    // serverless.template on disk. That file is shared with the other generator-running test classes, so this
+    // class must join the serialization collection to avoid racing on the template file.
+    [Collection(TestServerlessAppCollection.Name)]
     public class DurableExecutionDiagnosticsTests
     {
         // Minimal serializer registration so the generator does not also emit AWSLambda0108.

--- a/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/DurableExecutionSerializerContextDiagnosticsTests.cs
+++ b/Libraries/test/Amazon.Lambda.Annotations.SourceGenerators.Tests/DurableExecutionSerializerContextDiagnosticsTests.cs
@@ -16,6 +16,11 @@ namespace Amazon.Lambda.Annotations.SourceGenerators.Tests
     /// types must be registered on TContext with [JsonSerializable], otherwise serialization fails at
     /// invocation time.
     /// </summary>
+    // These cases emit only warnings (or no diagnostic), so the generator does not short-circuit on a fatal
+    // error and proceeds to the CloudFormation sync, which reads/writes a generated serverless.template on
+    // disk. That file is shared with the other generator-running test classes, so this class must join the
+    // serialization collection or its template read races with a concurrent write (surfacing as AWSLambda0001).
+    [Collection(TestServerlessAppCollection.Name)]
     public class DurableExecutionSerializerContextDiagnosticsTests
     {
         // Minimal durable SDK stubs. The real Amazon.Lambda.DurableExecution package cannot be referenced


### PR DESCRIPTION
## Problem

CI failed on the net8.0 `unit-tests` run with four failures in `DurableExecutionSerializerContextDiagnosticsTests`, each surfacing as an unexpected `AWSLambda0001`:

```
System.InvalidOperationException : Mismatch between number of diagnostics returned, expected "0" actual "1"
// error AWSLambda0001: ... Additional text encountered after finished reading JSON content: t. Path '', line 26, position 1.
   at Newtonsoft.Json.Linq.JObject.Parse(String json)
   at CloudFormationWriter.ApplyReport(...) line 72
   at Generator.Execute(...) line 264
```

The same run passed on net10.0, which pointed at a race rather than a logic error.

## Root cause

These test cases register only a **warning** (`AWSLambda0145`) or no diagnostic, so the source generator does not short-circuit on a fatal error and proceeds to the CloudFormation sync. `CloudFormationWriter.ApplyReport` reads and writes a generated `serverless.template` on disk (resolved by walking up from the on-disk attribute source files to the single `.csproj`).

That template file is shared with the other generator-running test classes — `SourceGeneratorTests` and `DurableExecutionE2ETests` — and xUnit runs distinct test classes **in parallel**. Those two classes are already protected by `[Collection(TestServerlessAppCollection.Name)]` (`DisableParallelization = true`), but the two durable *diagnostic* classes were not:

- `DurableExecutionSerializerContextDiagnosticsTests` (warnings only), and
- `DurableExecutionDiagnosticsTests` (via the non-fatal `ExplicitRole_ReportsCheckpointPolicyInfo` case).

So their template read could collide mid-write with a concurrent writer, yielding truncated/appended JSON and the spurious `AWSLambda0001`. net10 passed only by scheduling luck.

## Fix

Enroll both durable diagnostic classes in the existing serialization collection so no two generator-running test classes touch the shared `serverless.template` concurrently. Test-only change; no library behavior changes, so no change file.

## Verification

Full `Amazon.Lambda.Annotations.SourceGenerators.Tests` project on net8.0 (the TFM that failed) under normal parallel load:

```
Passed!  - Failed: 0, Passed: 583, Skipped: 0, Total: 583 - net8.0
```