### PR TITLE
feat(DurableExecution): FileSystemSerializer — offload large results to a filesystem (#2540)

### DIFF
--- a/.autover/changes/3d3d307e-cf33-421d-b9c4-c88670b5c5ef.json
+++ b/.autover/changes/3d3d307e-cf33-421d-b9c4-c88670b5c5ef.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.DurableExecution",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Add FileSystemSerializer for offloading large durable operation results to a filesystem (e.g. EFS/S3 Files), keeping only a small pointer in the checkpoint. It wraps an inner ILambdaSerializer, so callers control the on-the-wire format (JSON, compressed, etc.). Introduces the optional IDurableResultSerializer interface and DurableSerializationContext (EntityId \u002B DurableExecutionArn); when an operation\u0027s configured serializer implements it, the durable runtime supplies operation/execution identity so external storage can be keyed safely. Applied to Step, ChildContext, WaitForCondition, and Map/Parallel per-item results. Plain ILambdaSerializer serializers are unaffected."
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/DurableContext.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/DurableContext.cs
@@ -84,7 +84,8 @@ internal sealed class DurableContext : IDurableContext
         StepConfig? config,
         CancellationToken cancellationToken)
     {
-        var serializer = config?.Serializer ?? LambdaSerializerHelper.GetRequired(LambdaContext);
+        var defaultSerializer = LambdaSerializerHelper.GetRequired(LambdaContext);
+        var serializer = LambdaSerializerHelper.WithDefaultInner(config?.Serializer ?? defaultSerializer, defaultSerializer);
 
         var operationId = _idGenerator.NextId();
         var op = new StepOperation<T>(
@@ -147,7 +148,8 @@ internal sealed class DurableContext : IDurableContext
         ArgumentNullException.ThrowIfNull(config);
         ArgumentNullException.ThrowIfNull(config.WaitStrategy);
 
-        var serializer = config.Serializer ?? LambdaSerializerHelper.GetRequired(LambdaContext);
+        var defaultSerializer = LambdaSerializerHelper.GetRequired(LambdaContext);
+        var serializer = LambdaSerializerHelper.WithDefaultInner(config.Serializer ?? defaultSerializer, defaultSerializer);
         var operationId = _idGenerator.NextId();
         var op = new WaitForConditionOperation<TState>(
             operationId, name, _idGenerator.ParentId, check, config, serializer, Logger,
@@ -161,7 +163,8 @@ internal sealed class DurableContext : IDurableContext
         ChildContextConfig? config,
         CancellationToken cancellationToken)
     {
-        var serializer = config?.Serializer ?? LambdaSerializerHelper.GetRequired(LambdaContext);
+        var defaultSerializer = LambdaSerializerHelper.GetRequired(LambdaContext);
+        var serializer = LambdaSerializerHelper.WithDefaultInner(config?.Serializer ?? defaultSerializer, defaultSerializer);
 
         var operationId = _idGenerator.NextId();
 
@@ -246,7 +249,8 @@ internal sealed class DurableContext : IDurableContext
         // globally-registered serializer. This is the only serializer ConcurrentOperation
         // uses (per-unit child results + inline summary results); the aggregate batch
         // envelope is a source-generated structure and is unaffected.
-        var serializer = effectiveConfig.ItemSerializer ?? LambdaSerializerHelper.GetRequired(LambdaContext);
+        var defaultSerializer = LambdaSerializerHelper.GetRequired(LambdaContext);
+        var serializer = LambdaSerializerHelper.WithDefaultInner(effectiveConfig.ItemSerializer ?? defaultSerializer, defaultSerializer);
 
         var operationId = _idGenerator.NextId();
         var op = new Internal.ParallelOperation<T>(
@@ -279,7 +283,8 @@ internal sealed class DurableContext : IDurableContext
         // globally-registered serializer. This is the only serializer ConcurrentOperation
         // uses (per-unit child results + inline summary results); the aggregate batch
         // envelope is a source-generated structure and is unaffected.
-        var serializer = effectiveConfig.ItemSerializer ?? LambdaSerializerHelper.GetRequired(LambdaContext);
+        var defaultSerializer = LambdaSerializerHelper.GetRequired(LambdaContext);
+        var serializer = LambdaSerializerHelper.WithDefaultInner(effectiveConfig.ItemSerializer ?? defaultSerializer, defaultSerializer);
 
         var operationId = _idGenerator.NextId();
         var op = new Internal.MapOperation<TItem, TResult>(

--- a/Libraries/src/Amazon.Lambda.DurableExecution/FileSystemSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/FileSystemSerializer.cs
@@ -1,0 +1,424 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using System.Security.Cryptography;
+using Amazon.Lambda.Core;
+
+namespace Amazon.Lambda.DurableExecution;
+
+/// <summary>
+/// Controls when <see cref="FileSystemSerializer"/> writes a value to the filesystem.
+/// </summary>
+public enum FileSystemStorageMode
+{
+    /// <summary>
+    /// Every value is written to a file; the checkpoint stores only a file pointer.
+    /// Best for consistently large payloads or predictable checkpoint sizes.
+    /// </summary>
+    Always,
+
+    /// <summary>
+    /// The value is stored inline in the checkpoint unless it would exceed the durable
+    /// execution checkpoint size limit (~256&#160;KB), in which case it overflows to a
+    /// file. Best for mixed workloads where most payloads are small.
+    /// </summary>
+    Overflow,
+}
+
+/// <summary>
+/// Controls how the durable execution ARN (directory) and entity id (file name) are
+/// turned into filesystem path segments.
+/// </summary>
+public enum FileSystemPathEncoding
+{
+    /// <summary>
+    /// Human-navigable paths. The per-execution directory is built from the ARN's
+    /// function name, execution name and invocation id; the file name is the entity id,
+    /// URL-encoded. If the ARN does not match the expected durable-execution shape, the
+    /// whole ARN is URL-encoded into a single directory segment.
+    /// </summary>
+    Uri,
+
+    /// <summary>
+    /// The ARN (directory) and entity id (file name) are each replaced by their SHA-256
+    /// hex digest — fixed length and always filesystem-safe, at the cost of readability.
+    /// </summary>
+    Hash,
+}
+
+/// <summary>
+/// An <see cref="ILambdaSerializer"/> / <see cref="IDurableResultSerializer"/> that stores
+/// serialized durable operation results on a filesystem, keeping only a small pointer in
+/// the checkpoint. It wraps an <em>inner</em> serializer that performs the actual
+/// value&#8596;bytes conversion (JSON, compressed JSON, a custom format, …), so the choice
+/// of on-the-wire format is fully in the caller's control.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>⚠ Do NOT use with Lambda's ephemeral <c>/tmp</c> for values that must survive
+/// replay.</b> <c>/tmp</c> is local to a single execution environment; on replay a
+/// different environment may be used and the file will not be found. Use a durable,
+/// shared mount such as Amazon EFS or Amazon S3 Files, which persist across invocations
+/// and are visible to concurrent function instances.
+/// </para>
+/// <para>
+/// The checkpoint stores a JSON envelope that is either
+/// <c>{"data":"&lt;base64 inner bytes&gt;"}</c> (inline) or <c>{"file":"&lt;path&gt;"}</c>
+/// (pointer). The envelope is serialized with a source generator, so this type is
+/// Native-AOT-safe as long as the inner serializer is.
+/// </para>
+/// <para>
+/// <b>Lifecycle:</b> this serializer never deletes result files. A write for a given
+/// (execution, entity) overwrites its file in place, so retries and re-serializations
+/// of the same operation do not accumulate; but the files of completed or abandoned
+/// executions remain on the mount. Pair the base path with an external retention policy
+/// (an EFS lifecycle policy, an S3 lifecycle rule, or a scheduled cleanup keyed by the
+/// per-execution directory) so storage does not grow unbounded.
+/// </para>
+/// <para>
+/// This serializer must be used through a durable operation's per-operation serializer
+/// slot (for example <c>StepConfig.Serializer</c>) so it receives a
+/// <see cref="DurableSerializationContext"/>. Using it as a plain
+/// <see cref="ILambdaSerializer"/> (for example as the assembly-registered serializer)
+/// throws, because there is then no execution/entity identity to build a safe path.
+/// </para>
+/// </remarks>
+public sealed class FileSystemSerializer : ILambdaSerializer, IDurableResultSerializer
+{
+    // The durable execution checkpoint size limit is ~256 KB; leave 1 KB of headroom for
+    // the envelope wrapper and other checkpoint metadata.
+    private const int OverflowThresholdBytes = (256 * 1024) - 1024;
+
+    private static readonly Regex DurableExecutionArnPattern = new(
+        @"^arn:[^:]*:lambda:[^:]*:[^:]*:function:([^:/]+):[^:/]+/durable-execution/([^/]+)/([^/]+)$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant,
+        TimeSpan.FromSeconds(1));
+
+    private readonly ILambdaSerializer _inner;
+    private readonly string _basePath;
+    private readonly FileSystemStorageMode _storageMode;
+    private readonly FileSystemPathEncoding _pathEncoding;
+
+    /// <summary>Creates a new <see cref="FileSystemSerializer"/>.</summary>
+    /// <param name="inner">
+    /// The serializer that converts values to/from bytes (for example the global
+    /// <c>ILambdaContext.Serializer</c>, or a compressing/encrypting wrapper).
+    /// </param>
+    /// <param name="basePath">
+    /// Directory under which result files are written (for example <c>/mnt/efs/durable</c>).
+    /// Use a durable, shared mount — see the type remarks.
+    /// </param>
+    /// <param name="storageMode">When to write to a file. Defaults to <see cref="FileSystemStorageMode.Always"/>.</param>
+    /// <param name="pathEncoding">How to encode path segments. Defaults to <see cref="FileSystemPathEncoding.Uri"/>.</param>
+    public FileSystemSerializer(
+        ILambdaSerializer inner,
+        string basePath,
+        FileSystemStorageMode storageMode = FileSystemStorageMode.Always,
+        FileSystemPathEncoding pathEncoding = FileSystemPathEncoding.Uri)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        // Normalize once so stored file pointers are absolute and their resolution
+        // does not depend on the current working directory of a later invocation
+        // (which may run in a different execution environment). ValidatePathWithinBase
+        // still re-resolves for symlink safety, but the stored base is now stable.
+        _basePath = Path.GetFullPath(basePath ?? throw new ArgumentNullException(nameof(basePath)));
+        _storageMode = storageMode;
+        _pathEncoding = pathEncoding;
+    }
+
+    // ---- context-aware path (used by durable execution) ----
+
+    /// <inheritdoc />
+    public void Serialize<T>(T value, Stream stream, DurableSerializationContext context)
+    {
+        string path;
+        if (_storageMode == FileSystemStorageMode.Overflow)
+        {
+            // Overflow needs the serialized size to decide inline-vs-file, so it buffers.
+            byte[] bytes = InnerSerialize(value);
+            var inline = new FileSystemEnvelope { Data = Convert.ToBase64String(bytes) };
+            var inlineJson = JsonSerializer.Serialize(inline, FileSystemJsonContext.Default.FileSystemEnvelope);
+            if (Encoding.UTF8.GetByteCount(inlineJson) <= OverflowThresholdBytes)
+            {
+                var inlineBytes = Encoding.UTF8.GetBytes(inlineJson);
+                stream.Write(inlineBytes, 0, inlineBytes.Length);
+                return;
+            }
+            path = WriteBytesToFile(bytes, context);
+        }
+        else
+        {
+            // Always: stream the inner serialization straight to the file — no large in-memory
+            // intermediate, which is the whole point of offloading big payloads.
+            path = WriteStreamingToFile(value, context);
+        }
+
+        var envelope = new FileSystemEnvelope { File = path };
+        JsonSerializer.Serialize(stream, envelope, FileSystemJsonContext.Default.FileSystemEnvelope);
+    }
+
+    /// <inheritdoc />
+    public T Deserialize<T>(Stream stream, DurableSerializationContext context)
+    {
+        var envelope = JsonSerializer.Deserialize(stream, FileSystemJsonContext.Default.FileSystemEnvelope)
+            ?? throw new InvalidOperationException("FileSystemSerializer: empty or invalid envelope.");
+
+        if (envelope.File is not null)
+        {
+            // Guard against a tampered/corrupted checkpoint pointing outside the base path.
+            ValidatePathWithinBase(envelope.File);
+            if (!File.Exists(envelope.File))
+                throw new FileNotFoundException(
+                    $"FileSystemSerializer: offloaded payload file not found: '{envelope.File}'. " +
+                    "If the base path is Lambda's /tmp, the value cannot survive replay on a different " +
+                    "execution environment — use a durable shared mount such as EFS or S3 Files.",
+                    envelope.File);
+
+            // Stream the offloaded payload straight to the inner serializer instead of
+            // buffering the whole file into a byte[] — symmetric with the streaming
+            // write path (WriteStreamingToFile), so a large offloaded value is never
+            // fully materialized in memory just to be read back.
+            //
+            // FileShare.Delete (in addition to Read): the write path replaces a file in
+            // place via File.Move(overwrite: true). On POSIX/Linux that rename-over is
+            // atomic and an open read handle never blocks it (the reader keeps the old
+            // inode). On Windows/macOS, a held read handle opened WITHOUT FileShare.Delete
+            // blocks the rename-over, so a concurrent replay-read racing a re-serialize of
+            // the same entity would throw IOException. Granting Delete share keeps those
+            // non-Linux readers from blocking the atomic replace; the atomic-replace
+            // concurrency-safety itself is a POSIX/Linux property. (Prod runs Linux, but
+            // dev/test frequently run Windows/macOS.)
+            using var fileStream = new FileStream(
+                envelope.File, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete);
+            return _inner.Deserialize<T>(fileStream);
+        }
+
+        if (envelope.Data is not null)
+        {
+            byte[] bytes;
+            try
+            {
+                bytes = Convert.FromBase64String(envelope.Data);
+            }
+            catch (FormatException ex)
+            {
+                // Sibling checks in this method throw descriptive InvalidOperationExceptions;
+                // a corrupted inline envelope should be no different (a bare FormatException
+                // gives no context about which envelope field was malformed).
+                throw new InvalidOperationException(
+                    "FileSystemSerializer: inline envelope 'data' is not valid base64 — the checkpoint " +
+                    "is corrupted or was not written by this serializer.", ex);
+            }
+            return InnerDeserialize<T>(bytes);
+        }
+
+        throw new InvalidOperationException("FileSystemSerializer: envelope has neither 'file' nor 'data'.");
+    }
+
+    // ---- plain ILambdaSerializer path (only reachable outside durable execution) ----
+
+    void ILambdaSerializer.Serialize<T>(T response, Stream responseStream) =>
+        throw new NotSupportedException(
+            "FileSystemSerializer must be used via a durable operation's per-operation serializer " +
+            "(for example StepConfig.Serializer), which supplies the DurableSerializationContext needed " +
+            "to build a safe, unique file path. It cannot be used as a plain ILambdaSerializer.");
+
+    T ILambdaSerializer.Deserialize<T>(Stream requestStream) =>
+        throw new NotSupportedException(
+            "FileSystemSerializer must be used via a durable operation's per-operation serializer " +
+            "(for example StepConfig.Serializer). It cannot be used as a plain ILambdaSerializer.");
+
+    // ---- helpers ----
+
+    private byte[] InnerSerialize<T>(T value)
+    {
+        using var ms = new MemoryStream();
+        _inner.Serialize(value, ms);
+        return ms.ToArray();
+    }
+
+    private T InnerDeserialize<T>(byte[] bytes)
+    {
+        using var ms = new MemoryStream(bytes);
+        return _inner.Deserialize<T>(ms);
+    }
+
+    private string WriteStreamingToFile<T>(T value, DurableSerializationContext context)
+    {
+        var (path, tmp) = ResolveTargetPaths(context);
+        try
+        {
+            using (var fileStream = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                _inner.Serialize(value, fileStream);
+            }
+            File.Move(tmp, path, overwrite: true);
+        }
+        catch
+        {
+            TryDelete(tmp);
+            throw;
+        }
+        return path;
+    }
+
+    private string WriteBytesToFile(byte[] bytes, DurableSerializationContext context)
+    {
+        var (path, tmp) = ResolveTargetPaths(context);
+        try
+        {
+            File.WriteAllBytes(tmp, bytes);
+            File.Move(tmp, path, overwrite: true);
+        }
+        catch
+        {
+            TryDelete(tmp);
+            throw;
+        }
+        return path;
+    }
+
+    // Resolves the final file path and a unique temp path in the SAME directory. Writing to the
+    // temp file then atomically moving it means a concurrent replay/reader never observes a
+    // partially-written or truncated file. The temp name is unique so two writers of the same
+    // entity don't clobber each other's in-progress temp.
+    private (string path, string tmp) ResolveTargetPaths(DurableSerializationContext context)
+    {
+        var dir = ResolveExecutionDir(context.DurableExecutionArn);
+        // Guard the WRITE path the same way the read path is guarded: under Uri
+        // encoding the ARN-derived segments are inserted into the path unescaped
+        // (Uri.EscapeDataString does not escape '.', so it would NOT neutralize a
+        // '..' traversal segment either), so a tampered/malformed durable execution
+        // ARN containing '..' could otherwise resolve the per-execution directory
+        // outside the configured base path.
+        ValidateWriteDirWithinBase(dir);
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, EncodeSegment(context.EntityId) + ".bin");
+        var tmp = path + ".tmp-" + Guid.NewGuid().ToString("N");
+        return (path, tmp);
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { if (File.Exists(path)) File.Delete(path); } catch { /* best effort */ }
+    }
+
+    // Rejects a checkpoint file pointer that resolves outside the configured base path, so a
+    // tampered or corrupted envelope cannot turn deserialization into an arbitrary file read.
+    private void ValidatePathWithinBase(string filePath)
+    {
+        if (!IsWithinBase(filePath))
+            throw new InvalidOperationException(
+                $"FileSystemSerializer: refusing to read an offloaded payload outside the configured " +
+                $"base path. Path '{filePath}' does not resolve under '{_basePath}'.");
+    }
+
+    // Rejects a resolved per-execution write directory that lands outside the configured base
+    // path, so a tampered/malformed durable execution ARN (e.g. containing '..' traversal
+    // segments) cannot write offloaded payloads to an arbitrary filesystem location.
+    private void ValidateWriteDirWithinBase(string dir)
+    {
+        if (!IsWithinBase(dir))
+            throw new InvalidOperationException(
+                $"FileSystemSerializer: refusing to write an offloaded payload outside the configured " +
+                $"base path. Resolved directory '{dir}' does not resolve under '{_basePath}'. This can " +
+                "happen when the durable execution ARN contains path-traversal segments.");
+    }
+
+    // True when the fully-resolved candidate path lies under the fully-resolved base path.
+    private bool IsWithinBase(string candidate)
+    {
+        // Compare using the filesystem's casing rules. Ordinal alone would falsely
+        // reject an in-base path that differs only by case on Windows/macOS.
+        var comparison = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        var fullBase = ResolveReal(Path.GetFullPath(_basePath));
+        if (!fullBase.EndsWith(Path.DirectorySeparatorChar))
+            fullBase += Path.DirectorySeparatorChar;
+
+        var fullPath = ResolveReal(Path.GetFullPath(candidate));
+        return fullPath.StartsWith(fullBase, comparison);
+    }
+
+    // Best-effort resolution of a path to its real on-disk location, following a
+    // symlink on the leaf file/directory and on its immediate parent directory.
+    // Path.GetFullPath only collapses '..'/separators and does NOT follow symlinks,
+    // so without this a symlink planted under the base but pointing outside it would
+    // pass a purely lexical prefix check and defeat the containment guard. Both the
+    // base and the candidate are resolved the same way so a symlinked mount root
+    // (for example macOS /var -> /private/var) does not cause false rejections.
+    private static string ResolveReal(string fullPath)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(fullPath);
+            if (dir != null && Directory.Exists(dir))
+            {
+                var realDir = Directory.ResolveLinkTarget(dir, returnFinalTarget: true)?.FullName ?? dir;
+                fullPath = Path.Combine(realDir, Path.GetFileName(fullPath));
+            }
+            if (File.Exists(fullPath))
+                fullPath = File.ResolveLinkTarget(fullPath, returnFinalTarget: true)?.FullName ?? fullPath;
+            else if (Directory.Exists(fullPath))
+                fullPath = Directory.ResolveLinkTarget(fullPath, returnFinalTarget: true)?.FullName ?? fullPath;
+        }
+        catch
+        {
+            // Best effort — fall back to the lexical full path.
+        }
+        return fullPath;
+    }
+
+    private string ResolveExecutionDir(string arn)
+    {
+        if (_pathEncoding == FileSystemPathEncoding.Uri)
+        {
+            var match = DurableExecutionArnPattern.Match(arn);
+            if (match.Success)
+            {
+                return Path.Combine(
+                    _basePath,
+                    match.Groups[1].Value,   // function name
+                    match.Groups[2].Value,   // execution name
+                    match.Groups[3].Value);  // invocation id
+            }
+        }
+        return Path.Combine(_basePath, EncodeSegment(arn));
+    }
+
+    private string EncodeSegment(string value) =>
+        _pathEncoding == FileSystemPathEncoding.Hash
+            ? Sha256Hex(value)
+            : Uri.EscapeDataString(value);
+
+    private static string Sha256Hex(string value)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+}
+
+/// <summary>The checkpoint envelope written by <see cref="FileSystemSerializer"/>.</summary>
+internal sealed class FileSystemEnvelope
+{
+    /// <summary>Inline payload (base64 of the inner-serialized bytes). Set when stored inline.</summary>
+    [JsonPropertyName("data")]
+    public string? Data { get; set; }
+
+    /// <summary>Path to the file holding the inner-serialized bytes. Set when offloaded.</summary>
+    [JsonPropertyName("file")]
+    public string? File { get; set; }
+}
+
+[JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(FileSystemEnvelope))]
+internal partial class FileSystemJsonContext : JsonSerializerContext
+{
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/FileSystemSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/FileSystemSerializer.cs
@@ -56,7 +56,9 @@ public enum FileSystemPathEncoding
 /// serialized durable operation results on a filesystem, keeping only a small pointer in
 /// the checkpoint. It wraps an <em>inner</em> serializer that performs the actual
 /// value&#8596;bytes conversion (JSON, compressed JSON, a custom format, …), so the choice
-/// of on-the-wire format is fully in the caller's control.
+/// of on-the-wire format is fully in the caller's control. Construct it without an inner
+/// serializer (<see cref="FileSystemSerializer(string, FileSystemStorageMode, FileSystemPathEncoding)"/>)
+/// to reuse the durable execution's globally-registered serializer as the inner.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -88,7 +90,7 @@ public enum FileSystemPathEncoding
 /// throws, because there is then no execution/entity identity to build a safe path.
 /// </para>
 /// </remarks>
-public sealed class FileSystemSerializer : ILambdaSerializer, IDurableResultSerializer
+public sealed class FileSystemSerializer : ILambdaSerializer, IDurableResultSerializer, IDefaultInnerSerializer
 {
     // The durable execution checkpoint size limit is ~256 KB; leave 1 KB of headroom for
     // the envelope wrapper and other checkpoint metadata.
@@ -99,7 +101,7 @@ public sealed class FileSystemSerializer : ILambdaSerializer, IDurableResultSeri
         RegexOptions.Compiled | RegexOptions.CultureInvariant,
         TimeSpan.FromSeconds(1));
 
-    private readonly ILambdaSerializer _inner;
+    private readonly ILambdaSerializer? _inner;
     private readonly string _basePath;
     private readonly FileSystemStorageMode _storageMode;
     private readonly FileSystemPathEncoding _pathEncoding;
@@ -129,6 +131,48 @@ public sealed class FileSystemSerializer : ILambdaSerializer, IDurableResultSeri
         _basePath = Path.GetFullPath(basePath ?? throw new ArgumentNullException(nameof(basePath)));
         _storageMode = storageMode;
         _pathEncoding = pathEncoding;
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="FileSystemSerializer"/> that uses the durable execution's
+    /// globally-registered <see cref="ILambdaSerializer"/> (the assembly-level
+    /// <c>[assembly: LambdaSerializer(...)]</c> serializer, or the one passed to
+    /// <c>LambdaBootstrapBuilder.Create(handler, serializer)</c>) as its inner serializer.
+    /// </summary>
+    /// <remarks>
+    /// The inner serializer is supplied by the durable runtime when this instance is used
+    /// through a per-operation serializer slot (for example <c>StepConfig.Serializer</c>).
+    /// It saves you from having to thread <c>ctx.Serializer</c> in yourself when the
+    /// on-the-wire format is just the function's normal serializer.
+    /// </remarks>
+    /// <param name="basePath">
+    /// Directory under which result files are written (for example <c>/mnt/efs/durable</c>).
+    /// Use a durable, shared mount — see the type remarks.
+    /// </param>
+    /// <param name="storageMode">When to write to a file. Defaults to <see cref="FileSystemStorageMode.Always"/>.</param>
+    /// <param name="pathEncoding">How to encode path segments. Defaults to <see cref="FileSystemPathEncoding.Uri"/>.</param>
+    public FileSystemSerializer(
+        string basePath,
+        FileSystemStorageMode storageMode = FileSystemStorageMode.Always,
+        FileSystemPathEncoding pathEncoding = FileSystemPathEncoding.Uri)
+    {
+        _inner = null;
+        // Normalize once (see the inner-taking constructor) so a stored file pointer is
+        // absolute and stable across invocations, independent of the current directory.
+        _basePath = Path.GetFullPath(basePath ?? throw new ArgumentNullException(nameof(basePath)));
+        _storageMode = storageMode;
+        _pathEncoding = pathEncoding;
+    }
+
+    // When constructed without an explicit inner serializer, the durable runtime binds the
+    // globally-registered serializer here before the operation runs (see the parameterless-inner
+    // constructor). Returns a bound copy; a caller-supplied inner always wins and is left as-is.
+    ILambdaSerializer IDefaultInnerSerializer.WithDefaultInner(ILambdaSerializer inner)
+    {
+        if (inner is null) throw new ArgumentNullException(nameof(inner));
+        return _inner is not null
+            ? this
+            : new FileSystemSerializer(inner, _basePath, _storageMode, _pathEncoding);
     }
 
     // ---- context-aware path (used by durable execution) ----
@@ -193,9 +237,10 @@ public sealed class FileSystemSerializer : ILambdaSerializer, IDurableResultSeri
             // non-Linux readers from blocking the atomic replace; the atomic-replace
             // concurrency-safety itself is a POSIX/Linux property. (Prod runs Linux, but
             // dev/test frequently run Windows/macOS.)
+            var inner = RequireInner();
             using var fileStream = new FileStream(
                 envelope.File, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete);
-            return _inner.Deserialize<T>(fileStream);
+            return inner.Deserialize<T>(fileStream);
         }
 
         if (envelope.Data is not null)
@@ -235,27 +280,41 @@ public sealed class FileSystemSerializer : ILambdaSerializer, IDurableResultSeri
 
     // ---- helpers ----
 
+    // The inner serializer is either the one passed to the constructor or, for the
+    // inner-less constructor, the globally-registered serializer bound by the durable
+    // runtime via IDefaultInnerSerializer. If neither is present it means this instance
+    // was used outside a durable operation slot, where no global serializer is available.
+    private ILambdaSerializer RequireInner() =>
+        _inner ?? throw new InvalidOperationException(
+            "FileSystemSerializer was constructed without an inner serializer and the durable " +
+            "runtime did not supply a globally-registered ILambdaSerializer to use as the inner. " +
+            "Either pass an inner serializer to the constructor, or register one via " +
+            "[assembly: LambdaSerializer(typeof(...))] / LambdaBootstrapBuilder.Create(handler, serializer).");
+
     private byte[] InnerSerialize<T>(T value)
     {
+        var inner = RequireInner();
         using var ms = new MemoryStream();
-        _inner.Serialize(value, ms);
+        inner.Serialize(value, ms);
         return ms.ToArray();
     }
 
     private T InnerDeserialize<T>(byte[] bytes)
     {
+        var inner = RequireInner();
         using var ms = new MemoryStream(bytes);
-        return _inner.Deserialize<T>(ms);
+        return inner.Deserialize<T>(ms);
     }
 
     private string WriteStreamingToFile<T>(T value, DurableSerializationContext context)
     {
+        var inner = RequireInner();
         var (path, tmp) = ResolveTargetPaths(context);
         try
         {
             using (var fileStream = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
             {
-                _inner.Serialize(value, fileStream);
+                inner.Serialize(value, fileStream);
             }
             File.Move(tmp, path, overwrite: true);
         }

--- a/Libraries/src/Amazon.Lambda.DurableExecution/IDurableResultSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/IDurableResultSerializer.cs
@@ -18,7 +18,7 @@ namespace Amazon.Lambda.DurableExecution;
 /// <see cref="Amazon.Lambda.Core.ILambdaSerializer"/> conveys only the value and a stream —
 /// it has no way to tell the serializer which operation or execution a value belongs to.
 /// Serializers that offload results to external storage (for example
-/// <c>FileSystemSerializer</c>) need that identity to build a stable, unique
+/// <see cref="FileSystemSerializer"/>) need that identity to build a stable, unique
 /// location and to avoid different operations clobbering one another. Serializers that
 /// do not need it simply implement <see cref="Amazon.Lambda.Core.ILambdaSerializer"/> and
 /// are used unchanged.

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/ChildContextOperation.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/ChildContextOperation.cs
@@ -61,7 +61,7 @@ internal sealed class ChildContextOperation<T> : DurableOperation<T>
     /// verbatim, rather than re-serializing the (already round-tripped) return value.
     /// Re-serializing the return value double-transforms a non-round-tripping serializer
     /// (fresh vs replay diverge) and, for a context-aware serializer such as
-    /// <c>FileSystemSerializer</c>, writes a SECOND file at the parent's per-unit id
+    /// <see cref="FileSystemSerializer"/>, writes a SECOND file at the parent's per-unit id
     /// that orphans the child's file. <c>null</c> for virtual (Flat) children, for
     /// overflow-replay re-execution, and before a fresh success has been serialized.
     /// </summary>

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/IDefaultInnerSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/IDefaultInnerSerializer.cs
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Lambda.Core;
+
+namespace Amazon.Lambda.DurableExecution;
+
+/// <summary>
+/// Implemented by a per-operation serializer that wraps an inner
+/// <see cref="ILambdaSerializer"/> but may have been constructed without one, asking the
+/// durable runtime to supply the globally-registered serializer as its inner. The runtime
+/// calls <see cref="WithDefaultInner"/> when it resolves the effective serializer for an
+/// operation (see the serializer resolution in <c>DurableContext</c>).
+/// </summary>
+internal interface IDefaultInnerSerializer
+{
+    /// <summary>
+    /// Returns a serializer bound to <paramref name="inner"/> as its inner serializer. An
+    /// implementation that already has an explicitly-provided inner returns itself unchanged.
+    /// </summary>
+    ILambdaSerializer WithDefaultInner(ILambdaSerializer inner);
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/LambdaSerializerHelper.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/LambdaSerializerHelper.cs
@@ -19,6 +19,16 @@ internal static class LambdaSerializerHelper
         lambdaContext.Serializer ?? throw new InvalidOperationException(MissingSerializerMessage);
 
     /// <summary>
+    /// If <paramref name="serializer"/> was constructed to defer to the globally-registered
+    /// serializer for its inner format (see <see cref="IDefaultInnerSerializer"/>, e.g. the
+    /// inner-less <see cref="FileSystemSerializer"/> constructor), binds
+    /// <paramref name="defaultInner"/> as its inner and returns the bound serializer;
+    /// otherwise returns <paramref name="serializer"/> unchanged.
+    /// </summary>
+    public static ILambdaSerializer WithDefaultInner(ILambdaSerializer serializer, ILambdaSerializer defaultInner) =>
+        serializer is IDefaultInnerSerializer d ? d.WithDefaultInner(defaultInner) : serializer;
+
+    /// <summary>
     /// Serializes a durable operation result. If <paramref name="serializer"/> implements
     /// <see cref="IDurableResultSerializer"/>, the context-aware overload is used so the
     /// serializer can key external storage by operation/execution; otherwise the plain

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/FileSystemSerializerTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/FileSystemSerializerTests.cs
@@ -377,6 +377,40 @@ public class FileSystemSerializerTests : IDisposable
         Assert.Equal(new Poco { Id = 1, Name = "orig" }, read);
     }
 
+    [Fact]
+    public void InnerLessConstructor_BoundToDefaultInner_RoundTrips()
+    {
+        // The inner-less constructor defers to the globally-registered serializer, which the
+        // durable runtime binds via IDefaultInnerSerializer.WithDefaultInner before use.
+        var innerLess = new FileSystemSerializer(_base, FileSystemStorageMode.Always);
+        var bound = (FileSystemSerializer)((IDefaultInnerSerializer)innerLess).WithDefaultInner(_json);
+        var value = new Poco { Id = 9, Name = "bound" };
+
+        var envelope = Serialize(bound, value, DurableArnCtx());
+
+        Assert.Contains("\"file\"", envelope);
+        Assert.Equal(value, Deserialize<Poco>(bound, envelope, DurableArnCtx()));
+    }
+
+    [Fact]
+    public void WithDefaultInner_ExplicitInnerWins_ReturnsSameInstance()
+    {
+        // A caller-supplied inner is never overridden by the runtime's default.
+        var explicitInner = new FileSystemSerializer(_json, _base);
+        var result = ((IDefaultInnerSerializer)explicitInner).WithDefaultInner(new DefaultLambdaJsonSerializer());
+        Assert.Same(explicitInner, result);
+    }
+
+    [Fact]
+    public void InnerLessConstructor_WithoutBinding_Throws()
+    {
+        // Used without the runtime binding a default inner (e.g. outside a durable operation
+        // slot), there is no serializer to convert the value — fail with a clear message.
+        var innerLess = new FileSystemSerializer(_base, FileSystemStorageMode.Always);
+        Assert.Throws<InvalidOperationException>(
+            () => Serialize(innerLess, new Poco { Id = 1, Name = "x" }, DurableArnCtx()));
+    }
+
     private sealed class GzipJsonSerializer : ILambdaSerializer
     {
         private readonly ILambdaSerializer _json;

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/FileSystemSerializerTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/FileSystemSerializerTests.cs
@@ -1,0 +1,397 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.Serialization.SystemTextJson;
+using Xunit;
+
+namespace Amazon.Lambda.DurableExecution.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="FileSystemSerializer"/>: storage modes (Always/Overflow),
+/// path encodings (Uri/Hash), envelope shape, missing-file behavior, per-entity file
+/// separation, composition with a compressing inner serializer, and the plain-path guard.
+/// </summary>
+public class FileSystemSerializerTests : IDisposable
+{
+    private readonly string _base = Path.Combine(Path.GetTempPath(), "fsser-" + Guid.NewGuid().ToString("N"));
+    private readonly ILambdaSerializer _json = new DefaultLambdaJsonSerializer();
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_base)) Directory.Delete(_base, recursive: true); } catch { /* best effort */ }
+    }
+
+    public sealed class Poco
+    {
+        public int Id { get; set; }
+        public string? Name { get; set; }
+        public override bool Equals(object? o) => o is Poco p && p.Id == Id && p.Name == Name;
+        public override int GetHashCode() => Id;
+    }
+
+    private static DurableSerializationContext DurableArnCtx(string entity = "op-1") =>
+        new(entity, "arn:aws:lambda:us-east-1:123456789012:function:fn:1/durable-execution/exec-1/inv-1");
+
+    private static string Serialize<T>(FileSystemSerializer s, T value, DurableSerializationContext ctx)
+    {
+        using var ms = new MemoryStream();
+        ((IDurableResultSerializer)s).Serialize(value, ms, ctx);
+        return Encoding.UTF8.GetString(ms.ToArray());
+    }
+
+    private static T Deserialize<T>(FileSystemSerializer s, string envelope, DurableSerializationContext ctx)
+    {
+        using var ms = new MemoryStream(Encoding.UTF8.GetBytes(envelope));
+        return ((IDurableResultSerializer)s).Deserialize<T>(ms, ctx);
+    }
+
+    [Fact]
+    public void Always_WritesFile_EnvelopeIsPointer_AndRoundTrips()
+    {
+        var s = new FileSystemSerializer(_json, _base, FileSystemStorageMode.Always);
+        var value = new Poco { Id = 1, Name = "alice" };
+
+        var envelope = Serialize(s, value, DurableArnCtx());
+
+        Assert.Contains("\"file\"", envelope);
+        Assert.DoesNotContain("\"data\"", envelope);
+        Assert.NotEmpty(Directory.GetFiles(_base, "*.bin", SearchOption.AllDirectories));
+        Assert.Equal(value, Deserialize<Poco>(s, envelope, DurableArnCtx()));
+    }
+
+    [Fact]
+    public void Overflow_SmallValue_StoredInline_NoFile()
+    {
+        var s = new FileSystemSerializer(_json, _base, FileSystemStorageMode.Overflow);
+        var value = new Poco { Id = 7, Name = "small" };
+
+        var envelope = Serialize(s, value, DurableArnCtx());
+
+        Assert.Contains("\"data\"", envelope);
+        Assert.DoesNotContain("\"file\"", envelope);
+        Assert.False(Directory.Exists(_base) && Directory.GetFiles(_base, "*.bin", SearchOption.AllDirectories).Length > 0);
+        Assert.Equal(value, Deserialize<Poco>(s, envelope, DurableArnCtx()));
+    }
+
+    [Fact]
+    public void Overflow_LargeValue_OverflowsToFile_AndRoundTrips()
+    {
+        var s = new FileSystemSerializer(_json, _base, FileSystemStorageMode.Overflow);
+        var big = new string('x', 300 * 1024); // > ~256KB threshold once serialized
+
+        var envelope = Serialize(s, big, DurableArnCtx());
+
+        Assert.Contains("\"file\"", envelope);
+        Assert.Equal(big, Deserialize<string>(s, envelope, DurableArnCtx()));
+    }
+
+    [Fact]
+    public void Deserialize_MissingFile_ThrowsFileNotFound()
+    {
+        var s = new FileSystemSerializer(_json, _base, FileSystemStorageMode.Always);
+        var envelope = Serialize(s, new Poco { Id = 2, Name = "gone" }, DurableArnCtx());
+
+        foreach (var f in Directory.GetFiles(_base, "*.bin", SearchOption.AllDirectories))
+            File.Delete(f);
+
+        Assert.Throws<FileNotFoundException>(() => Deserialize<Poco>(s, envelope, DurableArnCtx()));
+    }
+
+    [Fact]
+    public void Deserialize_FilePointerOutsideBase_Throws()
+    {
+        var s = new FileSystemSerializer(_json, _base, FileSystemStorageMode.Always);
+        // A tampered/corrupted envelope pointing outside the base path must be rejected,
+        // not read (guards against arbitrary file reads on the mounted filesystem).
+        var evilPath = Path.Combine(Path.GetTempPath(), "evil-" + Guid.NewGuid().ToString("N") + ".bin");
+        var envelope = "{\"file\":" + JsonSerializer.Serialize(evilPath) + "}";
+        Assert.Throws<InvalidOperationException>(() => Deserialize<Poco>(s, envelope, DurableArnCtx()));
+    }
+
+    [Fact]
+    public void UriPathEncoding_BuildsPerExecutionDirsFromArn()
+    {
+        var s = new FileSystemSerializer(_json, _base, FileSystemStorageMode.Always, FileSystemPathEncoding.Uri);
+        Serialize(s, new Poco { Id = 3, Name = "n" }, DurableArnCtx("entity-3"));
+
+        var expectedDir = Path.Combine(_base, "fn", "exec-1", "inv-1");
+        Assert.True(Directory.Exists(expectedDir), $"expected per-execution dir {expectedDir}");
+        Assert.NotEmpty(Directory.GetFiles(expectedDir, "*.bin"));
+    }
+
+    [Fact]
+    public void HashPathEncoding_UsesSha256HexSegments()
+    {
+        var s = new FileSystemSerializer(_json, _base, FileSystemStorageMode.Always, FileSystemPathEncoding.Hash);
+        Serialize(s, new Poco { Id = 4, Name = "n" }, DurableArnCtx("entity-4"));
+
+        var file = Assert.Single(Directory.GetFiles(_base, "*.bin", SearchOption.AllDirectories));
+        // Directory segment (ARN hash) and file stem (entity hash) are 64-char lowercase hex.
+        var dirName = new DirectoryInfo(Path.GetDirectoryName(file)!).Name;
+        var stem = Path.GetFileNameWithoutExtension(file);
+        Assert.Matches("^[0-9a-f]{64}$", dirName);
+        Assert.Matches("^[0-9a-f]{64}$", stem);
+    }
+
+    [Fact]
+    public void DistinctEntityIds_WriteDistinctFiles()
+    {
+        var s = new FileSystemSerializer(_json, _base, FileSystemStorageMode.Always);
+        Serialize(s, new Poco { Id = 1, Name = "a" }, DurableArnCtx("op#0"));
+        Serialize(s, new Poco { Id = 2, Name = "b" }, DurableArnCtx("op#1"));
+
+        var files = Directory.GetFiles(_base, "*.bin", SearchOption.AllDirectories);
+        Assert.Equal(2, files.Length);
+    }
+
+    [Fact]
+    public void GzipInnerSerializer_Composes_CompressesFile_AndRoundTrips()
+    {
+        var gzip = new GzipJsonSerializer(_json);
+        var compressing = new FileSystemSerializer(gzip, _base, FileSystemStorageMode.Always);
+        var plain = new FileSystemSerializer(_json, _base + "-plain", FileSystemStorageMode.Always);
+
+        var value = new string('a', 50 * 1024); // highly compressible
+
+        var envelope = Serialize(compressing, value, DurableArnCtx("gz"));
+        Serialize(plain, value, DurableArnCtx("gz"));
+
+        var compressedFile = Assert.Single(Directory.GetFiles(_base, "*.bin", SearchOption.AllDirectories));
+        var plainFile = Assert.Single(Directory.GetFiles(_base + "-plain", "*.bin", SearchOption.AllDirectories));
+
+        Assert.True(new FileInfo(compressedFile).Length < new FileInfo(plainFile).Length,
+            "gzip inner serializer should produce a smaller file than the plain JSON inner");
+        Assert.Equal(value, Deserialize<string>(compressing, envelope, DurableArnCtx("gz")));
+
+        try { Directory.Delete(_base + "-plain", true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void PlainLambdaSerializerPath_Throws()
+    {
+        var s = (ILambdaSerializer)new FileSystemSerializer(_json, _base);
+        using var ms = new MemoryStream();
+        Assert.Throws<NotSupportedException>(() => s.Serialize(new Poco { Id = 1 }, ms));
+        Assert.Throws<NotSupportedException>(() => s.Deserialize<Poco>(new MemoryStream(Encoding.UTF8.GetBytes("{}"))));
+    }
+
+    // ---- V7a / V4: crafted ARN must not escape the base path on the WRITE side ----
+
+    [Fact]
+    public void Serialize_CraftedArnWithTraversal_ThrowsOnWrite_DoesNotEscapeBase()
+    {
+        var s = new FileSystemSerializer(_json, _base, FileSystemStorageMode.Always, FileSystemPathEncoding.Uri);
+
+        // Matches the durable-execution ARN shape, but the captured function/execution
+        // segments are ".." — resolving the per-execution write directory would traverse
+        // above the configured base path. Uri encoding does NOT neutralize ".", so the
+        // write path must reject this (the read path already had ValidatePathWithinBase).
+        var evilArn = "arn:aws:lambda:us-east-1:123456789012:function:..:1/durable-execution/../inv-1";
+        var ctx = new DurableSerializationContext("op-1", evilArn);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Serialize(s, new Poco { Id = 1 }, ctx));
+        Assert.Contains("base path", ex.Message);
+
+        // Nothing was written outside (or inside) the base.
+        Assert.False(Directory.Exists(_base) && Directory.GetFiles(_base, "*.bin", SearchOption.AllDirectories).Length > 0);
+    }
+
+    // ---- V7b: ARN that doesn't match the pattern falls back to a single encoded segment ----
+
+    [Fact]
+    public void UriPathEncoding_NonMatchingArn_FallsBackToSingleEncodedDirectorySegment()
+    {
+        var s = new FileSystemSerializer(_json, _base, FileSystemStorageMode.Always, FileSystemPathEncoding.Uri);
+
+        // Not a durable-execution ARN; it even contains slashes. The whole value must be
+        // URL-encoded into ONE directory segment directly under the base (slashes escaped
+        // to %2F), never split into nested directories.
+        var arn = "not-a-durable-execution-arn/with/slashes";
+        var ctx = new DurableSerializationContext("entity-b", arn);
+
+        var envelope = Serialize(s, new Poco { Id = 5, Name = "n" }, ctx);
+
+        var expectedDir = Path.Combine(_base, Uri.EscapeDataString(arn));
+        Assert.True(Directory.Exists(expectedDir), $"expected single fallback dir {expectedDir}");
+        Assert.NotEmpty(Directory.GetFiles(expectedDir, "*.bin"));
+        // The base has exactly one immediate child directory (the encoded segment).
+        Assert.Single(Directory.GetDirectories(_base));
+        Assert.Equal(new Poco { Id = 5, Name = "n" }, Deserialize<Poco>(s, envelope, ctx));
+    }
+
+    // ---- V7d: overflow inline/file boundary is inclusive at OverflowThresholdBytes ----
+
+    /// <summary>Inner serializer that emits a fixed number of raw bytes, so a test can size the
+    /// overflow envelope to the byte and pin the inline/file boundary.</summary>
+    private sealed class FixedSizeSerializer : ILambdaSerializer
+    {
+        private readonly int _rawBytes;
+        public FixedSizeSerializer(int rawBytes) => _rawBytes = rawBytes;
+        public void Serialize<T>(T response, Stream responseStream) => responseStream.Write(new byte[_rawBytes], 0, _rawBytes);
+        public T Deserialize<T>(Stream requestStream) => default!;
+    }
+
+    [Fact]
+    public void Overflow_Boundary_LargestInlineStaysInline_NextSizeOverflows()
+    {
+        // OverflowThresholdBytes = 256*1024 - 1024 (private). Decision: envelopeBytes
+        // <= threshold => inline. Base64 quantizes the payload to multiples of 4 bytes,
+        // so the exact threshold byte isn't individually addressable; instead we pin the
+        // transition: the largest raw payload whose envelope is <= threshold stays inline,
+        // and one raw byte more (which pushes the envelope past threshold) overflows.
+        const int threshold = (256 * 1024) - 1024;
+
+        var inlineRaw = LargestRawInline(threshold);
+
+        var inlineEnvelope = SerializeWithFixedInner(inlineRaw);
+        Assert.Contains("\"data\"", inlineEnvelope);
+        Assert.DoesNotContain("\"file\"", inlineEnvelope);
+
+        var overflowEnvelope = SerializeWithFixedInner(inlineRaw + 1);
+        Assert.Contains("\"file\"", overflowEnvelope);
+        Assert.DoesNotContain("\"data\"", overflowEnvelope);
+
+        string SerializeWithFixedInner(int rawBytes)
+        {
+            var s = new FileSystemSerializer(new FixedSizeSerializer(rawBytes), _base, FileSystemStorageMode.Overflow);
+            return Serialize(s, 0, DurableArnCtx("boundary-" + rawBytes));
+        }
+    }
+
+    // Largest raw byte count whose inline envelope ({"data":"<base64>"}) is <= threshold.
+    private static int LargestRawInline(int threshold)
+    {
+        // Envelope overhead around the base64 body: {"data":"..."} = 9 + 2 = 11 bytes.
+        for (var n = threshold; n > 0; n--)
+        {
+            var base64Len = ((n + 2) / 3) * 4;
+            if (11 + base64Len <= threshold)
+                return n;
+        }
+        return 0;
+    }
+
+    // ---- V6: corrupted inline base64 surfaces a descriptive InvalidOperationException ----
+
+    [Fact]
+    public void Deserialize_CorruptedInlineBase64_ThrowsDescriptiveInvalidOperationException()
+    {
+        var s = new FileSystemSerializer(_json, _base, FileSystemStorageMode.Overflow);
+        // A bare FormatException from Convert.FromBase64String would be inconsistent with
+        // this method's sibling descriptive InvalidOperationException checks.
+        var envelope = "{\"data\":\"not valid base64 !!!\"}";
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Deserialize<Poco>(s, envelope, DurableArnCtx()));
+        Assert.Contains("base64", ex.Message);
+        Assert.IsType<FormatException>(ex.InnerException);
+    }
+
+    // ---- V5: a relative basePath is normalized to an absolute pointer in the ctor ----
+
+    [Fact]
+    public void Ctor_RelativeBasePath_ProducesAbsoluteFilePointer()
+    {
+        var relative = "fsser-rel-" + Guid.NewGuid().ToString("N");
+        var s = new FileSystemSerializer(_json, relative, FileSystemStorageMode.Always);
+        try
+        {
+            var envelope = Serialize(s, new Poco { Id = 1, Name = "n" }, DurableArnCtx());
+
+            using var doc = JsonDocument.Parse(envelope);
+            var file = doc.RootElement.GetProperty("file").GetString()!;
+            // Normalizing _basePath in the ctor makes the stored pointer absolute, so a later
+            // invocation with a different CWD resolves it to the same file.
+            Assert.True(Path.IsPathFullyQualified(file), $"pointer should be absolute but was '{file}'");
+        }
+        finally
+        {
+            try { Directory.Delete(Path.GetFullPath(relative), recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    // ---- Comment 4: read handle must not block a concurrent atomic replace ----
+
+    /// <summary>Inner serializer whose <c>Deserialize</c> signals that the read stream is
+    /// open, then blocks until released — lets a test hold the real read FileStream open
+    /// and attempt a concurrent atomic replace (File.Move overwrite) over it.</summary>
+    private sealed class BlockingReadSerializer : ILambdaSerializer
+    {
+        private readonly ILambdaSerializer _inner = new DefaultLambdaJsonSerializer();
+        public ManualResetEventSlim Reading { get; } = new(false);
+        public ManualResetEventSlim Proceed { get; } = new(false);
+
+        public void Serialize<T>(T response, Stream responseStream) => _inner.Serialize(response, responseStream);
+
+        public T Deserialize<T>(Stream requestStream)
+        {
+            Reading.Set();
+            if (!Proceed.Wait(TimeSpan.FromSeconds(10)))
+                throw new TimeoutException("Proceed signal was not received.");
+            return _inner.Deserialize<T>(requestStream);
+        }
+    }
+
+    [Fact]
+    public async Task Deserialize_ReadHandleOpen_DoesNotBlockConcurrentAtomicReplace()
+    {
+        // NOTE: this test only meaningfully exercises the FileShare.Delete regression on
+        // Windows/macOS. On POSIX/Linux (CI), rename-over-an-open-fd (File.Move overwrite)
+        // ALWAYS succeeds regardless of the reader's share flags — the reader keeps the old
+        // inode — so on Linux the Assert.Null(moveEx) below would pass even WITHOUT
+        // FileShare.Delete, making it tautological there. It is the Windows/macOS run
+        // (dev/test) that actually guards the fix, where a read handle opened without
+        // FileShare.Delete blocks the rename-over and throws IOException.
+        //
+        // The read path opens the offloaded file with FileShare.Read | FileShare.Delete so
+        // a concurrent re-serialize (File.Move overwrite, the write path's atomic replace)
+        // can proceed while a replay-read is in flight. On Linux the open fd references the
+        // original inode regardless; on Windows/macOS a read handle opened WITHOUT
+        // FileShare.Delete blocks the rename-over and throws IOException. This test holds
+        // the real read FileStream open and asserts the replace succeeds.
+        var blocking = new BlockingReadSerializer();
+        var s = new FileSystemSerializer(blocking, _base, FileSystemStorageMode.Always);
+
+        var envelope = Serialize(s, new Poco { Id = 1, Name = "orig" }, DurableArnCtx("op#0"));
+        using var doc = JsonDocument.Parse(envelope);
+        var filePath = doc.RootElement.GetProperty("file").GetString()!;
+
+        // Open our real read FileStream, then block inside the inner deserialize while the
+        // handle is still open.
+        var readTask = Task.Run(() => Deserialize<Poco>(s, envelope, DurableArnCtx("op#0")));
+        Assert.True(blocking.Reading.Wait(TimeSpan.FromSeconds(10)), "the read never opened the file handle");
+
+        // Replace the file the way the write path does: a sibling temp file moved over the
+        // target while the reader holds it open.
+        var tmp = filePath + ".tmp-" + Guid.NewGuid().ToString("N");
+        File.WriteAllBytes(tmp, Encoding.UTF8.GetBytes("{\"Id\":2,\"Name\":\"replaced\"}"));
+        var moveEx = Record.Exception(() => File.Move(tmp, filePath, overwrite: true));
+        Assert.Null(moveEx); // FileShare.Delete keeps the in-flight reader from blocking the replace
+
+        // Release the reader; via its already-open handle it still reads the ORIGINAL bytes.
+        blocking.Proceed.Set();
+        var read = await readTask;
+        Assert.Equal(new Poco { Id = 1, Name = "orig" }, read);
+    }
+
+    private sealed class GzipJsonSerializer : ILambdaSerializer
+    {
+        private readonly ILambdaSerializer _json;
+        public GzipJsonSerializer(ILambdaSerializer json) => _json = json;
+
+        public void Serialize<T>(T response, Stream responseStream)
+        {
+            using var gz = new GZipStream(responseStream, CompressionLevel.Optimal, leaveOpen: true);
+            _json.Serialize(response, gz);
+        }
+
+        public T Deserialize<T>(Stream requestStream)
+        {
+            using var gz = new GZipStream(requestStream, CompressionMode.Decompress, leaveOpen: true);
+            return _json.Deserialize<T>(gz);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements aws/aws-lambda-dotnet#2540 (FileSystem offload for .NET Durable Execution) as **Option A — a serializer**: `FileSystemSerializer`.

> **Stacked PR** — targets `feature/durable-serializer-engine` (#2559), which is stacked on the per-operation serializer (#2555). Review/merge **#2555 → #2559 → #2558**.

The context-aware serializer engine (`IDurableResultSerializer`, `DurableSerializationContext`, `LambdaSerializerHelper` dispatch) and the Map/Parallel determinism + terminal-failure fixes it required live in **#2559**. This PR only adds the leaf serializer that exercises that engine, plus a couple of doc-link fixups.

## What's in this PR

### `FileSystemSerializer`
Implements both `ILambdaSerializer` and `IDurableResultSerializer`. It **wraps an inner serializer** (so callers control the on-the-wire format — JSON, gzip, custom), writes the serialized bytes to a filesystem, and keeps only a small `{"file":…}` | `{"data":…}` envelope in the checkpoint. Supports `Always`/`Overflow` storage modes and `Uri`/`Hash` path encoding; the envelope is source-generated (Native-AOT-safe). The plain `ILambdaSerializer` path throws, since offload requires the durable context to build a path.

**Durability:** must be used with a durable shared mount (EFS or S3 Files), **not** Lambda `/tmp` — documented on the type; `/tmp` is per-execution-environment and won't survive replay on a different environment.

### Usage
You attach it through a durable operation's per-operation serializer slot (e.g. `StepConfig.Serializer`) — that's how it receives the `DurableSerializationContext` it needs to build a per-execution path. Construct it by wrapping the serializer that does the actual value↔bytes conversion and pointing it at a durable mount:

```csharp
private async Task<Report> Workflow(Order input, IDurableContext ctx)
{
    // Wrap the inner (on-the-wire) serializer; write result files under an EFS mount.
    var fileSerializer = new FileSystemSerializer(
        inner: ctx.Serializer,                  // any ILambdaSerializer: JSON, gzip wrapper, custom, …
        basePath: "/mnt/efs/durable",           // a durable shared mount — NOT /tmp
        storageMode: FileSystemStorageMode.Always);

    // This step's result is offloaded to the filesystem; the checkpoint keeps only {"file":"…"}.
    var report = await ctx.StepAsync(
        async (_, ct) => await BuildLargeReportAsync(input, ct),
        name: "report",
        config: new StepConfig { Serializer = fileSerializer });

    return report;
}
```

**Only offload when the payload is large** — use `Overflow` so small results stay inline in the checkpoint and only oversized ones (approaching the ~256 KB limit) spill to a file:

```csharp
config: new StepConfig
{
    Serializer = new FileSystemSerializer(ctx.Serializer, "/mnt/efs/durable",
        FileSystemStorageMode.Overflow)
};
```

**Compose with any inner format** — e.g. gzip-compress before offloading, or use opaque hashed path segments instead of human-readable ones:

```csharp
new FileSystemSerializer(
    inner: new GzipLambdaSerializer(ctx.Serializer),   // your ILambdaSerializer wrapper
    basePath: "/mnt/efs/durable",
    storageMode: FileSystemStorageMode.Always,
    pathEncoding: FileSystemPathEncoding.Hash);         // SHA-256 segments; default is Uri (readable)
```

The same slot exists on the other per-operation configs (`ChildContextConfig.Serializer`, `InvokeConfig.Serializer`, …) and as `ItemSerializer` on `MapConfig<TItem>` / `ParallelConfig` to offload each item/branch result:

```csharp
config: new MapConfig<Order> { ItemSerializer = fileSerializer };
```

> Because the serializer is part of the workflow's deterministic definition, use the same base path and inner format for the life of an execution — a replay must be able to read back what a prior invocation wrote. Files are never auto-deleted; pair the mount with a retention policy (EFS lifecycle / S3 lifecycle / scheduled cleanup keyed by the per-execution directory). Registering `FileSystemSerializer` as the plain assembly-level `ILambdaSerializer` throws — it only works through a per-operation slot.

### Doc-link restoration
Restores the two `<see cref="FileSystemSerializer"/>` doc links in `IDurableResultSerializer` and `ChildContextOperation` that #2559 had to render as `<c>FileSystemSerializer</c>` (the type doesn't exist until this branch introduces it).

## Testing
- Unit suite green on net8.0 and net10.0. New tests cover context dispatch and FileSystemSerializer round-trip / storage modes / path encodings / missing-file / per-item / gzip composition / plain-path-throws.
- **Validated on real AWS EFS**: a large step result was offloaded to an EFS-mounted Lambda and read back byte-for-byte, with the checkpoint holding only the `{"file":"/mnt/efs/…"}` pointer (`RoundTripOk=true`, file present on EFS).

## Follow-ups (noted, not in this PR)
- **Execution-wide default serializer** hook (mirror the JS SDK's `configureSerdes({ defaultSerdes })`) so FileSystem offload can be applied to a whole execution without setting `config.Serializer` per operation. Deliberately out of scope here — this PR is per-operation only.
- **Committed cloud integration test on EFS**: requires VPC + EFS + mount targets + a Lambda-service VPC endpoint that the current durable integration harness doesn't support; a `/tmp` durable test would be flaky by design (cross-environment replay). Tracked as a separate test-infra task.

## Changelog
AutoVer Minor change file included.

