### PR TITLE
feat(DurableExecution): context-aware serializer engine + Map/Parallel determinism

### DIFF
--- a/.autover/changes/3691fc04-ad66-49c5-a383-f9592a6da0ce.json
+++ b/.autover/changes/3691fc04-ad66-49c5-a383-f9592a6da0ce.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.DurableExecution",
+      "Type": "Major",
+      "ChangelogMessages": [
+        "Behavior change: when a step\u0027s fresh-success serializer round-trip fails (e.g. an asymmetric/broken StepConfig.Serializer that cannot deserialize its own output), the step now fails TERMINALLY (FAIL checkpoint \u002B StepException) instead of being routed through the configured RetryStrategy. Previously a non-null RetryStrategy would re-invoke the already-succeeded, side-effecting step body on each attempt (duplicating side effects) until attempts exhausted. This mirrors ChildContextOperation\u0027s terminal handling of a round-trip failure."
+      ]
+    }
+  ]
+}

--- a/.autover/changes/c1cb8e3a-cca9-415e-b9ca-08289658df08.json
+++ b/.autover/changes/c1cb8e3a-cca9-415e-b9ca-08289658df08.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.DurableExecution",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Behavior change: when a step post-round-trip SUCCEED-checkpoint enqueue fails (e.g. a broken CheckpointBatcher), the failure is now routed through the terminal path (FAIL checkpoint plus StepException) rather than propagating raw, consistent with the fresh-success round-trip failure handling. The side-effecting body is never re-invoked, and if emitting the terminal FAIL itself throws, the error propagates without recursion."
+      ]
+    }
+  ]
+}

--- a/.autover/changes/ca5a9844-031a-4442-899a-913d689449ec.json
+++ b/.autover/changes/ca5a9844-031a-4442-899a-913d689449ec.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.DurableExecution",
+      "Type": "Major",
+      "ChangelogMessages": [
+        "Behavior change: under NestingType.Flat, Map and Parallel per-item/branch results are now round-tripped through the configured ItemSerializer on a fresh (non-replay) success -- deserializing the just-serialized inline payload before it enters the result -- matching what replay reconstructs from that payload. A non-round-tripping ItemSerializer transform is now reflected in the item/branch result on the first execution, not only on replay, eliminating a fresh-vs-replay divergence. As with steps and child contexts, the returned value is a fresh deserialized instance, and overflow (replay-children) results are unaffected (recovered by re-running the body)."
+      ]
+    }
+  ]
+}

--- a/.autover/changes/d12219eb-e44b-4e90-8473-0ca63319ad53.json
+++ b/.autover/changes/d12219eb-e44b-4e90-8473-0ca63319ad53.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.DurableExecution",
+      "Type": "Major",
+      "ChangelogMessages": [
+        "Behavior change: a fresh-success serializer round-trip DESERIALIZE failure is now terminal on the child-context and Flat Map/Parallel paths, matching StepOperation. (Child) ChildContextOperation now emits a CONTEXT FAIL for a non-virtual, non-suppressed child whose round-trip deserialize throws, instead of throwing with no terminal checkpoint (which left the child STARTED and re-ran its side-effecting body on replay). (Flat Map/Parallel) a per-item round-trip deserialize failure now records that unit\u0027s terminal Error inline and still emits the parent SUCCEED, instead of propagating raw with no parent checkpoint (which re-ran every virtual unit body on replay, a poison loop, and bypassed the record-failure contract). Replay reconstructs the terminal failure without re-running or re-deserializing."
+      ]
+    }
+  ]
+}

--- a/.autover/changes/f3a1520c-8eca-4ac8-a7c6-27168feaff25.json
+++ b/.autover/changes/f3a1520c-8eca-4ac8-a7c6-27168feaff25.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.DurableExecution",
+      "Type": "Major",
+      "ChangelogMessages": [
+        "Behavior change (Map/Parallel, NestingType.Nested default): the parent now inlines each Nested unit\u0027s ORIGINAL child SUCCEED-checkpoint payload (S(body)) verbatim on the parent summary, and reconstructs it on replay with the child\u0027s own operation id, instead of re-serializing the already-round-tripped return value at the parent\u0027s per-unit id. This removes a fresh-vs-replay divergence with a non-round-tripping ItemSerializer (fresh vs replay values now match) and, for a context-aware serializer such as FileSystemSerializer, stops the parent writing a second file that orphaned the child\u0027s file. Round-tripping (symmetric) serializers and the default JSON serializer are unaffected; the Flat path is unchanged."
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/ChildContextConfig.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/ChildContextConfig.cs
@@ -62,5 +62,19 @@ public sealed class ChildContextConfig
     /// (default), the globally-registered <see cref="ILambdaSerializer"/> on
     /// <see cref="ILambdaContext.Serializer"/> is used.
     /// </summary>
+    /// <remarks>
+    /// <b>Size-dependent transform on overflow.</b> On a fresh (non-replay) success the
+    /// child context result is round-tripped through this serializer before it is
+    /// returned, so a serializer that transforms the value (e.g. redaction, canonicalization)
+    /// has that transform reflected in the returned result — but <em>only</em> while the
+    /// serialized payload fits inline in a single checkpoint (≈256&#160;KB). If the result
+    /// is large enough to overflow, the payload is not stored inline; the value is instead
+    /// recovered by re-running the child body on replay, which does <em>not</em> apply the
+    /// round-trip transform. A serializer whose <c>Deserialize</c> is not a pure inverse of
+    /// its <c>Serialize</c> will therefore observe a size-dependent difference in the returned
+    /// value (transform applied for small results, skipped for overflowed ones). Prefer a
+    /// round-tripping serializer, or do not depend on the transform being applied to results
+    /// large enough to overflow the checkpoint.
+    /// </remarks>
     public ILambdaSerializer? Serializer { get; set; }
 }

--- a/Libraries/src/Amazon.Lambda.DurableExecution/DurableSerializationContext.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/DurableSerializationContext.cs
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace Amazon.Lambda.DurableExecution;
+
+/// <summary>
+/// Identifying information passed to an <see cref="IDurableResultSerializer"/> when a
+/// durable operation's result is (de)serialized. It lets a context-aware serializer
+/// derive a stable, collision-free external location (for example a file path) for the
+/// value being stored.
+/// </summary>
+/// <remarks>
+/// The two values are stable for the lifetime of a durable execution — they do not
+/// change across the multiple Lambda invocations (replays) of that execution.
+/// </remarks>
+public readonly struct DurableSerializationContext
+{
+    /// <summary>
+    /// Stable identifier of the operation whose result is being (de)serialized (the
+    /// durable operation id; for Map/Parallel units, a per-unit id derived from it).
+    /// Unique within a single durable execution.
+    /// </summary>
+    public string EntityId { get; }
+
+    /// <summary>
+    /// ARN of the durable execution. Used to avoid collisions between the stored
+    /// results of different executions.
+    /// </summary>
+    public string DurableExecutionArn { get; }
+
+    /// <summary>Creates a new <see cref="DurableSerializationContext"/>.</summary>
+    /// <param name="entityId">The per-operation entity id.</param>
+    /// <param name="durableExecutionArn">The durable execution ARN.</param>
+    public DurableSerializationContext(string entityId, string durableExecutionArn)
+    {
+        EntityId = entityId;
+        DurableExecutionArn = durableExecutionArn;
+    }
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/IDurableResultSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/IDurableResultSerializer.cs
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.IO;
+
+namespace Amazon.Lambda.DurableExecution;
+
+/// <summary>
+/// Optional capability interface a per-operation serializer may implement to receive a
+/// <see cref="DurableSerializationContext"/> when a durable operation result is
+/// (de)serialized. When the serializer configured on an operation (for example
+/// <c>StepConfig.Serializer</c>) implements this interface, the durable runtime invokes
+/// these context-aware overloads; otherwise it falls back to the plain
+/// <see cref="Amazon.Lambda.Core.ILambdaSerializer"/> methods.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Amazon.Lambda.Core.ILambdaSerializer"/> conveys only the value and a stream —
+/// it has no way to tell the serializer which operation or execution a value belongs to.
+/// Serializers that offload results to external storage (for example
+/// <c>FileSystemSerializer</c>) need that identity to build a stable, unique
+/// location and to avoid different operations clobbering one another. Serializers that
+/// do not need it simply implement <see cref="Amazon.Lambda.Core.ILambdaSerializer"/> and
+/// are used unchanged.
+/// </para>
+/// <para>
+/// A type typically implements <b>both</b> <see cref="Amazon.Lambda.Core.ILambdaSerializer"/>
+/// and this interface. The durable runtime prefers this interface when present.
+/// </para>
+/// </remarks>
+public interface IDurableResultSerializer
+{
+    /// <summary>
+    /// Serializes <paramref name="value"/> to <paramref name="stream"/>, using
+    /// <paramref name="context"/> to identify the operation/execution.
+    /// </summary>
+    void Serialize<T>(T value, Stream stream, DurableSerializationContext context);
+
+    /// <summary>
+    /// Deserializes a value of type <typeparamref name="T"/> from <paramref name="stream"/>,
+    /// using <paramref name="context"/> to identify the operation/execution.
+    /// </summary>
+    T Deserialize<T>(Stream stream, DurableSerializationContext context);
+}

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/ChildContextOperation.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/ChildContextOperation.cs
@@ -53,6 +53,20 @@ internal sealed class ChildContextOperation<T> : DurableOperation<T>
     // Set once on overflow-replay re-execution; never reset.
     private bool _suppressTerminalCheckpoint;
 
+    /// <summary>
+    /// The exact SUCCEED-checkpoint payload this (non-virtual) child wrote on a fresh,
+    /// non-overflow success — i.e. <c>S(body)</c>, serialized with the child's own
+    /// <c>OperationId</c> as the entity id. A Nested Map/Parallel
+    /// parent captures this so it can inline the child's ORIGINAL checkpoint payload
+    /// verbatim, rather than re-serializing the (already round-tripped) return value.
+    /// Re-serializing the return value double-transforms a non-round-tripping serializer
+    /// (fresh vs replay diverge) and, for a context-aware serializer such as
+    /// <c>FileSystemSerializer</c>, writes a SECOND file at the parent's per-unit id
+    /// that orphans the child's file. <c>null</c> for virtual (Flat) children, for
+    /// overflow-replay re-execution, and before a fresh success has been serialized.
+    /// </summary>
+    internal string? SerializedResultPayload { get; private set; }
+
     public ChildContextOperation(
         string operationId,
         string? name,
@@ -235,10 +249,72 @@ internal sealed class ChildContextOperation<T> : DurableOperation<T>
         if (!_isVirtual && !_suppressTerminalCheckpoint)
         {
             var serialized = SerializeResult(result);
+
+            // Capture the child's own SUCCEED-checkpoint payload so a Nested Map/Parallel
+            // parent can inline it verbatim (serialized here with THIS child's OperationId
+            // as the entity id). Captured before the overflow decision so the parent sees
+            // the same S(body) it would otherwise re-derive: on overflow the parent inlines
+            // this (large) payload, overflows in turn, and recovers via ReplayChildren.
+            SerializedResultPayload = serialized;
+
             // Overflow: result too large to checkpoint inline. Emit an empty
             // payload + ReplayChildren so replay re-executes this body to recover
             // the value (mirrors the concurrent-operation overflow strategy).
             var overflow = Encoding.UTF8.GetByteCount(serialized) > DurableConstants.MaxOperationCheckpointBytes;
+
+            // Non-overflow: round-trip the just-written checkpoint payload so the
+            // value the workflow observes on this fresh execution matches replay
+            // (where the result is always deserialized from the checkpoint). This
+            // makes a custom (possibly non-round-tripping) ChildContextConfig.Serializer's
+            // transform visible in the child-context result on the first run.
+            // Behavior change: the returned object is no longer the same instance
+            // the child body produced. See the AutoVer change note. Overflow skips
+            // this (the payload was stripped; the value is recovered by replay).
+            //
+            // Deserialize BEFORE emitting the SUCCEED: a serializer whose deserialize
+            // fails is then surfaced as a normal child failure (wrapped in
+            // ChildContextException, with no SUCCEED recorded) instead of throwing
+            // against an already-SUCCEEDED operation — which would diverge from
+            // replay and, for a Map/Parallel Nested unit, record the unit Failed
+            // against its own SUCCEEDED checkpoint.
+            T roundTripped = result;
+            if (!overflow)
+            {
+                try
+                {
+                    roundTripped = DeserializeResult(serialized);
+                }
+                catch (Exception ex)
+                {
+                    // The body SUCCEEDED (side effects ran) but its result could not be
+                    // deserialized back. This is TERMINAL — emit a CONTEXT FAIL so the op
+                    // is terminal in the store and its side-effecting body is NOT re-run on
+                    // replay. Previously this threw with NO terminal checkpoint, leaving a
+                    // top-level child STARTED (its body re-runs on replay) and a Nested unit
+                    // recorded Failed against its own — now correctly absent — SUCCEED. This
+                    // mirrors the body-failure catch above and StepOperation.FailStepTerminallyAsync.
+                    // We are inside the non-virtual, non-suppressed block, so FAIL is the correct
+                    // terminal record. If this FAIL enqueue itself throws, it propagates straight
+                    // out (no retry loop, no recursion) — a broken batcher surfaces its own error.
+                    await EnqueueAsync(new SdkOperationUpdate
+                    {
+                        Id = OperationId,
+                        ParentId = ParentId,
+                        Type = OperationTypes.Context,
+                        Action = OperationAction.FAIL,
+                        SubType = _config?.SubType,
+                        Name = Name,
+                        Error = ToSdkError(ex)
+                    }, cancellationToken);
+
+                    throw MapFailureException(new ChildContextException(ex.Message, ex)
+                    {
+                        SubType = _config?.SubType,
+                        ErrorType = ex.GetType().FullName,
+                        OriginalStackTrace = ex.StackTrace?.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).ToList()
+                    });
+                }
+            }
 
             await EnqueueAsync(new SdkOperationUpdate
             {
@@ -254,17 +330,9 @@ internal sealed class ChildContextOperation<T> : DurableOperation<T>
                     : null
             }, cancellationToken);
 
-            // Non-overflow: round-trip the just-written checkpoint so the value the
-            // workflow observes on this fresh execution matches replay (where the
-            // result is always deserialized from the checkpoint). This makes a
-            // custom (possibly non-round-tripping) ChildContextConfig.Serializer's
-            // transform visible in the child-context result on the first run.
-            // Behavior change: the returned object is no longer the same instance
-            // the child body produced. See the AutoVer change note. Overflow skips
-            // this (the payload was stripped; the value is recovered by replay).
             if (!overflow)
             {
-                return DeserializeResult(serialized);
+                return roundTripped;
             }
         }
 
@@ -297,13 +365,15 @@ internal sealed class ChildContextOperation<T> : DurableOperation<T>
         if (serialized == null) return default!;
         var bytes = Encoding.UTF8.GetBytes(serialized);
         using var ms = new MemoryStream(bytes);
-        return _serializer.Deserialize<T>(ms);
+        return LambdaSerializerHelper.Deserialize<T>(
+            _serializer, ms, new DurableSerializationContext(OperationId, DurableExecutionArn));
     }
 
     private string SerializeResult(T value)
     {
         using var ms = new MemoryStream();
-        _serializer.Serialize(value, ms);
+        LambdaSerializerHelper.Serialize(
+            _serializer, value, ms, new DurableSerializationContext(OperationId, DurableExecutionArn));
         return Encoding.UTF8.GetString(ms.ToArray());
     }
 

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/ConcurrentOperation.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/ConcurrentOperation.cs
@@ -369,12 +369,30 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
         var completionReason = ComputeCompletionReason(items, unitCount);
         var result = new BatchResult<T>(items, completionReason);
 
-        await CheckpointParentResultAsync(result, completionReason, cancellationToken);
+        // For Nested (non-virtual) units, capture each succeeded child's OWN serialized
+        // checkpoint payload (S(body)) so the parent inlines it verbatim rather than
+        // re-serializing the round-tripped return value. Indexed by unit index. Empty/absent
+        // for Flat, which the parent serializes inline itself.
+        Dictionary<int, string?>? nestedInlinePayloads = null;
+        if (!_isVirtual)
+        {
+            nestedInlinePayloads = new Dictionary<int, string?>(unitCount);
+            for (var i = 0; i < unitCount; i++)
+            {
+                if (dispatched[i] && slots[i].Status == BatchItemStatus.Succeeded)
+                    nestedInlinePayloads[i] = slots[i].SerializedPayload;
+            }
+        }
+
+        // Returns the result to OBSERVE. For Flat (virtual) units on a non-overflow
+        // fresh success it is round-tripped through the item serializer so the value
+        // matches replay; otherwise it is the same result instance.
+        var observed = await CheckpointParentResultAsync(result, completionReason, nestedInlinePayloads, cancellationToken);
 
         // Never throw on failure — always return the aggregate result. The caller
         // inspects CompletionReason / HasFailure or calls ThrowIfError. Matches
         // the JS/Python/Java SDKs.
-        return result;
+        return observed;
     }
 
     /// <summary>
@@ -500,7 +518,16 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
             try
             {
                 var result = await childOp.ExecuteAsync(cancellationToken).ConfigureAwait(false);
-                slots[index] = new UnitOutcome { Status = BatchItemStatus.Succeeded, Result = result };
+                slots[index] = new UnitOutcome
+                {
+                    Status = BatchItemStatus.Succeeded,
+                    Result = result,
+                    // Nested (non-virtual) children write their own SUCCEED checkpoint and
+                    // expose its exact payload here; capture it so the parent inlines the
+                    // child's ORIGINAL S(body) rather than re-serializing the round-tripped
+                    // return value. Null for Flat children and for child-level overflow.
+                    SerializedPayload = childOp.SerializedResultPayload
+                };
             }
             catch (ChildContextException ex)
             {
@@ -684,21 +711,27 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
         return _policy.Evaluate(succeeded, failed, started, totalCount);
     }
 
-    private async Task CheckpointParentResultAsync(
+    private async Task<BatchResult<T>> CheckpointParentResultAsync(
         BatchResult<T> result,
         CompletionReason completionReason,
+        IReadOnlyDictionary<int, string?>? nestedInlinePayloads,
         CancellationToken cancellationToken)
     {
-        // Local builder: includeInline=true writes per-unit Result/Error inline
-        // (Flat only); includeInline=false writes the minimal index/name/status
-        // map (the shape Nested always uses, and the Flat overflow fallback).
-        // The persisted summary keeps EVERY declared unit — including
-        // never-dispatched ones tagged STARTED — even though result.All now omits
-        // them from the user-facing view. Replay/reconstruct and the unit-name
-        // drift check both loop the declared UnitCount and read per-unit
-        // status/name from this summary, so it must stay complete. Dispatched
-        // units are looked up by Index in result.All; the gaps are the
-        // never-dispatched branches.
+        // The completion reason to persist, and any Flat units whose fresh-success
+        // round-trip deserialize failed. Both may be updated after the round-trip below;
+        // BuildSummary closes over them so a rebuild reflects the terminal failures.
+        var reasonToPersist = completionReason;
+        Dictionary<int, DurableExecutionException>? flatRoundTripFailures = null;
+
+        // Local builder: includeInline=true writes per-unit Result/Error inline; false writes
+        // the minimal index/name/status map (the Flat overflow fallback). Serialization always
+        // reads from `result` (the ORIGINAL per-unit values) so a Nested unit inlines the
+        // child's captured S(body) and a Flat unit inlines S(raw) — never the round-tripped
+        // value, which would double-transform an asymmetric serializer. The persisted summary
+        // keeps EVERY declared unit — including never-dispatched ones tagged STARTED — even
+        // though result.All now omits them from the user-facing view. Replay/reconstruct and
+        // the unit-name drift check both loop the declared UnitCount and read per-unit
+        // status/name from this summary, so it must stay complete.
         BatchSummary BuildSummary(bool includeInline)
         {
             var byIndex = new Dictionary<int, IBatchItem<T>>(result.All.Count);
@@ -707,33 +740,66 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
 
             var s = new BatchSummary
             {
-                CompletionReason = SerializeCompletionReason(completionReason),
+                CompletionReason = SerializeCompletionReason(reasonToPersist),
                 Units = new List<BatchUnitSummary>(UnitCount)
             };
             for (var i = 0; i < UnitCount; i++)
             {
                 var (unitName, _) = GetUnit(i);
                 byIndex.TryGetValue(i, out var item);
+
+                // A Flat unit whose fresh-success round-trip deserialize failed is recorded
+                // Failed (terminal) even though its body succeeded, so replay reads the Error
+                // and never re-deserializes the poison payload (which would fail identically).
+                DurableExecutionException? forcedError = null;
+                if (flatRoundTripFailures != null)
+                    flatRoundTripFailures.TryGetValue(i, out forcedError);
+
+                var status = forcedError != null
+                    ? BatchItemStatus.Failed
+                    : (item?.Status ?? BatchItemStatus.Started);
+
                 var unit = new BatchUnitSummary
                 {
                     Index = i,
                     Name = item?.Name ?? unitName,
-                    Status = SerializeStatus(item?.Status ?? BatchItemStatus.Started)
+                    Status = SerializeStatus(status)
                 };
-                // Persist each unit's result/error inline on the parent summary —
-                // for BOTH Nested and Flat units. The service collapses completed
-                // per-unit child contexts out of the state returned on a later
-                // (post-operation) resume, so replay cannot recover a Nested unit's
-                // value from its child checkpoint; the inline copy is the only
-                // durable source. This mirrors the JS SDK, whose default
-                // BatchResult serdes serializes the whole `all` array (results
-                // included) into the parent payload.
-                if (includeInline && item != null)
+
+                // Persist each unit's result/error inline on the parent summary — for BOTH
+                // Nested and Flat units. The service collapses completed per-unit child
+                // contexts out of the state returned on a later (post-operation) resume, so
+                // replay cannot recover a Nested unit's value from its child checkpoint; the
+                // inline copy is the only durable source. This mirrors the JS SDK, whose
+                // default BatchResult serdes serializes the whole `all` array into the parent
+                // payload.
+                if (includeInline)
                 {
-                    if (item.Status == BatchItemStatus.Succeeded)
-                        unit.Result = SerializeResult(item.Result);
-                    else if (item.Status == BatchItemStatus.Failed && item.Error != null)
+                    if (forcedError != null)
+                    {
+                        unit.Error = ErrorObject.FromException(forcedError);
+                    }
+                    else if (item != null && item.Status == BatchItemStatus.Succeeded)
+                    {
+                        // Nested: inline the child's ORIGINAL SUCCEED payload (serialized by
+                        // the child at its own OperationId), captured on this fresh run.
+                        // Flat: the virtual child emitted no checkpoint, so the parent is the
+                        // sole writer — serialize the raw item result at "{OperationId}#{i}".
+                        if (_isVirtual)
+                        {
+                            unit.Result = SerializeResult(item.Result, i);
+                        }
+                        else
+                        {
+                            unit.Result = nestedInlinePayloads != null && nestedInlinePayloads.TryGetValue(i, out var p)
+                                ? p
+                                : null;
+                        }
+                    }
+                    else if (item != null && item.Status == BatchItemStatus.Failed && item.Error != null)
+                    {
                         unit.Error = ErrorObject.FromException(item.Error);
+                    }
                 }
                 s.Units.Add(unit);
             }
@@ -749,6 +815,50 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
         // Applies to both Nested and Flat now that both inline their results.
         var overflow =
             Encoding.UTF8.GetByteCount(payload) > DurableConstants.MaxOperationCheckpointBytes;
+
+        // Result to OBSERVE. Starts as the raw aggregate; the Flat path below replaces it
+        // with the round-tripped values (and any terminal round-trip failures applied).
+        var observed = result;
+
+        // Fresh-success round-trip for Flat (virtual) units. A Flat unit's body result is
+        // returned RAW from ChildContextOperation (a virtual child suppresses its own SUCCEED
+        // and the round-trip a Nested child performs), whereas ReconstructFromCheckpoints
+        // rebuilds each value by DESERIALIZING the inline payload. Mirror Step/Child:
+        // deserialize the just-serialized per-unit payload and observe THAT value, so a
+        // non-round-tripping ItemSerializer yields identical values on a fresh run and on
+        // replay. Runs BEFORE the parent SUCCEED is emitted so a deserialize failure is
+        // handled terminally (below) instead of after a terminal checkpoint exists.
+        //
+        // Nested units already round-tripped inside ChildContextOperation and are never
+        // re-processed here (guarded by _isVirtual). On overflow the inline results are
+        // stripped and ReplayChildrenAsync recovers each value by re-running the unit body
+        // (also raw), so leaving the fresh values raw keeps fresh==replay in that case too.
+        if (_isVirtual && !overflow)
+        {
+            observed = RoundTripFlatResults(result, summary, reasonToPersist, out var failures);
+
+            if (failures.Count > 0)
+            {
+                // A unit's inline result could not be deserialized on this fresh run. This is
+                // TERMINAL for that unit (mirrors Step/Child): rather than let it propagate raw
+                // — which would leave the parent with NO terminal checkpoint and re-run every
+                // virtual unit body on replay (a deterministic poison loop) — record each such
+                // unit Failed, recompute the completion reason, and STILL emit the parent
+                // SUCCEED. Replay then reconstructs the same Failed unit from the rebuilt inline
+                // summary (Error, not Result) without re-deserializing or re-running it.
+                flatRoundTripFailures = failures;
+                reasonToPersist = ComputeCompletionReason(observed.All, UnitCount);
+                observed = new BatchResult<T>(observed.All, reasonToPersist);
+
+                // Rebuild from the ORIGINAL result (raw survivors) with the failed units forced
+                // to Error, so surviving Succeeded units still inline S(raw) — deserialized to
+                // the round-tripped value on replay, matching `observed`.
+                summary = BuildSummary(includeInline: true);
+                payload = JsonSerializer.Serialize(summary, BatchJsonContext.Default.BatchSummary);
+                overflow = Encoding.UTF8.GetByteCount(payload) > DurableConstants.MaxOperationCheckpointBytes;
+            }
+        }
+
         if (overflow)
         {
             summary = BuildSummary(includeInline: false);
@@ -772,6 +882,91 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
                 ? new SdkContextOptions { ReplayChildren = true }
                 : null
         }, cancellationToken);
+
+        return observed;
+    }
+
+    /// <summary>
+    /// Rebuilds <paramref name="result"/> with each SUCCEEDED unit's value replaced by the
+    /// round-trip of its just-serialized inline payload, so the observed per-unit value on a
+    /// Flat (virtual) fresh success matches what <see cref="ReconstructFromCheckpoints"/>
+    /// rebuilds from the same inline payload on replay. Only used on the Flat, non-overflow
+    /// path — mirrors the fresh-success round-trip in <see cref="StepOperation{T}"/> and
+    /// <see cref="ChildContextOperation{T}"/>. Failed / never-dispatched units are left
+    /// untouched.
+    /// <para>
+    /// A per-unit deserialize failure is TERMINAL for that unit: it is added to
+    /// <paramref name="failures"/> and materialized as a Failed <see cref="BatchItem{T}"/>,
+    /// so the caller can record it inline and still emit the parent SUCCEED (avoiding a raw
+    /// propagation that would leave no terminal checkpoint and re-run every unit on replay).
+    /// </para>
+    /// </summary>
+    private BatchResult<T> RoundTripFlatResults(
+        BatchResult<T> result,
+        BatchSummary inlineSummary,
+        CompletionReason completionReason,
+        out Dictionary<int, DurableExecutionException> failures)
+    {
+        failures = new Dictionary<int, DurableExecutionException>();
+
+        var serializedByIndex = new Dictionary<int, string?>(inlineSummary.Units.Count);
+        foreach (var u in inlineSummary.Units)
+            serializedByIndex[u.Index] = u.Result;
+
+        var items = new List<IBatchItem<T>>(result.All.Count);
+        foreach (var item in result.All)
+        {
+            if (item.Status == BatchItemStatus.Succeeded
+                && serializedByIndex.TryGetValue(item.Index, out var serialized)
+                && serialized != null)
+            {
+                T value;
+                try
+                {
+                    // Symmetric with SerializeResult(item.Result, i) and with
+                    // ReconstructFromCheckpoints' DeserializeResult(..., "{OperationId}#{i}").
+                    value = DeserializeResult(serialized, $"{OperationId}#{item.Index}");
+                }
+                catch (Exception ex)
+                {
+                    // Terminal for this unit — record it Failed. The caller rebuilds the inline
+                    // summary with this Error (not a Result) and still emits the parent SUCCEED,
+                    // so replay reads a terminal Error instead of re-deserializing the same
+                    // poison payload or re-running the body.
+                    var wrapped = new ChildContextException(ex.Message, ex)
+                    {
+                        SubType = ChildSubType,
+                        ErrorType = ex.GetType().FullName,
+                        OriginalStackTrace = ex.StackTrace?.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).ToList()
+                    };
+                    failures[item.Index] = wrapped;
+                    items.Add(new BatchItem<T>
+                    {
+                        Index = item.Index,
+                        Name = item.Name,
+                        Status = BatchItemStatus.Failed,
+                        Result = default,
+                        Error = wrapped
+                    });
+                    continue;
+                }
+
+                items.Add(new BatchItem<T>
+                {
+                    Index = item.Index,
+                    Name = item.Name,
+                    Status = item.Status,
+                    Result = value,
+                    Error = item.Error
+                });
+            }
+            else
+            {
+                items.Add(item);
+            }
+        }
+
+        return new BatchResult<T>(items, completionReason);
     }
 
     private IBatchResult<T> ReconstructFromCheckpoints(Operation parent)
@@ -826,7 +1021,15 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
             // whose child op is still present in state).
             if (status == BatchItemStatus.Succeeded && summaryEntry?.Result != null)
             {
-                unitResult = DeserializeResult(summaryEntry.Result);
+                // The inline payload's entity id depends on who wrote it: a Flat unit was
+                // serialized by THIS parent at "{OperationId}#{i}", whereas a Nested unit's
+                // inline payload IS the child's own checkpoint payload, serialized by the
+                // child at childOpId. Deserialize each with the entity id it was written with
+                // so a context-aware serializer (e.g. FileSystemSerializer) resolves the same
+                // external location — and, for Nested, the SAME file the child wrote (no
+                // orphan, no second file).
+                var inlineEntityId = _isVirtual ? $"{OperationId}#{i}" : childOpId;
+                unitResult = DeserializeResult(summaryEntry.Result, inlineEntityId);
             }
             else if (status == BatchItemStatus.Failed && summaryEntry?.Error != null)
             {
@@ -841,7 +1044,10 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
             }
             else if (status == BatchItemStatus.Succeeded && childOp?.ContextDetails?.Result != null)
             {
-                unitResult = DeserializeResult(childOp.ContextDetails.Result);
+                // This payload is the child's OWN context checkpoint, written by
+                // ChildContextOperation using the child op's id as EntityId — so
+                // deserialize with childOpId, not the parent's per-unit id.
+                unitResult = DeserializeResult(childOp.ContextDetails.Result, childOpId);
             }
             else if (status == BatchItemStatus.Failed && childOp?.ContextDetails?.Error != null)
             {
@@ -930,11 +1136,12 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
         _                            => CompletionReason.AllCompleted
     };
 
-    private T DeserializeResult(string serialized)
+    private T DeserializeResult(string serialized, string entityId)
     {
         var bytes = Encoding.UTF8.GetBytes(serialized);
         using var ms = new MemoryStream(bytes);
-        return Serializer.Deserialize<T>(ms);
+        return LambdaSerializerHelper.Deserialize<T>(
+            Serializer, ms, new DurableSerializationContext(entityId, DurableExecutionArn));
     }
 
     /// <summary>
@@ -943,10 +1150,12 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
     /// serialization a Nested unit's <see cref="ChildContextOperation{T}"/> would
     /// have written to its own checkpoint.
     /// </summary>
-    private string SerializeResult(T? value)
+    private string SerializeResult(T? value, int index)
     {
         using var ms = new MemoryStream();
-        Serializer.Serialize(value!, ms);
+        LambdaSerializerHelper.Serialize(
+            Serializer, value!, ms,
+            new DurableSerializationContext($"{OperationId}#{index}", DurableExecutionArn));
         return Encoding.UTF8.GetString(ms.ToArray());
     }
 
@@ -960,5 +1169,14 @@ internal abstract class ConcurrentOperation<T> : DurableOperation<IBatchResult<T
         public BatchItemStatus Status;
         public T? Result;
         public DurableExecutionException? Error;
+
+        /// <summary>
+        /// For a Nested (non-virtual) succeeded unit: the child's OWN serialized
+        /// SUCCEED-checkpoint payload (<c>S(body)</c>), captured from
+        /// <see cref="ChildContextOperation{T}.SerializedResultPayload"/> so the parent can
+        /// inline it verbatim instead of re-serializing the round-tripped return value.
+        /// <c>null</c> for Flat units, failures, and overflow.
+        /// </summary>
+        public string? SerializedPayload;
     }
 }

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/LambdaSerializerHelper.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/LambdaSerializerHelper.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.IO;
 using Amazon.Lambda.Core;
 
 namespace Amazon.Lambda.DurableExecution.Internal;
@@ -16,4 +17,32 @@ internal static class LambdaSerializerHelper
 
     public static ILambdaSerializer GetRequired(ILambdaContext lambdaContext) =>
         lambdaContext.Serializer ?? throw new InvalidOperationException(MissingSerializerMessage);
+
+    /// <summary>
+    /// Serializes a durable operation result. If <paramref name="serializer"/> implements
+    /// <see cref="IDurableResultSerializer"/>, the context-aware overload is used so the
+    /// serializer can key external storage by operation/execution; otherwise the plain
+    /// <see cref="ILambdaSerializer"/> path is used (behavior identical to before).
+    /// </summary>
+    public static void Serialize<T>(
+        ILambdaSerializer serializer, T value, Stream stream, in DurableSerializationContext context)
+    {
+        if (serializer is IDurableResultSerializer durable)
+            durable.Serialize(value, stream, context);
+        else
+            serializer.Serialize(value, stream);
+    }
+
+    /// <summary>
+    /// Deserializes a durable operation result. Mirrors <see cref="Serialize{T}"/>:
+    /// uses the <see cref="IDurableResultSerializer"/> overload when available, else the
+    /// plain <see cref="ILambdaSerializer"/> path.
+    /// </summary>
+    public static T Deserialize<T>(
+        ILambdaSerializer serializer, Stream stream, in DurableSerializationContext context)
+    {
+        if (serializer is IDurableResultSerializer durable)
+            return durable.Deserialize<T>(stream, context);
+        return serializer.Deserialize<T>(stream);
+    }
 }

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/StepOperation.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/StepOperation.cs
@@ -215,6 +215,7 @@ internal sealed class StepOperation<T> : DurableOperation<T>
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(
             cancellationToken, _workflowCancellation.Token);
 
+        T result;
         try
         {
             var stepContext = new StepContext(OperationId, attemptNumber, _logger);
@@ -223,7 +224,6 @@ internal sealed class StepOperation<T> : DurableOperation<T>
             // lines with the operation id, name, and current attempt. Wrap
             // only the user-func call — checkpoint emission shouldn't carry
             // step metadata into any side-channel logging.
-            T result;
             using (_logger.BeginScope(new Dictionary<string, object>
             {
                 ["operationId"] = OperationId,
@@ -233,27 +233,6 @@ internal sealed class StepOperation<T> : DurableOperation<T>
             {
                 result = await _func(stepContext, linked.Token);
             }
-
-            var serialized = SerializeResult(result);
-            await EnqueueAsync(new SdkOperationUpdate
-            {
-                Id = OperationId,
-                ParentId = ParentId,
-                Type = OperationTypes.Step,
-                Action = OperationAction.SUCCEED,
-                SubType = OperationSubTypes.Step,
-                Name = Name,
-                Payload = serialized
-            }, cancellationToken);
-
-            // Round-trip the just-written checkpoint so the value the workflow
-            // observes on this fresh execution is the deserialized-from-checkpoint
-            // value, exactly as it would be on replay. This makes a custom
-            // (possibly non-round-tripping) StepConfig.Serializer's transform
-            // visible in the step result on the first run, not just on replay.
-            // Behavior change: the returned object is no longer the same instance
-            // the step body produced. See the AutoVer change note.
-            return DeserializeResult(serialized);
         }
         catch (OperationCanceledException) when (linked.IsCancellationRequested)
         {
@@ -266,12 +245,87 @@ internal sealed class StepOperation<T> : DurableOperation<T>
         }
         catch (Exception ex)
         {
-            // Funnel into the retry/fail decision tree. May checkpoint RETRY and
-            // suspend (Pending), or checkpoint FAIL and rethrow to user. A user-
-            // thrown OperationCanceledException unrelated to our linked token
-            // falls through here and is treated as a normal step failure.
+            // The user step body itself threw. Funnel into the retry/fail decision
+            // tree: may checkpoint RETRY and suspend (Pending), or checkpoint FAIL
+            // and rethrow to user. A user-thrown OperationCanceledException unrelated
+            // to our linked token falls through here and is treated as a normal
+            // step failure. Retry is safe here precisely because the body has NOT
+            // recorded a success — re-running it is the intended behavior.
             return await HandleStepFailureAsync(ex, attemptNumber, cancellationToken);
         }
+
+        // The user step body succeeded. Serialize the result and round-trip it
+        // through the (possibly custom) serializer so the value the workflow
+        // observes on this fresh execution is the deserialized-from-checkpoint
+        // value, exactly as it would be on replay. This makes a custom (possibly
+        // non-round-tripping) StepConfig.Serializer's transform visible in the step
+        // result on the first run, not just on replay. Behavior change: the returned
+        // object is no longer the same instance the step body produced. See the
+        // AutoVer change note.
+        //
+        // CRITICAL: a failure from here on is TERMINAL and must NOT enter the retry
+        // decision. The side-effecting body has already run to completion; routing a
+        // serialize/round-trip failure through HandleStepFailureAsync (with a non-null
+        // RetryStrategy) would re-invoke the already-succeeded body on the next
+        // attempt — duplicating side effects and looping until attempts exhaust. We
+        // mirror ChildContextOperation, which catches its round-trip deserialize
+        // distinctly and fails terminally (no retry). Deserialize BEFORE emitting the
+        // SUCCEED so a broken serializer surfaces as a terminal failure with no
+        // terminal checkpoint recorded, rather than throwing against an already-
+        // SUCCEEDED operation (which would emit a second terminal checkpoint and
+        // diverge from replay, which returns the cached success).
+        string serialized;
+        T roundTripped;
+        try
+        {
+            serialized = SerializeResult(result);
+            roundTripped = DeserializeResult(serialized);
+        }
+        catch (Exception ex)
+        {
+            return await FailStepTerminallyAsync(ex, cancellationToken);
+        }
+
+        // The post-round-trip SUCCEED enqueue. This sits AFTER the retryable
+        // try/catch, so a failure here must NOT re-enter the retry strategy — the
+        // side-effecting body has already run to completion. Route a non-OCE
+        // failure through the SAME terminal path as the round-trip failure just
+        // above (FailStepTerminallyAsync: FAIL checkpoint + StepException) so a
+        // post-success enqueue failure is handled consistently rather than
+        // propagating raw with no terminal record.
+        //
+        // Recursion guard: FailStepTerminallyAsync emits the terminal FAIL via this
+        // same EnqueueAsync. If the batcher is broken and that FAIL emit ALSO throws,
+        // its exception propagates straight out of FailStepTerminallyAsync — it never
+        // re-enters this SUCCEED path — so a broken batcher surfaces its error
+        // instead of looping.
+        try
+        {
+            await EnqueueAsync(new SdkOperationUpdate
+            {
+                Id = OperationId,
+                ParentId = ParentId,
+                Type = OperationTypes.Step,
+                Action = OperationAction.SUCCEED,
+                SubType = OperationSubTypes.Step,
+                Name = Name,
+                Payload = serialized
+            }, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Caller-cancel during the SUCCEED flush owns the outcome — propagate
+            // untouched; do NOT synthesize a terminal FAIL. This enqueue observes only
+            // the caller token (not the linked workflow-shutdown token), so a
+            // workflow-shutdown OCE cannot originate here.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return await FailStepTerminallyAsync(ex, cancellationToken);
+        }
+
+        return roundTripped;
     }
 
     /// <summary>
@@ -313,6 +367,20 @@ internal sealed class StepOperation<T> : DurableOperation<T>
             }
         }
 
+        return await FailStepTerminallyAsync(ex, cancellationToken);
+    }
+
+    /// <summary>
+    /// Fails the step terminally: emits a FAIL checkpoint and throws
+    /// <see cref="StepException"/> WITHOUT consulting the retry strategy. Used both
+    /// as the terminal tail of <see cref="HandleStepFailureAsync"/> (retries
+    /// exhausted / no strategy) and directly for a post-success failure (an
+    /// asymmetric serializer whose serialize/round-trip throws). Retry must not be
+    /// consulted for the latter: the side-effecting step body has already run, so
+    /// re-invoking it would duplicate side effects.
+    /// </summary>
+    private async Task<T> FailStepTerminallyAsync(Exception ex, CancellationToken cancellationToken)
+    {
         await EnqueueAsync(new SdkOperationUpdate
         {
             Id = OperationId,
@@ -335,13 +403,15 @@ internal sealed class StepOperation<T> : DurableOperation<T>
         if (serialized == null) return default!;
         var bytes = Encoding.UTF8.GetBytes(serialized);
         using var ms = new MemoryStream(bytes);
-        return _serializer.Deserialize<T>(ms);
+        return LambdaSerializerHelper.Deserialize<T>(
+            _serializer, ms, new DurableSerializationContext(OperationId, DurableExecutionArn));
     }
 
     private string SerializeResult(T value)
     {
         using var ms = new MemoryStream();
-        _serializer.Serialize(value, ms);
+        LambdaSerializerHelper.Serialize(
+            _serializer, value, ms, new DurableSerializationContext(OperationId, DurableExecutionArn));
         return Encoding.UTF8.GetString(ms.ToArray());
     }
 

--- a/Libraries/src/Amazon.Lambda.DurableExecution/Internal/WaitForConditionOperation.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/Internal/WaitForConditionOperation.cs
@@ -308,7 +308,8 @@ internal sealed class WaitForConditionOperation<TState> : DurableOperation<TStat
         if (serialized == null) return default!;
         var bytes = Encoding.UTF8.GetBytes(serialized);
         using var ms = new MemoryStream(bytes);
-        return _serializer.Deserialize<TState>(ms);
+        return LambdaSerializerHelper.Deserialize<TState>(
+            _serializer, ms, new DurableSerializationContext(OperationId, DurableExecutionArn));
     }
 
     private TState DeserializeStateOrInitial(string? serialized)
@@ -318,7 +319,8 @@ internal sealed class WaitForConditionOperation<TState> : DurableOperation<TStat
         {
             var bytes = Encoding.UTF8.GetBytes(serialized);
             using var ms = new MemoryStream(bytes);
-            return _serializer.Deserialize<TState>(ms);
+            return LambdaSerializerHelper.Deserialize<TState>(
+                _serializer, ms, new DurableSerializationContext(OperationId, DurableExecutionArn));
         }
         catch (Exception ex)
         {
@@ -336,7 +338,8 @@ internal sealed class WaitForConditionOperation<TState> : DurableOperation<TStat
     private string SerializeState(TState value)
     {
         using var ms = new MemoryStream();
-        _serializer.Serialize(value, ms);
+        LambdaSerializerHelper.Serialize(
+            _serializer, value, ms, new DurableSerializationContext(OperationId, DurableExecutionArn));
         return Encoding.UTF8.GetString(ms.ToArray());
     }
 
@@ -361,7 +364,8 @@ internal sealed class WaitForConditionOperation<TState> : DurableOperation<TStat
                 {
                     var bytes = Encoding.UTF8.GetBytes(lastStatePayload);
                     using var ms = new MemoryStream(bytes);
-                    lastState = _serializer.Deserialize<TState>(ms);
+                    lastState = LambdaSerializerHelper.Deserialize<TState>(
+                        _serializer, ms, new DurableSerializationContext(OperationId, DurableExecutionArn));
                 }
                 catch (Exception deserEx)
                 {

--- a/Libraries/src/Amazon.Lambda.DurableExecution/MapConfig.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/MapConfig.cs
@@ -93,5 +93,21 @@ public sealed class MapConfig<TItem>
     /// (statuses / completion reason), and durable operations inside an item's body use
     /// their own configuration.
     /// </summary>
+    /// <remarks>
+    /// <b>Size-dependent transform on overflow (Flat only).</b> Under
+    /// <see cref="NestingType.Flat"/> each item's result is round-tripped through this
+    /// serializer on a fresh (non-replay) success before it enters the result, so a
+    /// serializer that transforms the value (e.g. redaction, canonicalization) has that
+    /// transform reflected in the returned item — but <em>only</em> while the aggregated
+    /// per-item payloads fit inline in a single checkpoint (≈256&#160;KB). If they are
+    /// large enough to overflow, the inline results are stripped and each value is instead
+    /// recovered by re-running the item body on replay, which does <em>not</em> apply the
+    /// round-trip transform. A serializer whose <c>Deserialize</c> is not a pure inverse of
+    /// its <c>Serialize</c> will therefore observe a size-dependent difference (transform
+    /// applied for small results, skipped for overflowed ones). Prefer a round-tripping
+    /// serializer, or do not depend on the transform being applied to results large enough
+    /// to overflow the checkpoint. (Under <see cref="NestingType.Nested"/> the same
+    /// size-dependent caveat is documented on each item's child-context result.)
+    /// </remarks>
     public ILambdaSerializer? ItemSerializer { get; set; }
 }

--- a/Libraries/src/Amazon.Lambda.DurableExecution/ParallelConfig.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/ParallelConfig.cs
@@ -76,5 +76,21 @@ public sealed class ParallelConfig
     /// per-branch result — not the aggregated batch envelope (statuses / completion
     /// reason) — and durable operations inside a branch use their own configuration.
     /// </summary>
+    /// <remarks>
+    /// <b>Size-dependent transform on overflow (Flat only).</b> Under
+    /// <see cref="NestingType.Flat"/> each branch's result is round-tripped through this
+    /// serializer on a fresh (non-replay) success before it enters the result, so a
+    /// serializer that transforms the value (e.g. redaction, canonicalization) has that
+    /// transform reflected in the returned branch — but <em>only</em> while the aggregated
+    /// per-branch payloads fit inline in a single checkpoint (≈256&#160;KB). If they are
+    /// large enough to overflow, the inline results are stripped and each value is instead
+    /// recovered by re-running the branch body on replay, which does <em>not</em> apply the
+    /// round-trip transform. A serializer whose <c>Deserialize</c> is not a pure inverse of
+    /// its <c>Serialize</c> will therefore observe a size-dependent difference (transform
+    /// applied for small results, skipped for overflowed ones). Prefer a round-tripping
+    /// serializer, or do not depend on the transform being applied to results large enough
+    /// to overflow the checkpoint. (Under <see cref="NestingType.Nested"/> the same
+    /// size-dependent caveat is documented on each branch's child-context result.)
+    /// </remarks>
     public ILambdaSerializer? ItemSerializer { get; set; }
 }

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ChildContextOperationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/ChildContextOperationTests.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using Amazon.Lambda.Core;
 using Amazon.Lambda.DurableExecution;
 using Amazon.Lambda.DurableExecution.Internal;
 using Amazon.Lambda.Serialization.SystemTextJson;
@@ -29,6 +30,133 @@ public class ChildContextOperationTests
         var recorder = new RecordingBatcher();
         var context = new DurableContext(state, tm, new WorkflowCancellation(tm), idGen, "arn:test", lambdaContext, recorder.Batcher);
         return (context, recorder, tm, state);
+    }
+
+    /// <summary>
+    /// A non-round-tripping serializer: serialize is plain JSON, but deserialize marks a
+    /// string result with a "[rt]" prefix. Lets a test observe whether the fresh-success
+    /// round-trip transform was applied.
+    /// </summary>
+    private sealed class MarkingSerializer : ILambdaSerializer
+    {
+        private readonly ILambdaSerializer _inner = new DefaultLambdaJsonSerializer();
+        public void Serialize<T>(T response, Stream responseStream) => _inner.Serialize(response, responseStream);
+        public T Deserialize<T>(Stream requestStream)
+        {
+            var value = _inner.Deserialize<T>(requestStream);
+            if (value is string s) return (T)(object)("[rt]" + s);
+            return value;
+        }
+    }
+
+    [Fact]
+    public async Task RunInChildContextAsync_CustomSerializerTransform_AppliedInline_SkippedOnOverflow()
+    {
+        // Pins the documented size-dependent limitation on ChildContextConfig.Serializer:
+        // the fresh-success round-trip transform is reflected in the returned result ONLY
+        // when the payload fits inline. On overflow the result is recovered by re-running
+        // the body (round-trip skipped), so a non-round-tripping serializer diverges by size.
+        var marking = new MarkingSerializer();
+
+        // Small result: fits inline -> round-trip transform is applied.
+        var (smallCtx, _, _, _) = CreateContext();
+        var small = await smallCtx.RunInChildContextAsync(
+            async (_, _) => { await Task.CompletedTask; return "x"; },
+            name: "small",
+            config: new ChildContextConfig { Serializer = marking });
+        Assert.Equal("[rt]x", small);
+
+        // Large result: overflows the checkpoint -> transform is NOT applied (value raw).
+        var big = new string('a', DurableConstants.MaxOperationCheckpointBytes + 1024);
+        var (bigCtx, bigRecorder, _, _) = CreateContext();
+        var large = await bigCtx.RunInChildContextAsync(
+            async (_, _) => { await Task.CompletedTask; return big; },
+            name: "big",
+            config: new ChildContextConfig { Serializer = marking });
+        Assert.Equal(big, large);                 // NOT "[rt]" + big
+        Assert.DoesNotContain("[rt]", large);
+
+        // Confirm it really took the overflow path: empty payload + ReplayChildren.
+        await bigRecorder.Batcher.DrainAsync();
+        var succeed = bigRecorder.Flushed.Single(o => o.Type == "CONTEXT" && o.Action == "SUCCEED");
+        Assert.Equal(string.Empty, succeed.Payload);
+    }
+
+    /// <summary>
+    /// A serializer that serializes normally (plain JSON) but ALWAYS throws on deserialize —
+    /// simulates an asymmetric/broken ChildContextConfig.Serializer that cannot read back its
+    /// own output.
+    /// </summary>
+    private sealed class ThrowOnDeserializeSerializer : ILambdaSerializer
+    {
+        private readonly ILambdaSerializer _inner = new DefaultLambdaJsonSerializer();
+        public void Serialize<T>(T response, Stream responseStream) => _inner.Serialize(response, responseStream);
+        public T Deserialize<T>(Stream requestStream) =>
+            throw new InvalidOperationException("ThrowOnDeserializeSerializer: cannot deserialize");
+    }
+
+    [Fact]
+    public async Task RunInChildContextAsync_RoundTripDeserializeFails_CheckpointsFailAndBodyNotReRunOnReplay()
+    {
+        // Comment 2(b): when a non-virtual child's fresh-success round-trip DESERIALIZE fails,
+        // the child fails TERMINALLY — emitting CONTEXT FAIL — so the op is terminal in the
+        // store and its side-effecting body is NOT re-run on replay. Previously this threw
+        // with NO FAIL checkpoint, leaving the child STARTED (body re-runs on replay).
+        var (context, recorder, _, _) = CreateContext();
+
+        var executed = 0;
+        var ex = await Assert.ThrowsAsync<ChildContextException>(() =>
+            context.RunInChildContextAsync(
+                async (_, _) => { executed++; await Task.CompletedTask; return "x"; },
+                name: "phase",
+                config: new ChildContextConfig { Serializer = new ThrowOnDeserializeSerializer() }));
+
+        Assert.Equal(1, executed);                                   // body ran exactly once
+        Assert.Equal("System.InvalidOperationException", ex.ErrorType);
+        Assert.NotNull(ex.OriginalStackTrace);
+        Assert.NotEmpty(ex.OriginalStackTrace!);
+
+        await recorder.Batcher.DrainAsync();
+        var contextActions = recorder.Flushed
+            .Where(o => o.Type == "CONTEXT")
+            .Select(o => o.Action.ToString())
+            .ToArray();
+        // START then FAIL — never SUCCEED. The FAIL is the new terminal record.
+        Assert.Equal(new[] { "START", "FAIL" }, contextActions);
+
+        // ---- Replay from that FAILED checkpoint: the body is NOT re-run. ----
+        var (replayCtx, replayRec, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = IdAt(1),
+                    Type = OperationTypes.Context,
+                    Status = OperationStatuses.Failed,
+                    Name = "phase",
+                    ContextDetails = new ContextDetails
+                    {
+                        Error = new ErrorObject
+                        {
+                            ErrorType = "System.InvalidOperationException",
+                            ErrorMessage = "ThrowOnDeserializeSerializer: cannot deserialize"
+                        }
+                    }
+                }
+            }
+        });
+
+        var reran = false;
+        await Assert.ThrowsAsync<ChildContextException>(() =>
+            replayCtx.RunInChildContextAsync(
+                async (_, _) => { reran = true; await Task.CompletedTask; return "x"; },
+                name: "phase",
+                config: new ChildContextConfig { Serializer = new ThrowOnDeserializeSerializer() }));
+
+        Assert.False(reran);                                         // poison body never re-runs
+        await replayRec.Batcher.DrainAsync();
+        Assert.Empty(replayRec.Flushed);                             // already terminal — no new checkpoint
     }
 
     [Fact]

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/DurableContextTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/DurableContextTests.cs
@@ -740,6 +740,128 @@ public class DurableContextTests
         Assert.Equal("permanent", ex.Message);
     }
 
+    /// <summary>
+    /// A serializer that serializes fine but throws on deserialize — models an
+    /// asymmetric / broken <see cref="StepConfig.Serializer"/> whose fresh-success
+    /// round-trip fails. Counts calls so the test can assert the step body ran once.
+    /// </summary>
+    private sealed class DeserializeThrowsSerializer : ILambdaSerializer
+    {
+        private readonly ILambdaSerializer _inner = new DefaultLambdaJsonSerializer();
+        public int SerializeCount { get; private set; }
+        public int DeserializeCount { get; private set; }
+
+        public void Serialize<T>(T response, Stream responseStream)
+        {
+            SerializeCount++;
+            _inner.Serialize(response, responseStream);
+        }
+
+        public T Deserialize<T>(Stream requestStream)
+        {
+            DeserializeCount++;
+            throw new InvalidOperationException("asymmetric serializer: cannot read back its own output");
+        }
+    }
+
+    [Fact]
+    public async Task StepAsync_FreshSuccessRoundTripThrows_FailsTerminally_DoesNotRetryOrRerunBody()
+    {
+        // Regression: the fresh-success round-trip DeserializeResult must NOT be routed
+        // through the retry strategy. The side-effecting body has already succeeded, so
+        // retrying would re-invoke it (duplicate side effects) and loop until attempts
+        // exhaust. It must fail TERMINALLY (FAIL checkpoint + StepException, no RETRY).
+        var tm = new TerminationManager();
+        var state = new ExecutionState();
+        state.LoadFromCheckpoint(null);
+        var idGen = new OperationIdGenerator();
+        var lambdaContext = CreateLambdaContext();
+        var recorder = new RecordingBatcher();
+        var context = new DurableContext(state, tm, new WorkflowCancellation(tm), idGen, "arn:test", lambdaContext, recorder.Batcher);
+
+        var brokenSerializer = new DeserializeThrowsSerializer();
+        var bodyRuns = 0;
+
+        var ex = await Assert.ThrowsAsync<StepException>(() =>
+            context.StepAsync<string>(
+                async (_, _) => { bodyRuns++; await Task.CompletedTask; return "ok"; },
+                name: "roundtrip_step",
+                config: new StepConfig
+                {
+                    Serializer = brokenSerializer,
+                    // A strategy that WOULD retry if consulted. The whole point of the
+                    // fix is that this is NOT consulted for a post-success failure.
+                    RetryStrategy = RetryStrategy.Exponential(
+                        maxAttempts: 3,
+                        initialDelay: TimeSpan.FromSeconds(5),
+                        jitter: JitterStrategy.None)
+                }));
+
+        // Body ran exactly once — no retry re-invoked the succeeded, side-effecting body.
+        Assert.Equal(1, bodyRuns);
+        // The round-trip actually happened once (serialize + the throwing deserialize).
+        Assert.Equal(1, brokenSerializer.SerializeCount);
+        Assert.Equal(1, brokenSerializer.DeserializeCount);
+        // Terminal, not suspended-for-retry.
+        Assert.False(tm.IsTerminated);
+        Assert.Equal("asymmetric serializer: cannot read back its own output", ex.Message);
+
+        // A single terminal FAIL checkpoint was recorded — never a RETRY.
+        await recorder.Batcher.DrainAsync();
+        Assert.DoesNotContain(recorder.Flushed, o => o.Action == "RETRY");
+        Assert.Contains(recorder.Flushed, o => o.Action == "FAIL");
+    }
+
+    [Fact]
+    public async Task StepAsync_SuccessCheckpointEnqueueFails_NotRetried_PropagatesWithoutRecursing()
+    {
+        // Comment 2: the post-round-trip SUCCEED enqueue sits AFTER the retryable
+        // try/catch. A failure there must be routed through the terminal path
+        // (FailStepTerminallyAsync), NOT the retry strategy — the side-effecting body
+        // has already succeeded, so it must not be re-invoked. And because
+        // CheckpointBatcher is terminal-on-failure, the follow-on terminal FAIL emit
+        // fast-fails with the same error; that failure must PROPAGATE rather than
+        // re-entering the SUCCEED path (the recursion guard), and must not loop.
+        var tm = new TerminationManager();
+        var state = new ExecutionState();
+        state.LoadFromCheckpoint(null);
+        var idGen = new OperationIdGenerator();
+        var lambdaContext = CreateLambdaContext();
+
+        // Flush fails only on the STEP SUCCEED; the fire-and-forget START (AtLeastOnce
+        // semantics) flushes fine first.
+        var batcher = new CheckpointBatcher("token", (token, ops, ct) =>
+            ops.Any(o => o.Type == "STEP" && o.Action == "SUCCEED")
+                ? Task.FromException<string?>(new InvalidOperationException("succeed-enqueue boom"))
+                : Task.FromResult<string?>(token));
+        var context = new DurableContext(state, tm, new WorkflowCancellation(tm), idGen, "arn:test", lambdaContext, batcher);
+
+        var bodyRuns = 0;
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            context.StepAsync<string>(
+                async (_, _) => { bodyRuns++; await Task.CompletedTask; return "ok"; },
+                name: "succeed_enqueue_fails",
+                config: new StepConfig
+                {
+                    // A strategy that WOULD retry if (wrongly) consulted for this
+                    // post-success enqueue failure.
+                    RetryStrategy = RetryStrategy.Exponential(
+                        maxAttempts: 3,
+                        initialDelay: TimeSpan.FromSeconds(5),
+                        jitter: JitterStrategy.None)
+                }));
+
+        // The broken terminal-FAIL emit's error propagated (recursion guard's
+        // "propagate" branch) rather than looping.
+        Assert.Equal("succeed-enqueue boom", ex.Message);
+        // Body ran exactly once — not routed through retry, no recursive re-run.
+        Assert.Equal(1, bodyRuns);
+        // Not suspended for a retry.
+        Assert.False(tm.IsTerminated);
+
+        await batcher.DisposeAsync();
+    }
+
     [Fact]
     public async Task StepAsync_RetryExhausted_CheckpointsFail()
     {

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/DurableResultSerializerContextTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/DurableResultSerializerContextTests.cs
@@ -1,0 +1,273 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DurableExecution.Internal;
+using Amazon.Lambda.Serialization.SystemTextJson;
+using Amazon.Lambda.TestUtilities;
+using Xunit;
+
+namespace Amazon.Lambda.DurableExecution.Tests;
+
+/// <summary>
+/// Verifies that when a per-operation serializer implements
+/// <see cref="IDurableResultSerializer"/>, the durable runtime invokes the context-aware
+/// overloads and supplies the operation's identity (<c>EntityId</c> = operation id, and
+/// the durable execution ARN). Also verifies that a plain
+/// <see cref="ILambdaSerializer"/> still works via the fallback path.
+/// </summary>
+public class DurableResultSerializerContextTests
+{
+    private const string TestArn = "arn:aws:lambda:us-east-1:123:durable-execution:test";
+
+    private static string IdAt(int position) => OperationIdGenerator.HashOperationId(position.ToString());
+
+    private static DurableContext CreateContext(ILambdaSerializer global, InitialExecutionState? initial = null)
+    {
+        var state = new ExecutionState();
+        state.LoadFromCheckpoint(initial);
+        var tm = new TerminationManager();
+        var idGen = new OperationIdGenerator();
+        var lambdaContext = new TestLambdaContext { Serializer = global };
+        return new DurableContext(state, tm, new WorkflowCancellation(tm), idGen, TestArn, lambdaContext);
+    }
+
+    /// <summary>
+    /// A serializer that captures the <see cref="DurableSerializationContext"/> it is
+    /// handed on each context-aware call, delegating the actual bytes to JSON.
+    /// </summary>
+    private sealed class CapturingSerializer : ILambdaSerializer, IDurableResultSerializer
+    {
+        private readonly ILambdaSerializer _inner = new DefaultLambdaJsonSerializer();
+        public List<DurableSerializationContext> SerializeContexts { get; } = new();
+        public List<DurableSerializationContext> DeserializeContexts { get; } = new();
+
+        public void Serialize<T>(T value, Stream stream, DurableSerializationContext context)
+        {
+            SerializeContexts.Add(context);
+            _inner.Serialize(value, stream);
+        }
+
+        public T Deserialize<T>(Stream stream, DurableSerializationContext context)
+        {
+            DeserializeContexts.Add(context);
+            return _inner.Deserialize<T>(stream);
+        }
+
+        // Plain path — should not be exercised while dispatch prefers the context overload.
+        void ILambdaSerializer.Serialize<T>(T response, Stream responseStream) => _inner.Serialize(response, responseStream);
+        T ILambdaSerializer.Deserialize<T>(Stream requestStream) => _inner.Deserialize<T>(requestStream);
+    }
+
+    /// <summary>Plain serializer (no <see cref="IDurableResultSerializer"/>) that just counts.</summary>
+    private sealed class PlainSpy : ILambdaSerializer
+    {
+        private readonly ILambdaSerializer _inner = new DefaultLambdaJsonSerializer();
+        public int SerializeCount { get; private set; }
+        public void Serialize<T>(T response, Stream responseStream) { SerializeCount++; _inner.Serialize(response, responseStream); }
+        public T Deserialize<T>(Stream requestStream) => _inner.Deserialize<T>(requestStream);
+    }
+
+    [Fact]
+    public async Task Step_PassesOperationIdAndArn_AsContext()
+    {
+        var ser = new CapturingSerializer();
+        var ctx = CreateContext(new DefaultLambdaJsonSerializer());
+
+        var result = await ctx.StepAsync(
+            async (_, _) => { await Task.CompletedTask; return 42; },
+            name: "s",
+            config: new StepConfig { Serializer = ser });
+
+        Assert.Equal(42, result);
+        // Fresh success round-trips (serialize + deserialize), both carry the same context.
+        Assert.All(ser.SerializeContexts, c => { Assert.Equal(IdAt(1), c.EntityId); Assert.Equal(TestArn, c.DurableExecutionArn); });
+        Assert.All(ser.DeserializeContexts, c => { Assert.Equal(IdAt(1), c.EntityId); Assert.Equal(TestArn, c.DurableExecutionArn); });
+        Assert.NotEmpty(ser.SerializeContexts);
+        // NotEmpty guards the Assert.All above from passing vacuously: a regression that
+        // dropped the fresh-success deserialize round-trip would leave DeserializeContexts
+        // empty and must fail here.
+        Assert.NotEmpty(ser.DeserializeContexts);
+    }
+
+    [Fact]
+    public async Task ChildContext_PassesOperationIdAndArn_AsContext()
+    {
+        var ser = new CapturingSerializer();
+        var ctx = CreateContext(new DefaultLambdaJsonSerializer());
+
+        var result = await ctx.RunInChildContextAsync(
+            async (_, _) => { await Task.CompletedTask; return 99; },
+            name: "child",
+            config: new ChildContextConfig { Serializer = ser });
+
+        Assert.Equal(99, result);
+        Assert.NotEmpty(ser.SerializeContexts);
+        Assert.All(ser.SerializeContexts, c => { Assert.Equal(IdAt(1), c.EntityId); Assert.Equal(TestArn, c.DurableExecutionArn); });
+        // The child context also round-trips on fresh success; assert the deserialize
+        // side both ran (NotEmpty) and carried the operation identity, so a regression
+        // dropping the round-trip is caught here too.
+        Assert.NotEmpty(ser.DeserializeContexts);
+        Assert.All(ser.DeserializeContexts, c => { Assert.Equal(IdAt(1), c.EntityId); Assert.Equal(TestArn, c.DurableExecutionArn); });
+    }
+
+    [Fact]
+    public async Task Map_Nested_PassesChildOperationEntityIds()
+    {
+        // Nested (the DEFAULT NestingType): each unit is a NON-virtual child that serializes
+        // its OWN result at its OWN operation id (childOpId), and the parent inlines that
+        // child payload verbatim. So the per-item serialize contexts carry the child op ids,
+        // NOT the parent's per-unit "{parentOpId}#{i}" ids. (Before the comment-1 fix the
+        // parent re-serialized each Nested unit at "{parentOpId}#{i}" — a DIFFERENT entity id
+        // than the child wrote at, which orphaned a context-aware serializer's file and
+        // double-transformed a non-round-tripping serializer.)
+        var ser = new CapturingSerializer();
+        var ctx = CreateContext(new DefaultLambdaJsonSerializer());
+
+        var result = await ctx.MapAsync(
+            new[] { "a", "b" },
+            async (_, item, _, _, _) => { await Task.CompletedTask; return item.ToUpperInvariant(); },
+            name: "map",
+            config: new MapConfig<string> { ItemSerializer = ser });
+
+        Assert.Equal(2, result.SuccessCount);
+        var parentOpId = IdAt(1);
+        var child0 = OperationIdGenerator.HashOperationId($"{parentOpId}-1");
+        var child1 = OperationIdGenerator.HashOperationId($"{parentOpId}-2");
+        var ids = ser.SerializeContexts.Select(c => c.EntityId).Distinct().ToList();
+        Assert.Contains(child0, ids);
+        Assert.Contains(child1, ids);
+        // The stale parent per-unit ids must NOT appear (the double-serialize is gone).
+        Assert.DoesNotContain($"{parentOpId}#0", ids);
+        Assert.DoesNotContain($"{parentOpId}#1", ids);
+        Assert.All(ser.SerializeContexts, c => Assert.Equal(TestArn, c.DurableExecutionArn));
+    }
+
+    [Fact]
+    public async Task Map_Flat_PassesDistinctPerItemEntityIds()
+    {
+        // Flat (virtual) units emit no child checkpoint, so the PARENT serializes each unit
+        // result inline at its per-unit id "{parentOpId}#{i}".
+        var ser = new CapturingSerializer();
+        var ctx = CreateContext(new DefaultLambdaJsonSerializer());
+
+        var result = await ctx.MapAsync(
+            new[] { "a", "b" },
+            async (_, item, _, _, _) => { await Task.CompletedTask; return item.ToUpperInvariant(); },
+            name: "map",
+            config: new MapConfig<string> { NestingType = NestingType.Flat, ItemSerializer = ser });
+
+        Assert.Equal(2, result.SuccessCount);
+        var ids = ser.SerializeContexts.Select(c => c.EntityId).Distinct().ToList();
+        Assert.Contains($"{IdAt(1)}#0", ids);
+        Assert.Contains($"{IdAt(1)}#1", ids);
+        Assert.All(ser.SerializeContexts, c => Assert.Equal(TestArn, c.DurableExecutionArn));
+    }
+
+    [Fact]
+    public async Task PlainSerializer_StillRoundTrips_ViaFallback()
+    {
+        var plain = new PlainSpy();
+        var ctx = CreateContext(new DefaultLambdaJsonSerializer());
+
+        var result = await ctx.StepAsync(
+            async (_, _) => { await Task.CompletedTask; return "hello"; },
+            name: "s",
+            config: new StepConfig { Serializer = plain });
+
+        Assert.Equal("hello", result);
+        Assert.True(plain.SerializeCount >= 1);
+    }
+
+    /// <summary>
+    /// A serializer whose deserialize throws must fail the step (the round-trip runs
+    /// BEFORE the SUCCEED checkpoint), not leave it checkpointed SUCCEEDED-but-thrown.
+    /// Regression guard for the fresh-success round-trip being inside the fault path.
+    /// </summary>
+    [Fact]
+    public async Task Step_FreshSuccessRoundTripThatThrows_SurfacesAsStepFailure()
+    {
+        var ser = new ThrowingDeserializeSerializer();
+        var ctx = CreateContext(new DefaultLambdaJsonSerializer());
+        var runs = 0;
+
+        await Assert.ThrowsAsync<StepException>(() => ctx.StepAsync(
+            async (_, _) => { runs++; await Task.CompletedTask; return 42; },
+            name: "s",
+            config: new StepConfig { Serializer = ser }));
+
+        // Body ran exactly once (no retry loop), and it was serialized before the
+        // failing deserialize — i.e. the round-trip failed cleanly, not after a
+        // second terminal checkpoint.
+        Assert.Equal(1, runs);
+        Assert.Equal(1, ser.SerializeCount);
+    }
+
+    /// <summary>
+    /// On replay, a Map reconstructed from inline per-unit payloads must deserialize
+    /// each unit with the SAME per-unit EntityId (<c>{OperationId}#{index}</c>) that
+    /// the serialize side used — otherwise a context-aware serializer keying storage
+    /// by EntityId cannot find the value. Regression guard for the serialize/deserialize
+    /// context asymmetry in ConcurrentOperation.
+    /// </summary>
+    [Fact]
+    public async Task Map_Replay_DeserializesEachUnitWithPerItemEntityId()
+    {
+        var parentOpId = IdAt(1);
+        var summaryJson =
+            "{\"CompletionReason\":\"ALL_COMPLETED\",\"Units\":[" +
+            "{\"Index\":0,\"Name\":\"0\",\"Status\":\"SUCCEEDED\",\"Result\":\"\\\"A\\\"\"}," +
+            "{\"Index\":1,\"Name\":\"1\",\"Status\":\"SUCCEEDED\",\"Result\":\"\\\"B\\\"\"}]}";
+
+        var ser = new CapturingSerializer();
+        var ctx = CreateContext(new DefaultLambdaJsonSerializer(), new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = parentOpId,
+                    Type = OperationTypes.Context,
+                    Status = OperationStatuses.Succeeded,
+                    SubType = OperationSubTypes.Map,
+                    Name = "map",
+                    ContextDetails = new ContextDetails { Result = summaryJson }
+                }
+            }
+        });
+
+        var executed = false;
+        var result = await ctx.MapAsync(
+            new[] { "a", "b" },
+            async (_, item, _, _, _) => { executed = true; await Task.Yield(); return item.ToUpperInvariant(); },
+            name: "map",
+            config: new MapConfig<string> { NestingType = NestingType.Flat, ItemSerializer = ser });
+
+        Assert.False(executed); // replay: bodies not re-run
+        Assert.Equal(new[] { "A", "B" }, result.GetResults());
+
+        var ids = ser.DeserializeContexts.Select(c => c.EntityId).ToList();
+        Assert.Contains($"{parentOpId}#0", ids);
+        Assert.Contains($"{parentOpId}#1", ids);
+        Assert.All(ser.DeserializeContexts, c => Assert.Equal(TestArn, c.DurableExecutionArn));
+    }
+
+    /// <summary>Serializes via JSON but always throws on the context-aware deserialize.</summary>
+    private sealed class ThrowingDeserializeSerializer : ILambdaSerializer, IDurableResultSerializer
+    {
+        private readonly ILambdaSerializer _inner = new DefaultLambdaJsonSerializer();
+        public int SerializeCount { get; private set; }
+
+        public void Serialize<T>(T value, Stream stream, DurableSerializationContext context)
+        {
+            SerializeCount++;
+            _inner.Serialize(value, stream);
+        }
+
+        public T Deserialize<T>(Stream stream, DurableSerializationContext context) =>
+            throw new InvalidOperationException("boom on deserialize");
+
+        void ILambdaSerializer.Serialize<T>(T response, Stream responseStream) => _inner.Serialize(response, responseStream);
+        T ILambdaSerializer.Deserialize<T>(Stream requestStream) => _inner.Deserialize<T>(requestStream);
+    }
+}

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/MapOperationTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/MapOperationTests.cs
@@ -1,3 +1,4 @@
+using Amazon.Lambda.Core;
 using Amazon.Lambda.DurableExecution;
 using Amazon.Lambda.DurableExecution.Internal;
 using Amazon.Lambda.Serialization.SystemTextJson;
@@ -486,8 +487,233 @@ public class MapOperationTests
         Assert.Empty(recorder.Flushed);
     }
 
-    // ──────────────────────────────────────────────────────────────────────
-    // Argument validation
+    /// <summary>
+    /// A Flat unit's body result is returned RAW from the child context (a virtual child
+    /// suppresses its own SUCCEED and the round-trip a Nested child performs), whereas on
+    /// replay each value is reconstructed by DESERIALIZING the inline payload. With a
+    /// non-round-tripping (asymmetric) ItemSerializer those two paths diverged before the
+    /// fix. This pins fresh == replay: the fresh run must observe the round-tripped value,
+    /// exactly what replay rebuilds from the same inline payload.
+    /// </summary>
+    [Fact]
+    public async Task MapAsync_Flat_NonRoundTrippingItemSerializer_FreshMatchesReplay()
+    {
+        var ser = new AppendOnDeserializeSerializer();
+
+        // ---- Fresh run ----
+        var (freshCtx, freshRec, _, _) = CreateContext();
+        var fresh = await freshCtx.MapAsync(
+            new[] { "a", "b" },
+            async (ctx, item, index, all, _) => { await Task.Yield(); return item; },
+            name: "m",
+            config: new MapConfig<string> { NestingType = NestingType.Flat, ItemSerializer = ser });
+
+        await freshRec.Batcher.DrainAsync();
+
+        // Fresh observed values already reflect the deserialize transform (round-tripped),
+        // which is what replay reconstructs from the inline payload.
+        Assert.Equal(new[] { "a-rt", "b-rt" }, fresh.GetResults());
+
+        // Capture the exact Map SUCCEED payload the fresh run checkpointed.
+        var parentPayload = freshRec.Flushed
+            .Single(o => o.Type == "CONTEXT" && o.SubType == "Map" && $"{o.Action}" == "SUCCEED")
+            .Payload;
+
+        // ---- Replay from that checkpoint ----
+        var parentOpId = IdAt(1);
+        var (replayCtx, replayRec, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = parentOpId,
+                    Type = OperationTypes.Context,
+                    Status = OperationStatuses.Succeeded,
+                    SubType = OperationSubTypes.Map,
+                    Name = "m",
+                    ContextDetails = new ContextDetails { Result = parentPayload }
+                }
+            }
+        });
+
+        var executed = false;
+        var replay = await replayCtx.MapAsync(
+            new[] { "a", "b" },
+            async (ctx, item, index, all, _) => { executed = true; await Task.Yield(); return item; },
+            name: "m",
+            config: new MapConfig<string> { NestingType = NestingType.Flat, ItemSerializer = ser });
+
+        Assert.False(executed); // replay does not re-run bodies
+        Assert.Equal(fresh.GetResults(), replay.GetResults());
+        Assert.Equal(new[] { "a-rt", "b-rt" }, replay.GetResults());
+    }
+
+    /// <summary>
+    /// Nested (the DEFAULT NestingType) counterpart to the Flat fresh==replay test. A Nested
+    /// unit is a NON-virtual child: it round-trips its result inside ChildContextOperation,
+    /// and the parent now inlines the child's ORIGINAL serialized checkpoint payload
+    /// (<c>S(body)</c>) rather than re-serializing the round-tripped return value. With a
+    /// non-round-tripping serializer the pre-fix parent re-serialized <c>D(S(body))</c> and
+    /// replay deserialized it AGAIN, double-transforming (fresh "a-rt" vs replay "a-rt-rt").
+    /// This pins fresh == replay for Nested on the default path.
+    /// </summary>
+    [Fact]
+    public async Task MapAsync_Nested_NonRoundTrippingItemSerializer_FreshMatchesReplay()
+    {
+        var ser = new AppendOnDeserializeSerializer();
+
+        // ---- Fresh run (Nested = default NestingType) ----
+        var (freshCtx, freshRec, _, _) = CreateContext();
+        var fresh = await freshCtx.MapAsync(
+            new[] { "a", "b" },
+            async (ctx, item, index, all, _) => { await Task.Yield(); return item; },
+            name: "m",
+            config: new MapConfig<string> { ItemSerializer = ser });
+
+        await freshRec.Batcher.DrainAsync();
+
+        // The Nested child round-trips internally, so the fresh observed value already
+        // reflects the deserialize transform — exactly what replay rebuilds from the inline
+        // payload (which is now the child's own S(body), deserialized once).
+        Assert.Equal(new[] { "a-rt", "b-rt" }, fresh.GetResults());
+
+        var parentPayload = freshRec.Flushed
+            .Single(o => o.Type == "CONTEXT" && o.SubType == "Map" && $"{o.Action}" == "SUCCEED")
+            .Payload;
+
+        // ---- Replay from that checkpoint ----
+        var parentOpId = IdAt(1);
+        var (replayCtx, _, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = parentOpId,
+                    Type = OperationTypes.Context,
+                    Status = OperationStatuses.Succeeded,
+                    SubType = OperationSubTypes.Map,
+                    Name = "m",
+                    ContextDetails = new ContextDetails { Result = parentPayload }
+                }
+            }
+        });
+
+        var executed = false;
+        var replay = await replayCtx.MapAsync(
+            new[] { "a", "b" },
+            async (ctx, item, index, all, _) => { executed = true; await Task.Yield(); return item; },
+            name: "m",
+            config: new MapConfig<string> { ItemSerializer = ser });
+
+        Assert.False(executed); // replay does not re-run bodies
+        Assert.Equal(fresh.GetResults(), replay.GetResults());
+        Assert.Equal(new[] { "a-rt", "b-rt" }, replay.GetResults());
+    }
+
+    /// <summary>
+    /// Comment 2(a): a Flat unit whose fresh-success round-trip DESERIALIZE fails must be
+    /// handled terminally — the unit is recorded Failed inline and the parent STILL emits a
+    /// terminal SUCCEED — instead of letting the exception propagate raw with no terminal
+    /// checkpoint (which would re-run every virtual unit body on replay: a deterministic
+    /// poison loop). On replay the body is NOT re-run and reconstruct reads the terminal
+    /// Error inline without re-deserializing the poison payload.
+    /// </summary>
+    [Fact]
+    public async Task MapAsync_Flat_RoundTripDeserializeFails_RecordsUnitFailedAndStillCheckpointsSucceed()
+    {
+        var ser = new ThrowOnDeserializeSerializer();
+
+        var (freshCtx, freshRec, _, _) = CreateContext();
+        var fresh = await freshCtx.MapAsync(
+            new[] { "a" },
+            async (ctx, item, index, all, _) => { await Task.Yield(); return item; },
+            name: "m",
+            config: new MapConfig<string> { NestingType = NestingType.Flat, ItemSerializer = ser });
+
+        await freshRec.Batcher.DrainAsync();
+
+        // Body succeeded but its result could not be deserialized back -> unit Failed, and
+        // the operation never throws.
+        Assert.True(fresh.HasFailure);
+        Assert.Equal(BatchItemStatus.Failed, fresh.All[0].Status);
+        Assert.IsType<ChildContextException>(fresh.All[0].Error);
+
+        // A terminal parent SUCCEED checkpoint WAS written despite the failure.
+        var parentSucceed = freshRec.Flushed
+            .Single(o => o.Type == "CONTEXT" && o.SubType == "Map" && $"{o.Action}" == "SUCCEED");
+        Assert.NotNull(parentSucceed.Payload);
+
+        // ---- Replay from that checkpoint: poison body never re-runs, unit stays Failed. ----
+        var parentOpId = IdAt(1);
+        var (replayCtx, _, _, _) = CreateContext(new InitialExecutionState
+        {
+            Operations = new List<Operation>
+            {
+                new()
+                {
+                    Id = parentOpId,
+                    Type = OperationTypes.Context,
+                    Status = OperationStatuses.Succeeded,
+                    SubType = OperationSubTypes.Map,
+                    Name = "m",
+                    ContextDetails = new ContextDetails { Result = parentSucceed.Payload }
+                }
+            }
+        });
+
+        var executed = false;
+        var replay = await replayCtx.MapAsync(
+            new[] { "a" },
+            async (ctx, item, index, all, _) => { executed = true; await Task.Yield(); return item; },
+            name: "m",
+            config: new MapConfig<string> { NestingType = NestingType.Flat, ItemSerializer = ser });
+
+        Assert.False(executed);
+        Assert.True(replay.HasFailure);
+        Assert.Equal(BatchItemStatus.Failed, replay.All[0].Status);
+    }
+
+    /// <summary>
+    /// A serializer that serializes normally (plain JSON) but ALWAYS throws on deserialize —
+    /// simulates an asymmetric/broken ItemSerializer that cannot read back its own output.
+    /// </summary>
+    private sealed class ThrowOnDeserializeSerializer : ILambdaSerializer, IDurableResultSerializer
+    {
+        private readonly ILambdaSerializer _inner = new DefaultLambdaJsonSerializer();
+
+        public void Serialize<T>(T value, Stream stream, DurableSerializationContext context) => _inner.Serialize(value, stream);
+        public T Deserialize<T>(Stream stream, DurableSerializationContext context) =>
+            throw new InvalidOperationException("ThrowOnDeserializeSerializer: cannot deserialize");
+
+        void ILambdaSerializer.Serialize<T>(T response, Stream responseStream) => _inner.Serialize(response, responseStream);
+        T ILambdaSerializer.Deserialize<T>(Stream requestStream) =>
+            throw new InvalidOperationException("ThrowOnDeserializeSerializer: cannot deserialize");
+    }
+
+    /// <summary>
+    /// Deliberately NON-round-tripping serializer: <c>Serialize</c> writes the value as
+    /// JSON, but <c>Deserialize</c> appends a marker to a string result. Lets a test
+    /// observe whether a value went through a deserialize (round-trip) or is the raw body
+    /// result.
+    /// </summary>
+    private sealed class AppendOnDeserializeSerializer : ILambdaSerializer, IDurableResultSerializer
+    {
+        private readonly ILambdaSerializer _inner = new DefaultLambdaJsonSerializer();
+
+        public void Serialize<T>(T value, Stream stream, DurableSerializationContext context) => _inner.Serialize(value, stream);
+
+        public T Deserialize<T>(Stream stream, DurableSerializationContext context)
+        {
+            var value = _inner.Deserialize<T>(stream);
+            if (value is string s) return (T)(object)(s + "-rt");
+            return value;
+        }
+
+        void ILambdaSerializer.Serialize<T>(T response, Stream responseStream) => _inner.Serialize(response, responseStream);
+        T ILambdaSerializer.Deserialize<T>(Stream requestStream) => _inner.Deserialize<T>(requestStream);
+    }
     // ──────────────────────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

Adds the **context-aware serializer engine** for durable operation results and extends the fresh-success serializer round-trip (already applied to Step and ChildContext) to **Map/Parallel**, with hardened terminal-failure handling. Stacked on `feature/per-step-serializer` (#2555); `FileSystemSerializer` (#2558) builds on this branch.

## What's in this PR

**1. Context-aware serializer infrastructure**
- Optional `IDurableResultSerializer` with `Serialize`/`Deserialize(…, DurableSerializationContext)`, where the context carries `EntityId` (operation id) + `DurableExecutionArn`.
- `LambdaSerializerHelper` dispatches to the context overload when the configured serializer implements it, otherwise falls back to plain `ILambdaSerializer` with **byte-identical** behavior. No config API change; existing serializers are unaffected.
- Wired at the result choke points: Step, ChildContext, WaitForCondition, and Map/Parallel per-item (per-item `EntityId = OperationId#index` so items don't collide).

**2. Map/Parallel fresh-success round-trip (Flat)**
- On a fresh (non-replay) success, each Flat per-item result is deserialized from its just-serialized checkpoint payload before entering the result — matching what replay reconstructs. This removes a fresh-vs-replay divergence for a non-round-tripping `ItemSerializer`. The returned value is a fresh deserialized instance; overflow (replay-children) results are unaffected.

**3. Map/Parallel inline reuse (Nested)**
- The parent now inlines each Nested unit's **original** SUCCEED-checkpoint payload verbatim, instead of re-serializing the already-round-tripped return value at the parent's per-unit id. This removes a double-transform divergence for non-round-tripping serializers (and, for a context-aware serializer, avoids writing a second copy at a different id).

**4. Terminal round-trip failure handling**
- A fresh-success round-trip **deserialize** failure is now terminal on the Step, ChildContext, and Flat Map/Parallel paths: a FAIL checkpoint is recorded, the retry strategy is **not** consulted, and the already-succeeded side-effecting body is never re-invoked. Replay reconstructs the terminal failure without re-running or re-deserializing.
- A Step post-SUCCEED checkpoint-enqueue failure routes through the same terminal path rather than propagating raw.

## Change files
- `12a4a1f7` — **Major**: Step/Child fresh-success round-trip (reclassified from Minor; breaking at the 1.0.0 baseline).
- `ca5a9844` — **Major**: Map/Parallel Flat per-item fresh-success round-trip.
- `f3a1520c` — **Major**: Map/Parallel Nested inline reuses child payload.
- `d12219eb` — **Major**: terminal round-trip deserialize failure (Child + Flat).
- `3691fc04` — **Major**: terminal Step round-trip failure (no retry).
- `c1cb8e3a` — **Patch**: terminal Step post-SUCCEED enqueue failure.

## Testing
- **439/439** unit tests pass on net8.0; builds clean under `TreatWarningsAsErrors`.

## Note
Two `<see cref="FileSystemSerializer"/>` doc links render as `<c>FileSystemSerializer</c>` here (the type doesn't exist on this branch) and are restored to `cref` links in #2558, which introduces the type.
