### PR TITLE
fix: complete emulator REST APIGatewayProxyRequest and null-safe AspNetCoreServer marshalling

### DIFF
--- a/.autover/changes/8c1d9773-a398-4953-97d4-9747e9606611.json
+++ b/.autover/changes/8c1d9773-a398-4953-97d4-9747e9606611.json
@@ -1,0 +1,18 @@
+﻿{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.AspNetCoreServer",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Null-safe marshalling for Path, HttpMethod, path parameters, and headers to avoid NullReferenceException with incomplete API Gateway events"
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.TestTool",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Populate RequestContext (and Path/HttpMethod defaults) when the API Gateway emulator builds REST APIGatewayProxyRequest events"
+      ]
+    }
+  ]
+}

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -157,6 +157,18 @@ namespace Amazon.Lambda.AspNetCoreServer
         /// <param name="lambdaContext"></param>
         protected override void MarshallRequest(InvokeFeatures features, APIGatewayProxyRequest apiGatewayRequest, ILambdaContext lambdaContext)
         {
+            if (apiGatewayRequest == null)
+            {
+                _logger.LogError("MarshallRequest: apiGatewayRequest is null");
+                throw new ArgumentNullException(nameof(apiGatewayRequest));
+            }
+
+            _logger.LogDebug("MarshallRequest: Path={Path}, HttpMethod={HttpMethod}, Resource={Resource}, RequestContext={HasContext}",
+                apiGatewayRequest.Path ?? "(null)",
+                apiGatewayRequest.HttpMethod ?? "(null)",
+                apiGatewayRequest.Resource ?? "(null)",
+                apiGatewayRequest.RequestContext != null);
+
             {
                 var authFeatures = (IHttpAuthenticationFeature)features;
 
@@ -201,7 +213,8 @@ namespace Amazon.Lambda.AspNetCoreServer
                 var rawQueryString = Utilities.CreateQueryStringParameters(
                     apiGatewayRequest.QueryStringParameters, apiGatewayRequest.MultiValueQueryStringParameters, true);
 
-                requestFeatures.RawTarget = apiGatewayRequest.Path + rawQueryString;
+                var pathForTarget = apiGatewayRequest.Path ?? "/";
+                requestFeatures.RawTarget = pathForTarget + rawQueryString;
                 requestFeatures.QueryString = rawQueryString;
                 requestFeatures.Path = path;
 
@@ -365,24 +378,24 @@ namespace Amazon.Lambda.AspNetCoreServer
             if (apiGatewayRequest.PathParameters != null && apiGatewayRequest.PathParameters.TryGetValue("proxy", out var proxy) &&
                 !string.IsNullOrEmpty(apiGatewayRequest.Resource))
             {
-                var proxyPath = proxy;
+                var proxyPath = proxy ?? "";
                 path = apiGatewayRequest.Resource.Replace("{proxy+}", proxyPath);
 
                 // Adds all the rest of non greedy parameters in apiGateway.Resource to the path
                 foreach (var pathParameter in apiGatewayRequest.PathParameters.Where(pp => pp.Key != "proxy"))
                 {
-                    path = path.Replace($"{{{pathParameter.Key}}}", pathParameter.Value);
+                    path = path.Replace($"{{{pathParameter.Key}}}", pathParameter.Value ?? "");
                 }
             }
 
             if (string.IsNullOrEmpty(path))
             {
-                path = apiGatewayRequest.Path;
+                path = apiGatewayRequest.Path ?? "/";
             }
 
-            if (!path.StartsWith("/"))
+            if (string.IsNullOrEmpty(path) || !path.StartsWith("/"))
             {
-                path = "/" + path;
+                path = "/" + (path ?? "");
             }
             return path;
         }
@@ -394,7 +407,7 @@ namespace Amazon.Lambda.AspNetCoreServer
         /// </summary>
         protected virtual string ParseHttpMethod(APIGatewayProxyRequest apiGatewayRequest)
         {
-            return apiGatewayRequest.HttpMethod;
+            return apiGatewayRequest.HttpMethod ?? "GET";
         }
 
         /// <summary>

--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/Utilities.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/Internal/Utilities.cs
@@ -190,14 +190,21 @@ namespace Amazon.Lambda.AspNetCoreServer.Internal
             {
                 foreach (var kvp in multiValues)
                 {
-                    headers[kvp.Key] = new StringValues(kvp.Value.ToArray());
+                    var values = kvp.Value?.Where(v => v != null).ToArray() ?? Array.Empty<string>();
+                    if (values.Length > 0)
+                    {
+                        headers[kvp.Key] = new StringValues(values);
+                    }
                 }
             }
             else if (singleValues?.Count > 0)
             {
                 foreach (var kvp in singleValues)
                 {
-                    headers[kvp.Key] = new StringValues(kvp.Value);
+                    if (kvp.Value != null)
+                    {
+                        headers[kvp.Key] = new StringValues(kvp.Value);
+                    }
                 }
             }
         }

--- a/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/HttpContextExtensions.cs
+++ b/Tools/LambdaTestTool-v2/src/Amazon.Lambda.TestTool/Extensions/HttpContextExtensions.cs
@@ -177,13 +177,34 @@ public static class HttpContextExtensions
             pathParameters = encodedPathParameters;
         }
 
+        var pathValue = path ?? "/";
+        var resourceValue = apiGatewayRouteConfig.Path ?? "";
+        var httpMethodValue = request.Method ?? "GET";
+        var userAgent = request.Headers.UserAgent.ToString();
+
         var proxyRequest = new APIGatewayProxyRequest
         {
-            Resource = apiGatewayRouteConfig.Path,
-            Path = path,
-            HttpMethod = request.Method,
+            Resource = resourceValue,
+            Path = pathValue,
+            HttpMethod = httpMethodValue,
             Body = body,
-            IsBase64Encoded = false
+            IsBase64Encoded = false,
+            RequestContext = new APIGatewayProxyRequest.ProxyRequestContext
+            {
+                Path = pathValue,
+                AccountId = "123456789012",
+                ResourceId = "test-invoke-resource-id",
+                Stage = "test-invoke-stage",
+                RequestId = HttpRequestUtility.GenerateRequestId(),
+                Identity = new APIGatewayProxyRequest.RequestIdentity
+                {
+                    SourceIp = "127.0.0.1",
+                    UserAgent = userAgent
+                },
+                ResourcePath = resourceValue,
+                HttpMethod = httpMethodValue,
+                ApiId = "test-invoke-api-id"
+            }
         };
 
         if (headers.Any())


### PR DESCRIPTION
*Issue #, if available:*
Fixes #2566

*Description of changes:*
When the Lambda Test Tool v2 API Gateway emulator translates an HTTP request into a REST `APIGatewayProxyRequest`, it omitted `RequestContext` and could leave `Path` / `HttpMethod` null. `Amazon.Lambda.AspNetCoreServer` then threw `NullReferenceException` while marshalling those incomplete events into ASP.NET Core features.

This PR:
1. **Amazon.Lambda.TestTool** — populate a minimal `RequestContext` (and default Path/HttpMethod) for emulator-built REST proxy events, closer to real API Gateway / test-invoke payloads. HTTP API v2 translation already set `RequestContext`.
2. **Amazon.Lambda.AspNetCoreServer** — null-safe marshalling for `Path`, `HttpMethod`, path parameters, and header values so incomplete events do not NRE.

Includes an AutoVer change file (Patch) for both projects.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.