### PR TITLE
Revert PGC out-out mechanism in bootstrap script

### DIFF
--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/bootstrap.net8.sh
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/bootstrap.net8.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-# PQC TLS keyshares are enabled by default via the AL2023 base-OS crypto policy. Customers can opt
-# out by setting AWS_LAMBDA_DISABLE_PQC_KEYSHARES (presence-based, including an empty value), which
-# selects the shipped classical-only openssl_non_pqc.cnf and takes precedence over a customer OPENSSL_CONF.
-if [ -n "${AWS_LAMBDA_DISABLE_PQC_KEYSHARES+x}" ]; then
-  export OPENSSL_CONF=/var/runtime/openssl_conf/openssl_non_pqc.cnf
-fi
-
 # .NET on Linux uses OpenSSL to handle certificates. The .NET runtime will load the certs by first reading
 # the default cert bundle file which can be overriden by the SSL_CERT_FILE env var. Then it will load the
 # certs in the default cert directory which can be overriden by the SSL_CERT_DIR env var. On AL2023

--- a/Libraries/src/Amazon.Lambda.RuntimeSupport/bootstrap.sh
+++ b/Libraries/src/Amazon.Lambda.RuntimeSupport/bootstrap.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-# PQC TLS keyshares are enabled by default via the AL2023 base-OS crypto policy. Customers can opt
-# out by setting AWS_LAMBDA_DISABLE_PQC_KEYSHARES (presence-based, including an empty value), which
-# selects the shipped classical-only openssl_non_pqc.cnf and takes precedence over a customer OPENSSL_CONF.
-if [ -n "${AWS_LAMBDA_DISABLE_PQC_KEYSHARES+x}" ]; then
-  export OPENSSL_CONF=/var/runtime/openssl_conf/openssl_non_pqc.cnf
-fi
-
 # This script is used to locate 2 files in the /var/task folder, where the end-user assembly is located
 # The 2 files are <assembly name>.deps.json and <assembly name>.runtimeconfig.json
 # These files are used to add the end-user assembly into context and make the code reachable to the dotnet process


### PR DESCRIPTION
*Description of changes:*
Lambda team asked us to revert the PGC out-out mechanism that we released in PR https://github.com/aws/aws-lambda-dotnet/pull/2539 because have decided to go down a different path.

The `Release Not Needed` label was added because the change is only in the shell scripts that are used in the managed runtime. Not in the released NuGet package.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
