### PR TITLE
fix(DurableExecution): resolve symlinks at every path component in FileSystemSerializer containment check

### DIFF
--- a/Libraries/src/Amazon.Lambda.DurableExecution/FileSystemSerializer.cs
+++ b/Libraries/src/Amazon.Lambda.DurableExecution/FileSystemSerializer.cs
@@ -407,32 +407,56 @@ public sealed class FileSystemSerializer : ILambdaSerializer, IDurableResultSeri
     }
 
     // Best-effort resolution of a path to its real on-disk location, following a
-    // symlink on the leaf file/directory and on its immediate parent directory.
-    // Path.GetFullPath only collapses '..'/separators and does NOT follow symlinks,
-    // so without this a symlink planted under the base but pointing outside it would
-    // pass a purely lexical prefix check and defeat the containment guard. Both the
-    // base and the candidate are resolved the same way so a symlinked mount root
-    // (for example macOS /var -> /private/var) does not cause false rejections.
+    // symlink at EVERY existing component of the path — not just the leaf and its
+    // immediate parent. Path.GetFullPath only collapses '..'/separators and does NOT
+    // follow symlinks, so without this a symlink planted under the base but pointing
+    // outside it would pass a purely lexical prefix check and defeat the containment
+    // guard. Resolving every component also means the base and the candidate are
+    // canonicalized identically no matter where a symlink sits in the path: a
+    // symlinked mount root used *as* the base (for example an EFS mount exposed as
+    // /mnt/link -> /mnt/real) resolves the same way the candidate paths built under
+    // it do, so containment is decided on real on-disk locations and legitimate
+    // reads/writes are not falsely rejected. A symlink above the base (for example
+    // macOS /var -> /private/var) is likewise resolved symmetrically on both sides.
+    // Components that do not exist yet (a per-execution directory validated before it
+    // is created) cannot be a symlink, so they are appended lexically.
     private static string ResolveReal(string fullPath)
     {
         try
         {
-            var dir = Path.GetDirectoryName(fullPath);
-            if (dir != null && Directory.Exists(dir))
+            var root = Path.GetPathRoot(fullPath);
+            if (string.IsNullOrEmpty(root))
+                return fullPath; // Not rooted (shouldn't happen post-GetFullPath); nothing to resolve against.
+
+            var current = root;
+            var rest = fullPath.Substring(root.Length);
+            foreach (var segment in rest.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
             {
-                var realDir = Directory.ResolveLinkTarget(dir, returnFinalTarget: true)?.FullName ?? dir;
-                fullPath = Path.Combine(realDir, Path.GetFileName(fullPath));
+                if (segment.Length == 0)
+                    continue;
+
+                current = Path.Combine(current, segment);
+
+                // Follow a symlink at this component (returnFinalTarget walks a chain
+                // of links to its ultimate target). A non-existent component or a
+                // regular file/dir yields null and is kept as-is.
+                var resolved = Directory.Exists(current)
+                    ? Directory.ResolveLinkTarget(current, returnFinalTarget: true)?.FullName
+                    : File.Exists(current)
+                        ? File.ResolveLinkTarget(current, returnFinalTarget: true)?.FullName
+                        : null;
+
+                if (resolved != null)
+                    current = resolved;
             }
-            if (File.Exists(fullPath))
-                fullPath = File.ResolveLinkTarget(fullPath, returnFinalTarget: true)?.FullName ?? fullPath;
-            else if (Directory.Exists(fullPath))
-                fullPath = Directory.ResolveLinkTarget(fullPath, returnFinalTarget: true)?.FullName ?? fullPath;
+
+            return current;
         }
         catch
         {
             // Best effort — fall back to the lexical full path.
+            return fullPath;
         }
-        return fullPath;
     }
 
     private string ResolveExecutionDir(string arn)

--- a/Libraries/test/Amazon.Lambda.DurableExecution.Tests/FileSystemSerializerTests.cs
+++ b/Libraries/test/Amazon.Lambda.DurableExecution.Tests/FileSystemSerializerTests.cs
@@ -200,6 +200,56 @@ public class FileSystemSerializerTests : IDisposable
         Assert.False(Directory.Exists(_base) && Directory.GetFiles(_base, "*.bin", SearchOption.AllDirectories).Length > 0);
     }
 
+    // ---- Symlinked base: a base path whose leaf is a symlink must not falsely reject reads/writes ----
+
+    [Fact]
+    public void SymlinkedBasePath_RoundTripsAndStaysContained()
+    {
+        // Model a real-world durable mount exposed through a symlink (e.g. an EFS mount
+        // surfaced as /mnt/link -> /mnt/real). The base path handed to the serializer is
+        // the *symlink*; every candidate path is built underneath it. The containment
+        // guard resolves the symlinked base to its real target, so it must resolve the
+        // candidates through the same symlink or it would reject every read and write.
+        var realDir = Path.Combine(Path.GetTempPath(), "fsser-real-" + Guid.NewGuid().ToString("N"));
+        var linkDir = Path.Combine(Path.GetTempPath(), "fsser-link-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(realDir);
+        try
+        {
+            try
+            {
+                Directory.CreateSymbolicLink(linkDir, realDir);
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or PlatformNotSupportedException)
+            {
+                // Creating symlinks can require elevation (Windows without Developer Mode).
+                // The behavior under test is filesystem-level, so skip where we cannot set up.
+                return;
+            }
+
+            var s = new FileSystemSerializer(_json, linkDir, FileSystemStorageMode.Always);
+            var value = new Poco { Id = 42, Name = "efs" };
+
+            // Write through the symlinked base — must not throw "outside the configured base path".
+            var envelope = Serialize(s, value, DurableArnCtx());
+            Assert.Contains("\"file\"", envelope);
+
+            // Read back through the same base — must not be rejected by the containment guard.
+            var round = Deserialize<Poco>(s, envelope, DurableArnCtx());
+            Assert.Equal(value, round);
+
+            // The payload physically landed under the real target directory.
+            Assert.True(
+                Directory.GetFiles(realDir, "*.bin", SearchOption.AllDirectories).Length > 0,
+                "offloaded payload should be written under the symlink's real target");
+        }
+        finally
+        {
+            // Delete the link itself (non-recursive) so cleanup never follows into the target.
+            try { Directory.Delete(linkDir, recursive: false); } catch { /* best effort */ }
+            try { Directory.Delete(realDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     // ---- V7b: ARN that doesn't match the pattern falls back to a single encoded segment ----
 
     [Fact]


### PR DESCRIPTION
Addresses @jnunn-aws's review comment on #2561: https://github.com/aws/aws-lambda-dotnet/pull/2561#discussion_r3935808937

## Problem

`FileSystemSerializer.IsWithinBase` runs both the base and the candidate through `ResolveReal`, but `ResolveReal` only followed a symlink on the **leaf** and its **immediate parent**. When the configured `basePath` is itself a symlink — e.g. an EFS mount exposed as `/mnt/link -> /mnt/real` — the two sides canonicalize asymmetrically:

- Base `/mnt/link` — its leaf *is* the symlink, so it resolves to `fullBase = /mnt/real/`.
- Candidate `/mnt/link/<func>/<exec>/<inv>/<entity>.bin` — the `/mnt/link` symlink sits several components **above** the leaf/parent, which `ResolveReal` never touched, so it stayed `/mnt/link/...`.
- `fullPath.StartsWith(fullBase)` is then `false`, so `ValidateWriteDirWithinBase` / `ValidatePathWithinBase` reject **every** offloaded write and read.

The macOS `/var -> /private/var` case in the code comment is safe only because that symlink sits *above* the base and is left unresolved symmetrically on both sides; a symlinked base *leaf* is not.

## Fix

`ResolveReal` now follows a symlink at **every existing component** of the path (walking root → leaf, calling `ResolveLinkTarget` per segment). Base and candidate are canonicalized identically no matter where the symlink sits, so a symlinked mount root used as the base resolves the same way the candidate paths built under it do. Non-existent trailing components (a per-execution directory validated before it is created) can't be symlinks and are appended lexically. This also strengthens escape detection: a symlink planted at any interior component that points outside the base is now caught, not just one on the leaf/parent.

## Test

Added `SymlinkedBasePath_RoundTripsAndStaysContained`: creates `link -> real`, constructs the serializer with the symlink as the base, and asserts a value round-trips and the payload physically lands under the real target. The test **fails before this change** (containment guard rejects the write) and passes after. It soft-skips where symlink creation requires elevation (Windows without Developer Mode).

All existing `FileSystemSerializerTests` pass (`net10.0`).